### PR TITLE
runtime: burn down libp2p net and node types hotspots

### DIFF
--- a/.pm/tasks/task_5c651f038f1b48e78460ad7f95f6e187.execution.md
+++ b/.pm/tasks/task_5c651f038f1b48e78460ad7f95f6e187.execution.md
@@ -1,0 +1,19 @@
+# task_5c651f038f1b48e78460ad7f95f6e187 Execution Log
+
+- task_uid: task_5c651f038f1b48e78460ad7f95f6e187
+- title: burn down oasis7 node types controller binding hotspot
+- owner_role: runtime_engineer
+- worktree_hint: /home/scc/worktrees/oasis7-engineering-rust-node-types-controller-binding-burn-down
+
+<!-- Append entries using:
+Example:
+  ## YYYY-MM-DD HH:MM:SS CST / role_name
+  - 完成内容: ...
+  - 遗留事项: ...
+-->
+
+## 2026-04-17 21:53:46 CST / runtime_engineer
+- 完成内容: 将 `crates/oasis7_node/src/types.rs` 内的 main-token controller binding 常量、类型、默认值、builder 与校验 helper 抽到新文件 `crates/oasis7_node/src/types/main_token_controller_binding.rs`，并在 `types.rs` 中改为模块重导出；根文件已从 1277 行降到 1069 行，未引入新的 structural slicing / allowlist 债，同时已从 `doc/.governance/rust-oversized-file-baseline.tsv` 退休对应冻结条目。
+- 完成内容: 已执行 `env -u RUSTC_WRAPPER cargo fmt --all`、`env -u RUSTC_WRAPPER cargo check -p oasis7_node`、`cargo test -p oasis7_node types::tests:: -- --nocapture`、`cargo test -p oasis7_node submit_consensus_action_payload_accepts_signed_main_token_genesis_action -- --nocapture` 与 `cargo test -p oasis7_node submit_consensus_action_payload_accepts_signed_main_token_treasury_action -- --nocapture`，均通过，证明 controller binding 导出与授权路径未回归。
+- 完成内容: `cargo test -p oasis7_node --lib -- --nocapture` 当前环境仍有 3 个非定向失败签名：`runtime_network_replication_respects_topic_isolation`（目录残留断言）、`runtime_gossip_replication_persists_guard_across_restart`（UDP 端口占用）、`runtime_fetch_handlers_reject_unsigned_fetch_request_in_signed_mode`（`NetworkProtocolUnavailable`）；本轮未触碰对应 replication/network 行为，先按现状记录，不在本 task 扩大修复范围。
+- 遗留事项: 下一批 Rust 1200 行治理继续优先处理 `crates/oasis7/src/viewer/runtime_live/llm_sidecar.rs`、`crates/oasis7/src/bin/oasis7_web_launcher/control_plane.rs`、`crates/oasis7_client_launcher/src/launcher_core.rs`、`crates/oasis7_node/src/replication.rs` 与剩余高体量测试文件；`oasis7_game_launcher.rs` 当前实测 916 行，不再列为超限热点。

--- a/.pm/tasks/task_5c651f038f1b48e78460ad7f95f6e187.yaml
+++ b/.pm/tasks/task_5c651f038f1b48e78460ad7f95f6e187.yaml
@@ -1,0 +1,26 @@
+task_uid: task_5c651f038f1b48e78460ad7f95f6e187
+title: "burn down oasis7 node types controller binding hotspot"
+owner_role: runtime_engineer
+worktree_hint: /home/scc/worktrees/oasis7-engineering-rust-node-types-controller-binding-burn-down
+execution_log_path: .pm/tasks/task_5c651f038f1b48e78460ad7f95f6e187.execution.md
+status: done
+priority: P2
+source_signal: null
+source_refs:
+  - doc/engineering/project.md
+  - doc/engineering/rust-governance/rust-1200-line-root-cause-governance-2026-03-29.project.md
+doc_refs:
+  - doc/engineering/rust-governance/rust-1200-line-root-cause-governance-2026-03-29.prd.md
+  - doc/engineering/rust-governance/rust-1200-line-root-cause-governance-2026-03-29.design.md
+related_prd:
+  - PRD-ENGINEERING-R1200-002
+  - PRD-ENGINEERING-R1200-004
+  - PRD-ENGINEERING-R1200-005
+acceptance:
+  - "reduce crates/oasis7_node/src/types.rs below the 1200-line limit without structural slicing debt"
+  - "preserve node controller binding validation behavior and public exports"
+  - "keep targeted oasis7_node validation green and structural slicing baseline unchanged"
+handoff_to: []
+updated_at: 2026-04-17T21:57:03+08:00
+last_started_at: 2026-04-17T21:49:20+08:00
+last_closed_at: 2026-04-17T21:57:03+08:00

--- a/.pm/tasks/task_fbffb4f8dc5b4326b6a09751f4779526.execution.md
+++ b/.pm/tasks/task_fbffb4f8dc5b4326b6a09751f4779526.execution.md
@@ -1,0 +1,18 @@
+# task_fbffb4f8dc5b4326b6a09751f4779526 Execution Log
+
+- task_uid: task_fbffb4f8dc5b4326b6a09751f4779526
+- title: burn down libp2p net orchestrator hotspot
+- owner_role: runtime_engineer
+- worktree_hint: /home/scc/worktrees/oasis7-engineering-rust-libp2p-net-orchestrator-burn-down
+
+<!-- Append entries using:
+Example:
+  ## YYYY-MM-DD HH:MM:SS CST / role_name
+  - 完成内容: ...
+  - 遗留事项: ...
+-->
+
+## 2026-04-17 21:39:22 CST / runtime_engineer
+- 完成内容: 将 `Libp2pNetwork::new` 内重复的 bootstrap / periodic 调度样板抽到新文件 `crates/oasis7_net/src/libp2p_net/constructor_support.rs`，新增 `schedule_periodic_republish`、`schedule_periodic_discovery_refresh`、`schedule_bootstrap_redial` 与 `enqueue_initial_bootstrap_dials`，把 `crates/oasis7_net/src/libp2p_net.rs` 从 1199 行压到 1156 行，未引入新的 structural slicing / allowlist 债。
+- 完成内容: 已执行 `env -u RUSTC_WRAPPER cargo fmt --all`、`env -u RUSTC_WRAPPER cargo check -p oasis7_net`、`cargo test -p oasis7_net --lib -- --nocapture`、`./scripts/check-rust-file-size.sh`、`./scripts/doc-governance-check.sh` 与 `git diff --check`；其中 `oasis7_net` 单测 122/122 通过，rust-size 检查保持 `structural slice files=49, include targets=48` 冻结值不变。
+- 遗留事项: 下一批 Rust 1200 行治理继续优先处理 `oasis7_game_launcher.rs`、`viewer/runtime_live/llm_sidecar.rs` 与 `oasis7_node/src/types.rs` 等剩余高体量热点。

