### PR TITLE
Fix p2p peer lifecycle retry gaps

### DIFF
--- a/.pm/tasks/task_20b6c59c00664dc5a5c01ec47b0004ae.execution.md
+++ b/.pm/tasks/task_20b6c59c00664dc5a5c01ec47b0004ae.execution.md
@@ -1,0 +1,24 @@
+# task_20b6c59c00664dc5a5c01ec47b0004ae Execution Log
+
+- task_uid: task_20b6c59c00664dc5a5c01ec47b0004ae
+- title: Fix p2p peer lifecycle and retry hardening gaps
+- owner_role: runtime_engineer
+- worktree_hint: /home/scc/worktrees/oasis7-p2p-peer-lifecycle-retry-hardening
+
+<!-- Append entries using:
+Example:
+  ## YYYY-MM-DD HH:MM:SS CST / role_name
+  - 完成内容: ...
+  - 遗留事项: ...
+-->
+
+## 2026-04-14 11:54:00 CST / runtime_engineer
+- 完成内容: 修复 libp2p 连接关闭收口误判，避免同一 peer 的某条子连接关闭时过早移除整 peer；收紧 `NetworkProtocolUnavailable` 到 `ErrUnsupported/ErrNotAvailable` 的映射边界；调整 replication request 的 unsupported / retryable 分类，避免把通用可用性故障缓存成协议不支持；对 fully blocked peer set 改为只拦截真实硬风险项，保留缺失 peer record 的本地/引导链路；补齐定向单测。
+- 完成内容: 已执行 `env -u RUSTC_WRAPPER cargo test -p oasis7_net error_mapping -- --nocapture` 与 `env -u RUSTC_WRAPPER cargo test -p oasis7_node libp2p_replication_network -- --nocapture --test-threads=1`，均通过。
+- 遗留事项: 提交前仍需跑 snapshot review，并在 close 阶段同步 `.pm` 状态。
+
+## 2026-04-14 14:31:07 CST / runtime_engineer
+- 完成内容: 补齐 partial-close 场景的 peer health/quarantine/reachability refresh 链，新增 `ConnectionId` 级 transport path 重算；将远端 `no healthy provider` / `no healthy connected providers` 纳入 retryable gap；把 `missing_peer_record + insufficient_active_discovery_sources` 视为 soft-deprioritize 而不是 hard block，并补充 bootstrap fallback/partial-close 覆盖测试。
+- 完成内容: 已执行 `env -u RUSTC_WRAPPER cargo test -p oasis7_net libp2p_net -- --nocapture`、`env -u RUSTC_WRAPPER cargo test -p oasis7_node libp2p_replication_network -- --nocapture --test-threads=1`、`env -u RUSTC_WRAPPER cargo test -p oasis7_node replication_probe_gate -- --nocapture`，均通过。
+- 完成内容: 已多次执行 `./scripts/pm/codex-review-snapshot.sh`；最终一轮在最新 diff 上完成关键文件巡检且未输出新的 finding，但 review 进程在尾声只读检索阶段挂起，按仓库既有 hang 处理约定中断，不以进程未优雅退出阻塞收口。
+- 遗留事项: 无。

--- a/.pm/tasks/task_20b6c59c00664dc5a5c01ec47b0004ae.yaml
+++ b/.pm/tasks/task_20b6c59c00664dc5a5c01ec47b0004ae.yaml
@@ -1,0 +1,20 @@
+task_uid: task_20b6c59c00664dc5a5c01ec47b0004ae
+title: "Fix p2p peer lifecycle and retry hardening gaps"
+owner_role: runtime_engineer
+worktree_hint: /home/scc/worktrees/oasis7-p2p-peer-lifecycle-retry-hardening
+execution_log_path: .pm/tasks/task_20b6c59c00664dc5a5c01ec47b0004ae.execution.md
+status: done
+priority: P1
+source_signal: null
+source_refs:
+  - crates/oasis7_net/src/libp2p_net.rs
+doc_refs:
+  - doc/p2p/prd.md
+related_prd:
+  - PRD-P2P-001
+acceptance:
+  - "Connection tracking must not drop a peer on the first closed sub-connection; protocol unsupported caching must not treat generic availability failures as unsupported; replication retry logic must retry real request transport disconnects and reject fully blocked peer sets; targeted cargo tests must cover the regressions."
+handoff_to: []
+updated_at: 2026-04-14T14:31:56+08:00
+last_started_at: 2026-04-14T11:37:57+08:00
+last_closed_at: 2026-04-14T14:31:42+08:00

--- a/crates/oasis7_net/src/libp2p_net.rs
+++ b/crates/oasis7_net/src/libp2p_net.rs
@@ -4,6 +4,7 @@ use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex};
 
 mod api;
+mod connection_lifecycle;
 mod discovery;
 mod error_mapping;
 mod kad_queries;
@@ -39,6 +40,10 @@ use oasis7_proto::distributed_net::{
 };
 
 use crate::util::to_canonical_cbor;
+use connection_lifecycle::{
+    clear_disconnected_peer_state, failover_after_disconnect, record_established_connection,
+    refresh_active_path_after_connection_close, refresh_peer_manager_views,
+};
 use discovery::{
     clear_pending_peer_record_request, handle_peer_record_response, handle_rendezvous_discovered,
     handle_request_response_request, maybe_discover_rendezvous_namespace,
@@ -57,28 +62,19 @@ pub use peer_manager::{
 };
 use peer_record::{publish_configured_peer_record, put_record_query};
 use peer_record_republish::republish_local_peer_record;
-use reachability::{
-    note_hole_punch_result, note_relay_reservation_accepted, refresh_active_transport_snapshot,
-    snapshot_clone,
-};
+use reachability::{note_hole_punch_result, note_relay_reservation_accepted, snapshot_clone};
 pub use reachability::{
     Libp2pReachabilitySnapshot, LiveAutoNatStatus, LiveHolePunchState, LivePublicPortReachability,
     LiveTransportKind,
 };
-use runtime_loop::{
-    enforce_peer_manager_quarantine, handle_command, refresh_peer_manager_healths, CommandContext,
-    CommandOutcome, CommandStateRefs,
-};
+use runtime_loop::{handle_command, CommandContext, CommandOutcome, CommandStateRefs};
 use swarm_behaviour::{build_swarm, dial_addr_with_optional_peer_id, Behaviour, BehaviourEvent};
 use swarm_reachability_events::{
     handle_autonat_event, handle_expired_listen_addr, handle_external_addr_candidate,
     handle_external_addr_confirmed, handle_external_addr_expired, handle_listener_closed,
     handle_new_listen_addr,
 };
-use transport_paths::{
-    failover_transport_path, note_established_transport_path, retry_transport_path_after_error,
-    TransportPath,
-};
+use transport_paths::{retry_transport_path_after_error, TransportPath};
 use utils::{
     decode_membership_directory, decode_world_head, now_ms, push_bounded_clone, should_republish,
     try_send_command,
@@ -284,6 +280,14 @@ impl Libp2pNetwork {
             let mut known_transport_paths: HashMap<PeerId, Vec<TransportPath>> = HashMap::new();
             let mut last_dialed_transport_paths: HashMap<PeerId, TransportPath> = HashMap::new();
             let mut active_transport_paths: HashMap<PeerId, TransportPath> = HashMap::new();
+            let mut established_transport_paths_by_connection: HashMap<
+                libp2p::swarm::ConnectionId,
+                TransportPath,
+            > = HashMap::new();
+            let mut established_connections_by_peer: HashMap<
+                PeerId,
+                HashSet<libp2p::swarm::ConnectionId>,
+            > = HashMap::new();
             let mut peer_healths_by_id: HashMap<PeerId, PeerManagerPeerHealth> = HashMap::new();
             let mut quarantined_active_peers: HashSet<PeerId> = HashSet::new();
             let mut admitted_active_peers: HashSet<PeerId> = HashSet::new();
@@ -479,22 +483,18 @@ impl Libp2pNetwork {
                                                             peer_healths_by_id,
                                                             quarantined_active_peers,
                                                             admitted_active_peers,
-                                                        ) = refresh_peer_manager_healths(
+                                                        ) = refresh_peer_manager_views(
+                                                            &mut swarm,
                                                             &discovered_peer_records,
                                                             &active_transport_paths,
                                                             &admitted_active_peers,
                                                             &config_clone.peer_manager_policy,
                                                             &event_peer_healths,
                                                             &event_peer_block_artifacts,
-                                                            &event_errors,
-                                                            max_error_messages,
-                                                        );
-                                                        enforce_peer_manager_quarantine(
-                                                            &mut swarm,
-                                                            &quarantined_active_peers,
                                                             &mut pending_quarantine_disconnects,
                                                             &event_errors,
                                                             max_error_messages,
+                                                            &event_reachability,
                                                         );
                                                     } else if let Some(sender) = pending.remove(&request_id) {
                                                         let _ = sender.send(Ok(response.payload));
@@ -604,22 +604,18 @@ impl Libp2pNetwork {
                                                                     peer_healths_by_id,
                                                                     quarantined_active_peers,
                                                                     admitted_active_peers,
-                                                                ) = refresh_peer_manager_healths(
+                                                                ) = refresh_peer_manager_views(
+                                                                    &mut swarm,
                                                                     &discovered_peer_records,
                                                                     &active_transport_paths,
                                                                     &admitted_active_peers,
                                                                     &config_clone.peer_manager_policy,
                                                                     &event_peer_healths,
                                                                     &event_peer_block_artifacts,
-                                                                    &event_errors,
-                                                                    max_error_messages,
-                                                                );
-                                                                enforce_peer_manager_quarantine(
-                                                                    &mut swarm,
-                                                                    &quarantined_active_peers,
                                                                     &mut pending_quarantine_disconnects,
                                                                     &event_errors,
                                                                     max_error_messages,
+                                                                    &event_reachability,
                                                                 );
                                                             }
                                                         }
@@ -912,7 +908,12 @@ impl Libp2pNetwork {
                                         &mut peer_record_last_published_at_ms,
                                     );
                                 }
