### PR TITLE
fix: sync stale m4 builtin identity hashes

### DIFF
--- a/.pm/registry/tasks.yaml
+++ b/.pm/registry/tasks.yaml
@@ -100,6 +100,13 @@ tasks:
     priority: P0
     source_signal: null
     updated_at: 2026-04-10T20:53:24+08:00
+  - task_uid: task_0a098672cf234dba9137adbad7064e5a
+    owner_role: wasm_platform_engineer
+    task_path: .pm/tasks/task_0a098672cf234dba9137adbad7064e5a.yaml
+    status: done
+    priority: P0
+    source_signal: null
+    updated_at: 2026-04-10T20:56:04+08:00
   - task_uid: task_3eb31966906e5ae7b8b8676d756c5510
     owner_role: producer_system_designer
     task_path: .pm/tasks/task_3eb31966906e5ae7b8b8676d756c5510.yaml

--- a/.pm/roles/wasm_platform_engineer/backlog/done.yaml
+++ b/.pm/roles/wasm_platform_engineer/backlog/done.yaml
@@ -1,4 +1,18 @@
 version: 1
 role: wasm_platform_engineer
 status: done
-tasks: []
+tasks:
+  - task_uid: task_0a098672cf234dba9137adbad7064e5a
+    title: "Repair main-branch m4 builtin wasm identity drift"
+    priority: P0
+    source_signal: null
+    related_prd:
+      - PRD-WORLD_RUNTIME-021
+      - PRD-WORLD_RUNTIME-022
+    acceptance:
+      - "Refresh m4 builtin wasm tracked identity/hash artifacts to match current canonical CI evidence for m4.factory.miner.mk1"
+      - "Re-run targeted builtin wasm identity checks and m4 sync verification on the task worktree"
+      - "Confirm whether the latest main-branch Wasm Determinism Gate failure signature is resolved"
+    handoff_to: []
+    status: done
+    task_path: .pm/tasks/task_0a098672cf234dba9137adbad7064e5a.yaml

--- a/.pm/tasks/task_0a098672cf234dba9137adbad7064e5a.execution.md
+++ b/.pm/tasks/task_0a098672cf234dba9137adbad7064e5a.execution.md
@@ -24,3 +24,9 @@ Example:
 - 完成内容: 已复跑 `env -u RUSTC_WRAPPER cargo test -p oasis7 builtin_identity_manifest --tests`，4 个 builtin identity 测试全部通过；已执行 `./scripts/pm/lint.sh` 与 `git diff --check`，均通过。
 - 完成内容: 提交前快照 review 已执行，输出未发现新的阻断项；review 会话末尾出现该机型已知的 snapshot/stdin 关闭噪声，但不影响已收集到的审查证据。
 - 遗留事项: 待执行 close-phase、提交单任务 commit，并把修复分支推送用于收口 `main` 上当前 `Wasm Determinism Gate` 红灯。
+
+## 2026-04-10 21:45:00 CST / wasm_platform_engineer
+- 完成内容: 已执行 close-phase 并将 task `task_0a098672cf234dba9137adbad7064e5a` 迁移到 done backlog；`./scripts/pm/lint.sh` 在 close 后复跑通过。
+- 完成内容: 已提交 `fix: sync stale m4 builtin identity hashes`（`b8508f39`），并通过仓库 commit-tier 门禁，包括 `oasis7_consensus`、`oasis7_distfs`、`oasis7_viewer` 相关检查。
+- 完成内容: 已推送分支 `task/world-runtime-wasm-main-m4-identity-drift` 并创建 PR `#51`，用于收口 `main` 上当前 `Wasm Determinism Gate` 红灯。
+- 遗留事项: 等待 GitHub PR review / CI 结果；任务本地实现与 PM 收口已完成。