--- a/.pm/tasks/task_fbffb4f8dc5b4326b6a09751f4779526.yaml
+++ b/.pm/tasks/task_fbffb4f8dc5b4326b6a09751f4779526.yaml
@@ -1,0 +1,26 @@
+task_uid: task_fbffb4f8dc5b4326b6a09751f4779526
+title: "burn down libp2p net orchestrator hotspot"
+owner_role: runtime_engineer
+worktree_hint: /home/scc/worktrees/oasis7-engineering-rust-libp2p-net-orchestrator-burn-down
+execution_log_path: .pm/tasks/task_fbffb4f8dc5b4326b6a09751f4779526.execution.md
+status: done
+priority: P2
+source_signal: null
+source_refs:
+  - doc/engineering/project.md
+  - doc/engineering/rust-governance/rust-1200-line-root-cause-governance-2026-03-29.project.md
+doc_refs:
+  - doc/engineering/rust-governance/rust-1200-line-root-cause-governance-2026-03-29.prd.md
+  - doc/engineering/rust-governance/rust-1200-line-root-cause-governance-2026-03-29.design.md
+related_prd:
+  - PRD-ENGINEERING-R1200-002
+  - PRD-ENGINEERING-R1200-004
+  - PRD-ENGINEERING-R1200-005
+acceptance:
+  - "reduce libp2p_net root file below threshold without introducing structural slicing debt"
+  - "keep oasis7_net compile and targeted tests green"
+  - "preserve frozen structural slicing baseline count"
+handoff_to: []
+updated_at: 2026-04-17T21:41:00+08:00
+last_started_at: 2026-04-17T21:33:46+08:00
+last_closed_at: 2026-04-17T21:40:30+08:00

--- a/crates/oasis7_net/src/libp2p_net.rs
+++ b/crates/oasis7_net/src/libp2p_net.rs
@@ -6,6 +6,7 @@ use std::sync::{Arc, Mutex};
 mod api;
 mod config;
 mod connection_lifecycle;
+mod constructor_support;
 mod discovery;
 mod error_mapping;
 mod kad_queries;
@@ -37,6 +38,10 @@ pub use config::Libp2pNetworkConfig;
 use connection_lifecycle::{
     clear_disconnected_peer_state, failover_after_disconnect, record_established_connection,
     refresh_active_path_after_connection_close, refresh_peer_manager_views,
+};
+use constructor_support::{
+    enqueue_initial_bootstrap_dials, schedule_bootstrap_redial,
+    schedule_periodic_discovery_refresh, schedule_periodic_republish,
 };
 use discovery::{
     clear_pending_peer_record_request, handle_peer_record_response, handle_rendezvous_discovered,
@@ -227,57 +232,15 @@ impl Libp2pNetwork {
                 }
             }
 
-            if republish_interval_ms > 0 {
-                std::thread::spawn(move || {
-                    let mut republish_tx = republish_tx;
-                    loop {
-                        std::thread::sleep(std::time::Duration::from_millis(
-                            republish_interval_ms as u64,
-                        ));
-                        match republish_tx.try_send(Command::RepublishProviders) {
-                            Ok(()) => {}
-                            Err(err) if err.is_full() => {
-                                // Best effort: skip this republish tick if the command queue is saturated.
-                            }
-                            Err(_) => break,
-                        }
-                    }
-                });
+            schedule_periodic_republish(republish_tx, republish_interval_ms);
+            if peer_record_template.is_some() {
+                schedule_periodic_discovery_refresh(discovery_tx, discovery_query_interval_ms);
             }
-
-            if discovery_query_interval_ms > 0 && peer_record_template.is_some() {
-                std::thread::spawn(move || {
-                    let mut discovery_tx = discovery_tx;
-                    loop {
-                        std::thread::sleep(std::time::Duration::from_millis(
-                            discovery_query_interval_ms as u64,
-                        ));
-                        match discovery_tx.try_send(Command::RefreshPeerDiscovery) {
-                            Ok(()) => {}
-                            Err(err) if err.is_full() => {}
-                            Err(_) => break,
-                        }
-                    }
-                });
-            }
-
-            if bootstrap_redial_interval_ms > 0 && !bootstrap_redial_peers.is_empty() {
-                std::thread::spawn(move || {
-                    let mut bootstrap_redial_tx = bootstrap_redial_tx;
-                    loop {
-                        std::thread::sleep(std::time::Duration::from_millis(
-                            bootstrap_redial_interval_ms as u64,
-                        ));
-                        for addr in &bootstrap_redial_peers {
-                            match bootstrap_redial_tx.try_send(Command::Dial(addr.clone())) {
-                                Ok(()) => {}
-                                Err(err) if err.is_full() => break,
-                                Err(_) => return,
-                            }
-                        }
-                    }
-                });
-            }
+            schedule_bootstrap_redial(
+                bootstrap_redial_tx,
+                bootstrap_redial_peers,
+                bootstrap_redial_interval_ms,
+            );
 
             async_std::task::block_on(async move {
                 let mut command_rx = command_rx;
@@ -1164,13 +1127,7 @@ impl Libp2pNetwork {
                 }
             });
         });