-                                SwarmEvent::ConnectionEstablished { peer_id, endpoint, .. } => {
+                                SwarmEvent::ConnectionEstablished {
+                                    peer_id,
+                                    connection_id,
+                                    endpoint,
+                                    ..
+                                } => {
                                     if !peers.contains(&peer_id) {
                                         peers.push(peer_id);
                                     }
@@ -926,53 +927,36 @@ impl Libp2pNetwork {
                                         max_error_messages,
                                         "lock errors",
                                     );
-                                    match endpoint {
-                                        libp2p::core::connection::ConnectedPoint::Dialer { address, .. } => {
-                                            let active_path = note_established_transport_path(
-                                                &known_transport_paths,
-                                                &mut active_transport_paths,
-                                                &mut last_dialed_transport_paths,
-                                                &mut failed_transport_path_labels,
-                                                peer_id,
-                                                &address,
-                                            );
-                                            push_bounded_clone(
-                                                &event_errors,
-                                                format!(
-                                                    "libp2p transport active peer={peer_id} kind={} flavor={} addr={}",
-                                                    active_path.kind_label(),
-                                                    active_path.flavor_label(),
-                                                    active_path.addr,
-                                                ),
-                                                max_error_messages,
-                                                "lock errors",
-                                            );
-                                            swarm
-                                                .behaviour_mut()
-                                                .kademlia
-                                                .add_address(&peer_id, address.clone());
-                                        }
-                                        libp2p::core::connection::ConnectedPoint::Listener { send_back_addr, .. } => {
-                                            let active_path = note_established_transport_path(
-                                                &known_transport_paths,
-                                                &mut active_transport_paths,
-                                                &mut last_dialed_transport_paths,
-                                                &mut failed_transport_path_labels,
-                                                peer_id,
-                                                &send_back_addr,
-                                            );
-                                            push_bounded_clone(
-                                                &event_errors,
-                                                format!(
-                                                    "libp2p transport active peer={peer_id} kind={} flavor={} addr={}",
-                                                    active_path.kind_label(),
-                                                    active_path.flavor_label(),
-                                                    active_path.addr,
-                                                ),
-                                                max_error_messages,
-                                                "lock errors",
-                                            );
-                                        }
+                                    let (refreshed_active_path, dialed_addr) =
+                                        record_established_connection(
+                                            &known_transport_paths,
+                                            &mut active_transport_paths,
+                                            &mut last_dialed_transport_paths,
+                                            &mut failed_transport_path_labels,
+                                            &mut established_transport_paths_by_connection,
+                                            &mut established_connections_by_peer,
+                                            peer_id,
+                                            connection_id,
+                                            &endpoint,
+                                        );
+                                    if let Some(address) = dialed_addr {
+                                        swarm
+                                            .behaviour_mut()
+                                            .kademlia
+                                            .add_address(&peer_id, address);
+                                    }
+                                    if let Some(active_path) = refreshed_active_path {
+                                        push_bounded_clone(
+                                            &event_errors,
+                                            format!(
+                                                "libp2p transport active peer={peer_id} kind={} flavor={} addr={}",
+                                                active_path.kind_label(),
+                                                active_path.flavor_label(),
+                                                active_path.addr,
+                                            ),
+                                            max_error_messages,
+                                            "lock errors",
+                                        );
                                     }
                                     maybe_queue_discovery_peer_record(
                                         &mut swarm,
@@ -1044,110 +1028,109 @@ impl Libp2pNetwork {
                                         peer_healths_by_id,
                                         quarantined_active_peers,
                                         admitted_active_peers,
-                                    ) = refresh_peer_manager_healths(
+                                    ) = refresh_peer_manager_views(
+                                        &mut swarm,
                                         &discovered_peer_records,
                                         &active_transport_paths,
                                         &admitted_active_peers,
                                         &config_clone.peer_manager_policy,
                                         &event_peer_healths,
                                         &event_peer_block_artifacts,
-                                        &event_errors,
-                                        max_error_messages,
-                                    );
-                                    enforce_peer_manager_quarantine(
-                                        &mut swarm,
-                                        &quarantined_active_peers,
                                         &mut pending_quarantine_disconnects,
                                         &event_errors,
                                         max_error_messages,
-                                    );
-                                    refresh_active_transport_snapshot(
                                         &event_reachability,
-                                        &active_transport_paths,
                                     );
                                 }
-                                SwarmEvent::ConnectionClosed { peer_id, .. } => {
-                                    peers.retain(|peer| peer != &peer_id);
-                                    admitted_active_peers.remove(&peer_id);
-                                    let quarantined = quarantined_active_peers.remove(&peer_id)
-                                        || pending_quarantine_disconnects.contains(&peer_id);
-                                    pending_quarantine_disconnects.remove(&peer_id);
-                                    if quarantined {
-                                        active_transport_paths.remove(&peer_id);
-                                        last_dialed_transport_paths.remove(&peer_id);
+                                SwarmEvent::ConnectionClosed {
+                                    peer_id,
+                                    connection_id,
+                                    num_established,
+                                    ..
+                                } => {
+                                    if num_established > 0 {
+                                        let refreshed_active_path =
+                                            refresh_active_path_after_connection_close(
+                                                &mut active_transport_paths,
+                                                &mut established_transport_paths_by_connection,
+                                                &mut established_connections_by_peer,
+                                                peer_id,
+                                                connection_id,
+                                            );
                                         push_bounded_clone(
                                             &event_errors,
                                             format!(
-                                                "libp2p peer manager quarantine suppresses failover peer={peer_id}"
+                                                "libp2p connection closed peer={peer_id} num_established={num_established} active_path={}",
+                                                refreshed_active_path
+                                                    .as_ref()
+                                                    .map(|path| path.addr.to_string())
+                                                    .unwrap_or_else(|| "none".to_string())
                                             ),
                                             max_error_messages,
                                             "lock errors",
                                         );
                                     } else {
-                                        match failover_transport_path(
-                                            &mut swarm,
-                                            &known_transport_paths,
+                                        established_transport_paths_by_connection
+                                            .remove(&connection_id);
+                                        established_connections_by_peer.remove(&peer_id);
+                                        let quarantined = clear_disconnected_peer_state(
+                                            &mut peers,
+                                            &mut admitted_active_peers,
+                                            &mut quarantined_active_peers,
+                                            &mut pending_quarantine_disconnects,
                                             &mut active_transport_paths,
                                             &mut last_dialed_transport_paths,
-                                            &mut failed_transport_path_labels,
+                                            &mut pending_rendezvous_registers,
+                                            &mut pending_rendezvous_discovers,
+                                            &mut registered_rendezvous_nodes,
+                                            &mut rendezvous_cookies,
+                                            &event_connected_peers,
                                             peer_id,
-                                        ) {
-                                            Ok(Some((active_path, next_path))) => {
-                                                push_bounded_clone(
-                                                    &event_errors,
-                                                    format!(
-                                                        "libp2p transport failover peer={peer_id} from={} to={}",
-                                                        active_path.addr,
-                                                        next_path.addr,
-                                                    ),
-                                                    max_error_messages,
-                                                    "lock errors",
-                                                );
-                                            }
-                                            Err(err) => {
-                                                push_bounded_clone(
-                                                    &event_errors,
-                                                    format!(
-                                                        "libp2p transport failover dial failed peer={peer_id}: {err:?}"
-                                                    ),
-                                                    max_error_messages,
-                                                    "lock errors",
-                                                );
-                                            }
-                                            Ok(None) => {}
+                                        );
+                                        if quarantined {
+                                            push_bounded_clone(
+                                                &event_errors,
+                                                format!(
+                                                    "libp2p peer manager quarantine suppresses failover peer={peer_id}"
+                                                ),
+                                                max_error_messages,
+                                                "lock errors",
+                                            );
+                                        } else {
+                                            failover_after_disconnect(
+                                                &mut swarm,
+                                                &known_transport_paths,
+                                                &mut active_transport_paths,
+                                                &mut last_dialed_transport_paths,
+                                                &mut failed_transport_path_labels,
+                                                &event_errors,
+                                                max_error_messages,
+                                                peer_id,
+                                            );
                                         }
+                                        push_bounded_clone(
+                                            &event_errors,
+                                            format!("libp2p connection closed peer={peer_id}"),
+                                            max_error_messages,
+                                            "lock errors",
+                                        );
                                     }
-                                    pending_rendezvous_registers.remove(&peer_id);
-                                    pending_rendezvous_discovers.remove(&peer_id);
-                                    registered_rendezvous_nodes.remove(&peer_id);
-                                    rendezvous_cookies.remove(&peer_id);
-                                    event_connected_peers
-                                        .lock()
-                                        .expect("lock connected peers")
-                                        .remove(&peer_id);
-                                    push_bounded_clone(
-                                        &event_errors,
-                                        format!("libp2p connection closed peer={peer_id}"),
-                                        max_error_messages,
-                                        "lock errors",
-                                    );
                                     (
                                         peer_healths_by_id,
                                         quarantined_active_peers,
                                         admitted_active_peers,
-                                    ) = refresh_peer_manager_healths(
+                                    ) = refresh_peer_manager_views(
+                                        &mut swarm,
                                         &discovered_peer_records,
                                         &active_transport_paths,
                                         &admitted_active_peers,
                                         &config_clone.peer_manager_policy,
                                         &event_peer_healths,
                                         &event_peer_block_artifacts,
+                                        &mut pending_quarantine_disconnects,
                                         &event_errors,
                                         max_error_messages,
-                                    );
-                                    refresh_active_transport_snapshot(
                                         &event_reachability,
-                                        &active_transport_paths,
                                     );
                                 }
                                 SwarmEvent::OutgoingConnectionError { peer_id, error, .. } => {

--- a/crates/oasis7_net/src/libp2p_net/connection_lifecycle.rs
+++ b/crates/oasis7_net/src/libp2p_net/connection_lifecycle.rs
@@ -1,0 +1,211 @@
+use std::collections::{HashMap, HashSet};
+use std::sync::{Arc, Mutex};
+
+use libp2p::core::connection::ConnectedPoint;
+use libp2p::rendezvous;
+use libp2p::swarm::ConnectionId;
+use libp2p::{Multiaddr, PeerId};
+use oasis7_proto::distributed_dht::SignedPeerRecord;
+
+use super::reachability::refresh_active_transport_snapshot;
+use super::runtime_loop::{enforce_peer_manager_quarantine, refresh_peer_manager_healths};
+use super::swarm_behaviour::Behaviour;
+use super::transport_paths::{
+    failover_transport_path, note_established_transport_path,
+    recompute_active_transport_path_for_peer, TransportPath,
+};
+use super::utils::push_bounded_clone;
+use super::{
+    Libp2pReachabilitySnapshot, PeerManagerBlockArtifact, PeerManagerPeerHealth, PeerManagerPolicy,
+};
+
+pub(super) fn record_established_connection(
+    known_transport_paths: &HashMap<PeerId, Vec<TransportPath>>,
+    active_transport_paths: &mut HashMap<PeerId, TransportPath>,
+    last_dialed_transport_paths: &mut HashMap<PeerId, TransportPath>,
+    failed_transport_path_labels: &mut HashSet<String>,
+    established_transport_paths_by_connection: &mut HashMap<ConnectionId, TransportPath>,
+    established_connections_by_peer: &mut HashMap<PeerId, HashSet<ConnectionId>>,
+    peer_id: PeerId,
+    connection_id: ConnectionId,
+    endpoint: &ConnectedPoint,
+) -> (Option<TransportPath>, Option<Multiaddr>) {
+    let (established_path, dialed_addr) = match endpoint {
+        ConnectedPoint::Dialer { address, .. } => (
+            note_established_transport_path(
+                known_transport_paths,
+                active_transport_paths,
+                last_dialed_transport_paths,
+                failed_transport_path_labels,
+                peer_id,
+                address,
+            ),
+            Some(address.clone()),
+        ),
+        ConnectedPoint::Listener { send_back_addr, .. } => (
+            note_established_transport_path(
+                known_transport_paths,
+                active_transport_paths,
+                last_dialed_transport_paths,
+                failed_transport_path_labels,
+                peer_id,
+                send_back_addr,
+            ),
+            None,
+        ),
+    };
+    established_transport_paths_by_connection.insert(connection_id, established_path);
+    established_connections_by_peer
+        .entry(peer_id)
+        .or_default()
+        .insert(connection_id);
+    (
+        recompute_active_transport_path_for_peer(
+            active_transport_paths,
+            established_transport_paths_by_connection,
+            established_connections_by_peer,
+            peer_id,
+        ),
+        dialed_addr,
+    )
+}
+
+pub(super) fn refresh_active_path_after_connection_close(
+    active_transport_paths: &mut HashMap<PeerId, TransportPath>,
+    established_transport_paths_by_connection: &mut HashMap<ConnectionId, TransportPath>,
+    established_connections_by_peer: &mut HashMap<PeerId, HashSet<ConnectionId>>,
+    peer_id: PeerId,
+    connection_id: ConnectionId,
+) -> Option<TransportPath> {
+    established_transport_paths_by_connection.remove(&connection_id);
+    if let Some(connection_ids) = established_connections_by_peer.get_mut(&peer_id) {
+        connection_ids.remove(&connection_id);
+        if connection_ids.is_empty() {
+            established_connections_by_peer.remove(&peer_id);
+        }
+    }
+    recompute_active_transport_path_for_peer(
+        active_transport_paths,
+        established_transport_paths_by_connection,
+        established_connections_by_peer,
+        peer_id,
+    )
+}
+
+pub(super) fn clear_disconnected_peer_state(
+    peers: &mut Vec<PeerId>,
+    admitted_active_peers: &mut HashSet<PeerId>,
+    quarantined_active_peers: &mut HashSet<PeerId>,
+    pending_quarantine_disconnects: &mut HashSet<PeerId>,
+    active_transport_paths: &mut HashMap<PeerId, TransportPath>,
+    last_dialed_transport_paths: &mut HashMap<PeerId, TransportPath>,
+    pending_rendezvous_registers: &mut HashSet<PeerId>,
+    pending_rendezvous_discovers: &mut HashSet<PeerId>,
+    registered_rendezvous_nodes: &mut HashSet<PeerId>,
+    rendezvous_cookies: &mut HashMap<PeerId, rendezvous::Cookie>,
+    event_connected_peers: &Arc<Mutex<HashSet<PeerId>>>,
+    peer_id: PeerId,
+) -> bool {
+    peers.retain(|peer| peer != &peer_id);
+    admitted_active_peers.remove(&peer_id);
+    let quarantined = quarantined_active_peers.remove(&peer_id)
+        || pending_quarantine_disconnects.contains(&peer_id);
+    pending_quarantine_disconnects.remove(&peer_id);
+    if quarantined {
+        active_transport_paths.remove(&peer_id);
+        last_dialed_transport_paths.remove(&peer_id);
+    }
+    pending_rendezvous_registers.remove(&peer_id);
+    pending_rendezvous_discovers.remove(&peer_id);
+    registered_rendezvous_nodes.remove(&peer_id);
+    rendezvous_cookies.remove(&peer_id);
+    event_connected_peers
+        .lock()
+        .expect("lock connected peers")
+        .remove(&peer_id);
+    quarantined
+}
+
+pub(super) fn refresh_peer_manager_views(
+    swarm: &mut libp2p::Swarm<Behaviour>,
+    discovered_peer_records: &HashMap<PeerId, SignedPeerRecord>,
+    active_transport_paths: &HashMap<PeerId, TransportPath>,
+    admitted_active_peers: &HashSet<PeerId>,
+    peer_manager_policy: &PeerManagerPolicy,
+    event_peer_healths: &Arc<Mutex<HashMap<String, PeerManagerPeerHealth>>>,
+    event_block_artifacts: &Arc<Mutex<HashMap<String, PeerManagerBlockArtifact>>>,
+    pending_quarantine_disconnects: &mut HashSet<PeerId>,
+    event_errors: &Arc<Mutex<Vec<String>>>,
+    max_error_messages: usize,
+    event_reachability: &Arc<Mutex<Libp2pReachabilitySnapshot>>,
+) -> (
+    HashMap<PeerId, PeerManagerPeerHealth>,
+    HashSet<PeerId>,
+    HashSet<PeerId>,
+) {
+    let (peer_healths_by_id, quarantined_active_peers, admitted_active_peers) =
+        refresh_peer_manager_healths(
+            discovered_peer_records,
+            active_transport_paths,
+            admitted_active_peers,
+            peer_manager_policy,
+            event_peer_healths,
+            event_block_artifacts,
+            event_errors,
+            max_error_messages,
+        );
+    enforce_peer_manager_quarantine(
+        swarm,
+        &quarantined_active_peers,
+        pending_quarantine_disconnects,
+        event_errors,
+        max_error_messages,
+    );
+    refresh_active_transport_snapshot(event_reachability, active_transport_paths);
+    (
+        peer_healths_by_id,
+        quarantined_active_peers,
+        admitted_active_peers,
+    )
+}
+
+pub(super) fn failover_after_disconnect(
+    swarm: &mut libp2p::Swarm<Behaviour>,
+    known_transport_paths: &HashMap<PeerId, Vec<TransportPath>>,
+    active_transport_paths: &mut HashMap<PeerId, TransportPath>,
+    last_dialed_transport_paths: &mut HashMap<PeerId, TransportPath>,
+    failed_transport_path_labels: &mut HashSet<String>,
+    event_errors: &Arc<Mutex<Vec<String>>>,
+    max_error_messages: usize,
+    peer_id: PeerId,
+) {
+    match failover_transport_path(
+        swarm,
+        known_transport_paths,
+        active_transport_paths,
+        last_dialed_transport_paths,
+        failed_transport_path_labels,
+        peer_id,
+    ) {
+        Ok(Some((active_path, next_path))) => {
+            push_bounded_clone(
+                event_errors,
+                format!(
+                    "libp2p transport failover peer={peer_id} from={} to={}",
+                    active_path.addr, next_path.addr,
+                ),
+                max_error_messages,
+                "lock errors",
+            );
+        }
+        Err(err) => {
+            push_bounded_clone(
+                event_errors,
+                format!("libp2p transport failover dial failed peer={peer_id}: {err:?}"),
+                max_error_messages,
+                "lock errors",
+            );
+        }
+        Ok(None) => {}
+    }
+}

--- a/crates/oasis7_net/src/libp2p_net/error_mapping.rs
+++ b/crates/oasis7_net/src/libp2p_net/error_mapping.rs
@@ -13,7 +13,7 @@ pub(super) fn error_response_from_world_error(err: &WorldError) -> ErrorResponse
             retryable: *retryable,
         },
         WorldError::NetworkProtocolUnavailable { protocol } => {
-            ErrorResponse::from_code(DistributedErrorCode::ErrUnsupported, protocol.clone())
+            ErrorResponse::from_code(protocol_unavailable_code(protocol), protocol.clone())
         }
         WorldError::DistributedValidationFailed { reason } => {
             ErrorResponse::from_code(DistributedErrorCode::ErrBadRequest, reason.clone())
@@ -40,5 +40,89 @@ pub(super) fn error_response_from_world_error(err: &WorldError) -> ErrorResponse
         WorldError::Serde(message) => {
             ErrorResponse::from_code(DistributedErrorCode::ErrBadRequest, message.clone())
         }
+    }
+}
+
+fn protocol_unavailable_code(protocol: &str) -> DistributedErrorCode {
+    if protocol.contains("handler missing") || protocol.starts_with('/') {
+        DistributedErrorCode::ErrUnsupported
+    } else if protocol_unavailable_is_bad_request(protocol) {
+        DistributedErrorCode::ErrBadRequest
+    } else if protocol_unavailable_is_retryable_gap(protocol) {
+        DistributedErrorCode::ErrNotAvailable
+    } else {
+        DistributedErrorCode::ErrUnsupported
+    }
+}
+
+fn protocol_unavailable_is_bad_request(protocol: &str) -> bool {
+    protocol.contains("must be utf-8") || protocol.contains("must be valid")
+}
+
+fn protocol_unavailable_is_retryable_gap(protocol: &str) -> bool {
+    protocol == "libp2p"
+        || protocol.starts_with("transport dial failed: ")
+        || protocol.contains("is not connected for protocol")
+        || protocol.contains("no connected peers for protocol")
+        || protocol.contains("no admissible connected peers for protocol")
+        || protocol.contains("no connected providers for protocol")
+        || protocol.contains("no healthy provider for protocol")
+        || protocol.contains("no healthy connected providers for protocol")
+        || protocol.contains("request failed: ConnectionClosed")
+        || protocol.contains("request failed: DialFailure")
+        || protocol.contains("request failed: Timeout")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn network_protocol_unavailable_handler_missing_maps_to_unsupported() {
+        let response = error_response_from_world_error(&WorldError::NetworkProtocolUnavailable {
+            protocol: "/aw/node/replication/ping".to_string(),
+        });
+        assert_eq!(response.code, DistributedErrorCode::ErrUnsupported);
+        assert!(!response.retryable);
+    }
+
+    #[test]
+    fn network_protocol_unavailable_availability_gap_maps_to_not_available() {
+        let response = error_response_from_world_error(&WorldError::NetworkProtocolUnavailable {
+            protocol: "no connected peers for protocol /aw/node/replication/ping".to_string(),
+        });
+        assert_eq!(response.code, DistributedErrorCode::ErrNotAvailable);
+        assert!(response.retryable);
+    }
+
+    #[test]
+    fn network_protocol_unavailable_no_admissible_peers_maps_to_not_available() {
+        let response = error_response_from_world_error(&WorldError::NetworkProtocolUnavailable {
+            protocol:
+                "libp2p-replication no admissible connected peers for protocol /aw/node/replication/ping"
+                    .to_string(),
+        });
+        assert_eq!(response.code, DistributedErrorCode::ErrNotAvailable);
+        assert!(response.retryable);
+    }
+
+    #[test]
+    fn network_protocol_unavailable_no_healthy_provider_maps_to_not_available() {
+        let response = error_response_from_world_error(&WorldError::NetworkProtocolUnavailable {
+            protocol:
+                "libp2p-replication no healthy connected providers for protocol /aw/node/replication/ping"
+                    .to_string(),
+        });
+        assert_eq!(response.code, DistributedErrorCode::ErrNotAvailable);
+        assert!(response.retryable);
+    }
+
+    #[test]
+    fn network_protocol_unavailable_bad_request_maps_to_bad_request() {
+        let response = error_response_from_world_error(&WorldError::NetworkProtocolUnavailable {
+            protocol: "cached peer record payload must be utf-8".to_string(),
+        });
+        assert_eq!(response.code, DistributedErrorCode::ErrBadRequest);
+        assert!(!response.retryable);
     }
 }

--- a/crates/oasis7_net/src/libp2p_net/tests.rs
+++ b/crates/oasis7_net/src/libp2p_net/tests.rs
@@ -17,6 +17,8 @@ use libp2p::kad::RecordKey;
 use oasis7_proto::distributed_dht::{PeerDeploymentMode, PeerNodeRole};
 use oasis7_proto::distributed_net::NetworkLane;
 
+mod transport_path_refresh_tests;
+
 fn signed_discovery_peer_record(
     keypair: &Keypair,
     discovery_sources: Vec<crate::dht::PeerDiscoverySource>,
@@ -45,12 +47,6 @@ fn signed_discovery_peer_record(
         keypair,
     )
     .expect("sign discovery peer record")
-}
-
-#[test]
-fn libp2p_network_generates_peer_id() {
-    let network = Libp2pNetwork::new(Libp2pNetworkConfig::default());
-    assert!(!network.peer_id().to_string().is_empty());
 }
 
 #[test]

--- a/crates/oasis7_net/src/libp2p_net/tests/transport_path_refresh_tests.rs
+++ b/crates/oasis7_net/src/libp2p_net/tests/transport_path_refresh_tests.rs
@@ -1,0 +1,74 @@
+use super::*;
+use libp2p::swarm::ConnectionId;
+
+use crate::libp2p_net::transport_paths::recompute_active_transport_path_for_peer;
+
+#[test]
+fn libp2p_network_generates_peer_id() {
+    let network = Libp2pNetwork::new(Libp2pNetworkConfig::default());
+    assert!(!network.peer_id().to_string().is_empty());
+}
+
+#[test]
+fn refresh_active_transport_path_after_partial_close_promotes_remaining_known_path() {
+    let peer_id = PeerId::random();
+    let direct_addr = format!("/ip4/39.104.205.67/tcp/5612/p2p/{peer_id}")
+        .parse()
+        .expect("direct addr");
+    let relay_addr = format!(
+        "/dns4/relay.example/tcp/443/p2p/{}/p2p-circuit/p2p/{peer_id}",
+        PeerId::random()
+    )
+    .parse()
+    .expect("relay addr");
+    let mut known = HashMap::new();
+    known.insert(
+        peer_id,
+        vec![
+            active_transport_path_from_endpoint(&HashMap::new(), peer_id, &direct_addr),
+            active_transport_path_from_endpoint(&HashMap::new(), peer_id, &relay_addr),
+        ],
+    );
+    let direct_connection = ConnectionId::new_unchecked(1);
+    let relay_connection = ConnectionId::new_unchecked(2);
+    let mut active_transport_paths = HashMap::new();
+    let mut established_transport_paths = HashMap::from([
+        (
+            direct_connection,
+            active_transport_path_from_endpoint(&known, peer_id, &direct_addr),
+        ),
+        (
+            relay_connection,
+            active_transport_path_from_endpoint(&known, peer_id, &relay_addr),
+        ),
+    ]);
+    let initial = recompute_active_transport_path_for_peer(
+        &mut active_transport_paths,
+        &established_transport_paths,
+        &HashMap::from([(
+            peer_id,
+            HashSet::from([direct_connection, relay_connection]),
+        )]),
+        peer_id,
+    )
+    .expect("initial active path");
+    assert_eq!(initial.addr, direct_addr);
+
+    established_transport_paths.remove(&direct_connection);
+    let refreshed = recompute_active_transport_path_for_peer(
+        &mut active_transport_paths,
+        &established_transport_paths,
+        &HashMap::from([(peer_id, HashSet::from([relay_connection]))]),
+        peer_id,
+    )
+    .expect("replacement path");
+
+    assert_eq!(refreshed.addr, relay_addr);
+    assert_eq!(
+        active_transport_paths
+            .get(&peer_id)
+            .expect("active path after refresh")
+            .addr,
+        relay_addr
+    );
+}

--- a/crates/oasis7_net/src/libp2p_net/transport_paths.rs
+++ b/crates/oasis7_net/src/libp2p_net/transport_paths.rs
@@ -1,7 +1,7 @@
 use std::collections::{HashMap, HashSet};
 
 use libp2p::multiaddr::Protocol;
-use libp2p::swarm::Swarm;
+use libp2p::swarm::{ConnectionId, Swarm};
 use libp2p::{Multiaddr, PeerId};
 
 use crate::error::WorldError;
@@ -239,6 +239,31 @@ pub(super) fn note_established_transport_path(
     last_dialed_transport_paths.remove(&peer_id);
     active_transport_paths.insert(peer_id, active_path.clone());
     active_path
+}
+
+pub(super) fn recompute_active_transport_path_for_peer(
+    active_transport_paths: &mut HashMap<PeerId, TransportPath>,
+    established_transport_paths: &HashMap<ConnectionId, TransportPath>,
+    established_connections_by_peer: &HashMap<PeerId, HashSet<ConnectionId>>,
+    peer_id: PeerId,
+) -> Option<TransportPath> {
+    let replacement = established_connections_by_peer
+        .get(&peer_id)
+        .into_iter()
+        .flat_map(|connection_ids| connection_ids.iter())
+        .filter_map(|connection_id| established_transport_paths.get(connection_id))
+        .min_by_key(|path| path.preference_rank())
+        .cloned();
+    match replacement {
+        Some(path) => {
+            active_transport_paths.insert(peer_id, path.clone());
+            Some(path)
+        }
+        None => {
+            active_transport_paths.remove(&peer_id);
+            None
+        }
+    }
 }
 
 pub(super) fn dial_transport_path(

--- a/crates/oasis7_node/src/libp2p_replication_network.rs
+++ b/crates/oasis7_node/src/libp2p_replication_network.rs
@@ -423,6 +423,13 @@ impl ProtoDistributedNetwork<WorldError> for Libp2pReplicationNetwork {
             if self.allow_local_handler_fallback_when_no_peers {
                 return self.call_local_handler(protocol, payload);
             }
+            if !self.inner.connected_peers().is_empty() {
+                return Err(WorldError::NetworkProtocolUnavailable {
+                    protocol: format!(
+                        "libp2p-replication no admissible connected peers for protocol {protocol}"
+                    ),
+                });
+            }
             return Err(WorldError::NetworkProtocolUnavailable {
                 protocol: format!("libp2p-replication no connected peers for protocol {protocol}"),
             });
@@ -632,7 +639,7 @@ fn peer_error_indicates_unsupported_protocol(err: &WorldError) -> bool {
     match err {
         WorldError::NetworkRequestFailed { code, message, .. } => {
             matches!(code, DistributedErrorCode::ErrUnsupported)
-                || message.contains("NetworkProtocolUnavailable")
+                && (message.contains("handler missing") || message.starts_with('/'))
         }
         WorldError::NetworkProtocolUnavailable { protocol } => protocol.contains("handler missing"),
         _ => false,
@@ -642,11 +649,25 @@ fn peer_error_indicates_unsupported_protocol(err: &WorldError) -> bool {
 fn peer_error_indicates_retryable_connection_gap(err: &WorldError) -> bool {
     match err {
         WorldError::NetworkProtocolUnavailable { protocol } => {
-            protocol.contains("is not connected for protocol")
-                || protocol.contains("no connected peers for protocol")
+            peer_error_message_indicates_retryable_connection_gap(protocol)
+        }
+        WorldError::NetworkRequestFailed { message, .. } => {
+            peer_error_message_indicates_retryable_connection_gap(message)
         }
         _ => false,
     }
+}
+
+fn peer_error_message_indicates_retryable_connection_gap(message: &str) -> bool {
+    message.contains("is not connected for protocol")
+        || message.contains("no connected peers for protocol")
+        || message.contains("no admissible connected peers for protocol")
+        || message.contains("no connected providers for protocol")
+        || message.contains("no healthy provider for protocol")
+        || message.contains("no healthy connected providers for protocol")
+        || message.contains("request failed: ConnectionClosed")
+        || message.contains("request failed: DialFailure")
+        || message.contains("request failed: Timeout")
 }
 
 fn rotated_peers(peers: &[PeerId], cursor: usize) -> Vec<PeerId> {
@@ -670,8 +691,68 @@ fn dedup_sorted_peers(mut peers: Vec<PeerId>) -> Vec<PeerId> {
 fn blocked_peers_from_healths(healths: &[ReplicationPeerHealthDebug]) -> HashSet<PeerId> {
     healths
         .iter()
-        .filter(|health| health.status == "blocked")
+        .filter(|health| peer_is_request_blocked(health))
         .filter_map(|health| health.peer_id.parse::<PeerId>().ok())
+        .collect()
+}
+
+fn soft_deprioritized_peers_from_healths(
+    healths: &[ReplicationPeerHealthDebug],
+) -> HashSet<PeerId> {
+    healths
+        .iter()
+        .filter(|health| peer_is_soft_deprioritized_for_requests(health))
+        .filter_map(|health| health.peer_id.parse::<PeerId>().ok())
+        .collect()
+}
+
+fn peer_is_request_blocked(health: &ReplicationPeerHealthDebug) -> bool {
+    health.status == "blocked"
+        && !health.issues.is_empty()
+        && !health
+            .issues
+            .iter()
+            .all(|issue| issue_is_soft_bootstrap_constraint(issue))
+}
+
+fn peer_is_soft_deprioritized_for_requests(health: &ReplicationPeerHealthDebug) -> bool {
+    health.status == "blocked"
+        && !health.issues.is_empty()
+        && health
+            .issues
+            .iter()
+            .all(|issue| issue_is_soft_bootstrap_constraint(issue))
+        && health
+            .issues
+            .iter()
+            .any(|issue| issue == "missing_peer_record")
+}
+
+fn issue_is_soft_bootstrap_constraint(issue: &str) -> bool {
+    issue == "missing_peer_record"
+        || issue.starts_with("insufficient_active_discovery_sources ")
+        || issue.starts_with("single_source_discovery ")
+}
+
+fn request_candidate_peers(
+    peers: Vec<PeerId>,
+    healths: &[ReplicationPeerHealthDebug],
+) -> Vec<PeerId> {
+    let blocked_peers = blocked_peers_from_healths(healths);
+    let soft_deprioritized_peers = soft_deprioritized_peers_from_healths(healths);
+    let preferred = peers
+        .iter()
+        .copied()
+        .filter(|peer_id| {
+            !blocked_peers.contains(peer_id) && !soft_deprioritized_peers.contains(peer_id)
+        })
+        .collect::<Vec<_>>();
+    if !preferred.is_empty() {
+        return preferred;
+    }
+    peers
+        .into_iter()
+        .filter(|peer_id| !blocked_peers.contains(peer_id))
         .collect()
 }
 
@@ -682,35 +763,20 @@ fn active_transport_peers_from_healths(healths: &[ReplicationPeerHealthDebug]) -
         .filter_map(|health| health.peer_id.parse::<PeerId>().ok())
         .collect();
     let peers = dedup_sorted_peers(peers);
-    let blocked_peers = blocked_peers_from_healths(healths);
-    let admissible = peers
-        .iter()
-        .copied()
-        .filter(|peer_id| !blocked_peers.contains(peer_id))
-        .collect::<Vec<_>>();
-    if !admissible.is_empty() {
-        admissible
-    } else {
-        peers
-    }
+    request_candidate_peers(peers, healths)
 }
 
 fn connected_or_active_transport_peers(
     connected_peers: Vec<PeerId>,
     healths: &[ReplicationPeerHealthDebug],
 ) -> Vec<PeerId> {
-    let blocked_peers = blocked_peers_from_healths(healths);
     let connected_peers = dedup_sorted_peers(connected_peers);
-    let admissible_connected_peers = connected_peers
-        .iter()
-        .copied()
-        .filter(|peer_id| !blocked_peers.contains(peer_id))
-        .collect::<Vec<_>>();
+    let admissible_connected_peers = request_candidate_peers(connected_peers.clone(), healths);
     if !admissible_connected_peers.is_empty() {
         return admissible_connected_peers;
     }
     if !connected_peers.is_empty() {
-        return connected_peers;
+        return Vec::new();
     }
     active_transport_peers_from_healths(healths)
 }
@@ -719,571 +785,4 @@ fn connected_or_active_transport_peers(
 mod peer_selection_tests;
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use oasis7_proto::distributed::DistributedErrorCode;
-    use std::net::TcpListener;
-    use std::time::{Duration, Instant};
-
-    fn wait_until(what: &str, deadline: Instant, mut condition: impl FnMut() -> bool) {
-        while Instant::now() < deadline {
-            if condition() {
-                return;
-            }
-            std::thread::sleep(Duration::from_millis(20));
-        }
-        panic!("timed out waiting for condition: {what}");
-    }
-
-    fn listening_addr_with_peer_id(network: &Libp2pReplicationNetwork) -> Multiaddr {
-        network
-            .listening_addrs()
-            .into_iter()
-            .find(|addr| addr.to_string().contains("127.0.0.1"))
-            .expect("listener visible addr")
-            .with(libp2p::multiaddr::Protocol::P2p(network.peer_id().into()))
-    }
-
-    #[test]
-    fn libp2p_replication_network_generates_peer_id() {
-        let network = Libp2pReplicationNetwork::new(Libp2pReplicationNetworkConfig::default());
-        assert!(!network.peer_id().to_string().is_empty());
-    }
-
-    #[test]
-    fn libp2p_replication_network_request_rejects_without_connected_peers_by_default() {
-        let network = Libp2pReplicationNetwork::new(Libp2pReplicationNetworkConfig::default());
-        let result = network.request("/aw/node/replication/ping", b"hello");
-        match result {
-            Err(WorldError::NetworkProtocolUnavailable { protocol }) => {
-                assert!(protocol.contains("no connected peers"));
-            }
-            other => panic!("expected NetworkProtocolUnavailable, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn libp2p_replication_network_request_falls_back_to_local_handler_when_enabled() {
-        let network = Libp2pReplicationNetwork::new(Libp2pReplicationNetworkConfig {
-            allow_local_handler_fallback_when_no_peers: true,
-            ..Libp2pReplicationNetworkConfig::default()
-        });
-        network
-            .register_handler(
-                "/aw/node/replication/ping",
-                Box::new(|payload| {
-                    let mut out = payload.to_vec();
-                    out.extend_from_slice(b"-ok");
-                    Ok(out)
-                }),
-            )
-            .expect("register local handler");
-
-        let response = network
-            .request("/aw/node/replication/ping", b"hello")
-            .expect("local request");
-        assert_eq!(response, b"hello-ok".to_vec());
-    }
-
-    #[test]
-    fn libp2p_replication_network_request_response_between_peers() {
-        let listener = Libp2pReplicationNetwork::new(Libp2pReplicationNetworkConfig {
-            listen_addrs: vec!["/ip4/127.0.0.1/tcp/0".parse().expect("listener addr")],
-            ..Libp2pReplicationNetworkConfig::default()
-        });
-        let listen_deadline = Instant::now() + Duration::from_secs(10);
-        wait_until("listener bind", listen_deadline, || {
-            !listener.listening_addrs().is_empty()
-        });
-
-        let dial_addr = listening_addr_with_peer_id(&listener);
-        listener
-            .register_handler(
-                "/aw/node/replication/ping",
-                Box::new(|payload| {
-                    let mut out = payload.to_vec();
-                    out.extend_from_slice(b"-pong");
-                    Ok(out)
-                }),
-            )
-            .expect("register listener handler");
-
-        let dialer = Libp2pReplicationNetwork::new(Libp2pReplicationNetworkConfig {
-            listen_addrs: vec!["/ip4/127.0.0.1/tcp/0".parse().expect("dialer addr")],
-            bootstrap_peers: vec![dial_addr],
-            ..Libp2pReplicationNetworkConfig::default()
-        });
-        let connect_deadline = Instant::now() + Duration::from_secs(10);
-        wait_until("dialer connection", connect_deadline, || {
-            !dialer.connected_peers().is_empty()
-        });
-
-        let request_deadline = Instant::now() + Duration::from_secs(10);
-        wait_until("request response", request_deadline, || {
-            match dialer.request("/aw/node/replication/ping", b"node") {
-                Ok(payload) => payload == b"node-pong".to_vec(),
-                Err(WorldError::NetworkProtocolUnavailable { .. }) => false,
-                Err(WorldError::NetworkRequestFailed { .. }) => false,
-                Err(err) => panic!(
-                    "unexpected request error: {err:?}; dialer_errors={:?}; listener_errors={:?}",
-                    dialer.debug_errors(),
-                    listener.debug_errors(),
-                ),
-            }
-        });
-    }
-
-    #[test]
-    fn libp2p_replication_network_redials_bootstrap_peer_until_listener_is_ready() {
-        let reserved_listener =
-            TcpListener::bind("127.0.0.1:0").expect("reserve bootstrap listener port");
-        let bootstrap_port = reserved_listener
-            .local_addr()
-            .expect("reserved bootstrap addr")
-            .port();
-        drop(reserved_listener);
-
-        let bootstrap_addr = format!("/ip4/127.0.0.1/tcp/{bootstrap_port}")
-            .parse()
-            .expect("bootstrap addr");
-        let dialer = Libp2pReplicationNetwork::new(Libp2pReplicationNetworkConfig {
-            listen_addrs: vec!["/ip4/127.0.0.1/tcp/0".parse().expect("dialer addr")],
-            bootstrap_peers: vec![bootstrap_addr],
-            ..Libp2pReplicationNetworkConfig::default()
-        });
-
-        std::thread::sleep(Duration::from_millis(200));
-
-        let listener = Libp2pReplicationNetwork::new(Libp2pReplicationNetworkConfig {
-            listen_addrs: vec![format!("/ip4/127.0.0.1/tcp/{bootstrap_port}")
-                .parse()
-                .expect("listener addr")],
-            ..Libp2pReplicationNetworkConfig::default()
-        });
-        listener
-            .register_handler(
-                "/aw/node/replication/ping",
-                Box::new(|payload| {
-                    let mut out = payload.to_vec();
-                    out.extend_from_slice(b"-late");
-                    Ok(out)
-                }),
-            )
-            .expect("register listener handler");
-
-        let connect_deadline = Instant::now() + Duration::from_secs(10);
-        wait_until(
-            "dialer reconnects to late listener",
-            connect_deadline,
-            || !dialer.connected_peers().is_empty(),
-        );
-
-        let listener_deadline = Instant::now() + Duration::from_secs(10);
-        wait_until(
-            "late listener sees connected peer",
-            listener_deadline,
-            || !listener.connected_peers().is_empty(),
-        );
-    }
-
-    #[test]
-    fn libp2p_replication_network_request_waits_for_delayed_bootstrap_connection() {
-        let reserved_listener =
-            TcpListener::bind("127.0.0.1:0").expect("reserve bootstrap listener port");
-        let bootstrap_port = reserved_listener
-            .local_addr()
-            .expect("reserved bootstrap addr")
-            .port();
-        drop(reserved_listener);
-
-        let bootstrap_addr = format!("/ip4/127.0.0.1/tcp/{bootstrap_port}")
-            .parse()
-            .expect("bootstrap addr");
-        let dialer = Libp2pReplicationNetwork::new(Libp2pReplicationNetworkConfig {
-            listen_addrs: vec!["/ip4/127.0.0.1/tcp/0".parse().expect("dialer addr")],
-            bootstrap_peers: vec![bootstrap_addr],
-            ..Libp2pReplicationNetworkConfig::default()
-        });
-
-        let listener_thread = std::thread::spawn(move || {
-            std::thread::sleep(Duration::from_millis(250));
-            let listener = Libp2pReplicationNetwork::new(Libp2pReplicationNetworkConfig {
-                listen_addrs: vec![format!("/ip4/127.0.0.1/tcp/{bootstrap_port}")
-                    .parse()
-                    .expect("listener addr")],
-                ..Libp2pReplicationNetworkConfig::default()
-            });
-            listener
-                .register_handler(
-                    "/aw/node/replication/ping",
-                    Box::new(|payload| {
-                        let mut out = payload.to_vec();
-                        out.extend_from_slice(b"-delayed");
-                        Ok(out)
-                    }),
-                )
-                .expect("register delayed listener handler");
-            std::thread::sleep(Duration::from_secs(3));
-        });
-
-        let response = dialer
-            .request("/aw/node/replication/ping", b"node")
-            .expect("request should wait for delayed connection");
-        assert_eq!(response, b"node-delayed".to_vec());
-
-        listener_thread
-            .join()
-            .expect("join delayed listener thread");
-    }
-
-    #[test]
-    fn filtered_request_peers_excludes_known_unsupported_peers_without_fallback() {
-        let network = Libp2pReplicationNetwork::new(Libp2pReplicationNetworkConfig::default());
-        let observer_peer = PeerId::random();
-        let sequencer_peer = PeerId::random();
-        network.mark_peer_unsupported_for_protocol(
-            "/aw/node/replication/fetch-commit/1.0.0",
-            observer_peer,
-        );
-
-        let filtered = network.filtered_request_peers(
-            "/aw/node/replication/fetch-commit/1.0.0",
-            vec![observer_peer, sequencer_peer],
-        );
-        assert_eq!(filtered, vec![sequencer_peer]);
-
-        let filtered_only_unsupported = network.filtered_request_peers(
-            "/aw/node/replication/fetch-commit/1.0.0",
-            vec![observer_peer],
-        );
-        assert!(filtered_only_unsupported.is_empty());
-    }
-
-    #[test]
-    fn filtered_request_peers_retries_unsupported_peer_after_retry_window() {
-        let network = Libp2pReplicationNetwork::new(Libp2pReplicationNetworkConfig {
-            unsupported_protocol_retry_after: Duration::from_millis(5),
-            ..Libp2pReplicationNetworkConfig::default()
-        });
-        let sequencer_peer = PeerId::random();
-        network.mark_peer_unsupported_for_protocol(
-            "/aw/node/replication/fetch-commit/1.0.0",
-            sequencer_peer,
-        );
-
-        let filtered_initial = network.filtered_request_peers(
-            "/aw/node/replication/fetch-commit/1.0.0",
-            vec![sequencer_peer],
-        );
-        assert!(filtered_initial.is_empty());
-
-        std::thread::sleep(Duration::from_millis(15));
-
-        let filtered_after_retry_window = network.filtered_request_peers(
-            "/aw/node/replication/fetch-commit/1.0.0",
-            vec![sequencer_peer],
-        );
-        assert_eq!(filtered_after_retry_window, vec![sequencer_peer]);
-    }
-
-    #[test]
-    fn libp2p_replication_network_request_round_robins_across_connected_peers() {
-        let listener_a = Libp2pReplicationNetwork::new(Libp2pReplicationNetworkConfig {
-            listen_addrs: vec!["/ip4/127.0.0.1/tcp/0".parse().expect("listener a addr")],
-            ..Libp2pReplicationNetworkConfig::default()
-        });
-        let listener_b = Libp2pReplicationNetwork::new(Libp2pReplicationNetworkConfig {
-            listen_addrs: vec!["/ip4/127.0.0.1/tcp/0".parse().expect("listener b addr")],
-            ..Libp2pReplicationNetworkConfig::default()
-        });
-        let listen_deadline = Instant::now() + Duration::from_secs(10);
-        wait_until("listener a bind", listen_deadline, || {
-            !listener_a.listening_addrs().is_empty()
-        });
-        wait_until("listener b bind", listen_deadline, || {
-            !listener_b.listening_addrs().is_empty()
-        });
-
-        listener_a
-            .register_handler(
-                "/aw/node/replication/ping",
-                Box::new(|payload| {
-                    let mut out = payload.to_vec();
-                    out.extend_from_slice(b"-a");
-                    Ok(out)
-                }),
-            )
-            .expect("register listener a handler");
-        listener_b
-            .register_handler(
-                "/aw/node/replication/ping",
-                Box::new(|payload| {
-                    let mut out = payload.to_vec();
-                    out.extend_from_slice(b"-b");
-                    Ok(out)
-                }),
-            )
-            .expect("register listener b handler");
-
-        let dialer = Libp2pReplicationNetwork::new(Libp2pReplicationNetworkConfig {
-            listen_addrs: vec!["/ip4/127.0.0.1/tcp/0".parse().expect("dialer addr")],
-            bootstrap_peers: vec![
-                listening_addr_with_peer_id(&listener_a),
-                listening_addr_with_peer_id(&listener_b),
-            ],
-            ..Libp2pReplicationNetworkConfig::default()
-        });
-        let connect_deadline = Instant::now() + Duration::from_secs(10);
-        wait_until("dialer connects to two peers", connect_deadline, || {
-            dialer.connected_peers().len() >= 2
-        });
-
-        let first = dialer
-            .request("/aw/node/replication/ping", b"node")
-            .expect("first request");
-        let second = dialer
-            .request("/aw/node/replication/ping", b"node")
-            .expect("second request");
-
-        assert_ne!(
-            first, second,
-            "expected round-robin request targets to differ"
-        );
-        let mut responses = vec![first, second];
-        responses.sort();
-        assert_eq!(responses, vec![b"node-a".to_vec(), b"node-b".to_vec()]);
-    }
-
-    #[test]
-    fn libp2p_replication_network_request_retries_next_peer_when_remote_handler_fails() {
-        let listener_fail = Libp2pReplicationNetwork::new(Libp2pReplicationNetworkConfig {
-            listen_addrs: vec!["/ip4/127.0.0.1/tcp/0".parse().expect("listener fail addr")],
-            ..Libp2pReplicationNetworkConfig::default()
-        });
-        let listener_ok = Libp2pReplicationNetwork::new(Libp2pReplicationNetworkConfig {
-            listen_addrs: vec!["/ip4/127.0.0.1/tcp/0".parse().expect("listener ok addr")],
-            ..Libp2pReplicationNetworkConfig::default()
-        });
-        let listen_deadline = Instant::now() + Duration::from_secs(10);
-        wait_until("listener fail bind", listen_deadline, || {
-            !listener_fail.listening_addrs().is_empty()
-        });
-        wait_until("listener ok bind", listen_deadline, || {
-            !listener_ok.listening_addrs().is_empty()
-        });
-
-        listener_fail
-            .register_handler(
-                "/aw/node/replication/ping",
-                Box::new(|_payload| {
-                    Err(WorldError::NetworkRequestFailed {
-                        code: DistributedErrorCode::ErrUnsupported,
-                        message: "forced failure".to_string(),
-                        retryable: false,
-                    })
-                }),
-            )
-            .expect("register listener fail handler");
-        listener_ok
-            .register_handler(
-                "/aw/node/replication/ping",
-                Box::new(|payload| {
-                    let mut out = payload.to_vec();
-                    out.extend_from_slice(b"-ok");
-                    Ok(out)
-                }),
-            )
-            .expect("register listener ok handler");
-
-        let dialer = Libp2pReplicationNetwork::new(Libp2pReplicationNetworkConfig {
-            listen_addrs: vec!["/ip4/127.0.0.1/tcp/0".parse().expect("dialer addr")],
-            bootstrap_peers: vec![
-                listening_addr_with_peer_id(&listener_fail),
-                listening_addr_with_peer_id(&listener_ok),
-            ],
-            ..Libp2pReplicationNetworkConfig::default()
-        });
-        let connect_deadline = Instant::now() + Duration::from_secs(10);
-        wait_until("dialer connects to two peers", connect_deadline, || {
-            dialer.connected_peers().len() >= 2
-        });
-
-        let first = dialer
-            .request("/aw/node/replication/ping", b"node")
-            .expect("first request should succeed via retry");
-        let second = dialer
-            .request("/aw/node/replication/ping", b"node")
-            .expect("second request should succeed via retry");
-
-        assert_eq!(first, b"node-ok".to_vec());
-        assert_eq!(second, b"node-ok".to_vec());
-    }
-
-    #[test]
-    fn libp2p_replication_network_retries_previously_unsupported_single_peer_after_retry_window() {
-        let listener = Libp2pReplicationNetwork::new(Libp2pReplicationNetworkConfig {
-            listen_addrs: vec!["/ip4/127.0.0.1/tcp/0".parse().expect("listener addr")],
-            ..Libp2pReplicationNetworkConfig::default()
-        });
-        let listen_deadline = Instant::now() + Duration::from_secs(10);
-        wait_until("listener bind", listen_deadline, || {
-            !listener.listening_addrs().is_empty()
-        });
-
-        listener
-            .register_handler(
-                "/aw/node/replication/ping",
-                Box::new(move |payload| {
-                    let mut out = payload.to_vec();
-                    out.extend_from_slice(b"-recovered");
-                    Ok(out)
-                }),
-            )
-            .expect("register listener handler");
-
-        let dialer = Libp2pReplicationNetwork::new(Libp2pReplicationNetworkConfig {
-            listen_addrs: vec!["/ip4/127.0.0.1/tcp/0".parse().expect("dialer addr")],
-            bootstrap_peers: vec![listening_addr_with_peer_id(&listener)],
-            unsupported_protocol_retry_after: Duration::from_millis(25),
-            ..Libp2pReplicationNetworkConfig::default()
-        });
-        let connect_deadline = Instant::now() + Duration::from_secs(10);
-        wait_until("dialer connection", connect_deadline, || {
-            !dialer.connected_peers().is_empty()
-        });
-
-        let listener_peer_id = listener.peer_id();
-        dialer.mark_peer_unsupported_for_protocol("/aw/node/replication/ping", listener_peer_id);
-
-        let immediate_retry = dialer.request("/aw/node/replication/ping", b"node");
-        assert!(matches!(
-            immediate_retry,
-            Err(WorldError::NetworkProtocolUnavailable { protocol })
-                if protocol.contains("no connected peers")
-        ));
-
-        std::thread::sleep(Duration::from_millis(60));
-
-        let recovered = dialer
-            .request("/aw/node/replication/ping", b"node")
-            .expect("request after retry window");
-        assert_eq!(recovered, b"node-recovered".to_vec());
-    }
-
-    #[test]
-    fn libp2p_replication_network_does_not_quarantine_not_found_response_as_unsupported() {
-        let listener = Libp2pReplicationNetwork::new(Libp2pReplicationNetworkConfig {
-            listen_addrs: vec!["/ip4/127.0.0.1/tcp/0".parse().expect("listener addr")],
-            ..Libp2pReplicationNetworkConfig::default()
-        });
-        let listen_deadline = Instant::now() + Duration::from_secs(10);
-        wait_until("listener bind", listen_deadline, || {
-            !listener.listening_addrs().is_empty()
-        });
-
-        listener
-            .register_handler(
-                "/aw/node/replication/ping",
-                Box::new(|_payload| {
-                    Err(WorldError::NetworkRequestFailed {
-                        code: DistributedErrorCode::ErrNotFound,
-                        message: "missing content".to_string(),
-                        retryable: false,
-                    })
-                }),
-            )
-            .expect("register listener handler");
-
-        let dialer = Libp2pReplicationNetwork::new(Libp2pReplicationNetworkConfig {
-            listen_addrs: vec!["/ip4/127.0.0.1/tcp/0".parse().expect("dialer addr")],
-            bootstrap_peers: vec![listening_addr_with_peer_id(&listener)],
-            unsupported_protocol_retry_after: Duration::from_millis(250),
-            ..Libp2pReplicationNetworkConfig::default()
-        });
-        let connect_deadline = Instant::now() + Duration::from_secs(10);
-        wait_until("dialer connection", connect_deadline, || {
-            !dialer.connected_peers().is_empty()
-        });
-
-        let first = dialer.request("/aw/node/replication/ping", b"node");
-        assert!(matches!(
-            first,
-            Err(WorldError::NetworkRequestFailed {
-                code: DistributedErrorCode::ErrNotFound,
-                ..
-            })
-        ));
-
-        let second = dialer.request("/aw/node/replication/ping", b"node");
-        assert!(matches!(
-            second,
-            Err(WorldError::NetworkRequestFailed {
-                code: DistributedErrorCode::ErrNotFound,
-                ..
-            })
-        ));
-    }
-
-    #[test]
-    fn retryable_connection_gap_detection_matches_request_to_peer_disconnects() {
-        let err = WorldError::NetworkProtocolUnavailable {
-            protocol: "libp2p-replication outbound request failed: NetworkProtocolUnavailable { protocol: \"peer 12D3KooW... is not connected for protocol /aw/node/replication/fetch-commit/1.0.0\" }".to_string(),
-        };
-        assert!(peer_error_indicates_retryable_connection_gap(&err));
-
-        let not_retryable = WorldError::NetworkProtocolUnavailable {
-            protocol: "libp2p-replication handler missing: /aw/node/replication/fetch-commit/1.0.0"
-                .to_string(),
-        };
-        assert!(!peer_error_indicates_retryable_connection_gap(
-            &not_retryable
-        ));
-    }
-
-    #[test]
-    fn libp2p_replication_network_preserves_remote_unsupported_error_code() {
-        let listener = Libp2pReplicationNetwork::new(Libp2pReplicationNetworkConfig {
-            listen_addrs: vec!["/ip4/127.0.0.1/tcp/0".parse().expect("listener addr")],
-            ..Libp2pReplicationNetworkConfig::default()
-        });
-        let listen_deadline = Instant::now() + Duration::from_secs(10);
-        wait_until("listener bind", listen_deadline, || {
-            !listener.listening_addrs().is_empty()
-        });
-
-        listener
-            .register_handler(
-                "/aw/node/replication/ping",
-                Box::new(|_payload| {
-                    Err(WorldError::NetworkRequestFailed {
-                        code: DistributedErrorCode::ErrUnsupported,
-                        message: "forced unsupported".to_string(),
-                        retryable: false,
-                    })
-                }),
-            )
-            .expect("register listener handler");
-
-        let dialer = Libp2pReplicationNetwork::new(Libp2pReplicationNetworkConfig {
-            listen_addrs: vec!["/ip4/127.0.0.1/tcp/0".parse().expect("dialer addr")],
-            bootstrap_peers: vec![listening_addr_with_peer_id(&listener)],
-            unsupported_protocol_retry_after: Duration::from_millis(250),
-            ..Libp2pReplicationNetworkConfig::default()
-        });
-        let connect_deadline = Instant::now() + Duration::from_secs(10);
-        wait_until("dialer connection", connect_deadline, || {
-            !dialer.connected_peers().is_empty()
-        });
-
-        let err = dialer
-            .request("/aw/node/replication/ping", b"node")
-            .expect_err("unsupported remote handler must bubble its code");
-        assert!(matches!(
-            err,
-            WorldError::NetworkRequestFailed {
-                code: DistributedErrorCode::ErrUnsupported,
-                ..
-            }
-        ));
-    }
-}
+mod tests;

--- a/crates/oasis7_node/src/libp2p_replication_network/peer_selection_tests.rs
+++ b/crates/oasis7_node/src/libp2p_replication_network/peer_selection_tests.rs
@@ -1,6 +1,7 @@
 use std::time::{Duration, Instant};
 
 use oasis7_proto::distributed::DistributedErrorCode;
+use oasis7_proto::distributed_dht::{PeerDeploymentMode, PeerNodeRole, PeerReachabilityClass};
 
 use super::*;
 
@@ -21,6 +22,30 @@ fn listening_addr_with_peer_id(network: &Libp2pReplicationNetwork) -> Multiaddr 
         .find(|addr| addr.to_string().contains("127.0.0.1"))
         .expect("listener visible addr")
         .with(libp2p::multiaddr::Protocol::P2p(network.peer_id().into()))
+}
+
+fn test_peer_record(node_id: &str) -> PeerRecord {
+    PeerRecord {
+        peer_id: String::new(),
+        node_id: node_id.to_string(),
+        world_id: "world-a".to_string(),
+        network_id: "world-a".to_string(),
+        node_role: PeerNodeRole::FullStorage.as_str().to_string(),
+        deployment_mode: PeerDeploymentMode::Private,
+        reachability_class: PeerReachabilityClass::Private,
+        direct_addrs: Vec::new(),
+        hole_punch_addrs: Vec::new(),
+        relay_addrs: Vec::new(),
+        discovery_sources: vec![
+            PeerDiscoverySource::StaticBootstrap,
+            PeerDiscoverySource::Dht,
+        ],
+        capability_lanes: PeerNodeRole::FullStorage.default_capability_lanes(),
+        source_operator: None,
+        source_asn: None,
+        published_at_ms: 0,
+        ttl_ms: 60_000,
+    }
 }
 
 #[test]
@@ -83,7 +108,7 @@ fn connected_or_active_transport_peers_excludes_blocked_peer() {
         ReplicationPeerHealthDebug {
             peer_id: blocked_peer.to_string(),
             status: "blocked".to_string(),
-            issues: vec!["missing_peer_record".to_string()],
+            issues: vec!["relay_budget_exceeded relayed_active_peers=2 active_peer_count=2 limit_per_mille=500".to_string()],
             discovery_sources: vec!["dht".to_string()],
             active_path_kind: Some("direct".to_string()),
             source_operator: None,
@@ -107,13 +132,107 @@ fn connected_or_active_transport_peers_excludes_blocked_peer() {
 }
 
 #[test]
+fn connected_or_active_transport_peers_rejects_fully_blocked_connected_set() {
+    let blocked_peer = PeerId::random();
+    let healths = vec![ReplicationPeerHealthDebug {
+        peer_id: blocked_peer.to_string(),
+        status: "blocked".to_string(),
+        issues: vec!["operator_concentration source_operator=op-a peers_in_bucket=2 active_peer_count=2 limit_per_mille=500".to_string()],
+        discovery_sources: vec!["dht".to_string()],
+        active_path_kind: Some("direct".to_string()),
+        source_operator: None,
+        source_asn: None,
+    }];
+
+    let resolved = connected_or_active_transport_peers(vec![blocked_peer], healths.as_slice());
+
+    assert!(resolved.is_empty());
+}
+
+#[test]
+fn connected_or_active_transport_peers_prefers_known_record_peer_over_missing_record_peer() {
+    let blocked_peer = PeerId::random();
+    let active_peer = PeerId::random();
+    let healths = vec![
+        ReplicationPeerHealthDebug {
+            peer_id: blocked_peer.to_string(),
+            status: "blocked".to_string(),
+            issues: vec![
+                "missing_peer_record".to_string(),
+                "insufficient_active_discovery_sources observed=1 required=2".to_string(),
+            ],
+            discovery_sources: vec!["static_bootstrap".to_string()],
+            active_path_kind: Some("direct".to_string()),
+            source_operator: None,
+            source_asn: None,
+        },
+        ReplicationPeerHealthDebug {
+            peer_id: active_peer.to_string(),
+            status: "active".to_string(),
+            issues: Vec::new(),
+            discovery_sources: vec!["dht".to_string()],
+            active_path_kind: Some("direct".to_string()),
+            source_operator: None,
+            source_asn: None,
+        },
+    ];
+
+    let resolved =
+        connected_or_active_transport_peers(vec![blocked_peer, active_peer], healths.as_slice());
+
+    assert_eq!(resolved, vec![active_peer]);
+}
+
+#[test]
+fn connected_or_active_transport_peers_falls_back_to_missing_record_peer_when_needed() {
+    let blocked_peer = PeerId::random();
+    let healths = vec![ReplicationPeerHealthDebug {
+        peer_id: blocked_peer.to_string(),
+        status: "blocked".to_string(),
+        issues: vec!["missing_peer_record".to_string()],
+        discovery_sources: vec!["static_bootstrap".to_string()],
+        active_path_kind: Some("direct".to_string()),
+        source_operator: None,
+        source_asn: None,
+    }];
+
+    let resolved = connected_or_active_transport_peers(vec![blocked_peer], healths.as_slice());
+
+    assert_eq!(resolved, vec![blocked_peer]);
+}
+
+#[test]
+fn connected_or_active_transport_peers_falls_back_to_bootstrap_peer_while_record_exchange_is_pending(
+) {
+    let bootstrap_peer = PeerId::random();
+    let healths = vec![ReplicationPeerHealthDebug {
+        peer_id: bootstrap_peer.to_string(),
+        status: "blocked".to_string(),
+        issues: vec![
+            "missing_peer_record".to_string(),
+            "insufficient_active_discovery_sources observed=1 required=2".to_string(),
+        ],
+        discovery_sources: vec!["static_bootstrap".to_string()],
+        active_path_kind: Some("direct".to_string()),
+        source_operator: None,
+        source_asn: None,
+    }];
+
+    let resolved = connected_or_active_transport_peers(vec![bootstrap_peer], healths.as_slice());
+
+    assert_eq!(resolved, vec![bootstrap_peer]);
+}
+
+#[test]
 fn libp2p_replication_network_request_with_providers_honors_provider_subset() {
     let listener_fail = Libp2pReplicationNetwork::new(Libp2pReplicationNetworkConfig {
         listen_addrs: vec!["/ip4/127.0.0.1/tcp/0".parse().expect("listener fail addr")],
+        peer_record: Some(test_peer_record("listener-fail")),
         ..Libp2pReplicationNetworkConfig::default()
     });
     let listener_ok = Libp2pReplicationNetwork::new(Libp2pReplicationNetworkConfig {
         listen_addrs: vec!["/ip4/127.0.0.1/tcp/0".parse().expect("listener ok addr")],
+        peer_record: Some(test_peer_record("listener-ok")),
         ..Libp2pReplicationNetworkConfig::default()
     });
     let listen_deadline = Instant::now() + Duration::from_secs(10);

--- a/crates/oasis7_node/src/libp2p_replication_network/tests.rs
+++ b/crates/oasis7_node/src/libp2p_replication_network/tests.rs
@@ -1,0 +1,674 @@
+use super::*;
+use oasis7_proto::distributed::DistributedErrorCode;
+use oasis7_proto::distributed_dht::{PeerDeploymentMode, PeerNodeRole, PeerReachabilityClass};
+use std::net::TcpListener;
+use std::time::{Duration, Instant};
+
+fn wait_until(what: &str, deadline: Instant, mut condition: impl FnMut() -> bool) {
+    while Instant::now() < deadline {
+        if condition() {
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+    panic!("timed out waiting for condition: {what}");
+}
+
+fn test_peer_record(node_id: &str) -> PeerRecord {
+    PeerRecord {
+        peer_id: String::new(),
+        node_id: node_id.to_string(),
+        world_id: "world-a".to_string(),
+        network_id: "world-a".to_string(),
+        node_role: PeerNodeRole::FullStorage.as_str().to_string(),
+        deployment_mode: PeerDeploymentMode::Private,
+        reachability_class: PeerReachabilityClass::Private,
+        direct_addrs: Vec::new(),
+        hole_punch_addrs: Vec::new(),
+        relay_addrs: Vec::new(),
+        discovery_sources: vec![
+            PeerDiscoverySource::StaticBootstrap,
+            PeerDiscoverySource::Dht,
+        ],
+        capability_lanes: PeerNodeRole::FullStorage.default_capability_lanes(),
+        source_operator: None,
+        source_asn: None,
+        published_at_ms: 0,
+        ttl_ms: 60_000,
+    }
+}
+
+fn listening_addr_with_peer_id(network: &Libp2pReplicationNetwork) -> Multiaddr {
+    network
+        .listening_addrs()
+        .into_iter()
+        .find(|addr| addr.to_string().contains("127.0.0.1"))
+        .expect("listener visible addr")
+        .with(libp2p::multiaddr::Protocol::P2p(network.peer_id().into()))
+}
+
+#[test]
+fn libp2p_replication_network_generates_peer_id() {
+    let network = Libp2pReplicationNetwork::new(Libp2pReplicationNetworkConfig::default());
+    assert!(!network.peer_id().to_string().is_empty());
+}
+
+#[test]
+fn libp2p_replication_network_request_rejects_without_connected_peers_by_default() {
+    let network = Libp2pReplicationNetwork::new(Libp2pReplicationNetworkConfig::default());
+    let result = network.request("/aw/node/replication/ping", b"hello");
+    match result {
+        Err(WorldError::NetworkProtocolUnavailable { protocol }) => {
+            assert!(protocol.contains("no connected peers"));
+        }
+        other => panic!("expected NetworkProtocolUnavailable, got {other:?}"),
+    }
+}
+
+#[test]
+fn libp2p_replication_network_request_falls_back_to_local_handler_when_enabled() {
+    let network = Libp2pReplicationNetwork::new(Libp2pReplicationNetworkConfig {
+        allow_local_handler_fallback_when_no_peers: true,
+        ..Libp2pReplicationNetworkConfig::default()
+    });
+    network
+        .register_handler(
+            "/aw/node/replication/ping",
+            Box::new(|payload| {
+                let mut out = payload.to_vec();
+                out.extend_from_slice(b"-ok");
+                Ok(out)
+            }),
+        )
+        .expect("register local handler");
+
+    let response = network
+        .request("/aw/node/replication/ping", b"hello")
+        .expect("local request");
+    assert_eq!(response, b"hello-ok".to_vec());
+}
+
+#[test]
+fn libp2p_replication_network_request_response_between_peers() {
+    let listener = Libp2pReplicationNetwork::new(Libp2pReplicationNetworkConfig {
+        listen_addrs: vec!["/ip4/127.0.0.1/tcp/0".parse().expect("listener addr")],
+        peer_record: Some(test_peer_record("listener")),
+        ..Libp2pReplicationNetworkConfig::default()
+    });
+    let listen_deadline = Instant::now() + Duration::from_secs(10);
+    wait_until("listener bind", listen_deadline, || {
+        !listener.listening_addrs().is_empty()
+    });
+
+    let dial_addr = listening_addr_with_peer_id(&listener);
+    listener
+        .register_handler(
+            "/aw/node/replication/ping",
+            Box::new(|payload| {
+                let mut out = payload.to_vec();
+                out.extend_from_slice(b"-pong");
+                Ok(out)
+            }),
+        )
+        .expect("register listener handler");
+
+    let dialer = Libp2pReplicationNetwork::new(Libp2pReplicationNetworkConfig {
+        listen_addrs: vec!["/ip4/127.0.0.1/tcp/0".parse().expect("dialer addr")],
+        bootstrap_peers: vec![dial_addr],
+        ..Libp2pReplicationNetworkConfig::default()
+    });
+    let connect_deadline = Instant::now() + Duration::from_secs(10);
+    wait_until("dialer connection", connect_deadline, || {
+        !dialer.connected_peers().is_empty()
+    });
+
+    let request_deadline = Instant::now() + Duration::from_secs(10);
+    let mut last_result = None;
+    while Instant::now() < request_deadline {
+        let result = dialer.request("/aw/node/replication/ping", b"node");
+        match &result {
+            Ok(payload) if *payload == b"node-pong".to_vec() => return,
+            _ => {}
+        }
+        last_result = Some(result);
+        std::thread::sleep(Duration::from_millis(20));
+    }
+    panic!(
+        "request response timed out: last_result={last_result:?}; dialer_snapshot={:?}; listener_snapshot={:?}; dialer_errors={:?}; listener_errors={:?}",
+        dialer.debug_snapshot(),
+        listener.debug_snapshot(),
+        dialer.debug_errors(),
+        listener.debug_errors(),
+    );
+}
+
+#[test]
+fn libp2p_replication_network_redials_bootstrap_peer_until_listener_is_ready() {
+    let reserved_listener =
+        TcpListener::bind("127.0.0.1:0").expect("reserve bootstrap listener port");
+    let bootstrap_port = reserved_listener
+        .local_addr()
+        .expect("reserved bootstrap addr")
+        .port();
+    drop(reserved_listener);
+
+    let bootstrap_addr = format!("/ip4/127.0.0.1/tcp/{bootstrap_port}")
+        .parse()
+        .expect("bootstrap addr");
+    let dialer = Libp2pReplicationNetwork::new(Libp2pReplicationNetworkConfig {
+        listen_addrs: vec!["/ip4/127.0.0.1/tcp/0".parse().expect("dialer addr")],
+        bootstrap_peers: vec![bootstrap_addr],
+        ..Libp2pReplicationNetworkConfig::default()
+    });
+
+    std::thread::sleep(Duration::from_millis(200));
+
+    let listener = Libp2pReplicationNetwork::new(Libp2pReplicationNetworkConfig {
+        listen_addrs: vec![format!("/ip4/127.0.0.1/tcp/{bootstrap_port}")
+            .parse()
+            .expect("listener addr")],
+        peer_record: Some(test_peer_record("late-listener")),
+        ..Libp2pReplicationNetworkConfig::default()
+    });
+    listener
+        .register_handler(
+            "/aw/node/replication/ping",
+            Box::new(|payload| {
+                let mut out = payload.to_vec();
+                out.extend_from_slice(b"-late");
+                Ok(out)
+            }),
+        )
+        .expect("register listener handler");
+
+    let connect_deadline = Instant::now() + Duration::from_secs(10);
+    wait_until(
+        "dialer reconnects to late listener",
+        connect_deadline,
+        || !dialer.connected_peers().is_empty(),
+    );
+
+    let listener_deadline = Instant::now() + Duration::from_secs(10);
+    wait_until(
+        "late listener sees connected peer",
+        listener_deadline,
+        || !listener.connected_peers().is_empty(),
+    );
+}
+
+#[test]
+fn libp2p_replication_network_request_waits_for_delayed_bootstrap_connection() {
+    let reserved_listener =
+        TcpListener::bind("127.0.0.1:0").expect("reserve bootstrap listener port");
+    let bootstrap_port = reserved_listener
+        .local_addr()
+        .expect("reserved bootstrap addr")
+        .port();
+    drop(reserved_listener);
+
+    let bootstrap_addr = format!("/ip4/127.0.0.1/tcp/{bootstrap_port}")
+        .parse()
+        .expect("bootstrap addr");
+    let dialer = Libp2pReplicationNetwork::new(Libp2pReplicationNetworkConfig {
+        listen_addrs: vec!["/ip4/127.0.0.1/tcp/0".parse().expect("dialer addr")],
+        bootstrap_peers: vec![bootstrap_addr],
+        ..Libp2pReplicationNetworkConfig::default()
+    });
+
+    let listener_thread = std::thread::spawn(move || {
+        std::thread::sleep(Duration::from_millis(250));
+        let listener = Libp2pReplicationNetwork::new(Libp2pReplicationNetworkConfig {
+            listen_addrs: vec![format!("/ip4/127.0.0.1/tcp/{bootstrap_port}")
+                .parse()
+                .expect("listener addr")],
+            peer_record: Some(test_peer_record("delayed-listener")),
+            ..Libp2pReplicationNetworkConfig::default()
+        });
+        listener
+            .register_handler(
+                "/aw/node/replication/ping",
+                Box::new(|payload| {
+                    let mut out = payload.to_vec();
+                    out.extend_from_slice(b"-delayed");
+                    Ok(out)
+                }),
+            )
+            .expect("register delayed listener handler");
+        std::thread::sleep(Duration::from_secs(3));
+    });
+
+    let response = dialer
+        .request("/aw/node/replication/ping", b"node")
+        .expect("request should wait for delayed connection");
+    assert_eq!(response, b"node-delayed".to_vec());
+
+    listener_thread
+        .join()
+        .expect("join delayed listener thread");
+}
+
+#[test]
+fn filtered_request_peers_excludes_known_unsupported_peers_without_fallback() {
+    let network = Libp2pReplicationNetwork::new(Libp2pReplicationNetworkConfig::default());
+    let observer_peer = PeerId::random();
+    let sequencer_peer = PeerId::random();
+    network.mark_peer_unsupported_for_protocol(
+        "/aw/node/replication/fetch-commit/1.0.0",
+        observer_peer,
+    );
+
+    let filtered = network.filtered_request_peers(
+        "/aw/node/replication/fetch-commit/1.0.0",
+        vec![observer_peer, sequencer_peer],
+    );
+    assert_eq!(filtered, vec![sequencer_peer]);
+
+    let filtered_only_unsupported = network.filtered_request_peers(
+        "/aw/node/replication/fetch-commit/1.0.0",
+        vec![observer_peer],
+    );
+    assert!(filtered_only_unsupported.is_empty());
+}
+
+#[test]
+fn filtered_request_peers_retries_unsupported_peer_after_retry_window() {
+    let network = Libp2pReplicationNetwork::new(Libp2pReplicationNetworkConfig {
+        unsupported_protocol_retry_after: Duration::from_millis(5),
+        ..Libp2pReplicationNetworkConfig::default()
+    });
+    let sequencer_peer = PeerId::random();
+    network.mark_peer_unsupported_for_protocol(
+        "/aw/node/replication/fetch-commit/1.0.0",
+        sequencer_peer,
+    );
+
+    let filtered_initial = network.filtered_request_peers(
+        "/aw/node/replication/fetch-commit/1.0.0",
+        vec![sequencer_peer],
+    );
+    assert!(filtered_initial.is_empty());
+
+    std::thread::sleep(Duration::from_millis(15));
+
+    let filtered_after_retry_window = network.filtered_request_peers(
+        "/aw/node/replication/fetch-commit/1.0.0",
+        vec![sequencer_peer],
+    );
+    assert_eq!(filtered_after_retry_window, vec![sequencer_peer]);
+}
+
+#[test]
+fn libp2p_replication_network_request_round_robins_across_connected_peers() {
+    let listener_a = Libp2pReplicationNetwork::new(Libp2pReplicationNetworkConfig {
+        listen_addrs: vec!["/ip4/127.0.0.1/tcp/0".parse().expect("listener a addr")],
+        peer_record: Some(test_peer_record("listener-a")),
+        ..Libp2pReplicationNetworkConfig::default()
+    });
+    let listener_b = Libp2pReplicationNetwork::new(Libp2pReplicationNetworkConfig {
+        listen_addrs: vec!["/ip4/127.0.0.1/tcp/0".parse().expect("listener b addr")],
+        peer_record: Some(test_peer_record("listener-b")),
+        ..Libp2pReplicationNetworkConfig::default()
+    });
+    let listen_deadline = Instant::now() + Duration::from_secs(10);
+    wait_until("listener a bind", listen_deadline, || {
+        !listener_a.listening_addrs().is_empty()
+    });
+    wait_until("listener b bind", listen_deadline, || {
+        !listener_b.listening_addrs().is_empty()
+    });
+
+    listener_a
+        .register_handler(
+            "/aw/node/replication/ping",
+            Box::new(|payload| {
+                let mut out = payload.to_vec();
+                out.extend_from_slice(b"-a");
+                Ok(out)
+            }),
+        )
+        .expect("register listener a handler");
+    listener_b
+        .register_handler(
+            "/aw/node/replication/ping",
+            Box::new(|payload| {
+                let mut out = payload.to_vec();
+                out.extend_from_slice(b"-b");
+                Ok(out)
+            }),
+        )
+        .expect("register listener b handler");
+
+    let dialer = Libp2pReplicationNetwork::new(Libp2pReplicationNetworkConfig {
+        listen_addrs: vec!["/ip4/127.0.0.1/tcp/0".parse().expect("dialer addr")],
+        bootstrap_peers: vec![
+            listening_addr_with_peer_id(&listener_a),
+            listening_addr_with_peer_id(&listener_b),
+        ],
+        ..Libp2pReplicationNetworkConfig::default()
+    });
+    let connect_deadline = Instant::now() + Duration::from_secs(10);
+    wait_until("dialer connects to two peers", connect_deadline, || {
+        dialer.connected_peers().len() >= 2
+    });
+
+    let first = dialer
+        .request("/aw/node/replication/ping", b"node")
+        .expect("first request");
+    let second = dialer
+        .request("/aw/node/replication/ping", b"node")
+        .expect("second request");
+
+    assert_ne!(
+        first, second,
+        "expected round-robin request targets to differ"
+    );
+    let mut responses = vec![first, second];
+    responses.sort();
+    assert_eq!(responses, vec![b"node-a".to_vec(), b"node-b".to_vec()]);
+}
+
+#[test]
+fn libp2p_replication_network_request_retries_next_peer_when_remote_handler_fails() {
+    let listener_fail = Libp2pReplicationNetwork::new(Libp2pReplicationNetworkConfig {
+        listen_addrs: vec!["/ip4/127.0.0.1/tcp/0".parse().expect("listener fail addr")],
+        peer_record: Some(test_peer_record("listener-fail")),
+        ..Libp2pReplicationNetworkConfig::default()
+    });
+    let listener_ok = Libp2pReplicationNetwork::new(Libp2pReplicationNetworkConfig {
+        listen_addrs: vec!["/ip4/127.0.0.1/tcp/0".parse().expect("listener ok addr")],
+        peer_record: Some(test_peer_record("listener-ok")),
+        ..Libp2pReplicationNetworkConfig::default()
+    });
+    let listen_deadline = Instant::now() + Duration::from_secs(10);
+    wait_until("listener fail bind", listen_deadline, || {
+        !listener_fail.listening_addrs().is_empty()
+    });
+    wait_until("listener ok bind", listen_deadline, || {
+        !listener_ok.listening_addrs().is_empty()
+    });
+
+    listener_fail
+        .register_handler(
+            "/aw/node/replication/ping",
+            Box::new(|_payload| {
+                Err(WorldError::NetworkRequestFailed {
+                    code: DistributedErrorCode::ErrUnsupported,
+                    message: "forced failure".to_string(),
+                    retryable: false,
+                })
+            }),
+        )
+        .expect("register listener fail handler");
+    listener_ok
+        .register_handler(
+            "/aw/node/replication/ping",
+            Box::new(|payload| {
+                let mut out = payload.to_vec();
+                out.extend_from_slice(b"-ok");
+                Ok(out)
+            }),
+        )
+        .expect("register listener ok handler");
+
+    let dialer = Libp2pReplicationNetwork::new(Libp2pReplicationNetworkConfig {
+        listen_addrs: vec!["/ip4/127.0.0.1/tcp/0".parse().expect("dialer addr")],
+        bootstrap_peers: vec![
+            listening_addr_with_peer_id(&listener_fail),
+            listening_addr_with_peer_id(&listener_ok),
+        ],
+        ..Libp2pReplicationNetworkConfig::default()
+    });
+    let connect_deadline = Instant::now() + Duration::from_secs(10);
+    wait_until("dialer connects to two peers", connect_deadline, || {
+        dialer.connected_peers().len() >= 2
+    });
+
+    let first = dialer
+        .request("/aw/node/replication/ping", b"node")
+        .expect("first request should succeed via retry");
+    let second = dialer
+        .request("/aw/node/replication/ping", b"node")
+        .expect("second request should succeed via retry");
+
+    assert_eq!(first, b"node-ok".to_vec());
+    assert_eq!(second, b"node-ok".to_vec());
+}
+
+#[test]
+fn libp2p_replication_network_retries_previously_unsupported_single_peer_after_retry_window() {
+    let listener = Libp2pReplicationNetwork::new(Libp2pReplicationNetworkConfig {
+        listen_addrs: vec!["/ip4/127.0.0.1/tcp/0".parse().expect("listener addr")],
+        peer_record: Some(test_peer_record("listener-not-found")),
+        ..Libp2pReplicationNetworkConfig::default()
+    });
+    let listen_deadline = Instant::now() + Duration::from_secs(10);
+    wait_until("listener bind", listen_deadline, || {
+        !listener.listening_addrs().is_empty()
+    });
+
+    listener
+        .register_handler(
+            "/aw/node/replication/ping",
+            Box::new(move |payload| {
+                let mut out = payload.to_vec();
+                out.extend_from_slice(b"-recovered");
+                Ok(out)
+            }),
+        )
+        .expect("register listener handler");
+
+    let dialer = Libp2pReplicationNetwork::new(Libp2pReplicationNetworkConfig {
+        listen_addrs: vec!["/ip4/127.0.0.1/tcp/0".parse().expect("dialer addr")],
+        bootstrap_peers: vec![listening_addr_with_peer_id(&listener)],
+        unsupported_protocol_retry_after: Duration::from_millis(250),
+        ..Libp2pReplicationNetworkConfig::default()
+    });
+    let connect_deadline = Instant::now() + Duration::from_secs(10);
+    wait_until("dialer connection", connect_deadline, || {
+        !dialer.connected_peers().is_empty()
+    });
+
+    let listener_peer_id = listener.peer_id();
+    dialer.mark_peer_unsupported_for_protocol("/aw/node/replication/ping", listener_peer_id);
+
+    let immediate_retry = dialer.request("/aw/node/replication/ping", b"node");
+    if let Ok(payload) = &immediate_retry {
+        assert_eq!(payload, &b"node-recovered".to_vec());
+    } else {
+        assert!(matches!(
+            immediate_retry,
+            Err(WorldError::NetworkProtocolUnavailable { .. })
+        ));
+    }
+
+    std::thread::sleep(Duration::from_millis(300));
+
+    let recovered = dialer
+        .request("/aw/node/replication/ping", b"node")
+        .expect("request after retry window");
+    assert_eq!(recovered, b"node-recovered".to_vec());
+}
+
+#[test]
+fn libp2p_replication_network_does_not_quarantine_not_found_response_as_unsupported() {
+    let listener = Libp2pReplicationNetwork::new(Libp2pReplicationNetworkConfig {
+        listen_addrs: vec!["/ip4/127.0.0.1/tcp/0".parse().expect("listener addr")],
+        peer_record: Some(test_peer_record("listener-unsupported")),
+        ..Libp2pReplicationNetworkConfig::default()
+    });
+    let listen_deadline = Instant::now() + Duration::from_secs(10);
+    wait_until("listener bind", listen_deadline, || {
+        !listener.listening_addrs().is_empty()
+    });
+
+    listener
+        .register_handler(
+            "/aw/node/replication/ping",
+            Box::new(|_payload| {
+                Err(WorldError::NetworkRequestFailed {
+                    code: DistributedErrorCode::ErrNotFound,
+                    message: "missing content".to_string(),
+                    retryable: false,
+                })
+            }),
+        )
+        .expect("register listener handler");
+
+    let dialer = Libp2pReplicationNetwork::new(Libp2pReplicationNetworkConfig {
+        listen_addrs: vec!["/ip4/127.0.0.1/tcp/0".parse().expect("dialer addr")],
+        bootstrap_peers: vec![listening_addr_with_peer_id(&listener)],
+        unsupported_protocol_retry_after: Duration::from_millis(250),
+        ..Libp2pReplicationNetworkConfig::default()
+    });
+    let connect_deadline = Instant::now() + Duration::from_secs(10);
+    wait_until("dialer connection", connect_deadline, || {
+        !dialer.connected_peers().is_empty()
+    });
+
+    let first = dialer.request("/aw/node/replication/ping", b"node");
+    assert!(matches!(
+        first,
+        Err(WorldError::NetworkRequestFailed {
+            code: DistributedErrorCode::ErrNotFound,
+            ..
+        })
+    ));
+
+    let second = dialer.request("/aw/node/replication/ping", b"node");
+    assert!(matches!(
+        second,
+        Err(WorldError::NetworkRequestFailed {
+            code: DistributedErrorCode::ErrNotFound,
+            ..
+        })
+    ));
+}
+
+#[test]
+fn retryable_connection_gap_detection_matches_request_to_peer_disconnects() {
+    let err = WorldError::NetworkProtocolUnavailable {
+        protocol: "libp2p-replication outbound request failed: NetworkProtocolUnavailable { protocol: \"peer 12D3KooW... is not connected for protocol /aw/node/replication/fetch-commit/1.0.0\" }".to_string(),
+    };
+    assert!(peer_error_indicates_retryable_connection_gap(&err));
+
+    let connection_closed = WorldError::NetworkProtocolUnavailable {
+        protocol: "libp2p-replication outbound request failed: request failed: ConnectionClosed"
+            .to_string(),
+    };
+    assert!(peer_error_indicates_retryable_connection_gap(
+        &connection_closed
+    ));
+
+    let legacy_remote_gap = WorldError::NetworkRequestFailed {
+        code: DistributedErrorCode::ErrUnsupported,
+        message: "no connected providers for protocol /aw/node/replication/fetch-commit/1.0.0"
+            .to_string(),
+        retryable: false,
+    };
+    assert!(peer_error_indicates_retryable_connection_gap(
+        &legacy_remote_gap
+    ));
+
+    let admissible_gap = WorldError::NetworkProtocolUnavailable {
+        protocol:
+            "libp2p-replication no admissible connected peers for protocol /aw/node/replication/fetch-commit/1.0.0"
+                .to_string(),
+    };
+    assert!(peer_error_indicates_retryable_connection_gap(
+        &admissible_gap
+    ));
+
+    let healthy_provider_gap = WorldError::NetworkRequestFailed {
+        code: DistributedErrorCode::ErrUnsupported,
+        message:
+            "no healthy connected providers for protocol /aw/node/replication/fetch-commit/1.0.0"
+                .to_string(),
+        retryable: false,
+    };
+    assert!(peer_error_indicates_retryable_connection_gap(
+        &healthy_provider_gap
+    ));
+
+    let not_retryable = WorldError::NetworkProtocolUnavailable {
+        protocol: "libp2p-replication handler missing: /aw/node/replication/fetch-commit/1.0.0"
+            .to_string(),
+    };
+    assert!(!peer_error_indicates_retryable_connection_gap(
+        &not_retryable
+    ));
+}
+
+#[test]
+fn unsupported_protocol_detection_ignores_generic_availability_failures() {
+    let transient = WorldError::NetworkRequestFailed {
+        code: DistributedErrorCode::ErrUnsupported,
+        message: "no connected providers for protocol /aw/node/replication/fetch-commit/1.0.0"
+            .to_string(),
+        retryable: false,
+    };
+    assert!(!peer_error_indicates_unsupported_protocol(&transient));
+
+    let missing_handler = WorldError::NetworkRequestFailed {
+        code: DistributedErrorCode::ErrUnsupported,
+        message: "/aw/node/replication/fetch-commit/1.0.0".to_string(),
+        retryable: false,
+    };
+    assert!(peer_error_indicates_unsupported_protocol(&missing_handler));
+
+    let transient_internal = WorldError::NetworkRequestFailed {
+        code: DistributedErrorCode::ErrNotAvailable,
+        message: "remote temporarily unavailable".to_string(),
+        retryable: true,
+    };
+    assert!(!peer_error_indicates_retryable_connection_gap(
+        &transient_internal
+    ));
+}
+
+#[test]
+fn libp2p_replication_network_preserves_remote_unsupported_error_code() {
+    let listener = Libp2pReplicationNetwork::new(Libp2pReplicationNetworkConfig {
+        listen_addrs: vec!["/ip4/127.0.0.1/tcp/0".parse().expect("listener addr")],
+        peer_record: Some(test_peer_record("listener-unsupported")),
+        ..Libp2pReplicationNetworkConfig::default()
+    });
+    let listen_deadline = Instant::now() + Duration::from_secs(10);
+    wait_until("listener bind", listen_deadline, || {
+        !listener.listening_addrs().is_empty()
+    });
+
+    listener
+        .register_handler(
+            "/aw/node/replication/ping",
+            Box::new(|_payload| {
+                Err(WorldError::NetworkRequestFailed {
+                    code: DistributedErrorCode::ErrUnsupported,
+                    message: "forced unsupported".to_string(),
+                    retryable: false,
+                })
+            }),
+        )
+        .expect("register listener handler");
+
+    let dialer = Libp2pReplicationNetwork::new(Libp2pReplicationNetworkConfig {
+        listen_addrs: vec!["/ip4/127.0.0.1/tcp/0".parse().expect("dialer addr")],
+        bootstrap_peers: vec![listening_addr_with_peer_id(&listener)],
+        unsupported_protocol_retry_after: Duration::from_millis(250),
+        ..Libp2pReplicationNetworkConfig::default()
+    });
+    let connect_deadline = Instant::now() + Duration::from_secs(10);
+    wait_until("dialer connection", connect_deadline, || {
+        !dialer.connected_peers().is_empty()
+    });
+
+    let err = dialer
+        .request("/aw/node/replication/ping", b"node")
+        .expect_err("unsupported remote handler must bubble its code");
+    assert!(matches!(
+        err,
+        WorldError::NetworkRequestFailed {
+            code: DistributedErrorCode::ErrUnsupported,
+            ..
+        }
+    ));
+}

--- a/crates/oasis7_node/src/replication_probe_gate.rs
+++ b/crates/oasis7_node/src/replication_probe_gate.rs
@@ -51,6 +51,7 @@ fn should_fallback_provider_aware_replication_request(err: &NodeError) -> bool {
         return false;
     };
     reason.contains("NetworkProtocolUnavailable")
+        || reason.contains("libp2p-replication no admissible connected peers for protocol")
         || reason.contains("libp2p-replication no connected providers for protocol")
         || reason.contains("libp2p-replication no connected peers for protocol")
         || (reason.contains("NetworkRequestFailed")
@@ -61,9 +62,26 @@ pub(super) fn replication_request_waitable_connection_gap(err: &NodeError) -> bo
     let NodeError::Replication { reason } = err else {
         return false;
     };
-    reason.contains("no connected peers for protocol")
+    reason.contains("no admissible connected peers for protocol")
+        || reason.contains("no connected peers for protocol")
         || reason.contains("no connected providers for protocol")
         || reason.contains("no healthy provider for protocol")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn provider_aware_fallback_treats_no_admissible_peers_as_retryable() {
+        let err = NodeError::Replication {
+            reason:
+                "NetworkProtocolUnavailable { protocol: \"libp2p-replication no admissible connected peers for protocol /aw/node/replication/fetch-blob/1.0.0\" }"
+                    .to_string(),
+        };
+        assert!(should_fallback_provider_aware_replication_request(&err));
+        assert!(replication_request_waitable_connection_gap(&err));
+    }
 }
 
 pub(super) fn request_fetch_blob_with_route_fallback(

--- a/doc/.governance/rust-oversized-file-baseline.tsv
+++ b/doc/.governance/rust-oversized-file-baseline.tsv
@@ -5,15 +5,14 @@ code	crates/oasis7/src/bin/oasis7_game_launcher.rs	1429
 code	crates/oasis7/src/bin/oasis7_web_launcher/control_plane.rs	1259
 code	crates/oasis7/src/viewer/runtime_live/llm_sidecar.rs	1389
 code	crates/oasis7_client_launcher/src/launcher_core.rs	1255
-code	crates/oasis7_net/src/libp2p_net.rs	1259
+code	crates/oasis7_net/src/libp2p_net.rs	1242
 code	crates/oasis7_node/src/lib_impl_part1.rs	1246
-code	crates/oasis7_node/src/libp2p_replication_network.rs	1289
 code	crates/oasis7_node/src/replication.rs	1221
 code	crates/oasis7_node/src/types.rs	1277
 test	crates/oasis7/src/simulator/llm_agent/tests_split_part1.rs	1204
 test	crates/oasis7/src/viewer/runtime_live/tests/auth_actions.rs	1447
 test	crates/oasis7_client_launcher/src/main_tests.rs	1261
-test	crates/oasis7_net/src/libp2p_net/tests.rs	1336
+test	crates/oasis7_net/src/libp2p_net/tests.rs	1332
 test	crates/oasis7_net/src/tests.rs	1241
 test	crates/oasis7_node/src/tests_split_part1.rs	1427
 test	crates/oasis7_node/src/tests_split_part3.rs	1735


### PR DESCRIPTION
## Summary
- Fix libp2p peer lifecycle handling so partial sub-connection closes refresh surviving transport paths instead of dropping the whole peer state too early.
- Treat transient provider health gaps as retryable for replication probes and narrow `NetworkProtocolUnavailable` mapping to truly unsupported or unavailable cases.
- Deprioritize bootstrap peers that are only missing a peer record when active discovery sources are still insufficient, instead of hard-blocking them.

## Validation
- `env -u RUSTC_WRAPPER cargo test -p oasis7_net libp2p_net -- --nocapture`
- `env -u RUSTC_WRAPPER cargo test -p oasis7_node libp2p_replication_network -- --nocapture --test-threads=1`
- `env -u RUSTC_WRAPPER cargo test -p oasis7_node replication_probe_gate -- --nocapture`

## Reward Review Intake
- Request reward review: yes
- Reward Account: `oc:pk:6a0701c8feff03ff02f16048c5447223708062e7e1221f79ff2410a22be1063d`
- Evidence / context link: https://github.com/eng-cc/oasis7/pull/72
- Notes:
