### PR TITLE
Add AutoNAT reachability evidence to p2p auto mode

### DIFF
--- a/.pm/tasks/task_f9da1696bc8641f6b612541c195a5987.execution.md
+++ b/.pm/tasks/task_f9da1696bc8641f6b612541c195a5987.execution.md
@@ -16,3 +16,9 @@ Example:
 - 完成内容: `oasis7_chain_runtime` `/v1/chain/status` 已新增上述 probe 证据字段，方便 launcher/viewer/运维脚本审计 `private_safe` 与 `public_entry` 判定来源；同时回写 `doc/p2p/network/p2p-mainnet-private-reachability-architecture-2026-04-01.project.md`，把 P2PARCH-9 的“未接入完整 AutoNAT / port reachability probe”旧结论更新为当前实现真值。
 - 完成内容: 已执行 `env -u RUSTC_WRAPPER cargo fmt --all`、`env -u RUSTC_WRAPPER cargo test -p oasis7 --bin oasis7_chain_runtime -- --nocapture`、`env -u RUSTC_WRAPPER cargo test -p oasis7_net --lib -- --nocapture`、`env -u RUSTC_WRAPPER cargo test -p oasis7_node types::tests -- --nocapture`、`git diff --check`；相关改动面回归通过。
 - 遗留事项: `env -u RUSTC_WRAPPER cargo test -p oasis7_node --lib -- --nocapture` 仍有 4 条与本次 reachability 任务无直接对应的现有失败签名（connected peer order / peer-head sync / topic isolation / signed-mode fetch handler），本任务未扩大范围处理。
+
+## 2026-04-13 15:07:53 CST / runtime_engineer
+- 完成内容: 根据 PR review comment，收紧 `swarm.add_external_address/remove_external_address` 条件：默认仅对 relay listen addr 生效，不再把 loopback/private/unspecified 直连 listen addr 当成 external truth 注入 swarm；同时新增 predicate 单测，防止该边界回退。
+- 完成内容: 为不破坏本地 discovery / rendezvous harness，新增 `allow_loopback_external_addrs_for_testing` 显式 test-only 配置，仅在 `crates/oasis7_net/src/tests.rs` 的本地 loopback P2P 用例中开启，避免把测试 fallback 混入生产默认路径。
+- 验证结果: 已执行 `env -u RUSTC_WRAPPER cargo fmt --all`、`env -u RUSTC_WRAPPER cargo test -p oasis7_net --lib -- --nocapture`、`git diff --check`，结果通过。
+- 遗留事项: 待完成 snapshot review、提交并 push 回 PR，然后回帖/resolve 当前 review thread。

--- a/.pm/tasks/task_f9da1696bc8641f6b612541c195a5987.execution.md
+++ b/.pm/tasks/task_f9da1696bc8641f6b612541c195a5987.execution.md
@@ -1,0 +1,18 @@
+# task_f9da1696bc8641f6b612541c195a5987 Execution Log
+
+- task_uid: task_f9da1696bc8641f6b612541c195a5987
+- title: Complete AutoNAT and port reachability probes for P2P auto mode
+- owner_role: runtime_engineer
+- worktree_hint: /home/scc/worktrees/oasis7-p2p-p2p-reachability-autonat-probe-closure
+
+<!-- Append entries using:
+Example:
+  ## YYYY-MM-DD HH:MM:SS CST / role_name
+  - 完成内容: ...
+  - 遗留事项: ...
+-->
+## 2026-04-12 23:58:58 CST / runtime_engineer
+- 完成内容: 将 libp2p AutoNAT 与 external address confirmed/expired 事件接入 `oasis7_net` reachability snapshot，新增 `autonat_status/public_port_reachability/observed_public_addr/confirmed_external_direct_addrs` 运行时真值，并把 `oasis7_node` 的 user-mode recommender 调整为优先消费明确的 AutoNAT / public-port 证据，而不是只依赖 hole-punch/relay hint。
+- 完成内容: `oasis7_chain_runtime` `/v1/chain/status` 已新增上述 probe 证据字段，方便 launcher/viewer/运维脚本审计 `private_safe` 与 `public_entry` 判定来源；同时回写 `doc/p2p/network/p2p-mainnet-private-reachability-architecture-2026-04-01.project.md`，把 P2PARCH-9 的“未接入完整 AutoNAT / port reachability probe”旧结论更新为当前实现真值。
+- 完成内容: 已执行 `env -u RUSTC_WRAPPER cargo fmt --all`、`env -u RUSTC_WRAPPER cargo test -p oasis7 --bin oasis7_chain_runtime -- --nocapture`、`env -u RUSTC_WRAPPER cargo test -p oasis7_net --lib -- --nocapture`、`env -u RUSTC_WRAPPER cargo test -p oasis7_node types::tests -- --nocapture`、`git diff --check`；相关改动面回归通过。
+- 遗留事项: `env -u RUSTC_WRAPPER cargo test -p oasis7_node --lib -- --nocapture` 仍有 4 条与本次 reachability 任务无直接对应的现有失败签名（connected peer order / peer-head sync / topic isolation / signed-mode fetch handler），本任务未扩大范围处理。

--- a/.pm/tasks/task_f9da1696bc8641f6b612541c195a5987.yaml
+++ b/.pm/tasks/task_f9da1696bc8641f6b612541c195a5987.yaml
@@ -1,0 +1,21 @@
+task_uid: task_f9da1696bc8641f6b612541c195a5987
+title: "Complete AutoNAT and port reachability probes for P2P auto mode"
+owner_role: runtime_engineer
+worktree_hint: /home/scc/worktrees/oasis7-p2p-p2p-reachability-autonat-probe-closure
+execution_log_path: .pm/tasks/task_f9da1696bc8641f6b612541c195a5987.execution.md
+status: done
+priority: P2
+source_signal: null
+source_refs:
+  - doc/p2p/network/p2p-mainnet-private-reachability-architecture-2026-04-01.project.md
+doc_refs:
+  - doc/p2p/network/p2p-mainnet-private-reachability-architecture-2026-04-01.project.md
+related_prd:
+  - doc/p2p/network/p2p-mainnet-private-reachability-architecture-2026-04-01.prd.md
+acceptance:
+  - "Runtime recommendation consumes explicit AutoNAT and public-port reachability evidence instead of relying only on relay or hole-punch fallback signals"
+  - "Chain status exposes the new probe evidence so launcher or viewer can audit why a node is treated as private_safe or public_entry"
+handoff_to: []
+updated_at: 2026-04-13T00:00:15+08:00
+last_started_at: 2026-04-12T23:27:13+08:00
+last_closed_at: 2026-04-13T00:00:02+08:00

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4758,6 +4758,7 @@ dependencies = [
  "getrandom 0.2.17",
  "instant",
  "libp2p-allow-block-list",
+ "libp2p-autonat",
  "libp2p-connection-limits",
  "libp2p-core",
  "libp2p-dcutr",
@@ -4791,6 +4792,27 @@ dependencies = [
  "libp2p-identity",
  "libp2p-swarm",
  "void",
+]
+
+[[package]]
+name = "libp2p-autonat"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d95151726170e41b591735bf95c42b888fe4aa14f65216a9fbf0edcc04510586"
+dependencies = [
+ "async-trait",
+ "asynchronous-codec 0.6.2",
+ "futures",
+ "futures-timer",
+ "instant",
+ "libp2p-core",
+ "libp2p-identity",
+ "libp2p-request-response",
+ "libp2p-swarm",
+ "quick-protobuf",
+ "quick-protobuf-codec 0.2.0",
+ "rand 0.8.5",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/oasis7/src/bin/oasis7_chain_runtime.rs
+++ b/crates/oasis7/src/bin/oasis7_chain_runtime.rs
@@ -15,10 +15,11 @@ use oasis7::runtime::{
     NodeAssetBalance, NodeRewardMintRecord, ReleaseSecurityPolicy, RewardAssetConfig,
 };
 use oasis7_node::{
-    derive_libp2p_identity_keypair, Libp2pReplicationNetwork, Libp2pReplicationNetworkConfig,
-    NodeConfig, NodeFeedbackP2pConfig, NodeNetworkPolicy, NodePosConfig,
-    NodeReachabilityAutoDetection, NodeReplicationConfig, NodeReplicationNetworkHandle, NodeRole,
-    NodeRuntime, NodeSnapshot, NodeUserModeRecommendation, PosConsensusStatus, PosValidator,
+    derive_libp2p_identity_keypair, Libp2pReachabilitySnapshot, Libp2pReplicationNetwork,
+    Libp2pReplicationNetworkConfig, NodeConfig, NodeFeedbackP2pConfig, NodeNetworkPolicy,
+    NodePosConfig, NodeReachabilityAutoDetection, NodeReplicationConfig,
+    NodeReplicationNetworkHandle, NodeRole, NodeRuntime, NodeSnapshot, NodeUserModeRecommendation,
+    PosConsensusStatus, PosValidator,
 };
 use oasis7_proto::distributed_dht::{PeerDiscoverySource, PeerRecord};
 use oasis7_proto::storage_profile::{StorageProfile, StorageProfileConfig};
@@ -50,6 +51,8 @@ mod p2p_status;
 mod reward_runtime_settlement;
 #[path = "oasis7_chain_runtime/reward_runtime_worker.rs"]
 mod reward_runtime_worker;
+#[path = "oasis7_chain_runtime/status_payload.rs"]
+mod status_payload;
 #[path = "oasis7_chain_runtime/storage_metrics.rs"]
 mod storage_metrics;
 #[path = "oasis7_chain_runtime/transfer_submit_api.rs"]
@@ -71,12 +74,13 @@ use feedback_submit_api::{
 };
 use p2p_status::{
     applied_runtime_user_mode_label, build_live_node_network_policy_recommendation,
-    build_node_network_policy, peer_reachability_as_str,
+    build_node_network_policy,
 };
 use reward_runtime_worker::{
     init_shared_metrics, poll_worker_error, snapshot_metrics, start_reward_runtime_worker,
     stop_reward_runtime_worker, RewardRuntimeWorkerConfig, SharedRewardRuntimeMetrics,
 };
+use status_payload::{build_chain_p2p_status, ChainP2pStatus};
 #[cfg(test)]
 mod execution_bridge {
     use std::path::Path;
@@ -186,22 +190,6 @@ struct ChainStatusResponse {
     reward_runtime: reward_runtime_worker::RewardRuntimeMetricsSnapshot,
     storage: storage_metrics::StorageMetricsSnapshot,
     replication: ChainReplicationDebugStatus,
-}
-
-#[derive(Debug, Serialize)]
-struct ChainP2pStatus {
-    requested_user_mode: String,
-    recommended_user_mode: String,
-    effective_user_mode: String,
-    applied_effective_user_mode: Option<String>,
-    requires_explicit_public_entry_confirmation: bool,
-    detected_reachability: Option<String>,
-    hole_punch_viability: String,
-    relay_available: bool,
-    probe_stable: bool,
-    deployment_mode: String,
-    node_role_claim: String,
-    rationale: Vec<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -859,6 +847,7 @@ fn handle_chain_status_connection(
                 &p2p_recommendation,
                 applied_effective_user_mode,
                 effective_p2p_policy,
+                &live_snapshot,
                 p2p_detection,
                 release_security_policy.clone(),
                 snapshot_metrics(&reward_runtime_metrics),
@@ -893,6 +882,7 @@ fn build_chain_status_payload(
     live_p2p_recommendation: &NodeUserModeRecommendation,
     applied_effective_user_mode: Option<String>,
     effective_p2p_policy: NodeNetworkPolicy,
+    live_snapshot: &Libp2pReachabilitySnapshot,
     p2p_detection: NodeReachabilityAutoDetection,
     release_security_policy: ReleaseSecurityPolicy,
     reward_runtime_metrics: reward_runtime_worker::RewardRuntimeMetricsSnapshot,
@@ -936,33 +926,13 @@ fn build_chain_status_payload(
         },
         last_error: snapshot.last_error,
         execution_world_dir: execution_world_dir.display().to_string(),
-        p2p: ChainP2pStatus {
-            requested_user_mode: live_p2p_recommendation
-                .requested_user_mode
-                .as_str()
-                .to_string(),
-            recommended_user_mode: live_p2p_recommendation
-                .recommended_user_mode
-                .as_str()
-                .to_string(),
-            effective_user_mode: live_p2p_recommendation
-                .effective_user_mode
-                .as_str()
-                .to_string(),
+        p2p: build_chain_p2p_status(
+            live_p2p_recommendation,
             applied_effective_user_mode,
-            requires_explicit_public_entry_confirmation: live_p2p_recommendation
-                .requires_explicit_public_entry_confirmation,
-            detected_reachability: p2p_detection
-                .observed_reachability
-                .map(peer_reachability_as_str)
-                .map(str::to_string),
-            hole_punch_viability: p2p_detection.hole_punch_viability.to_string(),
-            relay_available: p2p_detection.relay_available,
-            probe_stable: p2p_detection.probe_stable,
-            deployment_mode: effective_p2p_policy.deployment_mode.as_str().to_string(),
-            node_role_claim: effective_p2p_policy.node_role_claim.as_str().to_string(),
-            rationale: live_p2p_recommendation.rationale.clone(),
-        },
+            effective_p2p_policy,
+            live_snapshot,
+            p2p_detection,
+        ),
         release_security_policy,
         reward_runtime: reward_runtime_metrics,
         storage: storage_metrics,

--- a/crates/oasis7/src/bin/oasis7_chain_runtime/cli.rs
+++ b/crates/oasis7/src/bin/oasis7_chain_runtime/cli.rs
@@ -4,7 +4,8 @@ use std::path::PathBuf;
 
 use oasis7::runtime::RewardAssetConfig;
 use oasis7_node::{
-    NodeHolePunchViability, NodeReachabilityAutoDetection, NodeRole, NodeUserMode, PosValidator,
+    NodeAutoNatStatus, NodeHolePunchViability, NodePublicPortReachability,
+    NodeReachabilityAutoDetection, NodeRole, NodeUserMode, PosValidator,
 };
 use oasis7_proto::distributed_dht::{PeerDeploymentMode, PeerNodeRole, PeerReachabilityClass};
 use oasis7_proto::storage_profile::StorageProfile;
@@ -420,6 +421,8 @@ pub(super) fn p2p_auto_detection_from_options(
     NodeReachabilityAutoDetection {
         observed_reachability: options.p2p_detected_reachability,
         hole_punch_viability: options.p2p_detected_hole_punch_viability,
+        autonat_status: NodeAutoNatStatus::Unknown,
+        public_port_reachability: NodePublicPortReachability::Unknown,
         relay_available: options.p2p_detected_relay_available,
         probe_stable: options.p2p_detected_probe_stable,
     }

--- a/crates/oasis7/src/bin/oasis7_chain_runtime/oasis7_chain_runtime_tests.rs
+++ b/crates/oasis7/src/bin/oasis7_chain_runtime/oasis7_chain_runtime_tests.rs
@@ -11,8 +11,9 @@ use super::{
 use ed25519_dalek::SigningKey;
 use oasis7::runtime::{ReleaseSecurityPolicy, World as RuntimeWorld};
 use oasis7_node::{
-    Libp2pReachabilitySnapshot, LiveHolePunchState, LiveTransportKind, NodeConfig,
-    NodeConsensusSnapshot, NodeHolePunchViability, NodeNetworkPolicy,
+    Libp2pReachabilitySnapshot, LiveAutoNatStatus, LiveHolePunchState, LivePublicPortReachability,
+    LiveTransportKind, NodeAutoNatStatus, NodeConfig, NodeConsensusSnapshot,
+    NodeHolePunchViability, NodeNetworkPolicy, NodePublicPortReachability,
     NodeReachabilityAutoDetection, NodeRole, NodeSnapshot, NodeUserMode, PosValidator,
 };
 use oasis7_proto::distributed_dht::{
@@ -467,6 +468,7 @@ fn live_reachability_snapshot_upgrades_detection_when_cli_hints_are_absent() {
             active_relay_path_count: 0,
             relay_reservation_active: false,
             hole_punch_state: LiveHolePunchState::Viable,
+            ..Libp2pReachabilitySnapshot::default()
         }),
     )
     .expect("recommendation");
@@ -503,6 +505,7 @@ fn relay_reservation_without_active_relay_path_does_not_claim_relay_only_reachab
             active_relay_path_count: 0,
             relay_reservation_active: true,
             hole_punch_state: LiveHolePunchState::Unknown,
+            ..Libp2pReachabilitySnapshot::default()
         }),
     )
     .expect("recommendation");
@@ -524,6 +527,7 @@ fn failed_hole_punch_snapshot_does_not_force_blocked_viability() {
             active_relay_path_count: 0,
             relay_reservation_active: false,
             hole_punch_state: LiveHolePunchState::Unknown,
+            ..Libp2pReachabilitySnapshot::default()
         }),
     )
     .expect("recommendation");
@@ -560,6 +564,7 @@ fn explicit_cli_detection_hints_override_live_snapshot() {
             active_relay_path_count: 1,
             relay_reservation_active: true,
             hole_punch_state: LiveHolePunchState::Viable,
+            ..Libp2pReachabilitySnapshot::default()
         }),
     )
     .expect("recommendation");
@@ -604,6 +609,37 @@ fn build_node_replication_config_uses_storage_profile_budget() {
     assert_eq!(
         config.max_hot_commit_messages(),
         storage_profile.replication_max_hot_commit_messages
+    );
+}
+
+#[test]
+fn live_reachability_snapshot_promotes_public_entry_from_autonat_probe() {
+    let options = parse_options(["--node-role", "observer"].into_iter()).expect("parse");
+    let (recommendation, detection) = build_live_node_network_policy_recommendation(
+        &options,
+        Some(&Libp2pReachabilitySnapshot {
+            autonat_status: LiveAutoNatStatus::Public,
+            public_port_reachability: LivePublicPortReachability::Reachable,
+            observed_public_addr: Some("/dns4/public.example/tcp/4001".to_string()),
+            confirmed_external_direct_addrs: vec!["/dns4/public.example/tcp/4001".to_string()],
+            ..Libp2pReachabilitySnapshot::default()
+        }),
+    )
+    .expect("recommendation");
+
+    assert_eq!(
+        detection.observed_reachability,
+        Some(PeerReachabilityClass::Public)
+    );
+    assert_eq!(detection.autonat_status, NodeAutoNatStatus::Public);
+    assert_eq!(
+        detection.public_port_reachability,
+        NodePublicPortReachability::Reachable
+    );
+    assert!(detection.probe_stable);
+    assert_eq!(
+        recommendation.recommended_user_mode,
+        NodeUserMode::PublicEntry
     );
 }
 
@@ -767,6 +803,8 @@ fn build_chain_status_payload_includes_storage_metrics() {
                 hole_punch_viability: NodeHolePunchViability::Viable,
                 relay_available: true,
                 probe_stable: true,
+                autonat_status: NodeAutoNatStatus::Public,
+                public_port_reachability: NodePublicPortReachability::Reachable,
             },
             false,
         )
@@ -776,11 +814,20 @@ fn build_chain_status_payload_includes_storage_metrics() {
             deployment_mode: PeerDeploymentMode::Private,
             node_role_claim: PeerNodeRole::FullStorage,
         },
+        &Libp2pReachabilitySnapshot {
+            autonat_status: LiveAutoNatStatus::Public,
+            public_port_reachability: LivePublicPortReachability::Reachable,
+            observed_public_addr: Some("/dns4/public.example/tcp/4001".to_string()),
+            confirmed_external_direct_addrs: vec!["/dns4/public.example/tcp/4001".to_string()],
+            ..Libp2pReachabilitySnapshot::default()
+        },
         NodeReachabilityAutoDetection {
             observed_reachability: Some(PeerReachabilityClass::Public),
             hole_punch_viability: NodeHolePunchViability::Viable,
             relay_available: true,
             probe_stable: true,
+            autonat_status: NodeAutoNatStatus::Public,
+            public_port_reachability: NodePublicPortReachability::Reachable,
         },
         ReleaseSecurityPolicy::default(),
         reward_runtime,
@@ -815,6 +862,16 @@ fn build_chain_status_payload_includes_storage_metrics() {
     );
     assert!(payload.p2p.requires_explicit_public_entry_confirmation);
     assert_eq!(payload.p2p.detected_reachability.as_deref(), Some("public"));
+    assert_eq!(payload.p2p.autonat_status, "public");
+    assert_eq!(payload.p2p.public_port_reachability, "reachable");
+    assert_eq!(
+        payload.p2p.observed_public_addr.as_deref(),
+        Some("/dns4/public.example/tcp/4001")
+    );
+    assert_eq!(
+        payload.p2p.confirmed_external_direct_addrs,
+        vec!["/dns4/public.example/tcp/4001".to_string()]
+    );
     assert_eq!(
         payload.release_security_policy,
         ReleaseSecurityPolicy::default()
@@ -887,6 +944,7 @@ fn production_release_policy_status_payload_reports_effective_policy() {
             deployment_mode: PeerDeploymentMode::Private,
             node_role_claim: PeerNodeRole::ValidatorCore,
         },
+        &Libp2pReachabilitySnapshot::default(),
         NodeReachabilityAutoDetection::default(),
         release_security_policy.clone(),
         reward_runtime,
@@ -970,6 +1028,7 @@ fn status_payload_reports_effective_policy_when_raw_override_differs_from_recomm
             deployment_mode: PeerDeploymentMode::Public,
             node_role_claim: PeerNodeRole::Relay,
         },
+        &Libp2pReachabilitySnapshot::default(),
         NodeReachabilityAutoDetection::default(),
         ReleaseSecurityPolicy::default(),
         reward_runtime,

--- a/crates/oasis7/src/bin/oasis7_chain_runtime/p2p_status.rs
+++ b/crates/oasis7/src/bin/oasis7_chain_runtime/p2p_status.rs
@@ -1,6 +1,7 @@
 use super::cli::{p2p_auto_detection_from_options, CliOptions};
 use oasis7_node::{
-    Libp2pReachabilitySnapshot, LiveHolePunchState, NodeNetworkPolicy,
+    Libp2pReachabilitySnapshot, LiveAutoNatStatus, LiveHolePunchState, LivePublicPortReachability,
+    NodeAutoNatStatus, NodeNetworkPolicy, NodePublicPortReachability,
     NodeReachabilityAutoDetection, NodeUserModeRecommendation,
 };
 use oasis7_proto::distributed_dht::PeerReachabilityClass;
@@ -72,6 +73,16 @@ fn merged_p2p_auto_detection(
             LiveHolePunchState::Blocked => oasis7_node::NodeHolePunchViability::Blocked,
         };
     }