--- a/.pm/tasks/task_0a098672cf234dba9137adbad7064e5a.execution.md
+++ b/.pm/tasks/task_0a098672cf234dba9137adbad7064e5a.execution.md
@@ -1,0 +1,26 @@
+# task_0a098672cf234dba9137adbad7064e5a Execution Log
+
+- task_uid: task_0a098672cf234dba9137adbad7064e5a
+- title: Repair main-branch m4 builtin wasm identity drift
+- owner_role: wasm_platform_engineer
+- worktree_hint: /home/scc/worktrees/oasis7-world-runtime-wasm-main-m4-identity-drift
+
+<!-- Append entries using:
+Example:
+  ## YYYY-MM-DD HH:MM:SS CST / role_name
+  - 完成内容: ...
+  - 遗留事项: ...
+-->
+## 2026-04-10 20:10:00 CST / wasm_platform_engineer
+- 完成内容: 在独立 worktree 复核 `main` 上 `Wasm Determinism Gate` 失败签名，确认 `m4.factory.miner.mk1` 的 tracked identity manifest 仍记录旧 `source_hash=c480...` / `identity_hash=f36d...`，而 GitHub gate 与本地 canonical builder receipt 一致指向 `source_hash=b270...`。
+- 完成内容: 最小化修补 `crates/oasis7/src/runtime/world/artifacts/m4_builtin_modules.identity.json` 中 `m4.factory.miner.mk1` 的 `source_hash` 与派生 `identity_hash`，将其回写为当前 canonical receipt 对应值。
+- 完成内容: 已完成单模块 `sync_builtin_wasm_identity --check` 验证（`m4.factory.miner.mk1`）与 `env -u RUSTC_WRAPPER cargo test -p oasis7 builtin_identity_manifest --tests` 回归，确认 runtime 可读取修正后的 m4 builtin identity。
+- 遗留事项: `./scripts/sync-m4-builtin-wasm-artifacts.sh --check` 仍在同一 worktree 内跑完整 22 个 m4 模块的 Docker canonical 校验，待其自然完成后作为最接近 GitHub `Wasm Determinism Gate` 的最终闭环证据。
+
+## 2026-04-10 21:07:00 CST / wasm_platform_engineer
+- 完成内容: 由于首轮 `sync-m4` 长跑中断但已留下 `15/22` 份 receipt/metadata，改为仅补建缺失的 7 个 m4 product 模块，并用现有 22 份 canonical receipt 对全量 `m4_builtin_modules.identity.json` 做逐项对账。
+- 完成内容: 全量对账发现除 `m4.factory.miner.mk1` 外，还存在两条隐藏陈旧记录：`m4.product.material.iron_ingot` 与 `m4.recipe.smelter.iron_ingot`。已同步回写这三条记录的 `source_hash` / `identity_hash`，其余 19 条与 canonical receipt 保持一致，无需改动。
+- 完成内容: 已执行 `env -u RUSTC_WRAPPER cargo run --quiet -p oasis7_distfs --bin sync_builtin_wasm_identity -- ... --check`，确认 `m4` identity manifest 对 22 个模块全部同步；已额外对 22 份 receipt 的 `wasm_hash_sha256` 与 `m4_builtin_modules.sha256` 做平台级对账，通过无漂移。
+- 完成内容: 已复跑 `env -u RUSTC_WRAPPER cargo test -p oasis7 builtin_identity_manifest --tests`，4 个 builtin identity 测试全部通过；已执行 `./scripts/pm/lint.sh` 与 `git diff --check`，均通过。
+- 完成内容: 提交前快照 review 已执行，输出未发现新的阻断项；review 会话末尾出现该机型已知的 snapshot/stdin 关闭噪声，但不影响已收集到的审查证据。
+- 遗留事项: 待执行 close-phase、提交单任务 commit，并把修复分支推送用于收口 `main` 上当前 `Wasm Determinism Gate` 红灯。

--- a/.pm/tasks/task_0a098672cf234dba9137adbad7064e5a.yaml
+++ b/.pm/tasks/task_0a098672cf234dba9137adbad7064e5a.yaml
@@ -1,0 +1,23 @@
+task_uid: task_0a098672cf234dba9137adbad7064e5a
+title: "Repair main-branch m4 builtin wasm identity drift"
+owner_role: wasm_platform_engineer
+worktree_hint: /home/scc/worktrees/oasis7-world-runtime-wasm-main-m4-identity-drift
+execution_log_path: .pm/tasks/task_0a098672cf234dba9137adbad7064e5a.execution.md
+status: done
+priority: P0
+source_signal: null
+source_refs:
+  - doc/world-runtime/project.md
+doc_refs:
+  - doc/world-runtime/project.md
+related_prd:
+  - PRD-WORLD_RUNTIME-021
+  - PRD-WORLD_RUNTIME-022
+acceptance:
+  - "Refresh m4 builtin wasm tracked identity/hash artifacts to match current canonical CI evidence for m4.factory.miner.mk1"
+  - "Re-run targeted builtin wasm identity checks and m4 sync verification on the task worktree"
+  - "Confirm whether the latest main-branch Wasm Determinism Gate failure signature is resolved"
+handoff_to: []
+updated_at: 2026-04-10T20:56:04+08:00
+last_started_at: 2026-04-10T19:43:36+08:00
+last_closed_at: 2026-04-10T20:56:04+08:00

