### PR TITLE
fix: validate provider wait_ticks against action catalog

### DIFF
--- a/.pm/tasks/task_9eeeedd9fbaf43859d1241728bd3dd12.execution.md
+++ b/.pm/tasks/task_9eeeedd9fbaf43859d1241728bd3dd12.execution.md
@@ -1,0 +1,23 @@
+# task_9eeeedd9fbaf43859d1241728bd3dd12 Execution Log
+
+- task_uid: task_9eeeedd9fbaf43859d1241728bd3dd12
+- title: Fix provider loopback wait_ticks catalog validation
+- owner_role: agent_engineer
+- worktree_hint: world-simulator-provider-wait-ticks-catalog-bug
+
+<!-- Append entries using:
+Example:
+  ## YYYY-MM-DD HH:MM:SS CST / role_name
+  - 完成内容: ...
+  - 遗留事项: ...
+-->
+
+## 2026-04-09 23:31:57 CST / agent_engineer
+- 完成内容: 在 `crates/oasis7/src/simulator/tests/provider_loopback_adapter.rs` 新增回归用例，证明 `ProviderLoopbackAdapter` 当前会错误接受未出现在请求 `action_catalog` 里的 `ProviderDecision::WaitTicks`；随后在 `crates/oasis7/src/simulator/provider_loopback_adapter.rs` 收紧校验逻辑，为 `wait_ticks` 增加与其他动作一致的 request catalog 校验，并抽出 `request_advertises_action_ref` 复用 helper。
+- 完成内容: 已先跑新增单测确认红灯，再回跑 `env -u RUSTC_WRAPPER cargo test -p oasis7 provider_loopback_adapter_rejects_wait_ticks_when_request_catalog_omits_it -- --nocapture` 与 `env -u RUSTC_WRAPPER cargo test -p oasis7 provider_loopback_adapter`，两者均通过；现存编译输出里只有与本任务无关的既有 unused warnings。
+- 遗留事项: 按用户要求，本次停在本地未提交状态；未执行 commit、review snapshot、landing。
+
+## 2026-04-10 01:18:30 CST / agent_engineer
+- 完成内容: 根据后续指令继续进入提交流程；已用独立 subagent 做提交前 review，唯一 finding 是 task/backlog 仍停在 `candidate`，现已通过 `./scripts/pm/move-task.sh --task-uid task_9eeeedd9fbaf43859d1241728bd3dd12 --to-status committed` 修正，代码改动未发现额外问题。
+- 完成内容: 已在当前 diff 上执行 `./scripts/pm/codex-review-snapshot.sh`；review 过程覆盖了代码 diff、PM task/backlog diff 以及 `provider_loopback_adapter` 定向测试。返回输出未暴露新的 actionable finding，但工具会话在尾部出现 `stdin is closed`，因此没有拿到简短总结行。
+- 遗留事项: 下一步执行单一 commit、推送 task 分支并创建 GitHub MR；landing 仍未执行。

--- a/.pm/tasks/task_9eeeedd9fbaf43859d1241728bd3dd12.execution.md
+++ b/.pm/tasks/task_9eeeedd9fbaf43859d1241728bd3dd12.execution.md
@@ -21,3 +21,9 @@ Example:
 - 完成内容: 根据后续指令继续进入提交流程；已用独立 subagent 做提交前 review，唯一 finding 是 task/backlog 仍停在 `candidate`，现已通过 `./scripts/pm/move-task.sh --task-uid task_9eeeedd9fbaf43859d1241728bd3dd12 --to-status committed` 修正，代码改动未发现额外问题。
 - 完成内容: 已在当前 diff 上执行 `./scripts/pm/codex-review-snapshot.sh`；review 过程覆盖了代码 diff、PM task/backlog diff 以及 `provider_loopback_adapter` 定向测试。返回输出未暴露新的 actionable finding，但工具会话在尾部出现 `stdin is closed`，因此没有拿到简短总结行。
 - 遗留事项: 下一步执行单一 commit、推送 task 分支并创建 GitHub MR；landing 仍未执行。
+
+## 2026-04-11 13:52:53 CST / agent_engineer
+- 完成内容: 已将当前分支 rebase 到最新 `origin/main`，并按 `main` 上的 `.pm` 新规则解决冲突，继续保留 `.pm/tasks/*.yaml` 为真值、`.pm/registry/tasks.yaml` 与 role backlog 为 git-ignored 本地生成视图，不把共享视图文件重新带回 Git。
+- 完成内容: 已按 PR review comment 修正 `scripts/collect-active-llm-retention-sample.sh` 中把 `stdbuf` 同时当作必需依赖和可选 fallback 的矛盾逻辑，改为真正可选；同时把 `doc/game/gameplay/gameplay-ten-minute-retention-recovery-2026-04-09.project.md` 的 Done Definition 改成与最终 `hold` verdict 一致。
+- 完成内容: 已完成 `bash -n scripts/collect-active-llm-retention-sample.sh`、`./scripts/doc-governance-check.sh` 与 `git diff --check` 验证。
+- 遗留事项: 继续执行提交前 review、提交修复 commit、推送当前 PR 分支，并在 PR 中收口 comment / merge 准备。

--- a/.pm/tasks/task_9eeeedd9fbaf43859d1241728bd3dd12.yaml
+++ b/.pm/tasks/task_9eeeedd9fbaf43859d1241728bd3dd12.yaml
@@ -1,0 +1,20 @@
+task_uid: task_9eeeedd9fbaf43859d1241728bd3dd12
+title: "Fix provider loopback wait_ticks catalog validation"
+owner_role: agent_engineer
+worktree_hint: world-simulator-provider-wait-ticks-catalog-bug
+execution_log_path: .pm/tasks/task_9eeeedd9fbaf43859d1241728bd3dd12.execution.md
+status: committed
+priority: P1
+source_signal: null
+source_refs:
+  - crates/oasis7/src/simulator/provider_loopback_adapter.rs
+doc_refs:
+  - doc/world-simulator/llm/llm-provider-loopback-http-integration-2026-03-12.prd.md
+related_prd:
+  - PRD-WORLD_SIMULATOR-037
+acceptance:
+  - "ProviderLoopbackAdapter must reject wait_ticks when request action_catalog does not advertise it; add regression test and keep targeted provider_loopback_adapter tests green."
+handoff_to: []
+updated_at: 2026-04-09T23:43:33+08:00
+last_started_at: 2026-04-09T23:21:41+08:00
+last_closed_at: 2026-04-09T23:35:12+08:00

--- a/crates/oasis7/src/simulator/provider_loopback_adapter.rs
+++ b/crates/oasis7/src/simulator/provider_loopback_adapter.rs
@@ -49,6 +49,14 @@ impl ProviderLoopbackAdapter {
         PHASE1_ALLOWED_ACTION_REFS
     }
 
