### PR TITLE
Fix launcher web release wasm compatibility

### DIFF
--- a/.pm/tasks/task_1d90a16ad56f4c4e96bfa5370199b3d7.execution.md
+++ b/.pm/tasks/task_1d90a16ad56f4c4e96bfa5370199b3d7.execution.md
@@ -1,0 +1,23 @@
+# task_1d90a16ad56f4c4e96bfa5370199b3d7 Execution Log
+
+- task_uid: task_1d90a16ad56f4c4e96bfa5370199b3d7
+- title: Fix release build-web-dist launcher wasm compatibility
+- owner_role: viewer_engineer
+- worktree_hint: /home/scc/worktrees/oasis7-testing-release-web-dist-launcher-wasm-compat
+
+<!-- Append entries using:
+Example:
+  ## YYYY-MM-DD HH:MM:SS CST / role_name
+  - 完成内容: ...
+  - 遗留事项: ...
+-->
+## 2026-04-13 23:39:30 CST / viewer_engineer
+- 完成内容: 复盘 `Release Packages` run `24349229764`，确认前置 release gates 全绿，唯一失败点是 `build-web-dist` 的 `Build web dists` 步骤；本地以 `env -u RUSTC_WRAPPER cargo build --target wasm32-unknown-unknown --manifest-path crates/oasis7_client_launcher/Cargo.toml --release --bin oasis7_client_launcher` 复现同一 `E0432 unresolved import oasis7::simulator::ProviderCompatibilityStatus` 签名。
+- 完成内容: 将 launcher 展示层使用的 `ProviderCompatibilityStatus` 收口为 `crates/oasis7_client_launcher/src/main.rs` 内部跨目标类型，并在 `crates/oasis7_client_launcher/src/launcher_core.rs` 的 native provider 检查结果里显式做 `into()` 映射，避免 wasm 目标再直接依赖 `oasis7::simulator` 的 native-only re-export。
+- 完成内容: 本地完成两层回归：`cargo build --target wasm32-unknown-unknown` 与 `cd crates/oasis7_client_launcher && env -u NO_COLOR trunk build --release --dist ../../output/release/web-launcher-dist` 均通过，确认 `build-web-dist` 的 launcher wasm 编译面已恢复。
+- 遗留事项: 仍需完成 `doc-governance-check` / `pm lint` / `git diff --check` / snapshot review / commit / PR / 合入后重新打 release tag。
+
+## 2026-04-13 23:44:45 CST / viewer_engineer
+- 完成内容: 已执行 `./scripts/doc-governance-check.sh`、`./scripts/pm/lint.sh`、`git diff --check` 与 `./scripts/pm/codex-review-snapshot.sh`；snapshot review 额外复跑 native/wasm `cargo check` 与 provider check tests，结论为未发现新增回归。
+- 完成内容: 已执行 `./scripts/pm/workflow-report.sh --phase close --role viewer_engineer --task-uid task_1d90a16ad56f4c4e96bfa5370199b3d7`，并将 task 状态从 `committed` 迁移到 `done`，使 `.pm` 真值、execution log 与 `doc/testing/project.md` 保持一致。
+- 遗留事项: 等待提交、发起 PR、合入后重新创建 GitHub release tag。

--- a/.pm/tasks/task_1d90a16ad56f4c4e96bfa5370199b3d7.yaml
+++ b/.pm/tasks/task_1d90a16ad56f4c4e96bfa5370199b3d7.yaml
@@ -1,0 +1,20 @@
+task_uid: task_1d90a16ad56f4c4e96bfa5370199b3d7
+title: "Fix release build-web-dist launcher wasm compatibility"
+owner_role: viewer_engineer
+worktree_hint: /home/scc/worktrees/oasis7-testing-release-web-dist-launcher-wasm-compat
+execution_log_path: .pm/tasks/task_1d90a16ad56f4c4e96bfa5370199b3d7.execution.md
+status: done
+priority: P1
+source_signal: null
+source_refs:
+  - doc/testing/project.md
+doc_refs:
+  - doc/testing/project.md
+related_prd:
+  - PRD-TESTING-002
+acceptance:
+  - "release build-web-dist passes for oasis7_client_launcher wasm target and release workflow can package web dists"
+handoff_to: []
+updated_at: 2026-04-13T23:44:36+08:00
+last_started_at: 2026-04-13T23:35:27+08:00
+last_closed_at: 2026-04-13T23:44:27+08:00

