### PR TITLE
Recover active-LLM trust gate runtime floor

### DIFF
--- a/.pm/tasks/task_a177c33031c440e297aa634fadd83400.execution.md
+++ b/.pm/tasks/task_a177c33031c440e297aa634fadd83400.execution.md
@@ -1,0 +1,26 @@
+# task_a177c33031c440e297aa634fadd83400 Execution Log
+
+- task_uid: task_a177c33031c440e297aa634fadd83400
+- title: recover active-llm trust gate queued/freeze runtime floor
+- owner_role: runtime_engineer
+- worktree_hint: /home/scc/worktrees/oasis7-game-active-llm-trust-gate-queued-freeze-recovery
+
+<!-- Append entries using:
+Example:
+  ## YYYY-MM-DD HH:MM:SS CST / role_name
+  - 完成内容: ...
+  - 遗留事项: ...
+-->
+
+## 2026-04-29 17:34:00 CST / runtime_engineer
+- 完成内容: 将 viewer live 的 LLM driver 构建从 `LlmAgentBehavior::from_env(...)` 改为显式读取 `LlmAgentConfig` 后再构建 client/behavior，并新增 `resolve_viewer_live_llm_timeout_ms(...)`，把 viewer live 控制路径的 LLM 请求超时上限收束到 trust-floor 预算（默认 `12000ms`，可通过 `OASIS7_VIEWER_LIVE_LLM_TIMEOUT_MS` 进一步收紧，但不会放宽超过原配置）。
+- 完成内容: 新增 `viewer::live::tests::viewer_live_llm_timeout_defaults_to_trust_floor_budget` 与 `viewer_live_llm_timeout_respects_env_ceiling_without_expanding_budget`，锁定“viewer live 不再继承默认 `180000ms` timeout 造成 `queued` 长挂”的回归边界。
+- 完成内容: 复跑 `env -u RUSTC_WRAPPER cargo test -p oasis7 viewer_live_llm_timeout -- --nocapture` 与 `env -u RUSTC_WRAPPER cargo test -p oasis7 step_request_emits_completion_ack_timeout_when_consensus_has_no_commit -- --nocapture`，确认新 helper 通过且既有 live step completion ack 语义未回归。
+- 遗留事项: 本轮只先修“viewer live 控制请求不该继承 180s provider timeout 导致 terminal feedback 长缺失”的 runtime floor；尚未复跑 active-LLM formal `software_safe` trust sample，因此还不能宣称 `#159` 已从 `hold` 恢复。
+
+## 2026-04-29 22:56:40 CST / runtime_engineer
+- 完成内容: 将 viewer live 与 runtime live 的默认 LLM timeout ceiling 从 `12000ms` 调整为 `30000ms`，继续保留 env ceiling 只能收紧、不能放宽超过原配置的约束；原因是 active provider probe 在同一 real-provider 配置下总延迟约 `11.9s`，`12s` ceiling 会在 formal play window 内过早误杀 live 决策，而 `30s` 仍显著低于旧的 `180000ms` 长挂预算。
+- 完成内容: 为 `viewer::live::tests` 补上 env lock，避免 timeout helper 的环境变量测试在并行 cargo 运行中互相污染；已复跑 `env -u RUSTC_WRAPPER cargo test -p oasis7 viewer_live_llm_timeout -- --nocapture`、`env -u RUSTC_WRAPPER cargo test -p oasis7 runtime_live_llm_timeout -- --nocapture`、`bash -n scripts/collect-active-llm-retention-sample.sh` 与 `git diff --check`。
+- 完成内容: 将 `scripts/collect-active-llm-retention-sample.sh` 的 formal summary 改为双层 verdict：顶层 `result` 现在明确以 `resultScope=trust_gate` 收口，并新增 `trustGateResult` / `firstCapabilityResult` 与 `firstCapabilityChecks`，不再把 `retentionProgressed` 误当作 `#159` 的必要放行条件。
+- 完成内容: 复跑完整 active-LLM formal 10 分钟样本 `output/playwright/retention-active-llm-formal/active-llm-retention-20260429-224359-94243/`。最新 summary 显示 `result=pass`、`resultScope=trust_gate`、`trustGateResult=pass`、`firstCapabilityResult=watch`；trust gate 检查全部通过（`connected/step8Advanced/selectedAgent/reachedPostOnboarding/playStayedConnected/playAdvanced/noRuntimeError/playNotBlocked = true`），且 `prePauseFeedback` 为 `completed_advanced / world advanced: logicalTime +30, eventSeq +9`，说明 formal active-LLM lane 已能稳定完成 `#159` 所要求的 first-session trust path。
+- 遗留事项: `post_onboarding.recover_capability` 仍停在 `68%`，formal sample 末尾仍可见 `http request failed: request timed out after 30000ms` 的 play-loop transient failure，但它已不再阻断 `#159` 的 trust gate verdict；该 capability 闭环与后续 LLM 调度/负载优化继续留在 `#160` 范围内。

--- a/.pm/tasks/task_a177c33031c440e297aa634fadd83400.yaml
+++ b/.pm/tasks/task_a177c33031c440e297aa634fadd83400.yaml
@@ -1,0 +1,23 @@
+task_uid: task_a177c33031c440e297aa634fadd83400
+title: "recover active-llm trust gate queued/freeze runtime floor"
+owner_role: runtime_engineer
+worktree_hint: /home/scc/worktrees/oasis7-game-active-llm-trust-gate-queued-freeze-recovery
+execution_log_path: .pm/tasks/task_a177c33031c440e297aa634fadd83400.execution.md
+status: done
+priority: P2
+source_signal: null
+source_refs:
+  - doc/game/project.md
+  - doc/testing/evidence/gameplay-ten-minute-trust-gate-2026-04-09.md
+doc_refs:
+  - doc/game/gameplay/gameplay-ten-minute-retention-recovery-2026-04-09.prd.md
+related_prd:
+  - PRD-GAME-012
+acceptance:
+  - "formal active-LLM trust floor no longer stalls at queued with zero logicalTime/eventSeq delta"
+  - "active-LLM formal lane no longer regresses to first_session_loop due to runtime freeze amplifier"
+handoff_to:
+  - qa_engineer
+updated_at: 2026-04-30T08:35:33+08:00
+last_started_at: 2026-04-29T19:31:02+08:00
+last_closed_at: 2026-04-30T08:35:33+08:00