+    detection.autonat_status = match live_snapshot.autonat_status {
+        LiveAutoNatStatus::Unknown => NodeAutoNatStatus::Unknown,
+        LiveAutoNatStatus::Public => NodeAutoNatStatus::Public,
+        LiveAutoNatStatus::Private => NodeAutoNatStatus::Private,
+    };
+    detection.public_port_reachability = match live_snapshot.public_port_reachability {
+        LivePublicPortReachability::Unknown => NodePublicPortReachability::Unknown,
+        LivePublicPortReachability::Reachable => NodePublicPortReachability::Reachable,
+        LivePublicPortReachability::Unreachable => NodePublicPortReachability::Unreachable,
+    };
     if !options.p2p_detected_relay_available_explicit {
         detection.relay_available =
             live_snapshot.relay_reservation_active || live_snapshot.active_relay_path_count > 0;
@@ -86,6 +97,13 @@ fn merged_p2p_auto_detection(
 fn live_reachability_hint(
     live_snapshot: &Libp2pReachabilitySnapshot,
 ) -> Option<PeerReachabilityClass> {
+    if matches!(
+        live_snapshot.public_port_reachability,
+        LivePublicPortReachability::Reachable
+    ) || matches!(live_snapshot.autonat_status, LiveAutoNatStatus::Public)
+    {
+        return Some(PeerReachabilityClass::Public);
+    }
     if live_snapshot.active_hole_punch_path_count > 0
         || matches!(live_snapshot.hole_punch_state, LiveHolePunchState::Viable)
     {
@@ -93,6 +111,13 @@ fn live_reachability_hint(
     }
     if live_snapshot.active_relay_path_count > 0 {
         return Some(PeerReachabilityClass::RelayOnly);
+    }
+    if matches!(
+        live_snapshot.public_port_reachability,
+        LivePublicPortReachability::Unreachable
+    ) || matches!(live_snapshot.autonat_status, LiveAutoNatStatus::Private)
+    {
+        return Some(PeerReachabilityClass::Private);
     }
     None
 }

--- a/crates/oasis7/src/bin/oasis7_chain_runtime/status_payload.rs
+++ b/crates/oasis7/src/bin/oasis7_chain_runtime/status_payload.rs
@@ -1,0 +1,67 @@
+use oasis7_node::{
+    Libp2pReachabilitySnapshot, NodeNetworkPolicy, NodeReachabilityAutoDetection,
+    NodeUserModeRecommendation,
+};
+use serde::Serialize;
+
+use super::p2p_status::peer_reachability_as_str;
+
+#[derive(Debug, Serialize)]
+pub(super) struct ChainP2pStatus {
+    pub(super) requested_user_mode: String,
+    pub(super) recommended_user_mode: String,
+    pub(super) effective_user_mode: String,
+    pub(super) applied_effective_user_mode: Option<String>,
+    pub(super) requires_explicit_public_entry_confirmation: bool,
+    pub(super) detected_reachability: Option<String>,
+    pub(super) hole_punch_viability: String,
+    pub(super) autonat_status: String,
+    pub(super) public_port_reachability: String,
+    pub(super) observed_public_addr: Option<String>,
+    pub(super) confirmed_external_direct_addrs: Vec<String>,
+    pub(super) relay_available: bool,
+    pub(super) probe_stable: bool,
+    pub(super) deployment_mode: String,
+    pub(super) node_role_claim: String,
+    pub(super) rationale: Vec<String>,
+}
+
+pub(super) fn build_chain_p2p_status(
+    live_p2p_recommendation: &NodeUserModeRecommendation,
+    applied_effective_user_mode: Option<String>,
+    effective_p2p_policy: NodeNetworkPolicy,
+    live_snapshot: &Libp2pReachabilitySnapshot,
+    p2p_detection: NodeReachabilityAutoDetection,
+) -> ChainP2pStatus {
+    ChainP2pStatus {
+        requested_user_mode: live_p2p_recommendation
+            .requested_user_mode
+            .as_str()
+            .to_string(),
+        recommended_user_mode: live_p2p_recommendation
+            .recommended_user_mode
+            .as_str()
+            .to_string(),
+        effective_user_mode: live_p2p_recommendation
+            .effective_user_mode
+            .as_str()
+            .to_string(),
+        applied_effective_user_mode,
+        requires_explicit_public_entry_confirmation: live_p2p_recommendation
+            .requires_explicit_public_entry_confirmation,
+        detected_reachability: p2p_detection
+            .observed_reachability
+            .map(peer_reachability_as_str)
+            .map(str::to_string),
+        hole_punch_viability: p2p_detection.hole_punch_viability.to_string(),
+        autonat_status: p2p_detection.autonat_status.to_string(),
+        public_port_reachability: p2p_detection.public_port_reachability.to_string(),
+        observed_public_addr: live_snapshot.observed_public_addr.clone(),
+        confirmed_external_direct_addrs: live_snapshot.confirmed_external_direct_addrs.clone(),
+        relay_available: p2p_detection.relay_available,
+        probe_stable: p2p_detection.probe_stable,
+        deployment_mode: effective_p2p_policy.deployment_mode.as_str().to_string(),
+        node_role_claim: effective_p2p_policy.node_role_claim.as_str().to_string(),
+        rationale: live_p2p_recommendation.rationale.clone(),
+    }
+}

--- a/crates/oasis7_net/Cargo.toml
+++ b/crates/oasis7_net/Cargo.toml
@@ -23,4 +23,4 @@ serde_cbor = "0.11"
 hex = "0.4"
 futures = { version = "0.3", optional = true }
 async-std = { version = "1", optional = true }
-libp2p = { version = "0.53", optional = true, default-features = false, features = ["async-std", "cbor", "dcutr", "dns", "gossipsub", "kad", "macros", "noise", "quic", "relay", "rendezvous", "request-response", "tcp", "yamux"] }
+libp2p = { version = "0.53", optional = true, default-features = false, features = ["async-std", "autonat", "cbor", "dcutr", "dns", "gossipsub", "kad", "macros", "noise", "quic", "relay", "rendezvous", "request-response", "tcp", "yamux"] }

--- a/crates/oasis7_net/src/lib.rs
+++ b/crates/oasis7_net/src/lib.rs
@@ -107,9 +107,9 @@ pub use replica_maintenance::{
 
 #[cfg(feature = "libp2p")]
 pub use libp2p_net::{
-    Libp2pNetwork, Libp2pNetworkConfig, Libp2pReachabilitySnapshot, LiveHolePunchState,
-    LiveTransportKind, PeerManagerBlockArtifact, PeerManagerHealthIssue, PeerManagerHealthStatus,
-    PeerManagerPeerHealth, PeerManagerPolicy,
+    Libp2pNetwork, Libp2pNetworkConfig, Libp2pReachabilitySnapshot, LiveAutoNatStatus,
+    LiveHolePunchState, LivePublicPortReachability, LiveTransportKind, PeerManagerBlockArtifact,
+    PeerManagerHealthIssue, PeerManagerHealthStatus, PeerManagerPeerHealth, PeerManagerPolicy,
 };
 
 #[cfg(test)]

--- a/crates/oasis7_net/src/libp2p_net.rs
+++ b/crates/oasis7_net/src/libp2p_net.rs
@@ -103,6 +103,7 @@ pub struct Libp2pNetworkConfig {
     pub keypair: Option<Keypair>,
     pub peer_record: Option<PeerRecord>,
     pub enable_rendezvous: bool,
+    pub allow_loopback_external_addrs_for_testing: bool,
     pub listen_addrs: Vec<Multiaddr>,
     pub bootstrap_peers: Vec<Multiaddr>,
     pub bootstrap_redial_interval_ms: i64,
@@ -121,6 +122,7 @@ impl Default for Libp2pNetworkConfig {
             keypair: None,
             peer_record: None,
             enable_rendezvous: false,
+            allow_loopback_external_addrs_for_testing: false,
             listen_addrs: Vec::new(),
             bootstrap_peers: Vec::new(),
             bootstrap_redial_interval_ms: DEFAULT_BOOTSTRAP_REDIAL_INTERVAL_MS,
@@ -157,12 +159,8 @@ enum Command {
         topic: String,
         payload: Vec<u8>,
     },
-    Subscribe {
-        topic: String,
-    },
-    Dial {
-        addr: Multiaddr,
-    },
+    Subscribe(String),
+    Dial(Multiaddr),
     Request {
         protocol: String,
         payload: Vec<u8>,
@@ -180,23 +178,20 @@ enum Command {
         handler: Handler,
         response: oneshot::Sender<Result<(), WorldError>>,
     },
-    PublishProvider {
-        key: String,
-        response: oneshot::Sender<Result<(), WorldError>>,
-    },
-    GetProviders {
-        key: String,
-        response: oneshot::Sender<Result<Vec<ProviderRecord>, WorldError>>,
-    },
+    PublishProvider(String, oneshot::Sender<Result<(), WorldError>>),
+    GetProviders(
+        String,
+        oneshot::Sender<Result<Vec<ProviderRecord>, WorldError>>,
+    ),
     PutWorldHead {
         key: String,
         payload: Vec<u8>,
         response: oneshot::Sender<Result<(), WorldError>>,
     },
-    GetWorldHead {
-        key: String,
-        response: oneshot::Sender<Result<Option<WorldHeadAnnounce>, WorldError>>,
-    },
+    GetWorldHead(
+        String,
+        oneshot::Sender<Result<Option<WorldHeadAnnounce>, WorldError>>,
+    ),
     PutMembershipDirectory {
         key: String,
         payload: Vec<u8>,
@@ -355,8 +350,7 @@ impl Libp2pNetwork {
                             bootstrap_redial_interval_ms as u64,
                         ));
                         for addr in &bootstrap_redial_peers {
-                            match bootstrap_redial_tx.try_send(Command::Dial { addr: addr.clone() })
-                            {
+                            match bootstrap_redial_tx.try_send(Command::Dial(addr.clone())) {
                                 Ok(()) => {}
                                 Err(err) if err.is_full() => break,
                                 Err(_) => return,
@@ -873,6 +867,7 @@ impl Libp2pNetwork {
                                         &event_listening_addrs,
                                         &event_reachability,
                                         &address,
+                                        config_clone.allow_loopback_external_addrs_for_testing,
                                         max_listening_addrs,
                                     );
                                     republish_local_peer_record(
@@ -891,6 +886,7 @@ impl Libp2pNetwork {
                                         &event_listening_addrs,
                                         &event_reachability,
                                         &address,
+                                        config_clone.allow_loopback_external_addrs_for_testing,
                                     );
                                     republish_local_peer_record(
                                         &mut swarm,
@@ -908,6 +904,7 @@ impl Libp2pNetwork {
                                         &event_listening_addrs,
                                         &event_reachability,
                                         addresses.as_slice(),
+                                        config_clone.allow_loopback_external_addrs_for_testing,
                                     );
                                     republish_local_peer_record(
                                         &mut swarm,
@@ -1233,7 +1230,7 @@ impl Libp2pNetwork {
         let mut bootstrap_tx = command_tx.clone();
         for addr in bootstrap_peers {
             // Best-effort: if the background task exits, dial requests can be dropped.
-            if bootstrap_tx.try_send(Command::Dial { addr }).is_err() {
+            if bootstrap_tx.try_send(Command::Dial(addr)).is_err() {
                 break;
             }
         }

--- a/crates/oasis7_net/src/libp2p_net.rs
+++ b/crates/oasis7_net/src/libp2p_net.rs
@@ -8,9 +8,11 @@ mod discovery;
 mod kad_queries;
 mod peer_manager;
 mod peer_record;
+mod peer_record_republish;
 mod reachability;
 mod runtime_loop;
 mod swarm_behaviour;
+mod swarm_reachability_events;
 mod transport_paths;
 mod utils;
 
@@ -52,16 +54,25 @@ pub use peer_manager::{
     PeerManagerPeerHealth, PeerManagerPolicy,
 };
 use peer_record::{publish_configured_peer_record, put_record_query};
+use peer_record_republish::republish_local_peer_record;
 use reachability::{
     note_hole_punch_result, note_relay_reservation_accepted, refresh_active_transport_snapshot,
-    snapshot_clone, sync_relay_reservation_from_listening_addrs,
+    snapshot_clone,
 };
-pub use reachability::{Libp2pReachabilitySnapshot, LiveHolePunchState, LiveTransportKind};
+pub use reachability::{
+    Libp2pReachabilitySnapshot, LiveAutoNatStatus, LiveHolePunchState, LivePublicPortReachability,
+    LiveTransportKind,
+};
 use runtime_loop::{
     enforce_peer_manager_quarantine, handle_command, refresh_peer_manager_healths, CommandContext,
     CommandOutcome, CommandStateRefs,
 };
 use swarm_behaviour::{build_swarm, dial_addr_with_optional_peer_id, Behaviour, BehaviourEvent};
+use swarm_reachability_events::{
+    handle_autonat_event, handle_expired_listen_addr, handle_external_addr_candidate,
+    handle_external_addr_confirmed, handle_external_addr_expired, handle_listener_closed,
+    handle_new_listen_addr,
+};
 use transport_paths::{
     failover_transport_path, note_established_transport_path, retry_transport_path_after_error,
     TransportPath,
@@ -683,6 +694,14 @@ impl Libp2pNetwork {
                                         _ => {}
                                     }
                                 }
+                                SwarmEvent::Behaviour(BehaviourEvent::Autonat(event)) => {
+                                    push_bounded_clone(
+                                        &event_errors,
+                                        handle_autonat_event(&event_reachability, &event),
+                                        max_error_messages,
+                                        "lock errors",
+                                    );
+                                }
                                 SwarmEvent::Behaviour(BehaviourEvent::RelayClient(event)) => {
                                     match event {
                                         relay::client::Event::ReservationReqAccepted { relay_peer_id, renewal, .. } => {
@@ -695,22 +714,15 @@ impl Libp2pNetwork {
                                                 max_error_messages,
                                                 "lock errors",
                                             );
-                                            if let Some(template) = peer_record_template.as_ref() {
-                                                let _ = publish_configured_peer_record(
-                                                    &mut swarm,
-                                                    &mut pending_dht,
-                                                    &keypair_clone,
-                                                    template,
-                                                    &event_listening_addrs,
-                                                    None,
-                                                );
-                                                peer_record_last_published_at_ms = Some(now_ms());
-                                                publish_discovery_provider(
-                                                    &mut swarm,
-                                                    &mut provider_keys,
-                                                    template.world_id.as_str(),
-                                                );
-                                            }
+                                            republish_local_peer_record(
+                                                &mut swarm,
+                                                &mut pending_dht,
+                                                &mut provider_keys,
+                                                &keypair_clone,
+                                                peer_record_template.as_ref(),
+                                                &event_listening_addrs,
+                                                &mut peer_record_last_published_at_ms,
+                                            );
                                         }
                                         relay::client::Event::OutboundCircuitEstablished { relay_peer_id, .. } => {
                                             push_bounded_clone(
@@ -825,100 +837,87 @@ impl Libp2pNetwork {
                                         );
                                     }
                                 }
-                                SwarmEvent::NewListenAddr { address, .. } => {
-                                    swarm.add_external_address(address.clone());
+                                SwarmEvent::NewExternalAddrCandidate { address } => {
                                     push_bounded_clone(
+                                        &event_errors,
+                                        handle_external_addr_candidate(&address),
+                                        max_error_messages,
+                                        "lock errors",
+                                    );
+                                }
+                                SwarmEvent::ExternalAddrConfirmed { address } => {
+                                    push_bounded_clone(
+                                        &event_errors,
+                                        handle_external_addr_confirmed(
+                                            &event_reachability,
+                                            &address,
+                                        ),
+                                        max_error_messages,
+                                        "lock errors",
+                                    );
+                                }
+                                SwarmEvent::ExternalAddrExpired { address } => {
+                                    push_bounded_clone(
+                                        &event_errors,
+                                        handle_external_addr_expired(
+                                            &event_reachability,
+                                            &address,
+                                        ),
+                                        max_error_messages,
+                                        "lock errors",
+                                    );
+                                }
+                                SwarmEvent::NewListenAddr { address, .. } => {
+                                    handle_new_listen_addr(
+                                        &mut swarm,
                                         &event_listening_addrs,
-                                        address.clone(),
-                                        max_listening_addrs,
-                                        "lock listening addrs",
-                                    );
-                                    let listening_addrs = event_listening_addrs
-                                        .lock()
-                                        .expect("lock listening addrs")
-                                        .clone();
-                                    sync_relay_reservation_from_listening_addrs(
                                         &event_reachability,
-                                        listening_addrs.as_slice(),
+                                        &address,
+                                        max_listening_addrs,
                                     );
-                                    if let Some(template) = peer_record_template.as_ref() {
-                                        let _ = publish_configured_peer_record(
-                                            &mut swarm,
-                                            &mut pending_dht,
-                                            &keypair_clone,
-                                            template,
-                                            &event_listening_addrs,
-                                            None,
-                                        );
-                                        peer_record_last_published_at_ms = Some(now_ms());
-                                        publish_discovery_provider(
-                                            &mut swarm,
-                                            &mut provider_keys,
-                                            template.world_id.as_str(),
-                                        );
-                                    }
+                                    republish_local_peer_record(
+                                        &mut swarm,
+                                        &mut pending_dht,
+                                        &mut provider_keys,
+                                        &keypair_clone,
+                                        peer_record_template.as_ref(),
+                                        &event_listening_addrs,
+                                        &mut peer_record_last_published_at_ms,
+                                    );
                                 }
                                 SwarmEvent::ExpiredListenAddr { address, .. } => {
-                                    swarm.remove_external_address(&address);
-                                    {
-                                        let mut listening_addrs = event_listening_addrs
-                                            .lock()
-                                            .expect("lock listening addrs");
-                                        listening_addrs.retain(|candidate| candidate != &address);
-                                        sync_relay_reservation_from_listening_addrs(
-                                            &event_reachability,
-                                            listening_addrs.as_slice(),
-                                        );
-                                    }
-                                    if let Some(template) = peer_record_template.as_ref() {
-                                        let _ = publish_configured_peer_record(
-                                            &mut swarm,
-                                            &mut pending_dht,
-                                            &keypair_clone,
-                                            template,
-                                            &event_listening_addrs,
-                                            None,
-                                        );
-                                        peer_record_last_published_at_ms = Some(now_ms());
-                                        publish_discovery_provider(
-                                            &mut swarm,
-                                            &mut provider_keys,
-                                            template.world_id.as_str(),
-                                        );
-                                    }
+                                    handle_expired_listen_addr(
+                                        &mut swarm,
+                                        &event_listening_addrs,
+                                        &event_reachability,
+                                        &address,
+                                    );
+                                    republish_local_peer_record(
+                                        &mut swarm,
+                                        &mut pending_dht,
+                                        &mut provider_keys,
+                                        &keypair_clone,
+                                        peer_record_template.as_ref(),
+                                        &event_listening_addrs,
+                                        &mut peer_record_last_published_at_ms,
+                                    );
                                 }
                                 SwarmEvent::ListenerClosed { addresses, .. } => {
-                                    for address in addresses.iter() {
-                                        swarm.remove_external_address(address);
-                                    }
-                                    {
-                                        let mut listening_addrs = event_listening_addrs
-                                            .lock()
-                                            .expect("lock listening addrs");
-                                        listening_addrs.retain(|candidate| {
-                                            !addresses.iter().any(|addr| addr == candidate)
-                                        });
-                                        sync_relay_reservation_from_listening_addrs(
-                                            &event_reachability,
-                                            listening_addrs.as_slice(),
-                                        );
-                                    }
-                                    if let Some(template) = peer_record_template.as_ref() {
-                                        let _ = publish_configured_peer_record(
-                                            &mut swarm,
-                                            &mut pending_dht,
-                                            &keypair_clone,
-                                            template,
-                                            &event_listening_addrs,
-                                            None,
-                                        );
-                                        peer_record_last_published_at_ms = Some(now_ms());
-                                        publish_discovery_provider(
-                                            &mut swarm,
-                                            &mut provider_keys,
-                                            template.world_id.as_str(),
-                                        );
-                                    }
+                                    handle_listener_closed(
+                                        &mut swarm,
+                                        &event_listening_addrs,
+                                        &event_reachability,
+                                        addresses.as_slice(),
+                                    );
+                                    republish_local_peer_record(
+                                        &mut swarm,
+                                        &mut pending_dht,
+                                        &mut provider_keys,
+                                        &keypair_clone,
+                                        peer_record_template.as_ref(),
+                                        &event_listening_addrs,
+                                        &mut peer_record_last_published_at_ms,
+                                    );
                                 }
                                 SwarmEvent::ConnectionEstablished { peer_id, endpoint, .. } => {
                                     if !peers.contains(&peer_id) {

--- a/crates/oasis7_net/src/libp2p_net/api.rs
+++ b/crates/oasis7_net/src/libp2p_net/api.rs
@@ -35,7 +35,7 @@ impl Libp2pNetwork {
     }
 
     pub fn dial(&self, addr: Multiaddr) -> Result<(), WorldError> {
-        self.enqueue_command(Command::Dial { addr })
+        self.enqueue_command(Command::Dial(addr))
     }
 
     pub fn listening_addrs(&self) -> Vec<Multiaddr> {
@@ -114,9 +114,7 @@ impl ProtoDistributedNetwork<WorldError> for Libp2pNetwork {
     }
 
     fn subscribe(&self, topic: &str) -> Result<NetworkSubscription, WorldError> {
-        self.enqueue_command(Command::Subscribe {
-            topic: topic.to_string(),
-        })?;
+        self.enqueue_command(Command::Subscribe(topic.to_string()))?;
         Ok(NetworkSubscription::new(
             topic.to_string(),
             Arc::clone(&self.inbox),
@@ -175,10 +173,7 @@ impl ProtoDistributedDht<WorldError> for Libp2pNetwork {
     ) -> Result<(), WorldError> {
         let key = dht_provider_key(world_id, content_hash);
         let (sender, receiver) = oneshot::channel();
-        self.enqueue_command(Command::PublishProvider {
-            key,
-            response: sender,
-        })?;
+        self.enqueue_command(Command::PublishProvider(key, sender))?;
         futures::executor::block_on(receiver).map_err(|_| {
             WorldError::NetworkProtocolUnavailable {
                 protocol: "libp2p".to_string(),
@@ -193,10 +188,7 @@ impl ProtoDistributedDht<WorldError> for Libp2pNetwork {
     ) -> Result<Vec<ProviderRecord>, WorldError> {
         let key = dht_provider_key(world_id, content_hash);
         let (sender, receiver) = oneshot::channel();
-        self.enqueue_command(Command::GetProviders {
-            key,
-            response: sender,
-        })?;
+        self.enqueue_command(Command::GetProviders(key, sender))?;
         futures::executor::block_on(receiver).map_err(|_| {
             WorldError::NetworkProtocolUnavailable {
                 protocol: "libp2p".to_string(),
@@ -223,10 +215,7 @@ impl ProtoDistributedDht<WorldError> for Libp2pNetwork {
     fn get_world_head(&self, world_id: &str) -> Result<Option<WorldHeadAnnounce>, WorldError> {
         let key = dht_world_head_key(world_id);
         let (sender, receiver) = oneshot::channel();
-        self.enqueue_command(Command::GetWorldHead {
-            key,
-            response: sender,
-        })?;
+        self.enqueue_command(Command::GetWorldHead(key, sender))?;
         futures::executor::block_on(receiver).map_err(|_| {
             WorldError::NetworkProtocolUnavailable {
                 protocol: "libp2p".to_string(),

--- a/crates/oasis7_net/src/libp2p_net/peer_record_republish.rs
+++ b/crates/oasis7_net/src/libp2p_net/peer_record_republish.rs
@@ -1,0 +1,38 @@
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use libp2p::identity::Keypair;
+use libp2p::kad;
+use libp2p::swarm::Swarm;
+use libp2p::Multiaddr;
+
+use oasis7_proto::distributed_dht::PeerRecord;
+
+use super::discovery::publish_discovery_provider;
+use super::kad_queries::PendingDhtQuery;
+use super::peer_record::publish_configured_peer_record;
+use super::swarm_behaviour::Behaviour;
+use super::utils::now_ms;
+
+pub(super) fn republish_local_peer_record(
+    swarm: &mut Swarm<Behaviour>,
+    pending_dht: &mut HashMap<kad::QueryId, PendingDhtQuery>,
+    provider_keys: &mut HashMap<String, i64>,
+    keypair: &Keypair,
+    peer_record_template: Option<&PeerRecord>,
+    listening_addrs: &Arc<Mutex<Vec<Multiaddr>>>,
+    peer_record_last_published_at_ms: &mut Option<i64>,
+) {
+    if let Some(template) = peer_record_template {
+        let _ = publish_configured_peer_record(
+            swarm,
+            pending_dht,
+            keypair,
+            template,
+            listening_addrs,
+            None,
+        );
+        *peer_record_last_published_at_ms = Some(now_ms());
+        publish_discovery_provider(swarm, provider_keys, template.world_id.as_str());
+    }
+}

--- a/crates/oasis7_net/src/libp2p_net/reachability.rs
+++ b/crates/oasis7_net/src/libp2p_net/reachability.rs
@@ -14,6 +14,20 @@ pub enum LiveHolePunchState {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LiveAutoNatStatus {
+    Unknown,
+    Public,
+    Private,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LivePublicPortReachability {
+    Unknown,
+    Reachable,
+    Unreachable,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LiveTransportKind {
     Direct,
     HolePunched,
@@ -28,6 +42,10 @@ pub struct Libp2pReachabilitySnapshot {
     pub active_relay_path_count: usize,
     pub relay_reservation_active: bool,
     pub hole_punch_state: LiveHolePunchState,
+    pub autonat_status: LiveAutoNatStatus,
+    pub public_port_reachability: LivePublicPortReachability,
+    pub observed_public_addr: Option<String>,
+    pub confirmed_external_direct_addrs: Vec<String>,
 }
 
 impl Default for Libp2pReachabilitySnapshot {
@@ -39,6 +57,10 @@ impl Default for Libp2pReachabilitySnapshot {
             active_relay_path_count: 0,
             relay_reservation_active: false,
             hole_punch_state: LiveHolePunchState::Unknown,
+            autonat_status: LiveAutoNatStatus::Unknown,
+            public_port_reachability: LivePublicPortReachability::Unknown,
+            observed_public_addr: None,
+            confirmed_external_direct_addrs: Vec::new(),
         }
     }
 }
@@ -47,12 +69,22 @@ impl Libp2pReachabilitySnapshot {
     pub fn has_live_signal(&self) -> bool {
         self.relay_reservation_active
             || !matches!(self.hole_punch_state, LiveHolePunchState::Unknown)
+            || !matches!(self.autonat_status, LiveAutoNatStatus::Unknown)
+            || !matches!(
+                self.public_port_reachability,
+                LivePublicPortReachability::Unknown
+            )
             || self.active_transport_kind.is_some()
     }
 
     pub fn has_stable_signal(&self) -> bool {
         self.relay_reservation_active
             || matches!(self.hole_punch_state, LiveHolePunchState::Viable)
+            || !matches!(self.autonat_status, LiveAutoNatStatus::Unknown)
+            || !matches!(
+                self.public_port_reachability,
+                LivePublicPortReachability::Unknown
+            )
             || self.active_transport_kind.is_some()
     }
 }
@@ -91,6 +123,45 @@ pub(super) fn note_hole_punch_result(
     }
 }
 
+pub(super) fn note_autonat_status(
+    shared: &Arc<Mutex<Libp2pReachabilitySnapshot>>,
+    status: LiveAutoNatStatus,
+    observed_public_addr: Option<&Multiaddr>,
+) {
+    let mut snapshot = shared.lock().expect("lock reachability snapshot");
+    snapshot.autonat_status = status;
+    snapshot.observed_public_addr = observed_public_addr.map(ToString::to_string);
+    recompute_public_port_reachability(&mut snapshot);
+}
+
+pub(super) fn note_external_addr_confirmed(
+    shared: &Arc<Mutex<Libp2pReachabilitySnapshot>>,
+    address: &Multiaddr,
+) {
+    if !is_public_direct_addr(address) {
+        return;
+    }
+    let mut snapshot = shared.lock().expect("lock reachability snapshot");
+    let label = address.to_string();
+    if !snapshot.confirmed_external_direct_addrs.contains(&label) {
+        snapshot.confirmed_external_direct_addrs.push(label);
+        snapshot.confirmed_external_direct_addrs.sort();
+    }
+    recompute_public_port_reachability(&mut snapshot);
+}
+
+pub(super) fn note_external_addr_expired(
+    shared: &Arc<Mutex<Libp2pReachabilitySnapshot>>,
+    address: &Multiaddr,
+) {
+    let mut snapshot = shared.lock().expect("lock reachability snapshot");
+    let label = address.to_string();
+    snapshot
+        .confirmed_external_direct_addrs
+        .retain(|candidate| candidate != &label);
+    recompute_public_port_reachability(&mut snapshot);
+}
+
 pub(super) fn refresh_active_transport_snapshot(
     shared: &Arc<Mutex<Libp2pReachabilitySnapshot>>,
     active_transport_paths: &HashMap<PeerId, TransportPath>,
@@ -121,6 +192,42 @@ pub(super) fn refresh_active_transport_snapshot(
 fn is_relay_addr(addr: &Multiaddr) -> bool {
     addr.iter()
         .any(|protocol| matches!(protocol, Protocol::P2pCircuit))
+}
+
+pub(super) fn is_public_direct_addr(addr: &Multiaddr) -> bool {
+    if is_relay_addr(addr) {
+        return false;
+    }
+    addr.iter().any(|protocol| match protocol {
+        Protocol::Ip4(ip) => {
+            !ip.is_private()
+                && !ip.is_loopback()
+                && !ip.is_link_local()
+                && !ip.is_broadcast()
+                && !ip.is_documentation()
+                && !ip.is_unspecified()
+        }
+        Protocol::Ip6(ip) => {
+            !ip.is_loopback()
+                && !ip.is_unspecified()
+                && !ip.is_unicast_link_local()
+                && !ip.is_unique_local()
+        }
+        Protocol::Dns(_) | Protocol::Dns4(_) | Protocol::Dns6(_) | Protocol::Dnsaddr(_) => true,
+        _ => false,
+    })
+}
+
+fn recompute_public_port_reachability(snapshot: &mut Libp2pReachabilitySnapshot) {
+    snapshot.public_port_reachability = if !snapshot.confirmed_external_direct_addrs.is_empty() {
+        LivePublicPortReachability::Reachable
+    } else {
+        match snapshot.autonat_status {
+            LiveAutoNatStatus::Unknown => LivePublicPortReachability::Unknown,
+            LiveAutoNatStatus::Public => LivePublicPortReachability::Reachable,
+            LiveAutoNatStatus::Private => LivePublicPortReachability::Unreachable,
+        }
+    };
 }
 
 fn preferred_transport_kind(snapshot: &Libp2pReachabilitySnapshot) -> Option<LiveTransportKind> {
@@ -220,5 +327,44 @@ mod tests {
         sync_relay_reservation_from_listening_addrs(&shared, &[direct_addr]);
         assert!(!snapshot_clone(&shared).relay_reservation_active);
         assert_eq!(snapshot_clone(&shared).active_transport_kind, None);
+    }
+
+    #[test]
+    fn autonat_public_status_marks_public_port_reachable() {
+        let shared = Arc::new(Mutex::new(Libp2pReachabilitySnapshot::default()));
+        let public_addr: Multiaddr = "/dns4/public.example/tcp/4001"
+            .parse()
+            .expect("public addr");
+
+        note_autonat_status(&shared, LiveAutoNatStatus::Public, Some(&public_addr));
+
+        let snapshot = snapshot_clone(&shared);
+        assert_eq!(snapshot.autonat_status, LiveAutoNatStatus::Public);
+        assert_eq!(
+            snapshot.public_port_reachability,
+            LivePublicPortReachability::Reachable
+        );
+        assert_eq!(
+            snapshot.observed_public_addr.as_deref(),
+            Some("/dns4/public.example/tcp/4001")
+        );
+    }
+
+    #[test]
+    fn external_addr_confirmed_tracks_direct_public_port_reachability() {
+        let shared = Arc::new(Mutex::new(Libp2pReachabilitySnapshot::default()));
+        let public_addr: Multiaddr = "/dns4/public.example/tcp/443".parse().expect("public addr");
+
+        note_external_addr_confirmed(&shared, &public_addr);
+        assert_eq!(
+            snapshot_clone(&shared).public_port_reachability,
+            LivePublicPortReachability::Reachable
+        );
+
+        note_external_addr_expired(&shared, &public_addr);
+        assert_eq!(
+            snapshot_clone(&shared).public_port_reachability,
+            LivePublicPortReachability::Unknown
+        );
     }
 }

--- a/crates/oasis7_net/src/libp2p_net/reachability.rs
+++ b/crates/oasis7_net/src/libp2p_net/reachability.rs
@@ -189,7 +189,7 @@ pub(super) fn refresh_active_transport_snapshot(
     snapshot.active_transport_kind = preferred_transport_kind(&snapshot);
 }
 
-fn is_relay_addr(addr: &Multiaddr) -> bool {
+pub(super) fn is_relay_addr(addr: &Multiaddr) -> bool {
     addr.iter()
         .any(|protocol| matches!(protocol, Protocol::P2pCircuit))
 }
@@ -216,6 +216,25 @@ pub(super) fn is_public_direct_addr(addr: &Multiaddr) -> bool {
         Protocol::Dns(_) | Protocol::Dns4(_) | Protocol::Dns6(_) | Protocol::Dnsaddr(_) => true,
         _ => false,
     })
+}
+
+fn is_loopback_direct_addr(addr: &Multiaddr) -> bool {
+    if is_relay_addr(addr) {
+        return false;
+    }
+    addr.iter().any(|protocol| match protocol {
+        Protocol::Ip4(ip) => ip.is_loopback(),
+        Protocol::Ip6(ip) => ip.is_loopback(),
+        _ => false,
+    })
+}
+
+pub(super) fn should_register_external_listen_addr(
+    addr: &Multiaddr,
+    allow_loopback_external_addrs_for_testing: bool,
+) -> bool {
+    is_relay_addr(addr)
+        || (allow_loopback_external_addrs_for_testing && is_loopback_direct_addr(addr))
 }
 
 fn recompute_public_port_reachability(snapshot: &mut Libp2pReachabilitySnapshot) {
@@ -366,5 +385,45 @@ mod tests {
             snapshot_clone(&shared).public_port_reachability,
             LivePublicPortReachability::Unknown
         );
+    }
+
+    #[test]
+    fn external_listen_addr_registration_only_keeps_relay_addrs_by_default() {
+        let relay_addr: Multiaddr = format!(
+            "/dns4/relay.example/tcp/443/p2p/{}/p2p-circuit",
+            PeerId::random()
+        )
+        .parse()
+        .expect("relay addr");
+        let loopback_addr: Multiaddr = "/ip4/127.0.0.1/tcp/4001".parse().expect("loopback addr");
+        let unspecified_addr: Multiaddr =
+            "/ip4/0.0.0.0/tcp/4001".parse().expect("unspecified addr");
+        let public_direct_addr: Multiaddr = "/dns4/node.example/tcp/4001"
+            .parse()
+            .expect("public direct addr");
+
+        assert!(should_register_external_listen_addr(&relay_addr, false));
+        assert!(!should_register_external_listen_addr(&loopback_addr, false));
+        assert!(!should_register_external_listen_addr(
+            &unspecified_addr,
+            false
+        ));
+        assert!(!should_register_external_listen_addr(
+            &public_direct_addr,
+            false
+        ));
+    }
+
+    #[test]
+    fn external_listen_addr_registration_allows_loopback_only_in_test_mode() {
+        let loopback_addr: Multiaddr = "/ip4/127.0.0.1/tcp/4001".parse().expect("loopback addr");
+        let unspecified_addr: Multiaddr =
+            "/ip4/0.0.0.0/tcp/4001".parse().expect("unspecified addr");
+
+        assert!(should_register_external_listen_addr(&loopback_addr, true));
+        assert!(!should_register_external_listen_addr(
+            &unspecified_addr,
+            true
+        ));
     }
 }

--- a/crates/oasis7_net/src/libp2p_net/runtime_loop.rs
+++ b/crates/oasis7_net/src/libp2p_net/runtime_loop.rs
@@ -428,7 +428,7 @@ pub(super) fn handle_command(
                 .publish(topic_handle, payload);
             CommandOutcome::Continue
         }
-        Some(Command::Subscribe { topic }) => {
+        Some(Command::Subscribe(topic)) => {
             if subscriptions.insert(topic.clone()) {
                 let topic_handle = IdentTopic::new(topic.clone());
                 if swarm
@@ -446,7 +446,7 @@ pub(super) fn handle_command(
             }
             CommandOutcome::Continue
         }
-        Some(Command::Dial { addr }) => {
+        Some(Command::Dial(addr)) => {
             if let Err(err) = super::dial_addr_with_optional_peer_id(swarm, addr) {
                 push_bounded_clone(
                     ctx.event_errors,
@@ -533,7 +533,7 @@ pub(super) fn handle_command(
             let _ = response.send(Ok(()));
             CommandOutcome::Continue
         }
-        Some(Command::PublishProvider { key, response }) => {
+        Some(Command::PublishProvider(key, response)) => {
             let dht_key = RecordKey::new(&key);
             match swarm.behaviour_mut().kademlia.start_providing(dht_key) {
                 Ok(query_id) => {
@@ -553,7 +553,7 @@ pub(super) fn handle_command(
             }
             CommandOutcome::Continue
         }
-        Some(Command::GetProviders { key, response }) => {
+        Some(Command::GetProviders(key, response)) => {
             let dht_key = RecordKey::new(&key);
             let query_id = swarm.behaviour_mut().kademlia.get_providers(dht_key);
             pending_dht.insert(
@@ -599,7 +599,7 @@ pub(super) fn handle_command(
             }
             CommandOutcome::Continue
         }
-        Some(Command::GetWorldHead { key, response }) => {
+        Some(Command::GetWorldHead(key, response)) => {
             let dht_key = RecordKey::new(&key);
             let query_id = swarm.behaviour_mut().kademlia.get_record(dht_key);
             pending_dht.insert(

--- a/crates/oasis7_net/src/libp2p_net/swarm_behaviour.rs
+++ b/crates/oasis7_net/src/libp2p_net/swarm_behaviour.rs
@@ -1,4 +1,5 @@
 use futures::future::Either;
+use libp2p::autonat;
 use libp2p::core::muxing::StreamMuxerBox;
 use libp2p::core::transport::OrTransport;
 use libp2p::dcutr;
@@ -31,6 +32,7 @@ pub(super) struct Behaviour {
     pub(super) gossipsub: gossipsub::Behaviour,
     pub(super) request_response: request_response::cbor::Behaviour<NetworkRequest, NetworkResponse>,
     pub(super) kademlia: kad::Behaviour<MemoryStore>,
+    pub(super) autonat: autonat::Behaviour,
     pub(super) relay_client: relay::client::Behaviour,
     pub(super) dcutr: dcutr::Behaviour,
     pub(super) rendezvous_client: Toggle<rendezvous_client::Behaviour>,
@@ -42,6 +44,7 @@ pub(super) enum BehaviourEvent {
     Gossipsub(gossipsub::Event),
     RequestResponse(request_response::Event<NetworkRequest, NetworkResponse>),
     Kademlia(kad::Event),
+    Autonat(autonat::Event),
     RelayClient(relay::client::Event),
     Dcutr(dcutr::Event),
     RendezvousClient(rendezvous_client::Event),
@@ -63,6 +66,12 @@ impl From<request_response::Event<NetworkRequest, NetworkResponse>> for Behaviou
 impl From<kad::Event> for BehaviourEvent {
     fn from(event: kad::Event) -> Self {
         BehaviourEvent::Kademlia(event)
+    }
+}
+
+impl From<autonat::Event> for BehaviourEvent {
+    fn from(event: autonat::Event) -> Self {
+        BehaviourEvent::Autonat(event)
     }
 }
 
@@ -118,6 +127,7 @@ pub(super) fn build_swarm(keypair: &Keypair, enable_rendezvous: bool) -> Swarm<B
         gossipsub,
         request_response,
         kademlia,
+        autonat: autonat::Behaviour::new(peer_id, Default::default()),
         relay_client,
         dcutr: dcutr::Behaviour::new(peer_id),
         rendezvous_client: Toggle::from(

--- a/crates/oasis7_net/src/libp2p_net/swarm_reachability_events.rs
+++ b/crates/oasis7_net/src/libp2p_net/swarm_reachability_events.rs
@@ -1,0 +1,104 @@
+use std::sync::{Arc, Mutex};
+
+use libp2p::autonat;
+use libp2p::swarm::Swarm;
+use libp2p::Multiaddr;
+
+use super::reachability::{
+    is_public_direct_addr, note_autonat_status, note_external_addr_confirmed,
+    note_external_addr_expired, sync_relay_reservation_from_listening_addrs,
+    Libp2pReachabilitySnapshot, LiveAutoNatStatus,
+};
+use super::swarm_behaviour::Behaviour;
+use super::utils::push_bounded_clone;
+
+pub(super) fn handle_autonat_event(
+    reachability: &Arc<Mutex<Libp2pReachabilitySnapshot>>,
+    event: &autonat::Event,
+) -> String {
+    match event {
+        autonat::Event::StatusChanged { old, new } => {
+            let (status, observed_addr) = match new {
+                autonat::NatStatus::Public(address) => (LiveAutoNatStatus::Public, Some(address)),
+                autonat::NatStatus::Private => (LiveAutoNatStatus::Private, None),
+                autonat::NatStatus::Unknown => (LiveAutoNatStatus::Unknown, None),
+            };
+            note_autonat_status(reachability, status, observed_addr);
+            format!("libp2p autonat status changed old={old:?} new={new:?}")
+        }
+        other => format!("libp2p autonat event {other:?}"),
+    }
+}
+
+pub(super) fn handle_external_addr_candidate(address: &Multiaddr) -> String {
+    format!("libp2p external address candidate address={address}")
+}
+
+pub(super) fn handle_external_addr_confirmed(
+    reachability: &Arc<Mutex<Libp2pReachabilitySnapshot>>,
+    address: &Multiaddr,
+) -> String {
+    note_external_addr_confirmed(reachability, address);
+    format!("libp2p external address confirmed address={address}")
+}
+
+pub(super) fn handle_external_addr_expired(
+    reachability: &Arc<Mutex<Libp2pReachabilitySnapshot>>,
+    address: &Multiaddr,
+) -> String {
+    note_external_addr_expired(reachability, address);
+    format!("libp2p external address expired address={address}")
+}
+
+pub(super) fn handle_new_listen_addr(
+    swarm: &mut Swarm<Behaviour>,
+    listening_addrs_shared: &Arc<Mutex<Vec<Multiaddr>>>,
+    reachability: &Arc<Mutex<Libp2pReachabilitySnapshot>>,
+    address: &Multiaddr,
+    max_listening_addrs: usize,
+) {
+    if !is_public_direct_addr(address) {
+        swarm.add_external_address(address.clone());
+    }
+    push_bounded_clone(
+        listening_addrs_shared,
+        address.clone(),
+        max_listening_addrs,
+        "lock listening addrs",
+    );
+    let listening_addrs = listening_addrs_shared
+        .lock()
+        .expect("lock listening addrs")
+        .clone();
+    sync_relay_reservation_from_listening_addrs(reachability, listening_addrs.as_slice());
+}
+
+pub(super) fn handle_expired_listen_addr(
+    swarm: &mut Swarm<Behaviour>,
+    listening_addrs_shared: &Arc<Mutex<Vec<Multiaddr>>>,
+    reachability: &Arc<Mutex<Libp2pReachabilitySnapshot>>,
+    address: &Multiaddr,
+) {
+    if !is_public_direct_addr(address) {
+        swarm.remove_external_address(address);
+    }
+    let mut listening_addrs = listening_addrs_shared.lock().expect("lock listening addrs");
+    listening_addrs.retain(|candidate| candidate != address);
+    sync_relay_reservation_from_listening_addrs(reachability, listening_addrs.as_slice());
+}
+
+pub(super) fn handle_listener_closed(
+    swarm: &mut Swarm<Behaviour>,
+    listening_addrs_shared: &Arc<Mutex<Vec<Multiaddr>>>,
+    reachability: &Arc<Mutex<Libp2pReachabilitySnapshot>>,
+    addresses: &[Multiaddr],
+) {
+    for address in addresses {
+        if !is_public_direct_addr(address) {
+            swarm.remove_external_address(address);
+        }
+    }
+    let mut listening_addrs = listening_addrs_shared.lock().expect("lock listening addrs");
+    listening_addrs.retain(|candidate| !addresses.iter().any(|addr| addr == candidate));
+    sync_relay_reservation_from_listening_addrs(reachability, listening_addrs.as_slice());
+}

--- a/crates/oasis7_net/src/libp2p_net/swarm_reachability_events.rs
+++ b/crates/oasis7_net/src/libp2p_net/swarm_reachability_events.rs
@@ -5,8 +5,8 @@ use libp2p::swarm::Swarm;
 use libp2p::Multiaddr;
 
 use super::reachability::{
-    is_public_direct_addr, note_autonat_status, note_external_addr_confirmed,
-    note_external_addr_expired, sync_relay_reservation_from_listening_addrs,
+    note_autonat_status, note_external_addr_confirmed, note_external_addr_expired,
+    should_register_external_listen_addr, sync_relay_reservation_from_listening_addrs,
     Libp2pReachabilitySnapshot, LiveAutoNatStatus,
 };
 use super::swarm_behaviour::Behaviour;
@@ -55,9 +55,10 @@ pub(super) fn handle_new_listen_addr(
     listening_addrs_shared: &Arc<Mutex<Vec<Multiaddr>>>,
     reachability: &Arc<Mutex<Libp2pReachabilitySnapshot>>,
     address: &Multiaddr,
+    allow_loopback_external_addrs_for_testing: bool,
     max_listening_addrs: usize,
 ) {
-    if !is_public_direct_addr(address) {
+    if should_register_external_listen_addr(address, allow_loopback_external_addrs_for_testing) {
         swarm.add_external_address(address.clone());
     }
     push_bounded_clone(
@@ -78,8 +79,9 @@ pub(super) fn handle_expired_listen_addr(
     listening_addrs_shared: &Arc<Mutex<Vec<Multiaddr>>>,
     reachability: &Arc<Mutex<Libp2pReachabilitySnapshot>>,
     address: &Multiaddr,
+    allow_loopback_external_addrs_for_testing: bool,
 ) {
-    if !is_public_direct_addr(address) {
+    if should_register_external_listen_addr(address, allow_loopback_external_addrs_for_testing) {
         swarm.remove_external_address(address);
     }
     let mut listening_addrs = listening_addrs_shared.lock().expect("lock listening addrs");
@@ -92,9 +94,11 @@ pub(super) fn handle_listener_closed(
     listening_addrs_shared: &Arc<Mutex<Vec<Multiaddr>>>,
     reachability: &Arc<Mutex<Libp2pReachabilitySnapshot>>,
     addresses: &[Multiaddr],
+    allow_loopback_external_addrs_for_testing: bool,
 ) {
     for address in addresses {
-        if !is_public_direct_addr(address) {
+        if should_register_external_listen_addr(address, allow_loopback_external_addrs_for_testing)
+        {
             swarm.remove_external_address(address);
         }
     }

--- a/crates/oasis7_net/src/libp2p_net/tests.rs
+++ b/crates/oasis7_net/src/libp2p_net/tests.rs
@@ -896,13 +896,8 @@ fn process_discovered_peer_record_does_not_poison_dial_dedupe_for_suspect_peer()
 fn try_send_command_reports_queue_disconnect() {
     let (sender, receiver) = mpsc::channel(1);
     drop(receiver);
-    let err = try_send_command(
-        &sender,
-        Command::Subscribe {
-            topic: "topic-a".to_string(),
-        },
-    )
-    .expect_err("send must fail once receiver is dropped");
+    let err = try_send_command(&sender, Command::Subscribe("topic-a".to_string()))
+        .expect_err("send must fail once receiver is dropped");
     assert!(matches!(
         err,
         WorldError::NetworkProtocolUnavailable { ref protocol }

--- a/crates/oasis7_net/src/tests.rs
+++ b/crates/oasis7_net/src/tests.rs
@@ -1,6 +1,10 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex};
 
+#[cfg(feature = "libp2p")]
+#[cfg(feature = "libp2p")]
+#[path = "tests_libp2p_helpers.rs"]
+mod libp2p_test_helpers;
 use oasis7_proto::distributed as proto_distributed;
 use oasis7_proto::distributed_dht::DistributedDht as _;
 use oasis7_proto::distributed_dht::SignedPeerRecord;
@@ -11,6 +15,8 @@ use oasis7_wasm_abi::ModuleAbiContract;
 
 use super::*;
 use crate::util::to_canonical_cbor;
+#[cfg(feature = "libp2p")]
+use libp2p_test_helpers::{loopback_test_bootstrap, loopback_test_peer};
 
 #[test]
 fn net_exports_are_available() {
@@ -308,11 +314,7 @@ fn libp2p_discovery_acquires_peer_from_dht_peer_record() {
         }
     }
 
-    let bootstrap = Libp2pNetwork::new(Libp2pNetworkConfig {
-        enable_rendezvous: true,
-        listen_addrs: vec!["/ip4/127.0.0.1/tcp/0".parse().expect("listen")],
-        ..Libp2pNetworkConfig::default()
-    });
+    let bootstrap = loopback_test_bootstrap(true);
     let deadline = Instant::now() + Duration::from_secs(10);
     wait_until("bootstrap listening", deadline, || {
         !bootstrap.listening_addrs().is_empty()
@@ -324,24 +326,15 @@ fn libp2p_discovery_acquires_peer_from_dht_peer_record() {
         .expect("bootstrap addr")
         .with(libp2p::multiaddr::Protocol::P2p(bootstrap.peer_id().into()));
 
-    let publisher = Libp2pNetwork::new(Libp2pNetworkConfig {
-        listen_addrs: vec!["/ip4/127.0.0.1/tcp/0".parse().expect("listen")],
-        bootstrap_peers: vec![bootstrap_addr.clone()],
-        peer_record: Some(default_peer_record("publisher")),
-        discovery_query_interval_ms: 100,
-        ..Libp2pNetworkConfig::default()
-    });
+    let publisher = loopback_test_peer(
+        vec![bootstrap_addr.clone()],
+        default_peer_record("publisher"),
+    );
     wait_until("publisher connected bootstrap", deadline, || {
         publisher.connected_peers().contains(&bootstrap.peer_id())
     });
 
-    let seeker = Libp2pNetwork::new(Libp2pNetworkConfig {
-        listen_addrs: vec!["/ip4/127.0.0.1/tcp/0".parse().expect("listen")],
-        bootstrap_peers: vec![bootstrap_addr],
-        peer_record: Some(default_peer_record("seeker")),
-        discovery_query_interval_ms: 100,
-        ..Libp2pNetworkConfig::default()
-    });
+    let seeker = loopback_test_peer(vec![bootstrap_addr], default_peer_record("seeker"));
     wait_until("seeker connected bootstrap", deadline, || {
         seeker.connected_peers().contains(&bootstrap.peer_id())
     });
@@ -408,10 +401,7 @@ fn libp2p_rendezvous_discovery_acquires_peer_from_bootstrap_registration() {
         }
     }
 
-    let bootstrap = Libp2pNetwork::new(Libp2pNetworkConfig {
-        listen_addrs: vec!["/ip4/127.0.0.1/tcp/0".parse().expect("listen")],
-        ..Libp2pNetworkConfig::default()
-    });
+    let bootstrap = loopback_test_bootstrap(true);
     let deadline = Instant::now() + Duration::from_secs(10);
     wait_until("bootstrap listening", deadline, || {
         !bootstrap.listening_addrs().is_empty()
@@ -423,24 +413,15 @@ fn libp2p_rendezvous_discovery_acquires_peer_from_bootstrap_registration() {
         .expect("bootstrap addr")
         .with(libp2p::multiaddr::Protocol::P2p(bootstrap.peer_id().into()));
 
-    let seeker = Libp2pNetwork::new(Libp2pNetworkConfig {
-        listen_addrs: vec!["/ip4/127.0.0.1/tcp/0".parse().expect("listen")],
-        bootstrap_peers: vec![bootstrap_addr.clone()],
-        peer_record: Some(rendezvous_peer_record("seeker")),
-        discovery_query_interval_ms: 100,
-        ..Libp2pNetworkConfig::default()
-    });
+    let seeker = loopback_test_peer(
+        vec![bootstrap_addr.clone()],
+        rendezvous_peer_record("seeker"),
+    );
     wait_until("seeker connected bootstrap", deadline, || {
         seeker.connected_peers().contains(&bootstrap.peer_id())
     });
 
-    let publisher = Libp2pNetwork::new(Libp2pNetworkConfig {
-        listen_addrs: vec!["/ip4/127.0.0.1/tcp/0".parse().expect("listen")],
-        bootstrap_peers: vec![bootstrap_addr],
-        peer_record: Some(rendezvous_peer_record("publisher")),
-        discovery_query_interval_ms: 100,
-        ..Libp2pNetworkConfig::default()
-    });
+    let publisher = loopback_test_peer(vec![bootstrap_addr], rendezvous_peer_record("publisher"));
     wait_until("publisher connected bootstrap", deadline, || {
         publisher.connected_peers().contains(&bootstrap.peer_id())
     });

--- a/crates/oasis7_net/src/tests_libp2p_helpers.rs
+++ b/crates/oasis7_net/src/tests_libp2p_helpers.rs
@@ -1,0 +1,27 @@
+use libp2p::Multiaddr;
+use oasis7_proto::distributed_dht::PeerRecord;
+
+use super::{Libp2pNetwork, Libp2pNetworkConfig};
+
+pub(super) fn loopback_test_bootstrap(enable_rendezvous: bool) -> Libp2pNetwork {
+    Libp2pNetwork::new(Libp2pNetworkConfig {
+        enable_rendezvous,
+        allow_loopback_external_addrs_for_testing: true,
+        listen_addrs: vec!["/ip4/127.0.0.1/tcp/0".parse().expect("listen")],
+        ..Libp2pNetworkConfig::default()
+    })
+}
+
+pub(super) fn loopback_test_peer(
+    bootstrap_peers: Vec<Multiaddr>,
+    peer_record: PeerRecord,
+) -> Libp2pNetwork {
+    Libp2pNetwork::new(Libp2pNetworkConfig {
+        allow_loopback_external_addrs_for_testing: true,
+        listen_addrs: vec!["/ip4/127.0.0.1/tcp/0".parse().expect("listen")],
+        bootstrap_peers,
+        peer_record: Some(peer_record),
+        discovery_query_interval_ms: 100,
+        ..Libp2pNetworkConfig::default()
+    })
+}

--- a/crates/oasis7_node/src/lib.rs
+++ b/crates/oasis7_node/src/lib.rs
@@ -75,15 +75,18 @@ pub use libp2p_replication_network_wasm::{
     derive_libp2p_identity_keypair, Libp2pReplicationNetwork, Libp2pReplicationNetworkConfig,
 };
 pub use network_bridge::NodeReplicationNetworkHandle;
-pub use oasis7_net::{Libp2pReachabilitySnapshot, LiveHolePunchState, LiveTransportKind};
+pub use oasis7_net::{
+    Libp2pReachabilitySnapshot, LiveAutoNatStatus, LiveHolePunchState, LivePublicPortReachability,
+    LiveTransportKind,
+};
 pub use replication::NodeReplicationConfig;
 pub use types::{
-    NodeCommittedActionBatch, NodeConfig, NodeConsensusMode, NodeConsensusSnapshot,
-    NodeFeedbackP2pConfig, NodeGossipConfig, NodeHolePunchViability,
+    NodeAutoNatStatus, NodeCommittedActionBatch, NodeConfig, NodeConsensusMode,
+    NodeConsensusSnapshot, NodeFeedbackP2pConfig, NodeGossipConfig, NodeHolePunchViability,
     NodeMainTokenControllerBindingConfig, NodeMainTokenControllerSignerPolicy, NodeNetworkPolicy,
-    NodePeerCommittedHead, NodePosConfig, NodeReachabilityAutoDetection,
-    NodeReplicaMaintenanceConfig, NodeRole, NodeSnapshot, NodeUserMode, NodeUserModeRecommendation,
-    PosConsensusStatus, PosValidator,
+    NodePeerCommittedHead, NodePosConfig, NodePublicPortReachability,
+    NodeReachabilityAutoDetection, NodeReplicaMaintenanceConfig, NodeRole, NodeSnapshot,
+    NodeUserMode, NodeUserModeRecommendation, PosConsensusStatus, PosValidator,
 };
 
 use feedback_runtime::{

--- a/crates/oasis7_node/src/types.rs
+++ b/crates/oasis7_node/src/types.rs
@@ -91,6 +91,81 @@ pub enum NodeHolePunchViability {
     Blocked,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NodeAutoNatStatus {
+    Unknown,
+    Public,
+    Private,
+}
+
+impl NodeAutoNatStatus {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Unknown => "unknown",
+            Self::Public => "public",
+            Self::Private => "private",
+        }
+    }
+}
+
+impl fmt::Display for NodeAutoNatStatus {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl FromStr for NodeAutoNatStatus {
+    type Err = String;
+
+    fn from_str(raw: &str) -> Result<Self, Self::Err> {
+        match raw.trim().to_ascii_lowercase().as_str() {
+            "unknown" => Ok(Self::Unknown),
+            "public" => Ok(Self::Public),
+            "private" => Ok(Self::Private),
+            _ => Err("autonat status must be one of: unknown, public, private".to_string()),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NodePublicPortReachability {
+    Unknown,
+    Reachable,
+    Unreachable,
+}
+
+impl NodePublicPortReachability {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Unknown => "unknown",
+            Self::Reachable => "reachable",
+            Self::Unreachable => "unreachable",
+        }
+    }
+}
+
+impl fmt::Display for NodePublicPortReachability {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl FromStr for NodePublicPortReachability {
+    type Err = String;
+
+    fn from_str(raw: &str) -> Result<Self, Self::Err> {
+        match raw.trim().to_ascii_lowercase().as_str() {
+            "unknown" => Ok(Self::Unknown),
+            "reachable" => Ok(Self::Reachable),
+            "unreachable" => Ok(Self::Unreachable),
+            _ => Err(
+                "public port reachability must be one of: unknown, reachable, unreachable"
+                    .to_string(),
+            ),
+        }
+    }
+}
+
 impl NodeHolePunchViability {
     pub fn as_str(self) -> &'static str {
         match self {
@@ -124,6 +199,8 @@ impl FromStr for NodeHolePunchViability {
 pub struct NodeReachabilityAutoDetection {
     pub observed_reachability: Option<PeerReachabilityClass>,
     pub hole_punch_viability: NodeHolePunchViability,
+    pub autonat_status: NodeAutoNatStatus,
+    pub public_port_reachability: NodePublicPortReachability,
     pub relay_available: bool,
     pub probe_stable: bool,
 }
@@ -133,6 +210,8 @@ impl Default for NodeReachabilityAutoDetection {
         Self {
             observed_reachability: None,
             hole_punch_viability: NodeHolePunchViability::Unknown,
+            autonat_status: NodeAutoNatStatus::Unknown,
+            public_port_reachability: NodePublicPortReachability::Unknown,
             relay_available: false,
             probe_stable: false,
         }
@@ -271,6 +350,11 @@ impl NodeNetworkPolicy {
             "hole_punch_viability={}",
             detection.hole_punch_viability
         ));
+        rationale.push(format!("autonat_status={}", detection.autonat_status));
+        rationale.push(format!(
+            "public_port_reachability={}",
+            detection.public_port_reachability
+        ));
         rationale.push(format!("relay_available={}", detection.relay_available));
         rationale.push(format!("probe_stable={}", detection.probe_stable));
         if requires_explicit_public_entry_confirmation {
@@ -298,6 +382,14 @@ fn recommend_user_mode(
 
     if matches!(runtime_role, NodeRole::Sequencer) {
         return NodeUserMode::PrivateSafe;
+    }
+
+    if matches!(
+        detection.public_port_reachability,
+        NodePublicPortReachability::Reachable
+    ) || matches!(detection.autonat_status, NodeAutoNatStatus::Public)
+    {
+        return NodeUserMode::PublicEntry;
     }
 
     if matches!(
@@ -1192,171 +1284,5 @@ pub struct NodeSnapshot {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn network_policy_blocks_observer_from_consensus_publish_lane() {
-        let policy = NodeNetworkPolicy {
-            deployment_mode: PeerDeploymentMode::Private,
-            node_role_claim: PeerNodeRole::ObserverLight,
-        };
-        assert!(!policy
-            .allows_lane_operation(NetworkLane::ConsensusGossip, NetworkLaneOperation::Publish));
-        assert!(policy.allows_lane_operation(
-            NetworkLane::ConsensusGossip,
-            NetworkLaneOperation::Subscribe
-        ));
-    }
-
-    #[test]
-    fn network_policy_limits_relay_to_control_lane() {
-        let policy = NodeNetworkPolicy {
-            deployment_mode: PeerDeploymentMode::Public,
-            node_role_claim: PeerNodeRole::Relay,
-        };
-        assert!(policy.allows_lane_operation(NetworkLane::Control, NetworkLaneOperation::Serve));
-        assert!(!policy.allows_lane_operation(NetworkLane::Sync, NetworkLaneOperation::Request));
-        assert!(
-            !policy.allows_lane_operation(NetworkLane::BlobState, NetworkLaneOperation::Subscribe)
-        );
-    }
-
-    #[test]
-    fn network_policy_allows_observer_requests_but_blocks_data_serving() {
-        let policy = NodeNetworkPolicy {
-            deployment_mode: PeerDeploymentMode::Private,
-            node_role_claim: PeerNodeRole::ObserverLight,
-        };
-        assert!(policy.allows_lane_operation(NetworkLane::Sync, NetworkLaneOperation::Request));
-        assert!(policy.allows_lane_operation(NetworkLane::BlobState, NetworkLaneOperation::Request));
-        assert!(!policy.allows_lane_operation(NetworkLane::Sync, NetworkLaneOperation::Serve));
-        assert!(!policy.allows_lane_operation(NetworkLane::BlobState, NetworkLaneOperation::Serve));
-    }
-
-    #[test]
-    fn auto_join_requires_confirmation_before_public_entry_upgrade() {
-        let recommendation = NodeNetworkPolicy::recommend_for_user_mode(
-            NodeRole::Storage,
-            NodeUserMode::AutoJoin,
-            NodeReachabilityAutoDetection {
-                observed_reachability: Some(PeerReachabilityClass::Public),
-                hole_punch_viability: NodeHolePunchViability::Viable,
-                relay_available: true,
-                probe_stable: true,
-            },
-            false,
-        )
-        .expect("recommendation");
-
-        assert_eq!(
-            recommendation.recommended_user_mode,
-            NodeUserMode::PublicEntry
-        );
-        assert_eq!(
-            recommendation.effective_user_mode,
-            NodeUserMode::PrivateSafe
-        );
-        assert!(recommendation.requires_explicit_public_entry_confirmation);
-        assert_eq!(
-            recommendation.effective_policy.deployment_mode,
-            PeerDeploymentMode::Private
-        );
-        assert_eq!(
-            recommendation.effective_policy.node_role_claim,
-            PeerNodeRole::FullStorage
-        );
-    }
-
-    #[test]
-    fn auto_join_can_promote_to_public_entry_after_consent() {
-        let recommendation = NodeNetworkPolicy::recommend_for_user_mode(
-            NodeRole::Observer,
-            NodeUserMode::AutoJoin,
-            NodeReachabilityAutoDetection {
-                observed_reachability: Some(PeerReachabilityClass::Hybrid),
-                hole_punch_viability: NodeHolePunchViability::Viable,
-                relay_available: true,
-                probe_stable: true,
-            },
-            true,
-        )
-        .expect("recommendation");
-
-        assert_eq!(
-            recommendation.recommended_user_mode,
-            NodeUserMode::PublicEntry
-        );
-        assert_eq!(
-            recommendation.effective_user_mode,
-            NodeUserMode::PublicEntry
-        );
-        assert!(!recommendation.requires_explicit_public_entry_confirmation);
-        assert_eq!(
-            recommendation.effective_policy.deployment_mode,
-            PeerDeploymentMode::Public
-        );
-        assert_eq!(
-            recommendation.effective_policy.node_role_claim,
-            PeerNodeRole::ObserverLight
-        );
-    }
-
-    #[test]
-    fn unstable_probe_falls_back_to_private_safe() {
-        let recommendation = NodeNetworkPolicy::recommend_for_user_mode(
-            NodeRole::Storage,
-            NodeUserMode::AutoJoin,
-            NodeReachabilityAutoDetection {
-                observed_reachability: Some(PeerReachabilityClass::Public),
-                hole_punch_viability: NodeHolePunchViability::Viable,
-                relay_available: true,
-                probe_stable: false,
-            },
-            true,
-        )
-        .expect("recommendation");
-
-        assert_eq!(
-            recommendation.recommended_user_mode,
-            NodeUserMode::PrivateSafe
-        );
-        assert_eq!(
-            recommendation.effective_user_mode,
-            NodeUserMode::PrivateSafe
-        );
-        assert_eq!(
-            recommendation.effective_policy.deployment_mode,
-            PeerDeploymentMode::Private
-        );
-    }
-
-    #[test]
-    fn sequencer_auto_join_never_auto_promotes_to_public_entry() {
-        let recommendation = NodeNetworkPolicy::recommend_for_user_mode(
-            NodeRole::Sequencer,
-            NodeUserMode::AutoJoin,
-            NodeReachabilityAutoDetection {
-                observed_reachability: Some(PeerReachabilityClass::Public),
-                hole_punch_viability: NodeHolePunchViability::Viable,
-                relay_available: true,
-                probe_stable: true,
-            },
-            true,
-        )
-        .expect("recommendation");
-
-        assert_eq!(
-            recommendation.recommended_user_mode,
-            NodeUserMode::PrivateSafe
-        );
-        assert_eq!(
-            recommendation.effective_user_mode,
-            NodeUserMode::PrivateSafe
-        );
-        assert_eq!(
-            recommendation.effective_policy.node_role_claim,
-            PeerNodeRole::ValidatorCore
-        );
-    }
-}
+#[path = "types_tests.rs"]
+mod tests;

--- a/crates/oasis7_node/src/types_tests.rs
+++ b/crates/oasis7_node/src/types_tests.rs
@@ -1,0 +1,194 @@
+use super::*;
+
+#[test]
+fn network_policy_blocks_observer_from_consensus_publish_lane() {
+    let policy = NodeNetworkPolicy {
+        deployment_mode: PeerDeploymentMode::Private,
+        node_role_claim: PeerNodeRole::ObserverLight,
+    };
+    assert!(
+        !policy.allows_lane_operation(NetworkLane::ConsensusGossip, NetworkLaneOperation::Publish)
+    );
+    assert!(policy.allows_lane_operation(
+        NetworkLane::ConsensusGossip,
+        NetworkLaneOperation::Subscribe
+    ));
+}
+
+#[test]
+fn network_policy_limits_relay_to_control_lane() {
+    let policy = NodeNetworkPolicy {
+        deployment_mode: PeerDeploymentMode::Public,
+        node_role_claim: PeerNodeRole::Relay,
+    };
+    assert!(policy.allows_lane_operation(NetworkLane::Control, NetworkLaneOperation::Serve));
+    assert!(!policy.allows_lane_operation(NetworkLane::Sync, NetworkLaneOperation::Request));
+    assert!(!policy.allows_lane_operation(NetworkLane::BlobState, NetworkLaneOperation::Subscribe));
+}
+
+#[test]
+fn network_policy_allows_observer_requests_but_blocks_data_serving() {
+    let policy = NodeNetworkPolicy {
+        deployment_mode: PeerDeploymentMode::Private,
+        node_role_claim: PeerNodeRole::ObserverLight,
+    };
+    assert!(policy.allows_lane_operation(NetworkLane::Sync, NetworkLaneOperation::Request));
+    assert!(policy.allows_lane_operation(NetworkLane::BlobState, NetworkLaneOperation::Request));
+    assert!(!policy.allows_lane_operation(NetworkLane::Sync, NetworkLaneOperation::Serve));
+    assert!(!policy.allows_lane_operation(NetworkLane::BlobState, NetworkLaneOperation::Serve));
+}
+
+#[test]
+fn auto_join_requires_confirmation_before_public_entry_upgrade() {
+    let recommendation = NodeNetworkPolicy::recommend_for_user_mode(
+        NodeRole::Storage,
+        NodeUserMode::AutoJoin,
+        NodeReachabilityAutoDetection {
+            observed_reachability: Some(PeerReachabilityClass::Public),
+            hole_punch_viability: NodeHolePunchViability::Viable,
+            relay_available: true,
+            probe_stable: true,
+            ..NodeReachabilityAutoDetection::default()
+        },
+        false,
+    )
+    .expect("recommendation");
+
+    assert_eq!(
+        recommendation.recommended_user_mode,
+        NodeUserMode::PublicEntry
+    );
+    assert_eq!(
+        recommendation.effective_user_mode,
+        NodeUserMode::PrivateSafe
+    );
+    assert!(recommendation.requires_explicit_public_entry_confirmation);
+    assert_eq!(
+        recommendation.effective_policy.deployment_mode,
+        PeerDeploymentMode::Private
+    );
+    assert_eq!(
+        recommendation.effective_policy.node_role_claim,
+        PeerNodeRole::FullStorage
+    );
+}
+
+#[test]
+fn auto_join_can_promote_to_public_entry_after_consent() {
+    let recommendation = NodeNetworkPolicy::recommend_for_user_mode(
+        NodeRole::Observer,
+        NodeUserMode::AutoJoin,
+        NodeReachabilityAutoDetection {
+            observed_reachability: Some(PeerReachabilityClass::Hybrid),
+            hole_punch_viability: NodeHolePunchViability::Viable,
+            relay_available: true,
+            probe_stable: true,
+            ..NodeReachabilityAutoDetection::default()
+        },
+        true,
+    )
+    .expect("recommendation");
+
+    assert_eq!(
+        recommendation.recommended_user_mode,
+        NodeUserMode::PublicEntry
+    );
+    assert_eq!(
+        recommendation.effective_user_mode,
+        NodeUserMode::PublicEntry
+    );
+    assert!(!recommendation.requires_explicit_public_entry_confirmation);
+    assert_eq!(
+        recommendation.effective_policy.deployment_mode,
+        PeerDeploymentMode::Public
+    );
+    assert_eq!(
+        recommendation.effective_policy.node_role_claim,
+        PeerNodeRole::ObserverLight
+    );
+}
+
+#[test]
+fn unstable_probe_falls_back_to_private_safe() {
+    let recommendation = NodeNetworkPolicy::recommend_for_user_mode(
+        NodeRole::Storage,
+        NodeUserMode::AutoJoin,
+        NodeReachabilityAutoDetection {
+            observed_reachability: Some(PeerReachabilityClass::Public),
+            hole_punch_viability: NodeHolePunchViability::Viable,
+            relay_available: true,
+            probe_stable: false,
+            ..NodeReachabilityAutoDetection::default()
+        },
+        true,
+    )
+    .expect("recommendation");
+
+    assert_eq!(
+        recommendation.recommended_user_mode,
+        NodeUserMode::PrivateSafe
+    );
+    assert_eq!(
+        recommendation.effective_user_mode,
+        NodeUserMode::PrivateSafe
+    );
+    assert_eq!(
+        recommendation.effective_policy.deployment_mode,
+        PeerDeploymentMode::Private
+    );
+}
+
+#[test]
+fn sequencer_auto_join_never_auto_promotes_to_public_entry() {
+    let recommendation = NodeNetworkPolicy::recommend_for_user_mode(
+        NodeRole::Sequencer,
+        NodeUserMode::AutoJoin,
+        NodeReachabilityAutoDetection {
+            observed_reachability: Some(PeerReachabilityClass::Public),
+            hole_punch_viability: NodeHolePunchViability::Viable,
+            relay_available: true,
+            probe_stable: true,
+            ..NodeReachabilityAutoDetection::default()
+        },
+        true,
+    )
+    .expect("recommendation");
+
+    assert_eq!(
+        recommendation.recommended_user_mode,
+        NodeUserMode::PrivateSafe
+    );
+    assert_eq!(
+        recommendation.effective_user_mode,
+        NodeUserMode::PrivateSafe
+    );
+    assert_eq!(
+        recommendation.effective_policy.node_role_claim,
+        PeerNodeRole::ValidatorCore
+    );
+}
+
+#[test]
+fn autonat_public_without_reachability_hint_still_recommends_public_entry() {
+    let recommendation = NodeNetworkPolicy::recommend_for_user_mode(
+        NodeRole::Observer,
+        NodeUserMode::AutoJoin,
+        NodeReachabilityAutoDetection {
+            autonat_status: NodeAutoNatStatus::Public,
+            public_port_reachability: NodePublicPortReachability::Reachable,
+            probe_stable: true,
+            ..NodeReachabilityAutoDetection::default()
+        },
+        true,
+    )
+    .expect("recommendation");
+
+    assert_eq!(
+        recommendation.recommended_user_mode,
+        NodeUserMode::PublicEntry
+    );
+    assert_eq!(
+        recommendation.effective_user_mode,
+        NodeUserMode::PublicEntry
+    );
+}

--- a/doc/.governance/rust-oversized-file-baseline.tsv
+++ b/doc/.governance/rust-oversized-file-baseline.tsv
@@ -1,16 +1,16 @@
 # schema: kind<TAB>path<TAB>line_count
 # kind in {code,test}; line_count is the frozen oversized baseline for tracked Rust files.
-code	crates/oasis7/src/bin/oasis7_chain_runtime.rs	1349
+code	crates/oasis7/src/bin/oasis7_chain_runtime.rs	1319
 code	crates/oasis7/src/bin/oasis7_game_launcher.rs	1429
 code	crates/oasis7/src/bin/oasis7_web_launcher/control_plane.rs	1259
 code	crates/oasis7/src/viewer/runtime_live/llm_sidecar.rs	1389
 code	crates/oasis7_client_launcher/src/launcher_core.rs	1258
 code	crates/oasis7_client_launcher/src/main.rs	1253
-code	crates/oasis7_net/src/libp2p_net.rs	1265
+code	crates/oasis7_net/src/libp2p_net.rs	1264
 code	crates/oasis7_node/src/lib_impl_part1.rs	1298
 code	crates/oasis7_node/src/libp2p_replication_network.rs	1339
 code	crates/oasis7_node/src/replication.rs	1221
-code	crates/oasis7_node/src/types.rs	1362
+code	crates/oasis7_node/src/types.rs	1288
 test	crates/oasis7/src/simulator/llm_agent/tests_split_part1.rs	1204
 test	crates/oasis7/src/viewer/runtime_live/tests/auth_actions.rs	1447
 test	crates/oasis7_client_launcher/src/main_tests.rs	1261

--- a/doc/.governance/rust-oversized-file-baseline.tsv
+++ b/doc/.governance/rust-oversized-file-baseline.tsv
@@ -6,7 +6,7 @@ code	crates/oasis7/src/bin/oasis7_web_launcher/control_plane.rs	1259
 code	crates/oasis7/src/viewer/runtime_live/llm_sidecar.rs	1389
 code	crates/oasis7_client_launcher/src/launcher_core.rs	1258
 code	crates/oasis7_client_launcher/src/main.rs	1253
-code	crates/oasis7_net/src/libp2p_net.rs	1264
+code	crates/oasis7_net/src/libp2p_net.rs	1261
 code	crates/oasis7_node/src/lib_impl_part1.rs	1298
 code	crates/oasis7_node/src/libp2p_replication_network.rs	1339
 code	crates/oasis7_node/src/replication.rs	1221
@@ -14,7 +14,7 @@ code	crates/oasis7_node/src/types.rs	1288
 test	crates/oasis7/src/simulator/llm_agent/tests_split_part1.rs	1204
 test	crates/oasis7/src/viewer/runtime_live/tests/auth_actions.rs	1447
 test	crates/oasis7_client_launcher/src/main_tests.rs	1261
-test	crates/oasis7_net/src/libp2p_net/tests.rs	1349
-test	crates/oasis7_net/src/tests.rs	1260
+test	crates/oasis7_net/src/libp2p_net/tests.rs	1344
+test	crates/oasis7_net/src/tests.rs	1241
 test	crates/oasis7_node/src/tests_split_part1.rs	1463
 test	crates/oasis7_node/src/tests_split_part3.rs	1781

--- a/doc/p2p/network/p2p-mainnet-private-reachability-architecture-2026-04-01.project.md
+++ b/doc/p2p/network/p2p-mainnet-private-reachability-architecture-2026-04-01.project.md
@@ -221,16 +221,16 @@
   - `oasis7_node` 新增用户层模式、reachability auto-detection、recommendation/effective-policy contract，并把 `public_entry` 自动升级收口为显式确认门
   - chain runtime CLI/status payload 已能承载 requested/recommended/effective user mode 与探测依据，且在未显式传入原始 `deployment_mode/node_role` 时默认走用户模式推荐
   - game launcher / web launcher / launcher UI schema 已统一透传 `chain_p2p_user_mode` 与 `chain_p2p_accept_public_entry`，为后续 viewer UX 接推荐态与确认态留好接口
-  - runtime status/recommender 现在会在 CLI 未显式覆盖对应字段时，自动吸收 libp2p live relay reservation、DCUtR success/failure 与 active transport path kind，作为 `auto_join / private_safe / public_entry` 默认推荐的 fallback 探测源
+  - runtime status/recommender 现在会在 CLI 未显式覆盖对应字段时，自动吸收 libp2p live AutoNAT status、confirmed external direct addr / public-port reachability、relay reservation、DCUtR success/failure 与 active transport path kind，作为 `auto_join / private_safe / public_entry` 默认推荐依据；`public_entry` 不再只靠 relay / hole-punch hint 做推断
   - runtime follow-up 已补 stale relay reservation 收口：live snapshot 现在会跟随 relayed listen addr 的 `new/expired` 生命周期重算 `relay_reservation_active`，不再把旧 reservation 证据永久滞留在 status/recommender
   - chain status 已把“实际运行态”与“当前 live 推荐态”拆开：保留 `effective_user_mode` 表示按实时 reachability snapshot 计算出的当前有效推荐态，并新增 `applied_effective_user_mode` 表示 runtime 在启动时实际应用的用户模式；若节点是通过底层 `deployment_mode/node_role` 显式 override 启动，则继续以 `deployment_mode/node_role_claim` 作为实际运行态真值
   - `viewer_engineer` 已将 chain status 的 P2P recommendation payload 接入 launcher：`oasis7_web_launcher` 会把 requested/recommended/applied user mode、reachability evidence、底层 role mapping 一起透传给 `oasis7_client_launcher`
   - `oasis7_client_launcher` 已新增用户可见 P2P 模式卡片，明确区分“请求模式 / 自动推荐 / 实际运行态”，并显示 reachability、hole-punch、relay、probe-stable 与 rationale 摘要
+  - chain runtime `/v1/chain/status` 现已额外暴露 `autonat_status/public_port_reachability/observed_public_addr/confirmed_external_direct_addrs`，便于 launcher / viewer 或运维脚本审计节点为何被判定为 `private_safe` 或 `public_entry`
   - launcher 高级配置已把 `chain_p2p_user_mode` 收口为 `auto_join / private_safe / public_entry` 三档 simple modes，并对 `public_entry` 增加显式确认门；未确认时拒绝启动高风险模式
   - `test_tier_full` 当前已以 `doc/testing/evidence/p2p-user-mode-launcher-ux-2026-04-07.md` 固化 launcher UX、confirm/reject 流程和用户模式语义对账
 - 遗留:
-  - 当前 runtime 已接入 relay / hole-punch / active-path live evidence，但仍未接入完整 AutoNAT / port reachability probe；CLI detection hint 继续保留为显式 override 通道，后续网络观测面仍需补齐真正的公网/NAT 探测源
-  - 当前 viewer UX 的检测依据仍来自 runtime 已暴露的 live snapshot / CLI hint；若后续接入真实 AutoNAT / public-port probe，需要继续把新增证据源并入口径回写到同一张 P2P 卡片
+  - CLI detection hint 继续保留为显式 override 通道；后续若 launcher/viewer 需要把 `autonat_status/public_port_reachability/observed_public_addr` 单独做成更强提示文案或图形标签，可在现有 status payload 基础上继续增强 UI，而不必再补底层探测链路
 - 完成定义:
   - 系统可在默认启动路径中自动选择用户模式，并给出可审计的探测依据
   - launcher/viewer 必须提供 `public_entry` 接受 / 拒绝路径，并保证最终运行态与用户确认结果一致可读


### PR DESCRIPTION
## Summary
- add AutoNAT and external-address-backed reachability evidence to libp2p live snapshot and node auto-mode recommendation
- expose AutoNAT/public-port reachability fields in /v1/chain/status and align the p2p architecture project doc with the new truth
- shrink touched oversized Rust files and sync the frozen oversized-file baseline after the refactor split

## Validation
- `env -u RUSTC_WRAPPER cargo test -p oasis7_net --lib -- --nocapture`
- `env -u RUSTC_WRAPPER cargo test -p oasis7 --bin oasis7_chain_runtime -- --nocapture`
- `env -u RUSTC_WRAPPER cargo test -p oasis7_node types::tests -- --nocapture`
- `git diff --check`
- commit hook: `./scripts/doc-governance-check.sh`
- commit hook: `./scripts/check-rust-file-size.sh`
- commit hook: `env -u RUSTC_WRAPPER cargo test -p oasis7_consensus --lib`
- commit hook: `env -u RUSTC_WRAPPER cargo test -p oasis7_distfs --lib`
- commit hook: `node crates/oasis7_viewer/scripts/software-safe-feedback-contract.test.mjs`

## Reward Review Intake
- Request reward review: `yes`
- Reward Account: `oc:pk:6a0701c8feff03ff02f16048c5447223708062e7e1221f79ff2410a22be1063d`
- Evidence / context link: `https://github.com/eng-cc/oasis7/commit/9b39fea24b92fb806d9381818eda3f9adfb93e3a`
- Notes: `P2P reachability truth closure for AutoNAT/public-port evidence; includes libp2p/node/runtime regression coverage.`