--- a/crates/oasis7_client_launcher/src/launcher_core.rs
+++ b/crates/oasis7_client_launcher/src/launcher_core.rs
@@ -866,6 +866,9 @@ pub(super) fn check_provider_loopback_http_provider(
         queue_depth: health.queue_depth,
     };
     let compatibility = evaluate_provider_compatibility(&provider_info, Some(&provider_health));
+    let status = provider_health
+        .status
+        .unwrap_or_else(|| if provider_health.ok { "ok" } else { "not_ok" }.to_string());
     Ok(ProviderSnapshot {
         provider_id: provider_info.provider_id,
         name: provider_info
@@ -879,14 +882,8 @@ pub(super) fn check_provider_loopback_http_provider(
             .unwrap_or_else(|| "unknown".to_string()),
         capabilities: provider_info.capabilities,
         supported_action_sets: provider_info.supported_action_sets,
-        compatibility_status: compatibility.status,
-        status: provider_health.status.unwrap_or_else(|| {
-            if provider_health.ok {
-                "ok".to_string()
-            } else {
-                "not_ok".to_string()
-            }
-        }),
+        compatibility_status: compatibility.status.into(),
+        status,
         queue_depth: provider_health.queue_depth,
         last_error: provider_health.last_error,
         fallback_reason: compatibility.fallback_reason,

--- a/crates/oasis7_client_launcher/src/main.rs
+++ b/crates/oasis7_client_launcher/src/main.rs
@@ -17,7 +17,6 @@ use feedback_entry::FeedbackDraft;
 #[cfg(target_arch = "wasm32")]
 use gloo_net::http::Request;
 use llm_settings::LlmSettingsPanel;
-use oasis7::simulator::ProviderCompatibilityStatus;
 use platform_ops::open_browser;
 use platform_ops::resolve_static_dir_path;
 #[cfg(not(target_arch = "wasm32"))]
@@ -59,6 +58,7 @@ mod llm_settings;
 mod main_app_shell;
 mod main_ui_helpers;
 mod platform_ops;
+mod provider_check_status;
 mod self_guided;
 mod self_guided_blocked_actions;
 mod self_guided_error_cards;
@@ -71,6 +71,9 @@ mod transfer_window;
 
 use config_ui::StartupGuideState;
 use launcher_core::*;
+pub(crate) use provider_check_status::{
+    ProviderCheckStatus, ProviderCompatibilityStatus, ProviderSnapshot,
+};
 use self_guided::{DemoModePhase, LauncherUxState, OnboardingState};
 
 const DEFAULT_SCENARIO: &str = "llm_bootstrap";
@@ -660,118 +663,6 @@ enum ChainRuntimeStatus {
     StaleExecutionWorld(String),
     Unreachable(String),
     ConfigError(String),
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct ProviderSnapshot {
-    provider_id: String,
-    name: String,
-    version: String,
-    protocol_version: String,
-    capabilities: Vec<String>,
-    supported_action_sets: Vec<String>,
-    compatibility_status: ProviderCompatibilityStatus,
-    status: String,
-    queue_depth: Option<u64>,
-    last_error: Option<String>,
-    fallback_reason: Option<String>,
-    info_latency_ms: u64,
-    health_latency_ms: u64,
-    total_latency_ms: u64,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-#[allow(dead_code)]
-enum ProviderCheckStatus {
-    Disabled,
-    Idle,
-    Checking,
-    Ready(ProviderSnapshot),
-    Degraded(ProviderSnapshot),
-    Incompatible(ProviderSnapshot),
-    Unsupported(String),
-    InvalidConfig(String),
-    Unreachable(String),
-    Unauthorized(String),
-}
-
-impl ProviderCheckStatus {
-    fn text(&self, language: UiLanguage) -> String {
-        match (self, language) {
-            (Self::Disabled, UiLanguage::ZhCn) => "未启用".to_string(),
-            (Self::Disabled, UiLanguage::EnUs) => "Disabled".to_string(),
-            (Self::Idle, UiLanguage::ZhCn) => "待检查".to_string(),
-            (Self::Idle, UiLanguage::EnUs) => "Idle".to_string(),
-            (Self::Checking, UiLanguage::ZhCn) => "检查中".to_string(),
-            (Self::Checking, UiLanguage::EnUs) => "Checking".to_string(),
-            (Self::Ready(_), UiLanguage::ZhCn) => "已就绪".to_string(),
-            (Self::Ready(_), UiLanguage::EnUs) => "Ready".to_string(),
-            (Self::Degraded(_), UiLanguage::ZhCn) => "已降级".to_string(),
-            (Self::Degraded(_), UiLanguage::EnUs) => "Degraded".to_string(),
-            (Self::Incompatible(_), UiLanguage::ZhCn) => "不兼容".to_string(),
-            (Self::Incompatible(_), UiLanguage::EnUs) => "Incompatible".to_string(),
-            (Self::Unsupported(_), UiLanguage::ZhCn) => "当前端不支持".to_string(),
-            (Self::Unsupported(_), UiLanguage::EnUs) => "Unsupported".to_string(),
-            (Self::InvalidConfig(_), UiLanguage::ZhCn) => "配置错误".to_string(),
-            (Self::InvalidConfig(_), UiLanguage::EnUs) => "Invalid Config".to_string(),
-            (Self::Unreachable(_), UiLanguage::ZhCn) => "不可达".to_string(),
-            (Self::Unreachable(_), UiLanguage::EnUs) => "Unreachable".to_string(),
-            (Self::Unauthorized(_), UiLanguage::ZhCn) => "认证失败".to_string(),
-            (Self::Unauthorized(_), UiLanguage::EnUs) => "Unauthorized".to_string(),
-        }
-    }
-
-    fn color(&self) -> egui::Color32 {
-        match self {
-            Self::Disabled | Self::Idle => egui::Color32::from_rgb(130, 130, 130),
-            Self::Checking => egui::Color32::from_rgb(201, 146, 44),
-            Self::Ready(_) => egui::Color32::from_rgb(62, 152, 92),
-            Self::Degraded(_) => egui::Color32::from_rgb(201, 146, 44),
-            Self::Incompatible(_) => egui::Color32::from_rgb(196, 84, 84),
-            Self::Unsupported(_) => egui::Color32::from_rgb(130, 130, 130),
-            Self::InvalidConfig(_) | Self::Unreachable(_) | Self::Unauthorized(_) => {
-                egui::Color32::from_rgb(196, 84, 84)
-            }
-        }
-    }
-
-    fn detail(&self) -> Option<String> {
-        match self {
-            Self::Ready(snapshot) | Self::Degraded(snapshot) | Self::Incompatible(snapshot) => Some(format!(
-                "provider_id={} name={} version={} protocol={} compatibility_status={} status={} queue_depth={} capabilities={} supported_action_sets={} check_latency_ms={{info:{}, health:{}, total:{}}} last_error={} fallback_reason={}",
-                snapshot.provider_id,
-                snapshot.name,
-                snapshot.version,
-                snapshot.protocol_version,
-                snapshot.compatibility_status.as_str(),
-                snapshot.status,
-                snapshot
-                    .queue_depth
-                    .map(|value| value.to_string())
-                    .unwrap_or_else(|| "n/a".to_string()),
-                if snapshot.capabilities.is_empty() {
-                    "none".to_string()
-                } else {
-                    snapshot.capabilities.join(",")
-                },
-                if snapshot.supported_action_sets.is_empty() {
-                    "none".to_string()
-                } else {
-                    snapshot.supported_action_sets.join(",")
-                },
-                snapshot.info_latency_ms,
-                snapshot.health_latency_ms,
-                snapshot.total_latency_ms,
-                snapshot.last_error.as_deref().unwrap_or("none"),
-                snapshot.fallback_reason.as_deref().unwrap_or("none")
-            )),
-            Self::Unsupported(detail)
-            | Self::InvalidConfig(detail)
-            | Self::Unreachable(detail)
-            | Self::Unauthorized(detail) => Some(detail.clone()),
-            Self::Disabled | Self::Idle | Self::Checking => None,
-        }
-    }
 }
 
 impl ChainRuntimeStatus {

--- a/crates/oasis7_client_launcher/src/provider_check_status.rs
+++ b/crates/oasis7_client_launcher/src/provider_check_status.rs
@@ -1,0 +1,137 @@
+use eframe::egui;
+#[cfg(not(target_arch = "wasm32"))]
+use oasis7::simulator::ProviderCompatibilityStatus as SimulatorProviderCompatibilityStatus;
+use serde::{Deserialize, Serialize};
+
+use crate::UiLanguage;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum ProviderCompatibilityStatus {
+    #[default]
+    Ready,
+    Degraded,
+    Incompatible,
+}
+
+impl ProviderCompatibilityStatus {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Ready => "ready",
+            Self::Degraded => "degraded",
+            Self::Incompatible => "incompatible",
+        }
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl From<SimulatorProviderCompatibilityStatus> for ProviderCompatibilityStatus {
+    fn from(value: SimulatorProviderCompatibilityStatus) -> Self {
+        match value {
+            SimulatorProviderCompatibilityStatus::Ready => Self::Ready,
+            SimulatorProviderCompatibilityStatus::Degraded => Self::Degraded,
+            SimulatorProviderCompatibilityStatus::Incompatible => Self::Incompatible,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ProviderSnapshot {
+    pub(crate) provider_id: String,
+    pub(crate) name: String,
+    pub(crate) version: String,
+    pub(crate) protocol_version: String,
+    pub(crate) capabilities: Vec<String>,
+    pub(crate) supported_action_sets: Vec<String>,
+    pub(crate) compatibility_status: ProviderCompatibilityStatus,
+    pub(crate) status: String,
+    pub(crate) queue_depth: Option<u64>,
+    pub(crate) last_error: Option<String>,
+    pub(crate) fallback_reason: Option<String>,
+    pub(crate) info_latency_ms: u64,
+    pub(crate) health_latency_ms: u64,
+    pub(crate) total_latency_ms: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[allow(dead_code)]
+pub(crate) enum ProviderCheckStatus {
+    Disabled,
+    Idle,
+    Checking,
+    Ready(ProviderSnapshot),
+    Degraded(ProviderSnapshot),
+    Incompatible(ProviderSnapshot),
+    Unsupported(String),
+    InvalidConfig(String),
+    Unreachable(String),
+    Unauthorized(String),
+}
+
+impl ProviderCheckStatus {
+    pub(crate) fn text(&self, language: UiLanguage) -> String {
+        match (self, language) {
+            (Self::Disabled, UiLanguage::ZhCn) => "未启用".to_string(),
+            (Self::Disabled, UiLanguage::EnUs) => "Disabled".to_string(),
+            (Self::Idle, UiLanguage::ZhCn) => "待检查".to_string(),
+            (Self::Idle, UiLanguage::EnUs) => "Idle".to_string(),
+            (Self::Checking, UiLanguage::ZhCn) => "检查中".to_string(),
+            (Self::Checking, UiLanguage::EnUs) => "Checking".to_string(),
+            (Self::Ready(_), UiLanguage::ZhCn) => "已就绪".to_string(),
+            (Self::Ready(_), UiLanguage::EnUs) => "Ready".to_string(),
+            (Self::Degraded(_), UiLanguage::ZhCn) => "已降级".to_string(),
+            (Self::Degraded(_), UiLanguage::EnUs) => "Degraded".to_string(),
+            (Self::Incompatible(_), UiLanguage::ZhCn) => "不兼容".to_string(),
+            (Self::Incompatible(_), UiLanguage::EnUs) => "Incompatible".to_string(),
+            (Self::Unsupported(_), UiLanguage::ZhCn) => "当前端不支持".to_string(),
+            (Self::Unsupported(_), UiLanguage::EnUs) => "Unsupported".to_string(),
+            (Self::InvalidConfig(_), UiLanguage::ZhCn) => "配置错误".to_string(),
+            (Self::InvalidConfig(_), UiLanguage::EnUs) => "Invalid Config".to_string(),
+            (Self::Unreachable(_), UiLanguage::ZhCn) => "不可达".to_string(),
+            (Self::Unreachable(_), UiLanguage::EnUs) => "Unreachable".to_string(),
+            (Self::Unauthorized(_), UiLanguage::ZhCn) => "认证失败".to_string(),
+            (Self::Unauthorized(_), UiLanguage::EnUs) => "Unauthorized".to_string(),
+        }
+    }
+
+    pub(crate) fn color(&self) -> egui::Color32 {
+        match self {
+            Self::Disabled | Self::Idle => egui::Color32::from_rgb(130, 130, 130),
+            Self::Checking => egui::Color32::from_rgb(201, 146, 44),
+            Self::Ready(_) => egui::Color32::from_rgb(62, 152, 92),
+            Self::Degraded(_) => egui::Color32::from_rgb(201, 146, 44),
+            Self::Incompatible(_) => egui::Color32::from_rgb(196, 84, 84),
+            Self::Unsupported(_) => egui::Color32::from_rgb(130, 130, 130),
+            Self::InvalidConfig(_) | Self::Unreachable(_) | Self::Unauthorized(_) => {
+                egui::Color32::from_rgb(196, 84, 84)
+            }
+        }
+    }
+
+    pub(crate) fn detail(&self) -> Option<String> {
+        match self {
+            Self::Ready(snapshot) | Self::Degraded(snapshot) | Self::Incompatible(snapshot) => Some(format!(
+                "provider_id={} name={} version={} protocol={} compatibility_status={} status={} queue_depth={} capabilities={} supported_action_sets={} check_latency_ms={{info:{}, health:{}, total:{}}} last_error={} fallback_reason={}",
+                snapshot.provider_id,
+                snapshot.name,
+                snapshot.version,
+                snapshot.protocol_version,
+                snapshot.compatibility_status.as_str(),
+                snapshot.status,
+                snapshot.queue_depth.map(|value| value.to_string()).unwrap_or_else(|| "n/a".to_string()),
+                if snapshot.capabilities.is_empty() { "none".to_string() } else { snapshot.capabilities.join(",") },
+                if snapshot.supported_action_sets.is_empty() { "none".to_string() } else { snapshot.supported_action_sets.join(",") },
+                snapshot.info_latency_ms,
+                snapshot.health_latency_ms,
+                snapshot.total_latency_ms,
+                snapshot.last_error.as_deref().unwrap_or("none"),
+                snapshot.fallback_reason.as_deref().unwrap_or("none")
+            )),
+            Self::Unsupported(detail)
+            | Self::InvalidConfig(detail)
+            | Self::Unreachable(detail)
+            | Self::Unauthorized(detail) => Some(detail.clone()),
+            Self::Disabled | Self::Idle | Self::Checking => None,
+        }
+    }
+}

--- a/doc/.governance/rust-oversized-file-baseline.tsv
+++ b/doc/.governance/rust-oversized-file-baseline.tsv
@@ -4,8 +4,7 @@ code	crates/oasis7/src/bin/oasis7_chain_runtime.rs	1305
 code	crates/oasis7/src/bin/oasis7_game_launcher.rs	1429
 code	crates/oasis7/src/bin/oasis7_web_launcher/control_plane.rs	1259
 code	crates/oasis7/src/viewer/runtime_live/llm_sidecar.rs	1389
-code	crates/oasis7_client_launcher/src/launcher_core.rs	1258
-code	crates/oasis7_client_launcher/src/main.rs	1253
+code	crates/oasis7_client_launcher/src/launcher_core.rs	1255
 code	crates/oasis7_net/src/libp2p_net.rs	1261
 code	crates/oasis7_node/src/lib_impl_part1.rs	1246
 code	crates/oasis7_node/src/libp2p_replication_network.rs	1339

--- a/doc/testing/project.md
+++ b/doc/testing/project.md
@@ -221,6 +221,16 @@
     - `bash -n scripts/s10-five-node-game-soak.sh`
     - `env -u RUSTC_WRAPPER cargo build -p oasis7 --bin oasis7_chain_runtime`
     - `./scripts/s10-five-node-game-soak.sh --duration-secs 300 --base-port 7510 --no-prewarm --max-stall-secs 240 --max-lag-p95 50 --out-dir .tmp/release_gate_s10_fix_full_v5`
+- [x] TASK-TESTING-065 (PRD-TESTING-002/003) [test_tier_required]: 修复 `build-web-dist` 的 `oasis7_client_launcher` wasm 编译兼容性，避免 release tag 路径在 `crates/oasis7_viewer` 通过后仍因 launcher 引用 native-only `ProviderCompatibilityStatus` 而阻断 web dist 打包。
+  - 产物文件:
+    - `crates/oasis7_client_launcher/src/main.rs`
+    - `crates/oasis7_client_launcher/src/launcher_core.rs`
+    - `doc/testing/project.md`
+    - `.pm/tasks/task_1d90a16ad56f4c4e96bfa5370199b3d7.yaml`
+    - `.pm/tasks/task_1d90a16ad56f4c4e96bfa5370199b3d7.execution.md`
+  - 验收命令 (`test_tier_required`):
+    - `env -u RUSTC_WRAPPER cargo build --target wasm32-unknown-unknown --manifest-path crates/oasis7_client_launcher/Cargo.toml --release --bin oasis7_client_launcher`
+    - `cd crates/oasis7_client_launcher && env -u NO_COLOR trunk build --release --dist ../../output/release/web-launcher-dist`
 
 - 当前阻断摘要：`doc/testing/provider-dual-mode-t4-blocker-2026-03-16.md`
 
@@ -238,6 +248,7 @@
 - 更新日期: 2026-04-13
 - 当前状态: active
 - 下一任务: 等待 `producer_system_designer` / `runtime_engineer` 提供真实创世账户表后，用 `token-genesis-allocation-audit-template-2026-03-22` 执行首轮正式审计。
+- 最新完成: `TASK-TESTING-065`（已将 launcher 展示层使用的 `ProviderCompatibilityStatus` 收口为 `oasis7_client_launcher` 本地跨目标类型，并在 native loopback provider 检查结果中显式映射，恢复 `build-web-dist` 的 wasm compile + `trunk build` 闭环。）
 - 最新完成: `TASK-TESTING-064`（已为 `release-gate-soak` 的 S10 五节点样本补齐显式 replication listen/peer 拓扑，并将 `s10-sequencer` 上精确匹配的 bootstrap `fetch-commit` protocol-unavailable 收口为 `<=2` warning；canonical `300s --no-prewarm` 本地样本已恢复 `metric_gate=pass / last_error_samples=0`。）
 - 最新完成: `TASK-TESTING-063`（已为 Web UI 闭环建立 canonical `*.manual.md` 操作手册，并将 `testing-manual`、testing README 与 PRD/project 职责边界同步收口。）
 - 最新完成: `TASK-TESTING-062`（已建立 Token 创世分配 QA 审计清单专题与执行模板，冻结比例/个人上限/流通边界/custody 语义的 QA 门禁。）


### PR DESCRIPTION
## Summary
- move launcher-local provider compatibility types into a dedicated module so the web/wasm launcher build no longer imports native-only `oasis7::simulator::ProviderCompatibilityStatus`
- map the native provider compatibility result into the launcher-local status in `launcher_core` without widening the simulator wasm surface
- refresh the oversized Rust baseline after shrinking `main.rs` below the limit and reducing `launcher_core.rs` to the current oversized count

## Validation
- `env -u RUSTC_WRAPPER cargo build --target wasm32-unknown-unknown --manifest-path crates/oasis7_client_launcher/Cargo.toml --release --bin oasis7_client_launcher`
- `cd crates/oasis7_client_launcher && env -u NO_COLOR trunk build --release --dist ../../output/release/web-launcher-dist`
- `./scripts/check-rust-file-size.sh`
- `./scripts/doc-governance-check.sh`
- `./scripts/pm/lint.sh`
- `./scripts/pm/codex-review-snapshot.sh`