-        let mut bootstrap_tx = command_tx.clone();
-        for addr in bootstrap_peers {
-            // Best-effort: if the background task exits, dial requests can be dropped.
-            if bootstrap_tx.try_send(Command::Dial(addr)).is_err() {
-                break;
-            }
-        }
+        enqueue_initial_bootstrap_dials(command_tx.clone(), bootstrap_peers);
         Self {
             peer_id,
             keypair,

--- a/crates/oasis7_net/src/libp2p_net/constructor_support.rs
+++ b/crates/oasis7_net/src/libp2p_net/constructor_support.rs
@@ -1,0 +1,64 @@
+use super::*;
+
+pub(super) fn schedule_periodic_republish(mut command_tx: mpsc::Sender<Command>, interval_ms: i64) {
+    if interval_ms <= 0 {
+        return;
+    }
+    std::thread::spawn(move || loop {
+        std::thread::sleep(std::time::Duration::from_millis(interval_ms as u64));
+        match command_tx.try_send(Command::RepublishProviders) {
+            Ok(()) => {}
+            Err(err) if err.is_full() => {}
+            Err(_) => break,
+        }
+    });
+}
+
+pub(super) fn schedule_periodic_discovery_refresh(
+    mut command_tx: mpsc::Sender<Command>,
+    interval_ms: i64,
+) {
+    if interval_ms <= 0 {
+        return;
+    }
+    std::thread::spawn(move || loop {
+        std::thread::sleep(std::time::Duration::from_millis(interval_ms as u64));
+        match command_tx.try_send(Command::RefreshPeerDiscovery) {
+            Ok(()) => {}
+            Err(err) if err.is_full() => {}
+            Err(_) => break,
+        }
+    });
+}
+
+pub(super) fn schedule_bootstrap_redial(
+    mut command_tx: mpsc::Sender<Command>,
+    peers: Vec<Multiaddr>,
+    interval_ms: i64,
+) {
+    if interval_ms <= 0 || peers.is_empty() {
+        return;
+    }
+    std::thread::spawn(move || loop {
+        std::thread::sleep(std::time::Duration::from_millis(interval_ms as u64));
+        for addr in &peers {
+            match command_tx.try_send(Command::Dial(addr.clone())) {
+                Ok(()) => {}
+                Err(err) if err.is_full() => break,
+                Err(_) => return,
+            }
+        }
+    });
+}
+
+pub(super) fn enqueue_initial_bootstrap_dials(
+    mut command_tx: mpsc::Sender<Command>,
+    peers: Vec<Multiaddr>,
+) {
+    for addr in peers {
+        // Best effort: if the background task exits, dial requests can be dropped.
+        if command_tx.try_send(Command::Dial(addr)).is_err() {
+            break;
+        }
+    }
+}

--- a/crates/oasis7_node/src/types.rs
+++ b/crates/oasis7_node/src/types.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeMap;
 use std::fmt;
 use std::net::SocketAddr;
 use std::path::PathBuf;
@@ -12,7 +12,12 @@ use oasis7_proto::distributed_net::{NetworkLane, NetworkLaneOperation};
 use crate::pos_validation::validate_pos_config;
 use crate::{NodeConsensusAction, NodeError, NodeReplicationConfig};
 
+mod main_token_controller_binding;
 mod node_config_flags;
+
+pub use main_token_controller_binding::{
+    NodeMainTokenControllerBindingConfig, NodeMainTokenControllerSignerPolicy,
+};
 
 const DEFAULT_MAX_PENDING_CONSENSUS_ACTIONS: usize = 4096;
 const DEFAULT_MAX_ENGINE_PENDING_CONSENSUS_ACTIONS: usize = 4096;
@@ -24,16 +29,6 @@ const DEFAULT_REPLICA_MAINTENANCE_MAX_CONTENT_HASH_SAMPLES: usize = 128;
 const DEFAULT_REPLICA_MAINTENANCE_POLL_INTERVAL_MS: i64 = 60_000;
 const DEFAULT_FEEDBACK_P2P_MAX_INCOMING_ANNOUNCES_PER_TICK: usize = 128;
 const DEFAULT_FEEDBACK_P2P_MAX_OUTGOING_ANNOUNCES_PER_TICK: usize = 128;
-const DEFAULT_MAIN_TOKEN_GENESIS_CONTROLLER_ACCOUNT_ID: &str = "msig.genesis.v1";
-const DEFAULT_MAIN_TOKEN_TREASURY_BUCKET_STAKING_REWARD: &str = "staking_reward_pool";
-const DEFAULT_MAIN_TOKEN_TREASURY_BUCKET_ECOSYSTEM_POOL: &str = "ecosystem_pool";
-const DEFAULT_MAIN_TOKEN_TREASURY_BUCKET_SECURITY_RESERVE: &str = "security_reserve";
-const DEFAULT_MAIN_TOKEN_TREASURY_CONTROLLER_STAKING_GOVERNANCE: &str =
-    "msig.staking_governance.v1";
-const DEFAULT_MAIN_TOKEN_TREASURY_CONTROLLER_ECOSYSTEM_GOVERNANCE: &str =
-    "msig.ecosystem_governance.v1";
-const DEFAULT_MAIN_TOKEN_TREASURY_CONTROLLER_SECURITY_COUNCIL: &str = "msig.security_council.v1";
-const DEFAULT_MAIN_TOKEN_CONTROLLER_SIGNER_THRESHOLD: u16 = 1;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum NodeRole {
@@ -602,163 +597,6 @@ pub struct NodeConfig {
     pub feedback_p2p: Option<NodeFeedbackP2pConfig>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct NodeMainTokenControllerBindingConfig {
-    pub genesis_controller_account_id: String,
-    pub treasury_bucket_controller_slots: BTreeMap<String, String>,
-    pub controller_signer_policies: BTreeMap<String, NodeMainTokenControllerSignerPolicy>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct NodeMainTokenControllerSignerPolicy {
-    pub threshold: u16,
-    pub allowed_public_keys: BTreeSet<String>,
-}
-
-impl Default for NodeMainTokenControllerSignerPolicy {
-    fn default() -> Self {
-        Self {
-            threshold: DEFAULT_MAIN_TOKEN_CONTROLLER_SIGNER_THRESHOLD,
-            allowed_public_keys: BTreeSet::new(),
-        }
-    }
-}
-
-impl Default for NodeMainTokenControllerBindingConfig {
-    fn default() -> Self {
-        let mut treasury_bucket_controller_slots = BTreeMap::new();
-        let mut controller_signer_policies = BTreeMap::new();
-        treasury_bucket_controller_slots.insert(
-            DEFAULT_MAIN_TOKEN_TREASURY_BUCKET_STAKING_REWARD.to_string(),
-            DEFAULT_MAIN_TOKEN_TREASURY_CONTROLLER_STAKING_GOVERNANCE.to_string(),
-        );
-        controller_signer_policies.insert(
-            DEFAULT_MAIN_TOKEN_TREASURY_CONTROLLER_STAKING_GOVERNANCE.to_string(),
-            NodeMainTokenControllerSignerPolicy::default(),
-        );
-        treasury_bucket_controller_slots.insert(
-            DEFAULT_MAIN_TOKEN_TREASURY_BUCKET_ECOSYSTEM_POOL.to_string(),
-            DEFAULT_MAIN_TOKEN_TREASURY_CONTROLLER_ECOSYSTEM_GOVERNANCE.to_string(),
-        );
-        controller_signer_policies.insert(
-            DEFAULT_MAIN_TOKEN_TREASURY_CONTROLLER_ECOSYSTEM_GOVERNANCE.to_string(),
-            NodeMainTokenControllerSignerPolicy::default(),
-        );
-        treasury_bucket_controller_slots.insert(
-            DEFAULT_MAIN_TOKEN_TREASURY_BUCKET_SECURITY_RESERVE.to_string(),
-            DEFAULT_MAIN_TOKEN_TREASURY_CONTROLLER_SECURITY_COUNCIL.to_string(),
-        );
-        controller_signer_policies.insert(
-            DEFAULT_MAIN_TOKEN_TREASURY_CONTROLLER_SECURITY_COUNCIL.to_string(),
-            NodeMainTokenControllerSignerPolicy::default(),
-        );
-        controller_signer_policies.insert(
-            DEFAULT_MAIN_TOKEN_GENESIS_CONTROLLER_ACCOUNT_ID.to_string(),
-            NodeMainTokenControllerSignerPolicy::default(),
-        );
-        Self {
-            genesis_controller_account_id: DEFAULT_MAIN_TOKEN_GENESIS_CONTROLLER_ACCOUNT_ID
-                .to_string(),
-            treasury_bucket_controller_slots,
-            controller_signer_policies,
-        }
-    }
-}
-
-impl NodeMainTokenControllerBindingConfig {
-    pub fn with_genesis_controller_account_id(
-        mut self,
-        account_id: impl Into<String>,
-    ) -> Result<Self, NodeError> {
-        self.genesis_controller_account_id = normalize_controller_slot_id(
-            account_id.into().as_str(),
-            "main_token_controller_binding.genesis_controller_account_id",
-        )?;
-        Ok(self)
-    }
-
-    pub fn with_treasury_bucket_controller_slot(
-        mut self,
-        bucket_id: impl Into<String>,
-        controller_account_id: impl Into<String>,
-    ) -> Result<Self, NodeError> {
-        let bucket_id = normalize_controller_slot_id(
-            bucket_id.into().as_str(),
-            "main_token_controller_binding.treasury bucket_id",
-        )?;
-        let controller_account_id = normalize_controller_slot_id(
-            controller_account_id.into().as_str(),
-            "main_token_controller_binding.treasury controller_account_id",
-        )?;
-        self.treasury_bucket_controller_slots
-            .insert(bucket_id, controller_account_id);
-        Ok(self)
-    }
-
-    pub fn validate(&self) -> Result<(), NodeError> {
-        normalize_controller_slot_id(
-            self.genesis_controller_account_id.as_str(),
-            "main_token_controller_binding.genesis_controller_account_id",
-        )?;
-        for (bucket_id, controller_account_id) in &self.treasury_bucket_controller_slots {
-            normalize_controller_slot_id(
-                bucket_id.as_str(),
-                "main_token_controller_binding.treasury bucket_id",
-            )?;
-            normalize_controller_slot_id(
-                controller_account_id.as_str(),
-                "main_token_controller_binding.treasury controller_account_id",
-            )?;
-        }
-        for (controller_account_id, policy) in &self.controller_signer_policies {
-            normalize_controller_slot_id(
-                controller_account_id.as_str(),
-                "main_token_controller_binding.controller_signer_policies account_id",
-            )?;
-            validate_controller_signer_policy(policy, controller_account_id.as_str())?;
-        }
-        Ok(())
-    }
-
-    pub fn with_controller_signer_policy(
-        mut self,
-        controller_account_id: impl Into<String>,
-        threshold: u16,
-        allowed_public_keys: Vec<String>,
-    ) -> Result<Self, NodeError> {
-        let controller_account_id = normalize_controller_slot_id(
-            controller_account_id.into().as_str(),
-            "main_token_controller_binding.controller_signer_policies account_id",
-        )?;
-        let policy = NodeMainTokenControllerSignerPolicy::new(threshold, allowed_public_keys)?;
-        self.controller_signer_policies
-            .insert(controller_account_id, policy);
-        Ok(self)
-    }
-}
-
-impl NodeMainTokenControllerSignerPolicy {
-    pub fn new(threshold: u16, allowed_public_keys: Vec<String>) -> Result<Self, NodeError> {
-        if threshold == 0 {
-            return Err(NodeError::InvalidConfig {
-                reason: "main_token_controller_binding signer threshold must be > 0".to_string(),
-            });
-        }
-        let mut normalized = BTreeSet::new();
-        for public_key in allowed_public_keys {
-            let public_key = normalize_ed25519_public_key_hex(
-                public_key.as_str(),
-                "main_token_controller_binding signer public key",
-            )?;
-            normalized.insert(public_key);
-        }
-        Ok(Self {
-            threshold,
-            allowed_public_keys: normalized,
-        })
-    }
-}
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct NodeReplicaMaintenanceConfig {
     pub enabled: bool,
@@ -1123,52 +961,6 @@ impl NodeConfig {
             gossip.dynamic_peer_ttl_ms = self.dynamic_gossip_peer_ttl_ms;
         }
     }
-}
-
-fn normalize_controller_slot_id(raw: &str, label: &str) -> Result<String, NodeError> {
-    let value = raw.trim();
-    if value.is_empty() {
-        return Err(NodeError::InvalidConfig {
-            reason: format!("{label} cannot be empty"),
-        });
-    }
-    Ok(value.to_string())
-}
-
-fn validate_controller_signer_policy(
-    policy: &NodeMainTokenControllerSignerPolicy,
-    controller_account_id: &str,
-) -> Result<(), NodeError> {
-    if policy.threshold == 0 {
-        return Err(NodeError::InvalidConfig {
-            reason: format!(
-                "main_token controller signer policy threshold must be > 0: controller_account_id={controller_account_id}"
-            ),
-        });
-    }
-    for public_key in &policy.allowed_public_keys {
-        normalize_ed25519_public_key_hex(
-            public_key.as_str(),
-            "main_token_controller_binding signer public key",
-        )?;
-    }
-    Ok(())
-}
-
-fn normalize_ed25519_public_key_hex(raw: &str, label: &str) -> Result<String, NodeError> {
-    let normalized = normalize_controller_slot_id(raw, label)?;
-    let bytes = hex::decode(normalized.as_str()).map_err(|err| NodeError::InvalidConfig {
-        reason: format!("decode {label} failed: {err}"),
-    })?;
-    if bytes.len() != 32 {
-        return Err(NodeError::InvalidConfig {
-            reason: format!(
-                "{label} length mismatch: expected 32 bytes, got {}",
-                bytes.len()
-            ),
-        });
-    }
-    Ok(hex::encode(bytes))
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/oasis7_node/src/types/main_token_controller_binding.rs
+++ b/crates/oasis7_node/src/types/main_token_controller_binding.rs
@@ -1,0 +1,217 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use crate::NodeError;
+
+const DEFAULT_MAIN_TOKEN_GENESIS_CONTROLLER_ACCOUNT_ID: &str = "msig.genesis.v1";
+const DEFAULT_MAIN_TOKEN_TREASURY_BUCKET_STAKING_REWARD: &str = "staking_reward_pool";
+const DEFAULT_MAIN_TOKEN_TREASURY_BUCKET_ECOSYSTEM_POOL: &str = "ecosystem_pool";
+const DEFAULT_MAIN_TOKEN_TREASURY_BUCKET_SECURITY_RESERVE: &str = "security_reserve";
+const DEFAULT_MAIN_TOKEN_TREASURY_CONTROLLER_STAKING_GOVERNANCE: &str =
+    "msig.staking_governance.v1";
+const DEFAULT_MAIN_TOKEN_TREASURY_CONTROLLER_ECOSYSTEM_GOVERNANCE: &str =
+    "msig.ecosystem_governance.v1";
+const DEFAULT_MAIN_TOKEN_TREASURY_CONTROLLER_SECURITY_COUNCIL: &str = "msig.security_council.v1";
+const DEFAULT_MAIN_TOKEN_CONTROLLER_SIGNER_THRESHOLD: u16 = 1;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NodeMainTokenControllerBindingConfig {
+    pub genesis_controller_account_id: String,
+    pub treasury_bucket_controller_slots: BTreeMap<String, String>,
+    pub controller_signer_policies: BTreeMap<String, NodeMainTokenControllerSignerPolicy>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NodeMainTokenControllerSignerPolicy {
+    pub threshold: u16,
+    pub allowed_public_keys: BTreeSet<String>,
+}
+
+impl Default for NodeMainTokenControllerSignerPolicy {
+    fn default() -> Self {
+        Self {
+            threshold: DEFAULT_MAIN_TOKEN_CONTROLLER_SIGNER_THRESHOLD,
+            allowed_public_keys: BTreeSet::new(),
+        }
+    }
+}
+
+impl Default for NodeMainTokenControllerBindingConfig {
+    fn default() -> Self {
+        let mut treasury_bucket_controller_slots = BTreeMap::new();
+        let mut controller_signer_policies = BTreeMap::new();
+        treasury_bucket_controller_slots.insert(
+            DEFAULT_MAIN_TOKEN_TREASURY_BUCKET_STAKING_REWARD.to_string(),
+            DEFAULT_MAIN_TOKEN_TREASURY_CONTROLLER_STAKING_GOVERNANCE.to_string(),
+        );
+        controller_signer_policies.insert(
+            DEFAULT_MAIN_TOKEN_TREASURY_CONTROLLER_STAKING_GOVERNANCE.to_string(),
+            NodeMainTokenControllerSignerPolicy::default(),
+        );
+        treasury_bucket_controller_slots.insert(
+            DEFAULT_MAIN_TOKEN_TREASURY_BUCKET_ECOSYSTEM_POOL.to_string(),
+            DEFAULT_MAIN_TOKEN_TREASURY_CONTROLLER_ECOSYSTEM_GOVERNANCE.to_string(),
+        );
+        controller_signer_policies.insert(
+            DEFAULT_MAIN_TOKEN_TREASURY_CONTROLLER_ECOSYSTEM_GOVERNANCE.to_string(),
+            NodeMainTokenControllerSignerPolicy::default(),
+        );
+        treasury_bucket_controller_slots.insert(
+            DEFAULT_MAIN_TOKEN_TREASURY_BUCKET_SECURITY_RESERVE.to_string(),
+            DEFAULT_MAIN_TOKEN_TREASURY_CONTROLLER_SECURITY_COUNCIL.to_string(),
+        );
+        controller_signer_policies.insert(
+            DEFAULT_MAIN_TOKEN_TREASURY_CONTROLLER_SECURITY_COUNCIL.to_string(),
+            NodeMainTokenControllerSignerPolicy::default(),
+        );
+        controller_signer_policies.insert(
+            DEFAULT_MAIN_TOKEN_GENESIS_CONTROLLER_ACCOUNT_ID.to_string(),
+            NodeMainTokenControllerSignerPolicy::default(),
+        );
+        Self {
+            genesis_controller_account_id: DEFAULT_MAIN_TOKEN_GENESIS_CONTROLLER_ACCOUNT_ID
+                .to_string(),
+            treasury_bucket_controller_slots,
+            controller_signer_policies,
+        }
+    }
+}
+
+impl NodeMainTokenControllerBindingConfig {
+    pub fn with_genesis_controller_account_id(
+        mut self,
+        account_id: impl Into<String>,
+    ) -> Result<Self, NodeError> {
+        self.genesis_controller_account_id = normalize_controller_slot_id(
+            account_id.into().as_str(),
+            "main_token_controller_binding.genesis_controller_account_id",
+        )?;
+        Ok(self)
+    }
+
+    pub fn with_treasury_bucket_controller_slot(
+        mut self,
+        bucket_id: impl Into<String>,
+        controller_account_id: impl Into<String>,
+    ) -> Result<Self, NodeError> {
+        let bucket_id = normalize_controller_slot_id(
+            bucket_id.into().as_str(),
+            "main_token_controller_binding.treasury bucket_id",
+        )?;
+        let controller_account_id = normalize_controller_slot_id(
+            controller_account_id.into().as_str(),
+            "main_token_controller_binding.treasury controller_account_id",
+        )?;
+        self.treasury_bucket_controller_slots
+            .insert(bucket_id, controller_account_id);
+        Ok(self)
+    }
+
+    pub fn validate(&self) -> Result<(), NodeError> {
+        normalize_controller_slot_id(
+            self.genesis_controller_account_id.as_str(),
+            "main_token_controller_binding.genesis_controller_account_id",
+        )?;
+        for (bucket_id, controller_account_id) in &self.treasury_bucket_controller_slots {
+            normalize_controller_slot_id(
+                bucket_id.as_str(),
+                "main_token_controller_binding.treasury bucket_id",
+            )?;
+            normalize_controller_slot_id(
+                controller_account_id.as_str(),
+                "main_token_controller_binding.treasury controller_account_id",
+            )?;
+        }
+        for (controller_account_id, policy) in &self.controller_signer_policies {
+            normalize_controller_slot_id(
+                controller_account_id.as_str(),
+                "main_token_controller_binding.controller_signer_policies account_id",
+            )?;
+            validate_controller_signer_policy(policy, controller_account_id.as_str())?;
+        }
+        Ok(())
+    }
+
+    pub fn with_controller_signer_policy(
+        mut self,
+        controller_account_id: impl Into<String>,
+        threshold: u16,
+        allowed_public_keys: Vec<String>,
+    ) -> Result<Self, NodeError> {
+        let controller_account_id = normalize_controller_slot_id(
+            controller_account_id.into().as_str(),
+            "main_token_controller_binding.controller_signer_policies account_id",
+        )?;
+        let policy = NodeMainTokenControllerSignerPolicy::new(threshold, allowed_public_keys)?;
+        self.controller_signer_policies
+            .insert(controller_account_id, policy);
+        Ok(self)
+    }
+}
+
+impl NodeMainTokenControllerSignerPolicy {
+    pub fn new(threshold: u16, allowed_public_keys: Vec<String>) -> Result<Self, NodeError> {
+        if threshold == 0 {
+            return Err(NodeError::InvalidConfig {
+                reason: "main_token_controller_binding signer threshold must be > 0".to_string(),
+            });
+        }
+        let mut normalized = BTreeSet::new();
+        for public_key in allowed_public_keys {
+            let public_key = normalize_ed25519_public_key_hex(
+                public_key.as_str(),
+                "main_token_controller_binding signer public key",
+            )?;
+            normalized.insert(public_key);
+        }
+        Ok(Self {
+            threshold,
+            allowed_public_keys: normalized,
+        })
+    }
+}
+
+fn normalize_controller_slot_id(raw: &str, label: &str) -> Result<String, NodeError> {
+    let value = raw.trim();
+    if value.is_empty() {
+        return Err(NodeError::InvalidConfig {
+            reason: format!("{label} cannot be empty"),
+        });
+    }
+    Ok(value.to_string())
+}
+
+fn validate_controller_signer_policy(
+    policy: &NodeMainTokenControllerSignerPolicy,
+    controller_account_id: &str,
+) -> Result<(), NodeError> {
+    if policy.threshold == 0 {
+        return Err(NodeError::InvalidConfig {
+            reason: format!(
+                "main_token controller signer policy threshold must be > 0: controller_account_id={controller_account_id}"
+            ),
+        });
+    }
+    for public_key in &policy.allowed_public_keys {
+        normalize_ed25519_public_key_hex(
+            public_key.as_str(),
+            "main_token_controller_binding signer public key",
+        )?;
+    }
+    Ok(())
+}
+
+fn normalize_ed25519_public_key_hex(raw: &str, label: &str) -> Result<String, NodeError> {
+    let normalized = normalize_controller_slot_id(raw, label)?;
+    let bytes = hex::decode(normalized.as_str()).map_err(|err| NodeError::InvalidConfig {
+        reason: format!("decode {label} failed: {err}"),
+    })?;
+    if bytes.len() != 32 {
+        return Err(NodeError::InvalidConfig {
+            reason: format!(
+                "{label} length mismatch: expected 32 bytes, got {}",
+                bytes.len()
+            ),
+        });
+    }
+    Ok(hex::encode(bytes))
+}

--- a/doc/.governance/rust-oversized-file-baseline.tsv
+++ b/doc/.governance/rust-oversized-file-baseline.tsv
@@ -4,7 +4,6 @@ code	crates/oasis7/src/bin/oasis7_web_launcher/control_plane.rs	1257
 code	crates/oasis7/src/viewer/runtime_live/llm_sidecar.rs	1389
 code	crates/oasis7_client_launcher/src/launcher_core.rs	1254
 code	crates/oasis7_node/src/replication.rs	1221
-code	crates/oasis7_node/src/types.rs	1277
 test	crates/oasis7/src/simulator/llm_agent/tests_split_part1.rs	1204
 test	crates/oasis7/src/viewer/runtime_live/tests/auth_actions.rs	1335
 test	crates/oasis7_client_launcher/src/main_tests.rs	1261

--- a/doc/engineering/project.md
+++ b/doc/engineering/project.md
@@ -136,6 +136,7 @@
   历史说明：本页更早阶段若出现“commit-before review”或固定使用 `codex-review-snapshot.sh` 的描述，均仅作历史追踪保留；现已被 `TASK-ENGINEERING-113` 与 `drop-local-review-script` supersede，当前默认口径为 GitHub PR review。
 - [x] TASK-ENGINEERING-PMVIEW-001 (PRD-ENGINEERING-021/015) [test_tier_required] + [test_tier_full]: 将 `.pm` registry/backlog 降级为 git-ignored 本地生成视图，新增 `sync-views` 入口并让 PM 读路径在缺失时自动重建；同时收口 engineering 根 `project.md` 的热点写法，并冻结“新工程治理任务允许使用 topic-scoped 稳定 task ID”的口径。
 - [x] task-worktree-pm-bootstrap (PRD-ENGINEERING-021) [test_tier_required]: 给 `scripts/new-task-worktree.sh` 增加 `--pm-*` 原子 bootstrap，确保 `.pm` task 在目标 worktree 内完成创建、提升到 committed 并记录 workflow start，同时新增 source-worktree-clean smoke。 Trace: .pm/tasks/task_c1560decfc2b40fab17803fa78909b34.yaml
+- [x] libp2p-net-orchestrator-burn-down (PRD-ENGINEERING-R1200-002/004/005) [test_tier_required]: 抽离 `Libp2pNetwork::new` 的 bootstrap / periodic 调度样板到 `constructor_support.rs`，将 `crates/oasis7_net/src/libp2p_net.rs` 从 1199 行压到 1156 行，并保持 frozen structural slicing baseline 不变。 Trace: .pm/tasks/task_fbffb4f8dc5b4326b6a09751f4779526.yaml
 
 ## 依赖
 - 模块设计总览：`doc/engineering/design.md`

--- a/doc/engineering/project.md
+++ b/doc/engineering/project.md
@@ -137,6 +137,7 @@
 - [x] TASK-ENGINEERING-PMVIEW-001 (PRD-ENGINEERING-021/015) [test_tier_required] + [test_tier_full]: 将 `.pm` registry/backlog 降级为 git-ignored 本地生成视图，新增 `sync-views` 入口并让 PM 读路径在缺失时自动重建；同时收口 engineering 根 `project.md` 的热点写法，并冻结“新工程治理任务允许使用 topic-scoped 稳定 task ID”的口径。
 - [x] task-worktree-pm-bootstrap (PRD-ENGINEERING-021) [test_tier_required]: 给 `scripts/new-task-worktree.sh` 增加 `--pm-*` 原子 bootstrap，确保 `.pm` task 在目标 worktree 内完成创建、提升到 committed 并记录 workflow start，同时新增 source-worktree-clean smoke。 Trace: .pm/tasks/task_c1560decfc2b40fab17803fa78909b34.yaml
 - [x] libp2p-net-orchestrator-burn-down (PRD-ENGINEERING-R1200-002/004/005) [test_tier_required]: 抽离 `Libp2pNetwork::new` 的 bootstrap / periodic 调度样板到 `constructor_support.rs`，将 `crates/oasis7_net/src/libp2p_net.rs` 从 1199 行压到 1156 行，并保持 frozen structural slicing baseline 不变。 Trace: .pm/tasks/task_fbffb4f8dc5b4326b6a09751f4779526.yaml
+- [x] rust-node-types-controller-binding-burn-down (PRD-ENGINEERING-R1200-002/004/005) [test_tier_required]: 将 `crates/oasis7_node/src/types.rs` 的 main-token controller binding 默认值、校验与 builder 逻辑抽到 `types/main_token_controller_binding.rs`，把根文件从 1277 行压到 1069 行，同时保持对外类型名与 targeted `oasis7_node` 验证链路不变。 Trace: .pm/tasks/task_5c651f038f1b48e78460ad7f95f6e187.yaml
 
 ## 依赖
 - 模块设计总览：`doc/engineering/design.md`

--- a/doc/engineering/rust-governance/rust-1200-line-root-cause-governance-2026-03-29.project.md
+++ b/doc/engineering/rust-governance/rust-1200-line-root-cause-governance-2026-03-29.project.md
@@ -15,6 +15,7 @@
 - [x] TASK-ENGINEERING-057 (PRD-ENGINEERING-R1200-004/005) [test_tier_required]: 收口超限测试文件治理策略，冻结残余 13 个测试尾债并建立下一批 burn-down 清单。
 - [x] TASK-ENGINEERING-104 (PRD-ENGINEERING-R1200-001/003/005) [test_tier_required]: 修复 `rust-oversized-file-baseline.tsv` 被误清空后的 required gate 阻断，按当前仓库实况重写 frozen baseline，并把专项状态从“已收口”拉回到继续 burn-down 的真实阶段。
 - [x] libp2p-net-orchestrator-burn-down (PRD-ENGINEERING-R1200-002/004/005) [test_tier_required]: 抽离 `Libp2pNetwork::new` 内 bootstrap / periodic 调度样板到 `crates/oasis7_net/src/libp2p_net/constructor_support.rs`，将 `crates/oasis7_net/src/libp2p_net.rs` 从 1199 行压到 1156 行，并保持 `rust-structural-slicing-baseline.tsv` 冻结值不变。 Trace: .pm/tasks/task_fbffb4f8dc5b4326b6a09751f4779526.yaml
+- [x] rust-node-types-controller-binding-burn-down (PRD-ENGINEERING-R1200-002/004/005) [test_tier_required]: 将 `crates/oasis7_node/src/types.rs` 的 main-token controller binding 逻辑抽到 `crates/oasis7_node/src/types/main_token_controller_binding.rs`，把根文件从 1277 行压到 1069 行，并保持 structural slicing baseline 不变。 Trace: .pm/tasks/task_5c651f038f1b48e78460ad7f95f6e187.yaml
 
 ## 依赖
 - `doc/engineering/prd.md`
@@ -36,10 +37,11 @@
 ## 状态
 - 更新日期: 2026-04-17
 - 当前阶段: active
-- 当前任务: `libp2p-net-orchestrator-burn-down` 已完成，`Libp2pNetwork::new` 的 bootstrap / periodic 调度样板已抽离到独立 helper，`crates/oasis7_net/src/libp2p_net.rs` 已从 1199 行降到 1156 行；当前 frozen oversized baseline 仍为 12 个生产文件 / 7 个测试文件，structural slicing baseline 保持不变。
-- 阻塞项: 无新的脚本阻断；当前真实约束是仓库仍存在 12 个生产 Rust 超限文件与 7 个测试 Rust 超限文件，后续治理不得再宣称 `oversized code files=0, test files=0` 已达成。
+- 当前任务: `libp2p-net-orchestrator-burn-down` 与 `rust-node-types-controller-binding-burn-down` 已完成，`crates/oasis7_net/src/libp2p_net.rs` 已从 1199 行降到 1156 行，`crates/oasis7_node/src/types.rs` 已从 1277 行降到 1069 行并从 frozen oversized baseline 退休；当前 frozen baseline 收敛为 4 个生产文件 / 6 个测试文件，structural slicing baseline 保持不变。
+- 阻塞项: 无新的脚本阻断；当前真实约束是仓库仍存在 4 个生产 Rust 超限文件与 6 个测试 Rust 超限文件，后续治理不得再宣称 `oversized code files=0, test files=0` 已达成。
 - 最新完成:
   - `TASK-ENGINEERING-104`：确认 `doc/.governance/rust-oversized-file-baseline.tsv` 在 `2026-03-30` 被提交为只剩注释的空壳，导致 `scripts/check-rust-file-size.sh` 在 required gate 中把全部存量超限项误判为“相对 HEAD 新增”；现已按当前仓库实况重写 baseline，恢复 `scripts/ci-tests.sh required` 的 frozen baseline 语义，并把专项状态改回继续 burn-down。
+  - `rust-node-types-controller-binding-burn-down`：`crates/oasis7_node/src/types.rs` 新增子模块 `types/main_token_controller_binding.rs`，将 main-token controller binding 常量、默认值、builder 与校验 helper 外提，根文件已从 1277 行降到 1069 行，并同步从 `rust-oversized-file-baseline.tsv` 退休旧冻结条目；`cargo check -p oasis7_node`、`cargo test -p oasis7_node types::tests:: -- --nocapture` 以及两条 controller-binding 授权定向测试通过，`cargo test -p oasis7_node --lib -- --nocapture` 仍存在 3 条与 replication/network 相关的现有失败签名，已在 execution log 留痕。
   - `TASK-ENGINEERING-054`：`oasis7_chain_runtime.rs` 拆出 `cli.rs`，`execution_bridge.rs` 迁移为目录模块，门禁基线已退休旧入口超限项。
   - `TASK-ENGINEERING-055`：`viewer/runtime_live.rs` 与测试集拆为目录模块；同时把 `runtime/events.rs`、`state.rs`、`apply_domain_event_*`、`world/event_processing.rs` 压回 1200 行内，清零本批新增 runtime 超限。
   - `TASK-ENGINEERING-056`：`oasis7_viewer` 首批治理与本轮 runtime / launcher 收尾已完成，退役了 `egui_right_panel_player_guide.rs`、`web_test_api.rs`、`viewer_automation.rs` 以及 `oasis7_provider_parity_bench.rs`、`oasis7_pure_api_client.rs`、`oasis7_provider_local_bridge.rs`、`oasis7_web_launcher/control_plane.rs`、`runtime/world/persistence.rs`、`viewer/live_split_part1.rs`、`runtime/world/governance.rs`、`runtime/world/module_actions_impl_part2.rs` 的生产超限基线。
@@ -60,5 +62,5 @@
   - 测试尾债 burn-down：`crates/oasis7/src/runtime/tests/economy_priority_logistics.rs` 已拆出 `crates/oasis7/src/runtime/tests/economy_priority_governance_tests.rs`，根文件降到 1174 行；`cargo test -p oasis7 runtime::tests::economy_priority_logistics::governance_tests::govern_profile_actions_emit_events_and_update_profile_state -- --nocapture` 与 `cargo test -p oasis7 runtime::tests::economy_priority_logistics::governance_tests::industry_stage_progresses_from_bootstrap_to_scale_out_and_governance -- --nocapture` 通过，`rust-oversized-file-baseline.tsv` 已同步移除该冻结项。
   - 测试尾债 burn-down：`crates/oasis7/src/runtime/tests/module_action_loop_split_part3.rs` 已拆出 `crates/oasis7/src/runtime/tests/module_action_loop_release_controls_tests.rs`，根文件降到 1147 行；`cargo test -p oasis7 runtime::tests::module_action_loop::release_controls_tests::module_release_shadow_rejects_missing_artifact_identity -- --nocapture`、`cargo test -p oasis7 runtime::tests::module_action_loop::release_controls_tests::rollback_module_instance_reverts_to_historical_version_and_emits_audit -- --nocapture` 与 `cargo test -p oasis7 runtime::tests::module_action_loop::release_controls_tests::module_release_apply_with_finality_succeeds_in_production_policy -- --nocapture` 通过，`rust-oversized-file-baseline.tsv` 已同步移除最后一条冻结测试基线。
 - 下一步:
-  - 继续按既有门禁链路执行 `./scripts/check-rust-file-size.sh`、`./scripts/doc-governance-check.sh` 与 `git diff --check`，确保当前 12 个生产文件 / 7 个测试文件之外不再新增超限项。
-  - 重新拆解下一批 Rust 1200 行 burn-down 任务，优先处理 `oasis7_game_launcher.rs`、`viewer/runtime_live/llm_sidecar.rs`、`oasis7_node/src/types.rs` 与对应高体量测试文件。
+  - 继续按既有门禁链路执行 `./scripts/check-rust-file-size.sh`、`./scripts/doc-governance-check.sh` 与 `git diff --check`，确保当前 4 个生产文件 / 6 个测试文件之外不再新增超限项。
+  - 重新拆解下一批 Rust 1200 行 burn-down 任务，优先处理 `crates/oasis7/src/viewer/runtime_live/llm_sidecar.rs`、`crates/oasis7/src/bin/oasis7_web_launcher/control_plane.rs`、`crates/oasis7_client_launcher/src/launcher_core.rs`、`crates/oasis7_node/src/replication.rs` 与剩余高体量测试文件。

--- a/doc/engineering/rust-governance/rust-1200-line-root-cause-governance-2026-03-29.project.md
+++ b/doc/engineering/rust-governance/rust-1200-line-root-cause-governance-2026-03-29.project.md
@@ -14,6 +14,7 @@
 - [x] TASK-ENGINEERING-056 (PRD-ENGINEERING-R1200-002/004/005) [test_tier_required] + [test_tier_full]: 完成 `oasis7_viewer` 首批治理，并继续清理 runtime / launcher 余量；本轮门禁已将生产 Rust 超限文件清零。
 - [x] TASK-ENGINEERING-057 (PRD-ENGINEERING-R1200-004/005) [test_tier_required]: 收口超限测试文件治理策略，冻结残余 13 个测试尾债并建立下一批 burn-down 清单。
 - [x] TASK-ENGINEERING-104 (PRD-ENGINEERING-R1200-001/003/005) [test_tier_required]: 修复 `rust-oversized-file-baseline.tsv` 被误清空后的 required gate 阻断，按当前仓库实况重写 frozen baseline，并把专项状态从“已收口”拉回到继续 burn-down 的真实阶段。
+- [x] libp2p-net-orchestrator-burn-down (PRD-ENGINEERING-R1200-002/004/005) [test_tier_required]: 抽离 `Libp2pNetwork::new` 内 bootstrap / periodic 调度样板到 `crates/oasis7_net/src/libp2p_net/constructor_support.rs`，将 `crates/oasis7_net/src/libp2p_net.rs` 从 1199 行压到 1156 行，并保持 `rust-structural-slicing-baseline.tsv` 冻结值不变。 Trace: .pm/tasks/task_fbffb4f8dc5b4326b6a09751f4779526.yaml
 
 ## 依赖
 - `doc/engineering/prd.md`
@@ -33,9 +34,9 @@
 - Batch B/C/D (`TASK-ENGINEERING-054~057`) 依赖 `TASK-ENGINEERING-052/053` 先把门禁、基线与完成态建立起来。
 
 ## 状态
-- 更新日期: 2026-04-09
+- 更新日期: 2026-04-17
 - 当前阶段: active
-- 当前任务: `TASK-ENGINEERING-104` 已完成，恢复了 `rust-oversized-file-baseline.tsv` 与 required gate 的一致性；当前 frozen baseline 为 12 个生产文件 / 7 个测试文件，专项重新回到持续 burn-down 状态。
+- 当前任务: `libp2p-net-orchestrator-burn-down` 已完成，`Libp2pNetwork::new` 的 bootstrap / periodic 调度样板已抽离到独立 helper，`crates/oasis7_net/src/libp2p_net.rs` 已从 1199 行降到 1156 行；当前 frozen oversized baseline 仍为 12 个生产文件 / 7 个测试文件，structural slicing baseline 保持不变。
 - 阻塞项: 无新的脚本阻断；当前真实约束是仓库仍存在 12 个生产 Rust 超限文件与 7 个测试 Rust 超限文件，后续治理不得再宣称 `oversized code files=0, test files=0` 已达成。
 - 最新完成:
   - `TASK-ENGINEERING-104`：确认 `doc/.governance/rust-oversized-file-baseline.tsv` 在 `2026-03-30` 被提交为只剩注释的空壳，导致 `scripts/check-rust-file-size.sh` 在 required gate 中把全部存量超限项误判为“相对 HEAD 新增”；现已按当前仓库实况重写 baseline，恢复 `scripts/ci-tests.sh required` 的 frozen baseline 语义，并把专项状态改回继续 burn-down。
@@ -43,6 +44,7 @@
   - `TASK-ENGINEERING-055`：`viewer/runtime_live.rs` 与测试集拆为目录模块；同时把 `runtime/events.rs`、`state.rs`、`apply_domain_event_*`、`world/event_processing.rs` 压回 1200 行内，清零本批新增 runtime 超限。
   - `TASK-ENGINEERING-056`：`oasis7_viewer` 首批治理与本轮 runtime / launcher 收尾已完成，退役了 `egui_right_panel_player_guide.rs`、`web_test_api.rs`、`viewer_automation.rs` 以及 `oasis7_provider_parity_bench.rs`、`oasis7_pure_api_client.rs`、`oasis7_provider_local_bridge.rs`、`oasis7_web_launcher/control_plane.rs`、`runtime/world/persistence.rs`、`viewer/live_split_part1.rs`、`runtime/world/governance.rs`、`runtime/world/module_actions_impl_part2.rs` 的生产超限基线。
   - `TASK-ENGINEERING-057`：`rust-oversized-file-baseline.tsv` 已刷新为只保留 13 个测试尾债；`module_actions_impl_part2` 新增 `release_support.rs`，`governance_internal.rs` 已放宽必要 helper 可见性，并在对齐最新 `main` 时同步把 `crates/oasis7_node/src/tests_action_payload.rs` 的冻结行数刷新到 1622。
+  - `libp2p-net-orchestrator-burn-down`：`crates/oasis7_net/src/libp2p_net.rs` 新增 `constructor_support.rs`，将 `Libp2pNetwork::new` 内重复的 republish / discovery refresh / bootstrap redial / initial bootstrap dials 调度逻辑外提；根文件已从 1199 行降到 1156 行，`cargo test -p oasis7_net --lib -- --nocapture` 122 项通过，`check-rust-file-size` 保持 `structural slice files=49, include targets=48` 冻结值不变。
   - 后续补修：`crates/oasis7_viewer` 已补齐 `player_experience_hud -> player_experience` 的薄包装 helper，并更新 `tests_selection_details.rs` 的 `AgentClaimState` 新字段；`cargo test -p oasis7_viewer --tests --no-run` 与 `cargo test -p oasis7_viewer` 已恢复通过。
   - 测试尾债 burn-down：`crates/oasis7_viewer/src/egui_right_panel_tests.rs` 已进一步拆出 `egui_right_panel_observe_tests.rs`，根文件降到 979 行；`cargo test -p oasis7_viewer egui_right_panel -- --nocapture` 通过，`rust-oversized-file-baseline.tsv` 已同步移除该冻结项。
   - 测试尾债 burn-down：`crates/oasis7/src/viewer/live/tests.rs` 已拆出 `crates/oasis7/src/viewer/live/tests_auth.rs`，根文件降到 879 行；`cargo test -p oasis7 viewer::live::tests -- --nocapture` 通过，`rust-oversized-file-baseline.tsv` 已同步移除该冻结项。
@@ -59,4 +61,4 @@
   - 测试尾债 burn-down：`crates/oasis7/src/runtime/tests/module_action_loop_split_part3.rs` 已拆出 `crates/oasis7/src/runtime/tests/module_action_loop_release_controls_tests.rs`，根文件降到 1147 行；`cargo test -p oasis7 runtime::tests::module_action_loop::release_controls_tests::module_release_shadow_rejects_missing_artifact_identity -- --nocapture`、`cargo test -p oasis7 runtime::tests::module_action_loop::release_controls_tests::rollback_module_instance_reverts_to_historical_version_and_emits_audit -- --nocapture` 与 `cargo test -p oasis7 runtime::tests::module_action_loop::release_controls_tests::module_release_apply_with_finality_succeeds_in_production_policy -- --nocapture` 通过，`rust-oversized-file-baseline.tsv` 已同步移除最后一条冻结测试基线。
 - 下一步:
   - 继续按既有门禁链路执行 `./scripts/check-rust-file-size.sh`、`./scripts/doc-governance-check.sh` 与 `git diff --check`，确保当前 12 个生产文件 / 7 个测试文件之外不再新增超限项。
-  - 重新拆解下一批 Rust 1200 行 burn-down 任务，优先处理 `oasis7_game_launcher.rs`、`viewer/runtime_live/llm_sidecar.rs`、`oasis7_net/src/libp2p_net.rs`、`oasis7_node/src/types.rs` 与对应高体量测试文件。
+  - 重新拆解下一批 Rust 1200 行 burn-down 任务，优先处理 `oasis7_game_launcher.rs`、`viewer/runtime_live/llm_sidecar.rs`、`oasis7_node/src/types.rs` 与对应高体量测试文件。


### PR DESCRIPTION
## Scope
- reduce libp2p net constructor orchestration hotspot
- reduce oasis7_node types controller-binding hotspot

## Verification
- cargo fmt / cargo check targeted crates
- targeted rust-size and doc-governance gates
- commit-tier required checks