+    fn request_advertises_action_ref(request: &DecisionRequest, action_ref: &str) -> bool {
+        request
+            .observation
+            .action_catalog
+            .iter()
+            .any(|entry| entry.action_ref == action_ref)
+    }
+
     fn validate_response(
         &self,
         request: &DecisionRequest,
@@ -64,6 +72,13 @@ impl ProviderLoopbackAdapter {
         match &response.decision {
             ProviderDecision::Wait => Ok(()),
             ProviderDecision::WaitTicks { .. } => {
+                if !Self::request_advertises_action_ref(request, "wait_ticks") {
+                    return Err(DecisionProviderError::new(
+                        "action_ref_not_in_catalog",
+                        "action_ref `wait_ticks` is not present in request action_catalog",
+                        false,
+                    ));
+                }
                 if Self::phase1_allowed_action_refs().contains(&"wait_ticks") {
                     Ok(())
                 } else {
@@ -75,12 +90,7 @@ impl ProviderLoopbackAdapter {
                 }
             }
             ProviderDecision::Act { action_ref, action } => {
-                if !request
-                    .observation
-                    .action_catalog
-                    .iter()
-                    .any(|entry| entry.action_ref == *action_ref)
-                {
+                if !Self::request_advertises_action_ref(request, action_ref) {
                     return Err(DecisionProviderError::new(
                         "action_ref_not_in_catalog",
                         format!(

--- a/crates/oasis7/src/simulator/tests/provider_loopback_adapter.rs
+++ b/crates/oasis7/src/simulator/tests/provider_loopback_adapter.rs
@@ -160,6 +160,37 @@ fn provider_loopback_adapter_maps_provider_error_envelope_to_decision_provider_e
     assert!(err.retryable);
 }
 
+#[test]
+fn provider_loopback_adapter_rejects_wait_ticks_when_request_catalog_omits_it() {
+    let mut request = golden_decision_provider_fixtures()
+        .into_iter()
+        .next()
+        .expect("fixture")
+        .request;
+    request
+        .observation
+        .action_catalog
+        .retain(|entry| entry.action_ref != "wait_ticks");
+    let wait_ticks_response = DecisionResponse {
+        decision: ProviderDecision::WaitTicks { ticks: 2 },
+        provider_error: None,
+        diagnostics: ProviderDiagnostics::default(),
+        trace_payload: ProviderTraceEnvelope::default(),
+        memory_write_intents: vec![],
+    };
+    let base_url = spawn_mock_http_server(1, move |_| MockHttpResponse {
+        status_code: 200,
+        body: serde_json::to_string(&wait_ticks_response).expect("encode response"),
+    });
+
+    let mut adapter = ProviderLoopbackAdapter::new(base_url.as_str(), None, 200).expect("adapter");
+    let err = adapter
+        .decide(&request)
+        .expect_err("wait_ticks outside action_catalog should be rejected");
+    assert_eq!(err.code, "action_ref_not_in_catalog");
+    assert!(err.message.contains("wait_ticks"));
+}
+
 fn setup_kernel_with_provider_agent(agent_id: &str) -> WorldKernel {
     let mut kernel = WorldKernel::with_config(WorldConfig {
         move_cost_per_km_electricity: 0,

--- a/doc/game/gameplay/gameplay-ten-minute-retention-recovery-2026-04-09.project.md
+++ b/doc/game/gameplay/gameplay-ten-minute-retention-recovery-2026-04-09.project.md
@@ -67,7 +67,7 @@
 - `TASK-GAME-062`
   - [x] 首次进入不再依赖手动 reopen/reload 才可控
   - [x] `software_safe` 不再把明确 `blocked` / `timeout_no_progress` 压扁成伪 timeout，前台会回填正确控制反馈
-  - [x] viewer-side regression、execution log 与相关证据已回写；fresh active-LLM formal re-certification 由 `TASK-GAME-065` 复核后更新为 `watch`
+  - [x] viewer-side regression、execution log 与相关证据已回写；fresh active-LLM formal re-certification 已交由 `TASK-GAME-065` 复核并形成当前 `hold` 裁决
 - `TASK-GAME-063`
   - [x] 10 分钟工业中循环包可在同一会话完成
   - [x] 建厂/首产出/停机恢复/扩产取舍均有 canonical 状态与前台反馈锚点

--- a/scripts/collect-active-llm-retention-sample.sh
+++ b/scripts/collect-active-llm-retention-sample.sh
@@ -125,7 +125,6 @@ done
 
 ab_require
 require_cmd rg
-require_cmd stdbuf
 
 stamp="$(date +%Y%m%d-%H%M%S)-$$"
 run_id="${run_id_override:-active-llm-retention-${stamp}}"


### PR DESCRIPTION
## Summary
- reject provider `wait_ticks` responses when the current request `action_catalog` does not advertise `wait_ticks`
- add a regression test that reproduces the previous false acceptance path
- record the task in `.pm` and move it to `committed`

## Validation
- env -u RUSTC_WRAPPER cargo test -p oasis7 provider_loopback_adapter_rejects_wait_ticks_when_request_catalog_omits_it -- --nocapture
- env -u RUSTC_WRAPPER cargo test -p oasis7 provider_loopback_adapter
- ./scripts/pm/lint.sh
- pre-commit review: subagent review completed; `./scripts/pm/codex-review-snapshot.sh` executed on current diff (tool output returned without new actionable findings, though the review session ended without a concise final summary line after its internal test run)