--- a/crates/oasis7/src/runtime/world/artifacts/m4_builtin_modules.identity.json
+++ b/crates/oasis7/src/runtime/world/artifacts/m4_builtin_modules.identity.json
@@ -33,9 +33,9 @@
       "hash_tokens": [
         "linux-x86_64=5232b320279daeb36851857093e7ce5e94a32a8506f73021f180752ae8d6d2ed"
       ],
-      "source_hash": "c48081875f8642a52468ac6f68949e3b8aefbaee4034792ba79d426d76556117",
+      "source_hash": "b2705c49d3d02671ce389bafeddaa11bd59e156511ad41b0688c032b6f7d9d89",
       "build_manifest_hash": "60a5c3364a3e1f412ff7a8e7c3e4835a25023c5b72271ceecb68f2b950b3e563",
-      "identity_hash": "f36d029ef8a568db4f7f906c9a2283373e30faae584e2aa31823c07b5c1ffd5a"
+      "identity_hash": "cf8ae646176f461952c8f629c1784b03aa390c47d1f04020ec420bf4fb5d0862"
     },
     {
       "module_id": "m4.factory.smelter.mk1",
@@ -114,9 +114,9 @@
       "hash_tokens": [
         "linux-x86_64=afa099e408e741442cc46d5fea58cbe861c18fe141fd9a128b2ea4c0f2963e54"
       ],
-      "source_hash": "78b7deceb0790eeffb073b712657263b4337d0008416b8f902256f44c2b501fa",
+      "source_hash": "2ce77451ed9a1ccfa39c9a350dc88283459b5ef3096ff2d94d5b357cd99d0fc8",
       "build_manifest_hash": "60a5c3364a3e1f412ff7a8e7c3e4835a25023c5b72271ceecb68f2b950b3e563",
-      "identity_hash": "6267d05a841c78880525a9a58a33bd80a4c2482b5524966dcb61b0570ae92126"
+      "identity_hash": "85c6295f38f15e0a2e8f3aedd12f81e05cc11630f91049d6562fa8459802b94d"
     },
     {
       "module_id": "m4.recipe.assembler.control_chip",
@@ -204,9 +204,9 @@
       "hash_tokens": [
         "linux-x86_64=3ebf745fc7137e1aae0ea6464cc1acb746f862b7cb33020501ffe3544bc4f8c9"
       ],
-      "source_hash": "ee61d2d55f22b4b884e96cb5f9d82d281f130236bcf45e8e5c80b78ac5fd055c",
+      "source_hash": "e60917947f36e8696a6168578d181ce1a19ffa8ca926de8a361689ca8cc3276a",
       "build_manifest_hash": "60a5c3364a3e1f412ff7a8e7c3e4835a25023c5b72271ceecb68f2b950b3e563",
-      "identity_hash": "fba4c95ac4c4ff5c77f183a8c48f48e21bbbb4b1e5dd94c16db56b6ca2c4702a"
+      "identity_hash": "aac0a9d5facf22665c5e8fc4d77d6193e5f58f55e8732fd51530c26cb690ad8f"
     },
     {
       "module_id": "m4.recipe.smelter.polymer_resin",


### PR DESCRIPTION
## Summary
- sync the stale m4 builtin identity entries for miner, product.material.iron_ingot, and recipe.smelter.iron_ingot
- verify the updated identity manifest against 22 canonical m4 build receipts and current hash manifest tokens
- record the PM task/workflow closure for the main-branch Wasm Determinism Gate fix

## Validation
- env -u RUSTC_WRAPPER cargo run --quiet -p oasis7_distfs --bin sync_builtin_wasm_identity -- --module-ids-path crates/oasis7/src/runtime/world/artifacts/m4_builtin_module_ids.txt --module-manifest-map-path crates/oasis7/src/runtime/world/artifacts/builtin_module_manifest_map.txt --hash-manifest-path crates/oasis7/src/runtime/world/artifacts/m4_builtin_modules.sha256 --identity-manifest-path crates/oasis7/src/runtime/world/artifacts/m4_builtin_modules.identity.json --metadata-dir .tmp/builtin-wasm-sync-modules --workspace-root . --profile release --canonical-platforms linux-x86_64 --check
- python3 inline receipt-vs-hash-manifest verification for all 22 m4 modules
- env -u RUSTC_WRAPPER cargo test -p oasis7 builtin_identity_manifest --tests
- ./scripts/pm/lint.sh
- git diff --check
- ./scripts/pm/codex-review-snapshot.sh