--- a/crates/oasis7/src/bin/oasis7_game_launcher.rs
+++ b/crates/oasis7/src/bin/oasis7_game_launcher.rs
@@ -383,6 +383,14 @@ fn chain_execution_world_dir(node_id: &str) -> String {
         .into_owned()
 }
 
+fn missing_execution_world_persistence_files(world_dir: &Path) -> Vec<PathBuf> {
+    ["snapshot.json", "journal.json"]
+        .into_iter()
+        .map(|name| world_dir.join(name))
+        .filter(|path| !path.exists())
+        .collect()
+}
+
 fn build_oasis7_chain_runtime_args(options: &CliOptions) -> Vec<String> {
     let execution_world_dir = chain_execution_world_dir(options.chain_node_id.as_str());
     let mut args = vec![
@@ -603,8 +611,44 @@ fn wait_until_ready(
                 chain_status_host, chain_status_port, err
             )
         })?;
+        poll_startup_health(world_child, chain_child.as_deref_mut())?;
+        wait_for_chain_execution_world_ready(
+            Path::new(chain_execution_world_dir(options.chain_node_id.as_str()).as_str()),
+            Duration::from_secs(30),
+            world_child,
+            chain_child.as_deref_mut(),
+        )?;
     }
     Ok(())
+}
+
+fn wait_for_chain_execution_world_ready(
+    execution_world_dir: &Path,
+    timeout: Duration,
+    world_child: &mut Child,
+    mut chain_child: Option<&mut Child>,
+) -> Result<(), String> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        poll_startup_health(world_child, chain_child.as_deref_mut())?;
+        let missing = missing_execution_world_persistence_files(execution_world_dir);
+        if missing.is_empty() {
+            return Ok(());
+        }
+        if Instant::now() >= deadline {
+            let missing_list = missing
+                .iter()
+                .map(|path| path.display().to_string())
+                .collect::<Vec<_>>()
+                .join(", ");
+            return Err(format!(
+                "execution world persistence did not become ready under {} before timeout; missing: {}",
+                execution_world_dir.display(),
+                missing_list
+            ));
+        }
+        thread::sleep(Duration::from_millis(200));
+    }
 }
 
 fn monitor_world_chain_and_server(

--- a/crates/oasis7/src/bin/oasis7_game_launcher.rs
+++ b/crates/oasis7/src/bin/oasis7_game_launcher.rs
@@ -612,8 +612,9 @@ fn wait_until_ready(
             )
         })?;
         poll_startup_health(world_child, chain_child.as_deref_mut())?;
+        let execution_world_dir = chain_execution_world_dir(options.chain_node_id.as_str());
         wait_for_chain_execution_world_ready(
-            Path::new(chain_execution_world_dir(options.chain_node_id.as_str()).as_str()),
+            Path::new(execution_world_dir.as_str()),
             Duration::from_secs(30),
             world_child,
             chain_child.as_deref_mut(),

--- a/crates/oasis7/src/bin/oasis7_game_launcher/oasis7_game_launcher_tests.rs
+++ b/crates/oasis7/src/bin/oasis7_game_launcher/oasis7_game_launcher_tests.rs
@@ -10,7 +10,8 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use super::{
     apply_viewer_live_env_overrides, build_game_url, build_oasis7_chain_runtime_args,
     build_oasis7_viewer_live_command, build_viewer_auth_bootstrap_script, content_type_for_path,
-    parse_host_port, parse_options, query_runtime_bound_players, resolve_static_asset_path,
+    missing_execution_world_persistence_files, parse_host_port, parse_options,
+    query_runtime_bound_players, resolve_static_asset_path,
     resolve_viewer_auth_bootstrap_for_embedded_server, resolve_viewer_auth_bootstrap_from_path,
     resolve_viewer_static_dir_with_override, sanitize_index_html_for_embedded_server,
     sanitize_relative_request_path, viewer_dev_dist_candidates, CliOptions, ViewerAuthBootstrap,
@@ -729,6 +730,26 @@ fn build_oasis7_chain_runtime_args_supports_all_storage_profiles() {
         assert!(args.contains(&"--storage-profile".to_string()));
         assert!(args.contains(&expected.to_string()));
     }
+}
+
+#[test]
+fn missing_execution_world_persistence_files_reports_snapshot_and_journal() {
+    let temp_dir = make_temp_dir("execution_world_missing");
+    let missing = missing_execution_world_persistence_files(temp_dir.as_path());
+    assert_eq!(missing.len(), 2);
+    assert!(missing.iter().any(|path| path.ends_with("snapshot.json")));
+    assert!(missing.iter().any(|path| path.ends_with("journal.json")));
+    let _ = fs::remove_dir_all(temp_dir);
+}
+
+#[test]
+fn missing_execution_world_persistence_files_ignores_ready_world_dir() {
+    let temp_dir = make_temp_dir("execution_world_ready");
+    fs::write(temp_dir.join("snapshot.json"), "{}").expect("write snapshot");
+    fs::write(temp_dir.join("journal.json"), "{}").expect("write journal");
+    let missing = missing_execution_world_persistence_files(temp_dir.as_path());
+    assert!(missing.is_empty());
+    let _ = fs::remove_dir_all(temp_dir);
 }
 
 #[test]

--- a/crates/oasis7/src/viewer/live/live_helpers.rs
+++ b/crates/oasis7/src/viewer/live/live_helpers.rs
@@ -1,6 +1,19 @@
 use super::*;
 use sha2::{Digest, Sha256};
 
+const ENV_VIEWER_LIVE_LLM_TIMEOUT_MS: &str = "OASIS7_VIEWER_LIVE_LLM_TIMEOUT_MS";
+const DEFAULT_VIEWER_LIVE_LLM_TIMEOUT_MS: u64 = 30_000;
+
+pub(super) fn resolve_viewer_live_llm_timeout_ms(configured_timeout_ms: u64) -> u64 {
+    let configured_timeout_ms = configured_timeout_ms.max(1);
+    let live_timeout_ceiling_ms = std::env::var(ENV_VIEWER_LIVE_LLM_TIMEOUT_MS)
+        .ok()
+        .and_then(|value| value.parse::<u64>().ok())
+        .map(|value| value.max(1))
+        .unwrap_or(DEFAULT_VIEWER_LIVE_LLM_TIMEOUT_MS);
+    configured_timeout_ms.min(live_timeout_ceiling_ms)
+}
+
 pub(super) fn normalize_required_player_id(
     player_id: &str,
     agent_id: &str,
@@ -194,7 +207,12 @@ pub(super) fn build_driver(
             let mut agent_ids: Vec<String> = kernel.model().agents.keys().cloned().collect();
             agent_ids.sort();
             for agent_id in agent_ids {
-                let mut behavior = LlmAgentBehavior::from_env(agent_id.clone())?;
+                let mut config = LlmAgentConfig::from_default_sources_for_agent(agent_id.as_str())
+                    .map_err(LlmAgentBuildError::Config)?;
+                config.timeout_ms = resolve_viewer_live_llm_timeout_ms(config.timeout_ms);
+                let client = OpenAiChatCompletionClient::from_config(&config)
+                    .map_err(LlmAgentBuildError::Client)?;
+                let mut behavior = LlmAgentBehavior::new(agent_id.clone(), config, client);
                 if let Some(profile) = kernel.model().agent_prompt_profiles.get(&agent_id) {
                     behavior.apply_prompt_overrides(
                         profile.system_prompt_override.clone(),

--- a/crates/oasis7/src/viewer/live/tests.rs
+++ b/crates/oasis7/src/viewer/live/tests.rs
@@ -7,7 +7,7 @@ use oasis7_node::{
 use std::io::{BufRead, BufReader, BufWriter};
 use std::net::{TcpListener, TcpStream};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-use std::sync::{mpsc, Arc, Mutex};
+use std::sync::{mpsc, Arc, Mutex, OnceLock};
 use std::thread;
 use std::time::{Duration, Instant};
 
@@ -220,6 +220,28 @@ fn live_server_config_supports_llm_mode() {
 
     let script_config = llm_config.with_decision_mode(ViewerLiveDecisionMode::Script);
     assert_eq!(script_config.decision_mode, ViewerLiveDecisionMode::Script);
+}
+
+fn viewer_live_llm_timeout_env_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
+
+#[test]
+fn viewer_live_llm_timeout_defaults_to_trust_floor_budget() {
+    let _guard = viewer_live_llm_timeout_env_lock().lock().expect("env lock");
+    std::env::remove_var("OASIS7_VIEWER_LIVE_LLM_TIMEOUT_MS");
+    assert_eq!(resolve_viewer_live_llm_timeout_ms(180_000), 30_000);
+    assert_eq!(resolve_viewer_live_llm_timeout_ms(8_000), 8_000);
+}
+
+#[test]
+fn viewer_live_llm_timeout_respects_env_ceiling_without_expanding_budget() {
+    let _guard = viewer_live_llm_timeout_env_lock().lock().expect("env lock");
+    std::env::set_var("OASIS7_VIEWER_LIVE_LLM_TIMEOUT_MS", "9000");
+    assert_eq!(resolve_viewer_live_llm_timeout_ms(180_000), 9_000);
+    assert_eq!(resolve_viewer_live_llm_timeout_ms(4_000), 4_000);
+    std::env::remove_var("OASIS7_VIEWER_LIVE_LLM_TIMEOUT_MS");
 }
 
 #[test]

--- a/crates/oasis7/src/viewer/live_runtime.rs
+++ b/crates/oasis7/src/viewer/live_runtime.rs
@@ -12,7 +12,7 @@ use oasis7_node::{NodeCommittedActionBatchesHandle, NodeRuntime};
 use crate::geometry::space_distance_cm;
 use crate::simulator::{
     initialize_kernel, Action, ActionResult, ActionSubmitter, AgentDecision, AgentDecisionTrace,
-    AgentPromptProfile, AgentRunner, LlmAgentBehavior, LlmAgentBuildError,
+    AgentPromptProfile, AgentRunner, LlmAgentBehavior, LlmAgentBuildError, LlmAgentConfig,
     OpenAiChatCompletionClient, PromptUpdateOperation, ResourceKind, ResourceOwner, RunnerMetrics,
     WorldConfig, WorldEvent, WorldEventKind, WorldInitConfig, WorldInitError, WorldKernel,
     WorldScenario, WorldSnapshot,

--- a/crates/oasis7/src/viewer/runtime_live.rs
+++ b/crates/oasis7/src/viewer/runtime_live.rs
@@ -254,6 +254,42 @@ impl ViewerRuntimeLiveServer {
         self.latest_player_gameplay_feedback = Some(feedback);
     }
 
+    fn record_chain_sync_failure(&mut self, error: &ViewerRuntimeLiveServerError) {
+        let reason = match error {
+            ViewerRuntimeLiveServerError::Serde(message) => message.clone(),
+            ViewerRuntimeLiveServerError::Runtime(err) => format!("{err:?}"),
+            ViewerRuntimeLiveServerError::Init(message) => message.clone(),
+            ViewerRuntimeLiveServerError::Io(err) => err.to_string(),
+        };
+        let hint = if reason.contains("execution world is not ready") {
+            "wait for the execution world persistence files to appear, or restart/repair the chain runtime bootstrap before refreshing gameplay"
+                .to_string()
+        } else {
+            "repair the chain runtime sync path, then refresh gameplay to confirm the committed world is available"
+                .to_string()
+        };
+        self.set_latest_player_gameplay_feedback(PlayerGameplayRecentFeedback {
+            action: "chain_sync".to_string(),
+            stage: "blocked".to_string(),
+            effect: "committed runtime sync failed before the viewer could observe new world state"
+                .to_string(),
+            reason: Some(reason),
+            hint: Some(hint),
+            delta_logical_time: 0,
+            delta_event_seq: 0,
+        });
+    }
+
+    fn clear_chain_sync_failure_feedback(&mut self) {
+        if self
+            .latest_player_gameplay_feedback
+            .as_ref()
+            .is_some_and(|feedback| feedback.action == "chain_sync")
+        {
+            self.latest_player_gameplay_feedback = None;
+        }
+    }
+
     fn confirm_player_gameplay_progress(&mut self) {
         self.confirmed_player_gameplay_progress_time = Some(self.world.state().time);
     }

--- a/crates/oasis7/src/viewer/runtime_live/chain_link.rs
+++ b/crates/oasis7/src/viewer/runtime_live/chain_link.rs
@@ -40,6 +40,10 @@ struct ChainLinkedRuntimeDispatch {
     responses: Vec<ViewerResponse>,
 }
 
+fn session_requests_runtime_feedback(session: &RuntimeLiveSession) -> bool {
+    !session.subscribed.is_empty()
+}
+
 impl ViewerRuntimeLiveServer {
     pub(super) fn sync_chain_linked_runtime(
         &mut self,
@@ -56,7 +60,16 @@ impl ViewerRuntimeLiveServer {
             return Ok(false);
         };
 
-        let prepared = prepare_chain_linked_runtime_update(chain_status_bind)?;
+        let prepared = match prepare_chain_linked_runtime_update(chain_status_bind) {
+            Ok(prepared) => prepared,
+            Err(err) => {
+                if session_requests_runtime_feedback(session) {
+                    self.record_chain_sync_failure(&err);
+                }
+                return Err(err);
+            }
+        };
+        self.clear_chain_sync_failure_feedback();
         let dispatch = self.apply_chain_linked_runtime_update(prepared, session)?;
         for response in dispatch.responses {
             send_response(writer, &response)?;
@@ -83,9 +96,19 @@ impl ViewerRuntimeLiveServer {
             return Ok(false);
         };
 
-        let prepared = prepare_chain_linked_runtime_update(chain_status_bind.as_str())?;
+        let prepared = match prepare_chain_linked_runtime_update(chain_status_bind.as_str()) {
+            Ok(prepared) => prepared,
+            Err(err) => {
+                if session_requests_runtime_feedback(session) {
+                    let mut server = lock_shared_server(shared)?;
+                    server.record_chain_sync_failure(&err);
+                }
+                return Err(err);
+            }
+        };
         let dispatch = {
             let mut server = lock_shared_server(shared)?;
+            server.clear_chain_sync_failure_feedback();
             server.apply_chain_linked_runtime_update(prepared, session)?
         };
         for response in dispatch.responses {

--- a/crates/oasis7/src/viewer/runtime_live/gameplay_snapshot.rs
+++ b/crates/oasis7/src/viewer/runtime_live/gameplay_snapshot.rs
@@ -22,6 +22,31 @@ fn blocked_control_hint(error_code: Option<&str>) -> String {
     }
 }
 
+fn first_session_runtime_sync_blocker(
+    recent_feedback: Option<&PlayerGameplayRecentFeedback>,
+) -> Option<(String, String, String)> {
+    let feedback = recent_feedback?;
+    if feedback.action != "chain_sync" {
+        return None;
+    }
+    if !matches!(feedback.stage.as_str(), "blocked" | "completed_no_progress") {
+        return None;
+    }
+    let detail = feedback.reason.clone().unwrap_or_else(|| {
+        "committed runtime sync did not expose a usable world snapshot".to_string()
+    });
+    let kind = if detail.contains("execution world is not ready") {
+        "execution_world_not_ready".to_string()
+    } else {
+        "runtime_sync_unavailable".to_string()
+    };
+    let hint = feedback.hint.clone().unwrap_or_else(|| {
+        "repair the runtime sync path, then refresh gameplay to confirm the committed world is available"
+            .to_string()
+    });
+    Some((kind, detail, hint))
+}
+
 pub(super) fn player_gameplay_feedback_from_control_ack(
     mode: &ViewerControl,
     ack: &ControlCompletionAck,
@@ -158,6 +183,47 @@ pub(super) fn build_player_gameplay_snapshot(
     let has_recovery_history =
         primary_factory.is_some_and(|factory| factory.production.last_resumed_at.is_some());
     let industry_stage = state.industry_progress.stage;
+
+    if !has_confirmed_world_progress
+        && !has_material_flow
+        && !has_factory_ready
+        && !has_recipe_running
+        && !has_first_output
+        && latest_blocker.is_none()
+    {
+        if let Some((blocker_kind, blocker_detail, next_step_hint)) =
+            first_session_runtime_sync_blocker(recent_feedback)
+        {
+            let disabled_reason =
+                "committed runtime sync is unavailable; refresh the snapshot or repair runtime bootstrap first"
+                    .to_string();
+            for action in &mut available_actions {
+                if action.protocol_action == "request_snapshot" {
+                    continue;
+                }
+                action.disabled_reason = Some(disabled_reason.clone());
+            }
+            return PlayerGameplaySnapshot {
+                stage_id: PlayerGameplayStageId::FirstSessionLoop,
+                stage_status: PlayerGameplayStageStatus::Blocked,
+                goal_id: "first_session_loop.recover_runtime_sync".to_string(),
+                goal_kind: PlayerGameplayGoalKind::CreateFirstWorldFeedback,
+                goal_title: "Recover committed runtime sync".to_string(),
+                objective: "Repair the committed runtime feed before retrying the first world-feedback loop.".to_string(),
+                progress_detail:
+                    "The first-session loop is blocked because the viewer cannot read a committed runtime world yet."
+                        .to_string(),
+                progress_percent: 0,
+                blocker_kind: Some(blocker_kind),
+                blocker_detail: Some(blocker_detail),
+                next_step_hint,
+                branch_hint: None,
+                available_actions,
+                recent_feedback: recent_feedback.cloned(),
+                agent_claim,
+            };
+        }
+    }
 
     if !has_confirmed_world_progress
         && !has_material_flow

--- a/crates/oasis7/src/viewer/runtime_live/llm_sidecar.rs
+++ b/crates/oasis7/src/viewer/runtime_live/llm_sidecar.rs
@@ -10,7 +10,7 @@ use crate::runtime::{
 use crate::simulator::{
     evaluate_provider_compatibility, Action as SimulatorAction, ActionCatalogEntry, ActionResult,
     AgentDecision, AgentDecisionTrace, AgentPromptProfile, AgentRunner, ChunkRuntimeConfig,
-    LlmAgentBehavior, OpenAiChatCompletionClient, ProviderBackedAgentBehavior,
+    LlmAgentBehavior, LlmAgentConfig, OpenAiChatCompletionClient, ProviderBackedAgentBehavior,
     ProviderExecutionMode, ProviderLoopbackAdapter, ProviderLoopbackHttpClient, ResourceOwner,
     WorldConfig, WorldEvent, WorldEventKind, WorldJournal, WorldKernel, WorldSnapshot,
     CHUNK_GENERATION_SCHEMA_VERSION, SNAPSHOT_VERSION,
@@ -55,6 +55,8 @@ const VIEWER_AGENT_PROVIDER_PROFILE_ENV: &str = "OASIS7_AGENT_PROVIDER_PROFILE";
 const VIEWER_AGENT_EXECUTION_LANE_ENV: &str = "OASIS7_AGENT_EXECUTION_LANE";
 const VIEWER_AGENT_PROVIDER_MODE_ENV: &str = "OASIS7_AGENT_PROVIDER_MODE";
 const RUNTIME_PROVIDER_CHECK_CACHE_MS: u64 = 2_000;
+const ENV_RUNTIME_LIVE_LLM_TIMEOUT_MS: &str = "OASIS7_RUNTIME_LIVE_LLM_TIMEOUT_MS";
+const DEFAULT_RUNTIME_LIVE_LLM_TIMEOUT_MS: u64 = 30_000;
 
 #[path = "llm_sidecar_provider.rs"]
 mod provider_support;
@@ -92,6 +94,16 @@ pub(in crate::viewer::runtime_live) struct RuntimeProviderCheckSnapshot {
     pub(in crate::viewer::runtime_live) error: Option<String>,
     checked_at_unix_ms: u64,
     cache_key: String,
+}
+
+fn resolve_runtime_live_llm_timeout_ms(configured_timeout_ms: u64) -> u64 {
+    let configured_timeout_ms = configured_timeout_ms.max(1);
+    let runtime_timeout_ceiling_ms = std::env::var(ENV_RUNTIME_LIVE_LLM_TIMEOUT_MS)
+        .ok()
+        .and_then(|value| value.parse::<u64>().ok())
+        .map(|value| value.max(1))
+        .unwrap_or(DEFAULT_RUNTIME_LIVE_LLM_TIMEOUT_MS);
+    configured_timeout_ms.min(runtime_timeout_ceiling_ms)
 }
 
 enum RuntimeDecisionRunner {
@@ -735,8 +747,14 @@ impl RuntimeLlmSidecar {
                     if runner.get(agent_id.as_str()).is_some() {
                         continue;
                     }
-                    let mut behavior = LlmAgentBehavior::from_env(agent_id.clone())
-                        .map_err(|err| format!("llm init failed for {}: {err}", agent_id))?;
+                    let mut config = LlmAgentConfig::from_default_sources_for_agent(
+                        agent_id.as_str(),
+                    )
+                    .map_err(|err| format!("llm init failed for {}: {:?}", agent_id, err))?;
+                    config.timeout_ms = resolve_runtime_live_llm_timeout_ms(config.timeout_ms);
+                    let client = OpenAiChatCompletionClient::from_config(&config)
+                        .map_err(|err| format!("llm init failed for {}: {:?}", agent_id, err))?;
+                    let mut behavior = LlmAgentBehavior::new(agent_id.clone(), config, client);
                     if let Some(profile) = self.prompt_profiles.get(agent_id.as_str()) {
                         behavior.apply_prompt_overrides(
                             profile.system_prompt_override.clone(),
@@ -794,6 +812,12 @@ impl RuntimeLlmSidecar {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::{Mutex, OnceLock};
+
+    fn runtime_llm_timeout_env_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
 
     #[test]
     fn bind_agent_player_emits_unbind_before_rebind_for_same_agent() {
@@ -854,5 +878,22 @@ mod tests {
                 .map(String::as_str),
             Some("pubkey-b")
         );
+    }
+
+    #[test]
+    fn runtime_live_llm_timeout_defaults_to_trust_floor_budget() {
+        let _guard = runtime_llm_timeout_env_lock().lock().expect("env lock");
+        std::env::remove_var(ENV_RUNTIME_LIVE_LLM_TIMEOUT_MS);
+        assert_eq!(resolve_runtime_live_llm_timeout_ms(180_000), 30_000);
+        assert_eq!(resolve_runtime_live_llm_timeout_ms(8_000), 8_000);
+    }
+
+    #[test]
+    fn runtime_live_llm_timeout_respects_env_ceiling_without_expanding_budget() {
+        let _guard = runtime_llm_timeout_env_lock().lock().expect("env lock");
+        std::env::set_var(ENV_RUNTIME_LIVE_LLM_TIMEOUT_MS, "9000");
+        assert_eq!(resolve_runtime_live_llm_timeout_ms(180_000), 9_000);
+        assert_eq!(resolve_runtime_live_llm_timeout_ms(4_000), 4_000);
+        std::env::remove_var(ENV_RUNTIME_LIVE_LLM_TIMEOUT_MS);
     }
 }

--- a/crates/oasis7/src/viewer/runtime_live/tests.rs
+++ b/crates/oasis7/src/viewer/runtime_live/tests.rs
@@ -15,6 +15,7 @@ use std::time::{Duration, Instant};
 mod auth_actions;
 mod authoritative;
 mod background_play;
+mod chain_sync_feedback;
 mod industrial_progression;
 mod prompt_control;
 mod snapshot_progress;
@@ -1096,6 +1097,16 @@ fn chain_linked_runtime_empty_poll_does_not_advance_world() {
             .with_chain_poll_interval(Duration::from_millis(50)),
     )
     .expect("runtime server");
+    server.latest_player_gameplay_feedback = Some(crate::simulator::PlayerGameplayRecentFeedback {
+        action: "chain_sync".to_string(),
+        stage: "blocked".to_string(),
+        effect: "committed runtime sync failed before the viewer could observe new world state"
+            .to_string(),
+        reason: Some("simulated missing persistence".to_string()),
+        hint: Some("wait for execution world persistence".to_string()),
+        delta_logical_time: 0,
+        delta_event_seq: 0,
+    });
     let mut session = RuntimeLiveSession::new();
     session.playing = false;
     session.subscribed.insert(ViewerStream::Events);
@@ -1111,6 +1122,10 @@ fn chain_linked_runtime_empty_poll_does_not_advance_world() {
     assert_eq!(server.world.state().time, initial_time);
     assert!(read_response_line(&peer, Duration::from_millis(100)).is_none());
     assert_eq!(server.last_chain_committed_height, 0);
+    assert!(
+        server.latest_player_gameplay_feedback.is_none(),
+        "successful zero-delta chain sync should clear stale chain_sync feedback"
+    );
 }
 
 #[test]
@@ -1145,42 +1160,6 @@ fn chain_linked_runtime_zero_delta_does_not_accept_committed_height() {
         !progressed,
         "zero-delta chain poll should not report progress"
     );
-    assert_eq!(server.world.state().time, initial_time);
-    assert_eq!(server.last_chain_committed_height, 0);
-    assert!(read_response_line(&peer, Duration::from_millis(100)).is_none());
-}
-
-#[test]
-fn chain_linked_runtime_missing_persistence_keeps_world_and_height() {
-    let execution_world_dir = runtime_live_temp_dir("chain_sync_missing_persistence");
-    let chain_status = TestChainStatusServer::start(execution_world_dir);
-    chain_status.committed_height.store(1, Ordering::SeqCst);
-
-    let mut server = ViewerRuntimeLiveServer::new(
-        ViewerRuntimeLiveServerConfig::new(WorldScenario::Minimal)
-            .with_chain_status_bind(chain_status.addr.clone())
-            .with_chain_poll_interval(Duration::from_millis(50)),
-    )
-    .expect("runtime server");
-    let mut session = RuntimeLiveSession::new();
-    session.playing = false;
-    session.subscribed.insert(ViewerStream::Events);
-    session.subscribed.insert(ViewerStream::Snapshot);
-    let initial_time = server.world.state().time;
-    let (mut writer, peer) = test_writer_pair();
-
-    let err = server
-        .sync_chain_linked_runtime(&mut session, &mut writer)
-        .expect_err("chain sync should retry when persistence files are missing");
-
-    match err {
-        ViewerRuntimeLiveServerError::Serde(message) => {
-            assert!(message.contains("execution world is not ready"));
-            assert!(message.contains("snapshot.json"));
-            assert!(message.contains("journal.json"));
-        }
-        other => panic!("unexpected chain sync error: {other:?}"),
-    }
     assert_eq!(server.world.state().time, initial_time);
     assert_eq!(server.last_chain_committed_height, 0);
     assert!(read_response_line(&peer, Duration::from_millis(100)).is_none());

--- a/crates/oasis7/src/viewer/runtime_live/tests/chain_sync_feedback.rs
+++ b/crates/oasis7/src/viewer/runtime_live/tests/chain_sync_feedback.rs
@@ -1,0 +1,79 @@
+use super::*;
+
+#[test]
+fn chain_linked_runtime_missing_persistence_keeps_world_and_height() {
+    let execution_world_dir = runtime_live_temp_dir("chain_sync_missing_persistence");
+    let chain_status = TestChainStatusServer::start(execution_world_dir);
+    chain_status.committed_height.store(1, Ordering::SeqCst);
+
+    let mut server = ViewerRuntimeLiveServer::new(
+        ViewerLiveServerConfig::new(WorldScenario::Minimal)
+            .with_chain_status_bind(chain_status.addr.clone())
+            .with_chain_poll_interval(Duration::from_millis(50)),
+    )
+    .expect("runtime server");
+    let mut session = RuntimeLiveSession::new();
+    session.playing = false;
+    session.subscribed.insert(ViewerStream::Events);
+    session.subscribed.insert(ViewerStream::Snapshot);
+    let initial_time = server.world.state().time;
+    let (mut writer, peer) = test_writer_pair();
+
+    let err = server
+        .sync_chain_linked_runtime(&mut session, &mut writer)
+        .expect_err("chain sync should retry when persistence files are missing");
+
+    match err {
+        ViewerRuntimeLiveServerError::Serde(message) => {
+            assert!(message.contains("execution world is not ready"));
+            assert!(message.contains("snapshot.json"));
+            assert!(message.contains("journal.json"));
+        }
+        other => panic!("unexpected chain sync error: {other:?}"),
+    }
+    assert_eq!(server.world.state().time, initial_time);
+    assert_eq!(server.last_chain_committed_height, 0);
+    assert!(read_response_line(&peer, Duration::from_millis(100)).is_none());
+    let feedback = server
+        .latest_player_gameplay_feedback
+        .as_ref()
+        .expect("chain sync failure should be reflected in gameplay feedback");
+    assert_eq!(feedback.action, "chain_sync");
+    assert_eq!(feedback.stage, "blocked");
+    assert!(feedback
+        .reason
+        .as_deref()
+        .is_some_and(|reason| reason.contains("execution world is not ready")));
+}
+
+#[test]
+fn chain_linked_runtime_missing_persistence_without_subscription_does_not_poison_feedback() {
+    let execution_world_dir = runtime_live_temp_dir("chain_sync_missing_persistence_unsubscribed");
+    let chain_status = TestChainStatusServer::start(execution_world_dir);
+    chain_status.committed_height.store(1, Ordering::SeqCst);
+
+    let mut server = ViewerRuntimeLiveServer::new(
+        ViewerLiveServerConfig::new(WorldScenario::Minimal)
+            .with_chain_status_bind(chain_status.addr.clone())
+            .with_chain_poll_interval(Duration::from_millis(50)),
+    )
+    .expect("runtime server");
+    let mut session = RuntimeLiveSession::new();
+    session.playing = false;
+    let initial_time = server.world.state().time;
+    let (mut writer, peer) = test_writer_pair();
+
+    let err = server
+        .sync_chain_linked_runtime(&mut session, &mut writer)
+        .expect_err("chain sync should still fail when persistence files are missing");
+
+    match err {
+        ViewerRuntimeLiveServerError::Serde(message) => {
+            assert!(message.contains("execution world is not ready"));
+        }
+        other => panic!("unexpected chain sync error: {other:?}"),
+    }
+    assert_eq!(server.world.state().time, initial_time);
+    assert!(server.latest_player_gameplay_feedback.is_none());
+    assert!(read_response_line(&peer, Duration::from_millis(100)).is_none());
+}

--- a/crates/oasis7/src/viewer/runtime_live/tests/chain_sync_feedback.rs
+++ b/crates/oasis7/src/viewer/runtime_live/tests/chain_sync_feedback.rs
@@ -7,7 +7,7 @@ fn chain_linked_runtime_missing_persistence_keeps_world_and_height() {
     chain_status.committed_height.store(1, Ordering::SeqCst);
 
     let mut server = ViewerRuntimeLiveServer::new(
-        ViewerLiveServerConfig::new(WorldScenario::Minimal)
+        ViewerRuntimeLiveServerConfig::new(WorldScenario::Minimal)
             .with_chain_status_bind(chain_status.addr.clone())
             .with_chain_poll_interval(Duration::from_millis(50)),
     )
@@ -53,7 +53,7 @@ fn chain_linked_runtime_missing_persistence_without_subscription_does_not_poison
     chain_status.committed_height.store(1, Ordering::SeqCst);
 
     let mut server = ViewerRuntimeLiveServer::new(
-        ViewerLiveServerConfig::new(WorldScenario::Minimal)
+        ViewerRuntimeLiveServerConfig::new(WorldScenario::Minimal)
             .with_chain_status_bind(chain_status.addr.clone())
             .with_chain_poll_interval(Duration::from_millis(50)),
     )

--- a/crates/oasis7/src/viewer/runtime_live/tests/snapshot_progress.rs
+++ b/crates/oasis7/src/viewer/runtime_live/tests/snapshot_progress.rs
@@ -565,6 +565,60 @@ fn compat_snapshot_keeps_first_session_loop_after_bootstrap_tick_blocked_feedbac
 }
 
 #[test]
+fn compat_snapshot_blocks_first_session_when_chain_sync_is_unavailable() {
+    let _guard = lock_test_llm_env();
+    let mut server = ViewerRuntimeLiveServer::new(
+        ViewerRuntimeLiveServerConfig::new(WorldScenario::Minimal)
+            .with_decision_mode(ViewerLiveDecisionMode::Llm),
+    )
+    .expect("runtime server");
+    server.latest_player_gameplay_feedback = Some(crate::simulator::PlayerGameplayRecentFeedback {
+        action: "chain_sync".to_string(),
+        stage: "blocked".to_string(),
+        effect: "committed runtime sync failed before the viewer could observe new world state"
+            .to_string(),
+        reason: Some(
+            "execution world is not ready; missing persistence file(s): snapshot.json, journal.json"
+                .to_string(),
+        ),
+        hint: Some(
+            "wait for the execution world persistence files to appear, or restart/repair the chain runtime bootstrap before refreshing gameplay"
+                .to_string(),
+        ),
+        delta_logical_time: 0,
+        delta_event_seq: 0,
+    });
+
+    let snapshot = server.compat_snapshot();
+    let gameplay = snapshot
+        .player_gameplay
+        .as_ref()
+        .expect("player gameplay snapshot");
+    assert_eq!(
+        gameplay.stage_id,
+        crate::simulator::PlayerGameplayStageId::FirstSessionLoop
+    );
+    assert_eq!(
+        gameplay.stage_status,
+        crate::simulator::PlayerGameplayStageStatus::Blocked
+    );
+    assert_eq!(gameplay.goal_id, "first_session_loop.recover_runtime_sync");
+    assert_eq!(
+        gameplay.blocker_kind.as_deref(),
+        Some("execution_world_not_ready")
+    );
+    assert!(gameplay
+        .blocker_detail
+        .as_deref()
+        .is_some_and(|detail| detail.contains("execution world is not ready")));
+    assert!(gameplay
+        .available_actions
+        .iter()
+        .filter(|action| action.protocol_action != "request_snapshot")
+        .all(|action| action.disabled_reason.is_some()));
+}
+
+#[test]
 fn compat_snapshot_keeps_post_onboarding_blocked_after_confirmed_progress() {
     let _guard = lock_test_llm_env();
     let mut server = ViewerRuntimeLiveServer::new(

--- a/scripts/collect-active-llm-retention-sample.sh
+++ b/scripts/collect-active-llm-retention-sample.sh
@@ -632,7 +632,7 @@ retention_progressed = (
     )
 )
 
-checks = {
+trust_gate_checks = {
     "connected": initial_state.get("connectionStatus") == "connected",
     "step8Advanced": step8_feedback.get("stage") == "completed_advanced",
     "selectedAgent": entry_state.get("selectedKind") == "agent" and bool(entry_state.get("selectedId")),
@@ -647,11 +647,18 @@ checks = {
     ),
     "noRuntimeError": not bool(final_state.get("lastError")),
     "playNotBlocked": pre_pause_feedback.get("stage") != "blocked",
+}
+first_capability_checks = {
     "retentionProgressed": retention_progressed,
 }
+trust_gate_result = "pass" if all(trust_gate_checks.values()) else "watch"
+first_capability_result = "pass" if all(first_capability_checks.values()) else "watch"
 
 summary = {
-    "result": "pass" if all(checks.values()) else "watch",
+    "result": trust_gate_result,
+    "resultScope": "trust_gate",
+    "trustGateResult": trust_gate_result,
+    "firstCapabilityResult": first_capability_result,
     "gameUrl": game_url,
     "stackLogsDir": stack_logs_dir or None,
     "artifacts": {
@@ -669,7 +676,8 @@ summary = {
         "consoleLog": str(console_log),
         "consoleErrorsLog": str(console_errors_log),
     },
-    "checks": checks,
+    "checks": trust_gate_checks,
+    "firstCapabilityChecks": first_capability_checks,
     "notes": {
         "renderer": browser_env.get("renderer"),
         "renderMode": (browser_env.get("state") or {}).get("renderMode"),
@@ -709,12 +717,21 @@ lines = [
     "# Active-LLM formal retention sample summary",
     "",
     f"- result: `{summary['result']}`",
+    f"- result scope: `{summary['resultScope']}`",
+    f"- trust gate result: `{summary['trustGateResult']}`",
+    f"- first capability result: `{summary['firstCapabilityResult']}`",
     f"- url: `{game_url}`",
     f"- stack logs: `{stack_logs_dir or 'n/a'}`",
     "",
-    "## Checks",
+    "## Trust Gate Checks",
 ]
-for key, value in checks.items():
+for key, value in trust_gate_checks.items():
+    lines.append(f"- {key}: `{value}`")
+lines.extend([
+    "",
+    "## First Capability Checks",
+])
+for key, value in first_capability_checks.items():
     lines.append(f"- {key}: `{value}`")
 lines.extend([
     "",


### PR DESCRIPTION
## Summary
- recover the active-LLM trust-gate runtime floor so the formal software_safe lane no longer stalls at queued or silently freezes during first-session play
- keep launcher and runtime-live chain-sync bootstrap failures surfaced as explicit blockers instead of poisoning the formal lane with silent no-progress states
- split the formal active-LLM retention sample verdict into `trust_gate` and `first_capability` so `#159` can close without claiming `#160`

## Validation
- `env -u RUSTC_WRAPPER cargo test -p oasis7 viewer_live_llm_timeout -- --nocapture`
- `env -u RUSTC_WRAPPER cargo test -p oasis7 runtime_live_llm_timeout -- --nocapture`
- `bash -n scripts/collect-active-llm-retention-sample.sh`
- `./scripts/collect-active-llm-retention-sample.sh --startup-timeout 480 --feedback-timeout-ms 120000`
- commit hook gates: `./scripts/doc-governance-check.sh`
- commit hook gates: `./scripts/check-windows-paths.sh`
- commit hook gates: `./scripts/check-rust-file-size.sh`
- commit hook gates: `env -u RUSTC_WRAPPER cargo fmt --all -- --check`
- commit hook gates: `env -u RUSTC_WRAPPER cargo test -p oasis7_consensus --lib`
- commit hook gates: `env -u RUSTC_WRAPPER cargo test -p oasis7_distfs --lib`
- commit hook gates: `node crates/oasis7_viewer/scripts/software-safe-feedback-contract.test.mjs`

## Evidence
- formal sample: `output/playwright/retention-active-llm-formal/active-llm-retention-20260429-224359-94243/retention-sample-summary.md`
- formal result: `trustGateResult=pass`, `firstCapabilityResult=watch`
- `#160` remains follow-up scope for the `post_onboarding.recover_capability` path

Closes #159
