### PR TITLE
Fix validator truth bootstrap from world registry

### DIFF
--- a/.pm/tasks/task_d27fd4eafe4c41bdb046d3fe3765033f.execution.md
+++ b/.pm/tasks/task_d27fd4eafe4c41bdb046d3fe3765033f.execution.md
@@ -1,0 +1,17 @@
+# task_d27fd4eafe4c41bdb046d3fe3765033f Execution Log
+
+- task_uid: task_d27fd4eafe4c41bdb046d3fe3765033f
+- title: move validator set and signer bindings to genesis truth
+- owner_role: runtime_engineer
+- worktree_hint: /home/scc/worktrees/oasis7-p2p-validator-genesis-truth
+
+<!-- Append entries using:
+Example:
+  ## YYYY-MM-DD HH:MM:SS CST / role_name
+  - 完成内容: ...
+  - 遗留事项: ...
+-->
+
+## 2026-05-06 12:24:18 CST / runtime_engineer
+- 完成内容: 复用 execution world 里的 `governance_finality_signer_registry` 作为 `oasis7_chain_runtime` 的 validator membership / signer binding 真值入口；当 registry 存在时，runtime 会用 world-state registry 覆盖本地 `NodePosConfig`，并把 replication remote writer allowlist 与 reward runtime node identity binding 统一切到这份 effective config。补齐 `governance_registry` 单测、`cargo check`、模块 PRD/project 与治理 signer externalization project 回写，明确 `--node-validator*` 退回为 bootstrap 或显式运维覆盖。
+- 遗留事项: 当前 world-state registry 路径默认采用三节点等权 stake 派生；若后续需要非等权 validator stake、on-chain onboarding/removal/rotation action 或 shared-network 实机证据，还需继续拆后续任务。

--- a/.pm/tasks/task_d27fd4eafe4c41bdb046d3fe3765033f.execution.md
+++ b/.pm/tasks/task_d27fd4eafe4c41bdb046d3fe3765033f.execution.md
@@ -19,3 +19,7 @@ Example:
 ## 2026-05-06 12:58:00 CST / runtime_engineer
 - 完成内容: 按“与当前 PR 算一个大任务”的口径，继续在同一 task/branch 上补齐 validator / finality signer 的设计方案：将治理 signer externalization 的现状校正为 `registry-first + local fallback`，冻结主流公链通用的 `apply -> approved_candidate -> probation_ready -> active -> rotate/revoke` 准入状态机，明确 `world-state registry` 才是正式激活真值，`--node-validator*` 与 operator-local env 只保留为 bootstrap / 显式运维覆盖；同时明确 controller signer 不属于公开 validator 申请路径，而是治理内部 appointment。同步回写模块主 PRD/project 与 `MAINNET-2` readiness 文档，避免“代码已切 registry 真值、设计仍停留在 local config”。
 - 遗留事项: 当前只冻结了 target workflow；candidate registry、activation action、shared-network probation、formal operator runbook 与真实治理 approval trail 仍待后续实现与实机证据收口。
+
+## 2026-05-06 14:03:00 CST / runtime_engineer
+- 完成内容: 将 validator / finality signer 准入闭环直接落入 runtime：新增 `governance_validator_admissions` world-state 持久化、`Submit/Approve/Activate/RevokeGovernanceValidatorAdmission` 四个治理动作，以及基于 `base finality registry + due admissions - revoked admissions` 的 effective finality registry 解析。`oasis7_chain_runtime` 与 `oasis7_governance_registry_audit` 现已统一读取 effective finality registry；新增独立 admission 生命周期测试，覆盖 `active` 生效、`probation_ready` 到期并入以及 revoke 后重新申请。
+- 遗留事项: 更大范围 shared-network probation、更多 controller/finality live drill 变体，以及最终 governance approval / ceremony / QA `pass` 仍需后续任务继续补证据。

--- a/.pm/tasks/task_d27fd4eafe4c41bdb046d3fe3765033f.execution.md
+++ b/.pm/tasks/task_d27fd4eafe4c41bdb046d3fe3765033f.execution.md
@@ -15,3 +15,7 @@ Example:
 ## 2026-05-06 12:24:18 CST / runtime_engineer
 - 完成内容: 复用 execution world 里的 `governance_finality_signer_registry` 作为 `oasis7_chain_runtime` 的 validator membership / signer binding 真值入口；当 registry 存在时，runtime 会用 world-state registry 覆盖本地 `NodePosConfig`，并把 replication remote writer allowlist 与 reward runtime node identity binding 统一切到这份 effective config。补齐 `governance_registry` 单测、`cargo check`、模块 PRD/project 与治理 signer externalization project 回写，明确 `--node-validator*` 退回为 bootstrap 或显式运维覆盖。
 - 遗留事项: 当前 world-state registry 路径默认采用三节点等权 stake 派生；若后续需要非等权 validator stake、on-chain onboarding/removal/rotation action 或 shared-network 实机证据，还需继续拆后续任务。
+
+## 2026-05-06 12:58:00 CST / runtime_engineer
+- 完成内容: 按“与当前 PR 算一个大任务”的口径，继续在同一 task/branch 上补齐 validator / finality signer 的设计方案：将治理 signer externalization 的现状校正为 `registry-first + local fallback`，冻结主流公链通用的 `apply -> approved_candidate -> probation_ready -> active -> rotate/revoke` 准入状态机，明确 `world-state registry` 才是正式激活真值，`--node-validator*` 与 operator-local env 只保留为 bootstrap / 显式运维覆盖；同时明确 controller signer 不属于公开 validator 申请路径，而是治理内部 appointment。同步回写模块主 PRD/project 与 `MAINNET-2` readiness 文档，避免“代码已切 registry 真值、设计仍停留在 local config”。
+- 遗留事项: 当前只冻结了 target workflow；candidate registry、activation action、shared-network probation、formal operator runbook 与真实治理 approval trail 仍待后续实现与实机证据收口。

--- a/.pm/tasks/task_d27fd4eafe4c41bdb046d3fe3765033f.yaml
+++ b/.pm/tasks/task_d27fd4eafe4c41bdb046d3fe3765033f.yaml
@@ -1,0 +1,20 @@
+task_uid: task_d27fd4eafe4c41bdb046d3fe3765033f
+title: "move validator set and signer bindings to genesis truth"
+owner_role: runtime_engineer
+worktree_hint: /home/scc/worktrees/oasis7-p2p-validator-genesis-truth
+execution_log_path: .pm/tasks/task_d27fd4eafe4c41bdb046d3fe3765033f.execution.md
+status: done
+priority: P2
+source_signal: null
+source_refs:
+  - doc/p2p/prd.md
+  - doc/p2p/project.md
+doc_refs:
+  - doc/p2p/prd.md
+  - doc/p2p/project.md
+related_prd: []
+acceptance: []
+handoff_to: []
+updated_at: 2026-05-06T12:25:33+08:00
+last_started_at: 2026-05-06T12:08:03+08:00
+last_closed_at: 2026-05-06T12:25:33+08:00

--- a/.pm/tasks/task_d27fd4eafe4c41bdb046d3fe3765033f.yaml
+++ b/.pm/tasks/task_d27fd4eafe4c41bdb046d3fe3765033f.yaml
@@ -15,6 +15,6 @@ doc_refs:
 related_prd: []
 acceptance: []
 handoff_to: []
-updated_at: 2026-05-06T13:02:04+08:00
-last_started_at: 2026-05-06T12:52:22+08:00
-last_closed_at: 2026-05-06T13:02:04+08:00
+updated_at: 2026-05-06T19:58:26+08:00
+last_started_at: 2026-05-06T13:29:32+08:00
+last_closed_at: 2026-05-06T19:58:26+08:00

--- a/.pm/tasks/task_d27fd4eafe4c41bdb046d3fe3765033f.yaml
+++ b/.pm/tasks/task_d27fd4eafe4c41bdb046d3fe3765033f.yaml
@@ -15,6 +15,6 @@ doc_refs:
 related_prd: []
 acceptance: []
 handoff_to: []
-updated_at: 2026-05-06T12:25:33+08:00
-last_started_at: 2026-05-06T12:08:03+08:00
-last_closed_at: 2026-05-06T12:25:33+08:00
+updated_at: 2026-05-06T13:02:04+08:00
+last_started_at: 2026-05-06T12:52:22+08:00
+last_closed_at: 2026-05-06T13:02:04+08:00

--- a/crates/oasis7/src/bin/oasis7_chain_runtime.rs
+++ b/crates/oasis7/src/bin/oasis7_chain_runtime.rs
@@ -243,10 +243,6 @@ fn run_chain_runtime(options: CliOptions) -> Result<(), String> {
         &keypair,
         &options.node_validator_signer_public_keys,
     )?;
-    let replication_remote_writer_allowlist = build_replication_remote_writer_allowlist(
-        validator_signer_bindings.values(),
-        &options.replication_remote_writer_public_keys,
-    );
     let mut pos_config = NodePosConfig::ethereum_like(validators.clone())
         .with_validator_signer_public_keys(validator_signer_bindings.clone())
         .map_err(|err| format!("failed to apply validator signer bindings: {err:?}"))?;
@@ -276,17 +272,23 @@ fn run_chain_runtime(options: CliOptions) -> Result<(), String> {
         config = config.with_gossip_optional(bind_addr, options.node_gossip_peers.clone());
     }
 
+    config = apply_traffic_profile_to_node_config(config, &options)?;
+    config = governance_registry::apply_world_governance_registry_overrides(
+        config,
+        paths.execution_world_dir.as_path(),
+    )?;
+    let effective_validator_signer_bindings =
+        config.pos_config.validator_signer_public_keys.clone();
+    let replication_remote_writer_allowlist = build_replication_remote_writer_allowlist(
+        effective_validator_signer_bindings.values(),
+        &options.replication_remote_writer_public_keys,
+    );
     config = config.with_replication(build_node_replication_config(
         options.node_id.as_str(),
         &keypair,
         &storage_profile_config,
         replication_remote_writer_allowlist.as_slice(),
     )?);
-    config = apply_traffic_profile_to_node_config(config, &options)?;
-    config = governance_registry::apply_world_governance_registry_overrides(
-        config,
-        paths.execution_world_dir.as_path(),
-    )?;
 
     let mut runtime = NodeRuntime::new(config);
     if require_execution {
@@ -319,7 +321,7 @@ fn run_chain_runtime(options: CliOptions) -> Result<(), String> {
         .map_err(|err| {
             format!("failed to derive reward runtime signer keypair for {signer_node_id}: {err}")
         })?;
-    let mut reward_runtime_node_identity_bindings = validator_signer_bindings;
+    let mut reward_runtime_node_identity_bindings = effective_validator_signer_bindings;
     if !reward_runtime_node_identity_bindings.contains_key(signer_node_id.as_str()) {
         reward_runtime_node_identity_bindings.insert(
             signer_node_id.clone(),

--- a/crates/oasis7/src/bin/oasis7_chain_runtime/governance_registry.rs
+++ b/crates/oasis7/src/bin/oasis7_chain_runtime/governance_registry.rs
@@ -17,8 +17,14 @@ pub(super) fn apply_world_governance_registry_overrides(
     execution_world_dir: &Path,
 ) -> Result<NodeConfig, String> {
     let world = super::execution_bridge::load_execution_world(execution_world_dir)?;
-    if let Some(registry) = world.governance_finality_signer_registry() {
-        let pos_config = node_pos_config_from_world_finality_registry(registry, &config.pos_config);
+    if let Some(registry) = world
+        .resolve_governance_effective_finality_signer_registry()
+        .map_err(|err| {
+            format!("failed to resolve world governance effective finality registry: {err:?}")
+        })?
+    {
+        let pos_config =
+            node_pos_config_from_world_finality_registry(&registry, &config.pos_config);
         config = config.with_pos_config(pos_config).map_err(|err| {
             format!("failed to apply world governance finality registry: {err:?}")
         })?;
@@ -111,8 +117,8 @@ fn node_main_token_controller_signer_policy_from_registry(
 mod tests {
     use super::apply_world_governance_registry_overrides;
     use oasis7::runtime::{
-        GovernanceFinalitySignerRegistry, GovernanceMainTokenControllerRegistry,
-        GovernanceThresholdSignerPolicy, World,
+        Action, GovernanceExecutionPolicy, GovernanceFinalitySignerRegistry,
+        GovernanceMainTokenControllerRegistry, GovernanceThresholdSignerPolicy, World,
     };
     use oasis7_node::{NodeConfig, NodeRole};
     use std::collections::{BTreeMap, BTreeSet};
@@ -272,5 +278,114 @@ mod tests {
         assert_eq!(config.pos_config.slot_duration_ms, 12_000);
         assert_eq!(config.pos_config.ticks_per_slot, 10);
         assert_eq!(config.pos_config.proposal_tick_phase, 9);
+    }
+
+    #[test]
+    fn world_effective_finality_registry_overrides_node_pos_config_after_validator_activation() {
+        let temp_dir = temp_dir("effective-finality-override");
+        let mut world = World::new();
+        world
+            .set_governance_execution_policy(GovernanceExecutionPolicy {
+                epoch_length_ticks: 10,
+                ..GovernanceExecutionPolicy::default()
+            })
+            .expect("set governance policy");
+        world
+            .set_governance_finality_signer_registry(GovernanceFinalitySignerRegistry {
+                slot_id: "governance.finality.v1".to_string(),
+                threshold: 2,
+                threshold_bps: 0,
+                signer_bindings: BTreeMap::from([
+                    (
+                        "validator-a".to_string(),
+                        "1111111111111111111111111111111111111111111111111111111111111111"
+                            .to_string(),
+                    ),
+                    (
+                        "validator-b".to_string(),
+                        "2222222222222222222222222222222222222222222222222222222222222222"
+                            .to_string(),
+                    ),
+                ]),
+            })
+            .expect("set finality registry");
+        world
+            .set_governance_main_token_controller_registry(GovernanceMainTokenControllerRegistry {
+                genesis_controller_account_id: "msig.genesis.v1".to_string(),
+                treasury_bucket_controller_slots: BTreeMap::from([(
+                    "ecosystem_pool".to_string(),
+                    "liveops".to_string(),
+                )]),
+                restricted_starter_claim_admin_account_ids: BTreeSet::from(["liveops".to_string()]),
+                controller_signer_policies: BTreeMap::from([
+                    (
+                        "msig.genesis.v1".to_string(),
+                        GovernanceThresholdSignerPolicy {
+                            threshold: 1,
+                            allowed_public_keys: BTreeSet::from([
+                                "6249e5a58278dbc4e629a16b5d33f6b84c39e3ceeb10e963bb9ef64ea4daac30"
+                                    .to_string(),
+                            ]),
+                        },
+                    ),
+                    (
+                        "liveops".to_string(),
+                        GovernanceThresholdSignerPolicy {
+                            threshold: 1,
+                            allowed_public_keys: BTreeSet::from([
+                                "13c160fc0f516b9a5663aa00c2a5446be6467f68ce341fdd79cdb64224dffd20"
+                                    .to_string(),
+                            ]),
+                        },
+                    ),
+                ]),
+            })
+            .expect("set controller registry");
+        world.submit_action(Action::SubmitGovernanceValidatorAdmission {
+            controller_account_id: "msig.genesis.v1".to_string(),
+            candidate_id: "candidate-c".to_string(),
+            node_id: "validator-c".to_string(),
+            finality_signer_public_key:
+                "3333333333333333333333333333333333333333333333333333333333333333".to_string(),
+            operator_owner: "ops.team".to_string(),
+            public_manifest_hash: "manifest-c".to_string(),
+        });
+        world.step().expect("submit validator admission");
+        world.submit_action(Action::ApproveGovernanceValidatorAdmission {
+            controller_account_id: "msig.genesis.v1".to_string(),
+            candidate_id: "candidate-c".to_string(),
+        });
+        world.step().expect("approve validator admission");
+        world.submit_action(Action::ActivateGovernanceValidatorAdmission {
+            controller_account_id: "msig.genesis.v1".to_string(),
+            candidate_id: "candidate-c".to_string(),
+            activation_epoch: 0,
+        });
+        world.step().expect("activate validator admission");
+        world.save_to_dir(&temp_dir).expect("save execution world");
+
+        let config =
+            NodeConfig::new("node-a", "world-a", NodeRole::Sequencer).expect("node config");
+        let config = apply_world_governance_registry_overrides(config, &temp_dir)
+            .expect("apply registry overrides");
+
+        let validator_ids = config
+            .pos_config
+            .validators
+            .iter()
+            .map(|validator| validator.validator_id.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            validator_ids,
+            vec!["validator-a", "validator-b", "validator-c"]
+        );
+        assert_eq!(
+            config
+                .pos_config
+                .validator_signer_public_keys
+                .get("validator-c")
+                .map(String::as_str),
+            Some("3333333333333333333333333333333333333333333333333333333333333333")
+        );
     }
 }

--- a/crates/oasis7/src/bin/oasis7_chain_runtime/governance_registry.rs
+++ b/crates/oasis7/src/bin/oasis7_chain_runtime/governance_registry.rs
@@ -1,26 +1,75 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::Path;
 
-use oasis7::runtime::{GovernanceMainTokenControllerRegistry, GovernanceThresholdSignerPolicy};
+use oasis7::runtime::{
+    GovernanceFinalitySignerRegistry, GovernanceMainTokenControllerRegistry,
+    GovernanceThresholdSignerPolicy,
+};
 use oasis7_node::{
     NodeConfig, NodeMainTokenControllerBindingConfig, NodeMainTokenControllerSignerPolicy,
+    NodePosConfig, PosValidator,
 };
 
+const WORLD_REGISTRY_EQUAL_VALIDATOR_STAKE: u64 = 100;
+
 pub(super) fn apply_world_governance_registry_overrides(
-    config: NodeConfig,
+    mut config: NodeConfig,
     execution_world_dir: &Path,
 ) -> Result<NodeConfig, String> {
     let world = super::execution_bridge::load_execution_world(execution_world_dir)?;
-    let Some(registry) = world.governance_main_token_controller_registry() else {
-        return Ok(config);
-    };
-    let binding = node_main_token_controller_binding_from_registry(
-        registry,
-        config.main_token_controller_binding.clone(),
-    );
-    config
-        .with_main_token_controller_binding(binding)
-        .map_err(|err| format!("failed to apply world governance controller registry: {err:?}"))
+    if let Some(registry) = world.governance_finality_signer_registry() {
+        let pos_config = node_pos_config_from_world_finality_registry(registry, &config.pos_config);
+        config = config.with_pos_config(pos_config).map_err(|err| {
+            format!("failed to apply world governance finality registry: {err:?}")
+        })?;
+    }
+    if let Some(registry) = world.governance_main_token_controller_registry() {
+        let binding = node_main_token_controller_binding_from_registry(
+            registry,
+            config.main_token_controller_binding.clone(),
+        );
+        config = config
+            .with_main_token_controller_binding(binding)
+            .map_err(|err| {
+                format!("failed to apply world governance controller registry: {err:?}")
+            })?;
+    }
+    Ok(config)
+}
+
+fn node_pos_config_from_world_finality_registry(
+    registry: &GovernanceFinalitySignerRegistry,
+    fallback: &NodePosConfig,
+) -> NodePosConfig {
+    let validators = registry
+        .signer_bindings
+        .keys()
+        .cloned()
+        .map(|validator_id| PosValidator {
+            validator_id,
+            stake: WORLD_REGISTRY_EQUAL_VALIDATOR_STAKE,
+        })
+        .collect::<Vec<PosValidator>>();
+    let validator_player_ids = registry
+        .signer_bindings
+        .keys()
+        .cloned()
+        .map(|validator_id| (validator_id.clone(), validator_id))
+        .collect::<BTreeMap<String, String>>();
+    NodePosConfig {
+        validators,
+        validator_player_ids,
+        validator_signer_public_keys: registry.signer_bindings.clone(),
+        supermajority_numerator: fallback.supermajority_numerator,
+        supermajority_denominator: fallback.supermajority_denominator,
+        epoch_length_slots: fallback.epoch_length_slots,
+        slot_duration_ms: fallback.slot_duration_ms,
+        ticks_per_slot: fallback.ticks_per_slot,
+        proposal_tick_phase: fallback.proposal_tick_phase,
+        adaptive_tick_scheduler_enabled: fallback.adaptive_tick_scheduler_enabled,
+        slot_clock_genesis_unix_ms: fallback.slot_clock_genesis_unix_ms,
+        max_past_slot_lag: fallback.max_past_slot_lag,
+    }
 }
 
 fn node_main_token_controller_binding_from_registry(
@@ -62,7 +111,8 @@ fn node_main_token_controller_signer_policy_from_registry(
 mod tests {
     use super::apply_world_governance_registry_overrides;
     use oasis7::runtime::{
-        GovernanceMainTokenControllerRegistry, GovernanceThresholdSignerPolicy, World,
+        GovernanceFinalitySignerRegistry, GovernanceMainTokenControllerRegistry,
+        GovernanceThresholdSignerPolicy, World,
     };
     use oasis7_node::{NodeConfig, NodeRole};
     use std::collections::{BTreeMap, BTreeSet};
@@ -148,5 +198,79 @@ mod tests {
                 .map(|policy| policy.threshold),
             Some(2)
         );
+    }
+
+    #[test]
+    fn world_finality_registry_overrides_node_pos_config() {
+        let temp_dir = temp_dir("finality-override");
+        let mut world = World::new();
+        world
+            .set_governance_finality_signer_registry(GovernanceFinalitySignerRegistry {
+                slot_id: "governance.finality.v1".to_string(),
+                threshold: 2,
+                threshold_bps: 0,
+                signer_bindings: BTreeMap::from([
+                    (
+                        "validator-a".to_string(),
+                        "1111111111111111111111111111111111111111111111111111111111111111"
+                            .to_string(),
+                    ),
+                    (
+                        "validator-b".to_string(),
+                        "2222222222222222222222222222222222222222222222222222222222222222"
+                            .to_string(),
+                    ),
+                    (
+                        "validator-c".to_string(),
+                        "3333333333333333333333333333333333333333333333333333333333333333"
+                            .to_string(),
+                    ),
+                ]),
+            })
+            .expect("set finality registry");
+        world.save_to_dir(&temp_dir).expect("save execution world");
+
+        let mut config =
+            NodeConfig::new("node-a", "world-a", NodeRole::Sequencer).expect("node config");
+        config.pos_config.slot_duration_ms = 12_000;
+        config.pos_config.ticks_per_slot = 10;
+        config.pos_config.proposal_tick_phase = 9;
+        let config = apply_world_governance_registry_overrides(config, &temp_dir)
+            .expect("apply registry overrides");
+
+        let validator_ids = config
+            .pos_config
+            .validators
+            .iter()
+            .map(|validator| validator.validator_id.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            validator_ids,
+            vec!["validator-a", "validator-b", "validator-c"]
+        );
+        assert!(config
+            .pos_config
+            .validators
+            .iter()
+            .all(|validator| validator.stake == 100));
+        assert_eq!(
+            config
+                .pos_config
+                .validator_signer_public_keys
+                .get("validator-b")
+                .map(String::as_str),
+            Some("2222222222222222222222222222222222222222222222222222222222222222")
+        );
+        assert_eq!(
+            config
+                .pos_config
+                .validator_player_ids
+                .get("validator-c")
+                .map(String::as_str),
+            Some("validator-c")
+        );
+        assert_eq!(config.pos_config.slot_duration_ms, 12_000);
+        assert_eq!(config.pos_config.ticks_per_slot, 10);
+        assert_eq!(config.pos_config.proposal_tick_phase, 9);
     }
 }

--- a/crates/oasis7/src/bin/oasis7_governance_registry_audit.rs
+++ b/crates/oasis7/src/bin/oasis7_governance_registry_audit.rs
@@ -109,7 +109,10 @@ fn build_audit_report(options: &CliOptions) -> Result<GovernanceRegistryAuditRep
     };
 
     let finality_registry = world
-        .governance_finality_signer_registry()
+        .resolve_governance_effective_finality_signer_registry()
+        .map_err(|err| {
+            format!("resolve effective governance finality signer registry failed: {err:?}")
+        })?
         .ok_or_else(|| "world is missing governance finality signer registry".to_string())?;
     let finality_keys = finality_registry
         .signer_bindings
@@ -400,8 +403,8 @@ fn print_help() {
 mod tests {
     use super::{build_audit_report, parse_options, validate_audit_report, CliOptions};
     use oasis7::runtime::{
-        GovernanceFinalitySignerRegistry, GovernanceMainTokenControllerRegistry,
-        GovernanceThresholdSignerPolicy, World,
+        Action, GovernanceExecutionPolicy, GovernanceFinalitySignerRegistry,
+        GovernanceMainTokenControllerRegistry, GovernanceThresholdSignerPolicy, World,
     };
     use std::collections::{BTreeMap, BTreeSet};
     use std::path::PathBuf;
@@ -771,5 +774,117 @@ mod tests {
         assert_eq!(report.manifest_match_pass, Some(true));
         assert_eq!(report.overall_status, "ready_for_ops_drill");
         assert!(validate_audit_report(&options, &report).is_empty());
+    }
+
+    #[test]
+    fn audit_report_reads_effective_finality_registry_after_validator_activation() {
+        let root = temp_dir("effective-finality");
+        std::fs::create_dir_all(&root).expect("create root");
+        let world_dir = root.join("world");
+        let manifest_path = root.join("public_manifest.json");
+        let mut world = World::new();
+        world
+            .set_governance_execution_policy(GovernanceExecutionPolicy {
+                epoch_length_ticks: 10,
+                ..GovernanceExecutionPolicy::default()
+            })
+            .expect("set governance policy");
+        world
+            .set_governance_finality_signer_registry(GovernanceFinalitySignerRegistry {
+                slot_id: "governance.finality.v1".to_string(),
+                threshold: 2,
+                threshold_bps: 0,
+                signer_bindings: BTreeMap::from([
+                    (
+                        "validator-a".to_string(),
+                        "1111111111111111111111111111111111111111111111111111111111111111"
+                            .to_string(),
+                    ),
+                    (
+                        "validator-b".to_string(),
+                        "2222222222222222222222222222222222222222222222222222222222222222"
+                            .to_string(),
+                    ),
+                ]),
+            })
+            .expect("set finality registry");
+        world
+            .set_governance_main_token_controller_registry(GovernanceMainTokenControllerRegistry {
+                genesis_controller_account_id: "msig.genesis.v1".to_string(),
+                treasury_bucket_controller_slots: BTreeMap::from([(
+                    "ecosystem_pool".to_string(),
+                    "liveops".to_string(),
+                )]),
+                restricted_starter_claim_admin_account_ids: BTreeSet::from(["liveops".to_string()]),
+                controller_signer_policies: BTreeMap::from([
+                    (
+                        "msig.genesis.v1".to_string(),
+                        GovernanceThresholdSignerPolicy {
+                            threshold: 1,
+                            allowed_public_keys: BTreeSet::from([
+                                "6249e5a58278dbc4e629a16b5d33f6b84c39e3ceeb10e963bb9ef64ea4daac30"
+                                    .to_string(),
+                            ]),
+                        },
+                    ),
+                    (
+                        "liveops".to_string(),
+                        GovernanceThresholdSignerPolicy {
+                            threshold: 1,
+                            allowed_public_keys: BTreeSet::from([
+                                "13c160fc0f516b9a5663aa00c2a5446be6467f68ce341fdd79cdb64224dffd20"
+                                    .to_string(),
+                            ]),
+                        },
+                    ),
+                ]),
+            })
+            .expect("set controller registry");
+        world.submit_action(Action::SubmitGovernanceValidatorAdmission {
+            controller_account_id: "msig.genesis.v1".to_string(),
+            candidate_id: "candidate-c".to_string(),
+            node_id: "validator-c".to_string(),
+            finality_signer_public_key:
+                "3333333333333333333333333333333333333333333333333333333333333333".to_string(),
+            operator_owner: "ops.team".to_string(),
+            public_manifest_hash: "manifest-c".to_string(),
+        });
+        world.step().expect("submit validator admission");
+        world.submit_action(Action::ApproveGovernanceValidatorAdmission {
+            controller_account_id: "msig.genesis.v1".to_string(),
+            candidate_id: "candidate-c".to_string(),
+        });
+        world.step().expect("approve validator admission");
+        world.submit_action(Action::ActivateGovernanceValidatorAdmission {
+            controller_account_id: "msig.genesis.v1".to_string(),
+            candidate_id: "candidate-c".to_string(),
+            activation_epoch: 0,
+        });
+        world.step().expect("activate validator admission");
+        world.save_to_dir(&world_dir).expect("save world");
+        std::fs::write(
+            &manifest_path,
+            serde_json::to_vec_pretty(&vec![
+                serde_json::json!({"slot_id":"governance.finality.v1","signer_id":"signer01","scheme":"ed25519","threshold":2,"public_key_hex":"1111111111111111111111111111111111111111111111111111111111111111"}),
+                serde_json::json!({"slot_id":"governance.finality.v1","signer_id":"signer02","scheme":"ed25519","threshold":2,"public_key_hex":"2222222222222222222222222222222222222222222222222222222222222222"}),
+                serde_json::json!({"slot_id":"governance.finality.v1","signer_id":"signer03","scheme":"ed25519","threshold":2,"public_key_hex":"3333333333333333333333333333333333333333333333333333333333333333"}),
+                serde_json::json!({"slot_id":"msig.genesis.v1","signer_id":"signer01","scheme":"ed25519","threshold":1,"public_key_hex":"6249e5a58278dbc4e629a16b5d33f6b84c39e3ceeb10e963bb9ef64ea4daac30"}),
+                serde_json::json!({"slot_id":"liveops","signer_id":"signer01","scheme":"ed25519","threshold":1,"public_key_hex":"13c160fc0f516b9a5663aa00c2a5446be6467f68ce341fdd79cdb64224dffd20"})
+            ])
+            .expect("encode manifest"),
+        )
+        .expect("write manifest");
+
+        let options = CliOptions {
+            world_dir,
+            public_manifest: Some(manifest_path),
+            finality_slot_id: "governance.finality.v1".to_string(),
+            default_expected_threshold: 2,
+            strict_manifest_match: true,
+            require_single_failure_tolerance: false,
+        };
+        let report = build_audit_report(&options).expect("build report");
+        assert_eq!(report.finality.signer_count, 3);
+        assert_eq!(report.finality.manifest_match, Some(true));
     }
 }

--- a/crates/oasis7/src/runtime/events.rs
+++ b/crates/oasis7/src/runtime/events.rs
@@ -508,6 +508,29 @@ pub enum Action {
         #[serde(default)]
         next_admin_account_ids: Vec<String>,
     },
+    SubmitGovernanceValidatorAdmission {
+        controller_account_id: String,
+        candidate_id: String,
+        node_id: String,
+        finality_signer_public_key: String,
+        operator_owner: String,
+        public_manifest_hash: String,
+    },
+    ApproveGovernanceValidatorAdmission {
+        controller_account_id: String,
+        candidate_id: String,
+    },
+    ActivateGovernanceValidatorAdmission {
+        controller_account_id: String,
+        candidate_id: String,
+        activation_epoch: u64,
+    },
+    RevokeGovernanceValidatorAdmission {
+        controller_account_id: String,
+        candidate_id: String,
+        node_id: String,
+        reason: String,
+    },
     OpenEconomicContract {
         creator_agent_id: String,
         contract_id: String,
@@ -787,6 +810,22 @@ impl Action {
                 operator_agent_id, ..
             } => Some(operator_agent_id.as_str()),
             Action::UpdateRestrictedStarterClaimAdminRegistry {
+                controller_account_id,
+                ..
+            }
+            | Action::SubmitGovernanceValidatorAdmission {
+                controller_account_id,
+                ..
+            }
+            | Action::ApproveGovernanceValidatorAdmission {
+                controller_account_id,
+                ..
+            }
+            | Action::ActivateGovernanceValidatorAdmission {
+                controller_account_id,
+                ..
+            }
+            | Action::RevokeGovernanceValidatorAdmission {
                 controller_account_id,
                 ..
             } => Some(controller_account_id.as_str()),

--- a/crates/oasis7/src/runtime/governance.rs
+++ b/crates/oasis7/src/runtime/governance.rs
@@ -287,6 +287,8 @@ pub struct GovernanceValidatorAdmissionRecord {
     pub public_manifest_hash: String,
     #[serde(default)]
     pub requested_at_epoch: u64,
+    #[serde(default)]
+    pub last_transition_tick: WorldTime,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub approved_at_epoch: Option<u64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/crates/oasis7/src/runtime/governance.rs
+++ b/crates/oasis7/src/runtime/governance.rs
@@ -262,6 +262,43 @@ pub struct GovernanceMainTokenControllerRegistry {
     pub controller_signer_policies: BTreeMap<String, GovernanceThresholdSignerPolicy>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum GovernanceValidatorAdmissionStatus {
+    #[default]
+    Applied,
+    ApprovedCandidate,
+    ProbationReady,
+    Active,
+    Revoked,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct GovernanceValidatorAdmissionRecord {
+    #[serde(default)]
+    pub candidate_id: String,
+    #[serde(default)]
+    pub node_id: String,
+    #[serde(default)]
+    pub finality_signer_public_key: String,
+    #[serde(default)]
+    pub operator_owner: String,
+    #[serde(default)]
+    pub public_manifest_hash: String,
+    #[serde(default)]
+    pub requested_at_epoch: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub approved_at_epoch: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub activation_epoch: Option<u64>,
+    #[serde(default)]
+    pub status: GovernanceValidatorAdmissionStatus,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub revoked_at_epoch: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub revocation_reason: Option<String>,
+}
+
 /// Events related to governance actions.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "type", content = "data")]
@@ -349,6 +386,32 @@ pub enum GovernanceEvent {
         controller_account_id: String,
         previous_admin_account_ids: Vec<String>,
         next_admin_account_ids: Vec<String>,
+    },
+    ValidatorAdmissionSubmitted {
+        controller_account_id: String,
+        candidate_id: String,
+        node_id: String,
+        finality_signer_public_key: String,
+        operator_owner: String,
+        public_manifest_hash: String,
+        requested_at_epoch: u64,
+    },
+    ValidatorAdmissionApproved {
+        controller_account_id: String,
+        candidate_id: String,
+        approved_at_epoch: u64,
+    },
+    ValidatorAdmissionActivated {
+        controller_account_id: String,
+        candidate_id: String,
+        activation_epoch: u64,
+    },
+    ValidatorAdmissionRevoked {
+        controller_account_id: String,
+        candidate_id: String,
+        node_id: String,
+        revoked_at_epoch: u64,
+        reason: String,
     },
 }
 

--- a/crates/oasis7/src/runtime/mod.rs
+++ b/crates/oasis7/src/runtime/mod.rs
@@ -88,7 +88,8 @@ pub use governance::{
     GovernanceFinalityEpochSnapshot, GovernanceFinalitySignerRegistry,
     GovernanceIdentityPenaltyMonitorStats, GovernanceIdentityPenaltyRecord,
     GovernanceIdentityPenaltyStatus, GovernanceMainTokenControllerRegistry,
-    GovernanceThresholdSignerPolicy, Proposal, ProposalDecision, ProposalStatus,
+    GovernanceThresholdSignerPolicy, GovernanceValidatorAdmissionRecord,
+    GovernanceValidatorAdmissionStatus, Proposal, ProposalDecision, ProposalStatus,
 };
 
 // Manifest

--- a/crates/oasis7/src/runtime/state.rs
+++ b/crates/oasis7/src/runtime/state.rs
@@ -21,7 +21,10 @@ use super::gameplay_state::{
     MetaProgressState, WarParticipantOutcome, WarState,
     GOVERNANCE_IDENTITY_DEFAULT_MAX_VOTE_WEIGHT,
 };
-use super::governance::{GovernanceFinalitySignerRegistry, GovernanceMainTokenControllerRegistry};
+use super::governance::{
+    GovernanceFinalitySignerRegistry, GovernanceMainTokenControllerRegistry,
+    GovernanceValidatorAdmissionRecord,
+};
 use super::main_token::{
     main_token_bucket_unlocked_amount, FirstAgentClaimApprovalRequestState,
     MainTokenAccountBalance, MainTokenConfig, MainTokenEpochIssuanceRecord,
@@ -526,6 +529,8 @@ pub struct WorldState {
     #[serde(default)]
     pub governance_finality_signer_registry: Option<GovernanceFinalitySignerRegistry>,
     #[serde(default)]
+    pub governance_validator_admissions: BTreeMap<String, GovernanceValidatorAdmissionRecord>,
+    #[serde(default)]
     pub governance_main_token_controller_registry: Option<GovernanceMainTokenControllerRegistry>,
     #[serde(default)]
     pub reward_signature_governance_policy: RewardSignatureGovernancePolicy,
@@ -603,6 +608,7 @@ impl Default for WorldState {
             node_identity_bindings: BTreeMap::new(),
             node_main_token_account_bindings: BTreeMap::new(),
             governance_finality_signer_registry: None,
+            governance_validator_admissions: BTreeMap::new(),
             governance_main_token_controller_registry: None,
             reward_signature_governance_policy: RewardSignatureGovernancePolicy::default(),
         }

--- a/crates/oasis7/src/runtime/tests/governance_validator_admission.rs
+++ b/crates/oasis7/src/runtime/tests/governance_validator_admission.rs
@@ -1,0 +1,194 @@
+use super::super::*;
+use std::collections::{BTreeMap, BTreeSet};
+
+fn seed_governance_world(world: &mut World) {
+    world
+        .set_governance_execution_policy(GovernanceExecutionPolicy {
+            epoch_length_ticks: 10,
+            ..GovernanceExecutionPolicy::default()
+        })
+        .expect("set governance policy");
+    world
+        .set_governance_finality_signer_registry(GovernanceFinalitySignerRegistry {
+            slot_id: "governance.finality.v1".to_string(),
+            threshold: 2,
+            threshold_bps: 0,
+            signer_bindings: BTreeMap::from([
+                (
+                    "validator-a".to_string(),
+                    "1111111111111111111111111111111111111111111111111111111111111111".to_string(),
+                ),
+                (
+                    "validator-b".to_string(),
+                    "2222222222222222222222222222222222222222222222222222222222222222".to_string(),
+                ),
+            ]),
+        })
+        .expect("set finality registry");
+    world
+        .set_governance_main_token_controller_registry(GovernanceMainTokenControllerRegistry {
+            genesis_controller_account_id: "msig.genesis.v1".to_string(),
+            treasury_bucket_controller_slots: BTreeMap::from([(
+                MAIN_TOKEN_TREASURY_BUCKET_ECOSYSTEM_POOL.to_string(),
+                "liveops".to_string(),
+            )]),
+            restricted_starter_claim_admin_account_ids: BTreeSet::from(["liveops".to_string()]),
+            controller_signer_policies: BTreeMap::from([
+                (
+                    "msig.genesis.v1".to_string(),
+                    GovernanceThresholdSignerPolicy {
+                        threshold: 1,
+                        allowed_public_keys: BTreeSet::from([
+                            "6249e5a58278dbc4e629a16b5d33f6b84c39e3ceeb10e963bb9ef64ea4daac30"
+                                .to_string(),
+                        ]),
+                    },
+                ),
+                (
+                    "liveops".to_string(),
+                    GovernanceThresholdSignerPolicy {
+                        threshold: 1,
+                        allowed_public_keys: BTreeSet::from([
+                            "13c160fc0f516b9a5663aa00c2a5446be6467f68ce341fdd79cdb64224dffd20"
+                                .to_string(),
+                        ]),
+                    },
+                ),
+            ]),
+        })
+        .expect("set controller registry");
+}
+
+fn submit_candidate(world: &mut World, candidate_id: &str, node_id: &str, public_key_hex: &str) {
+    world.submit_action(Action::SubmitGovernanceValidatorAdmission {
+        controller_account_id: "msig.genesis.v1".to_string(),
+        candidate_id: candidate_id.to_string(),
+        node_id: node_id.to_string(),
+        finality_signer_public_key: public_key_hex.to_string(),
+        operator_owner: "ops.team".to_string(),
+        public_manifest_hash: format!("manifest:{candidate_id}"),
+    });
+    world.step().expect("submit validator admission");
+}
+
+#[test]
+fn validator_admission_lifecycle_updates_effective_registry_and_allows_reapply_after_revoke() {
+    let mut world = World::new();
+    seed_governance_world(&mut world);
+
+    submit_candidate(
+        &mut world,
+        "candidate-c",
+        "validator-c",
+        "3333333333333333333333333333333333333333333333333333333333333333",
+    );
+    world.submit_action(Action::ApproveGovernanceValidatorAdmission {
+        controller_account_id: "msig.genesis.v1".to_string(),
+        candidate_id: "candidate-c".to_string(),
+    });
+    world.step().expect("approve validator admission");
+    world.submit_action(Action::ActivateGovernanceValidatorAdmission {
+        controller_account_id: "msig.genesis.v1".to_string(),
+        candidate_id: "candidate-c".to_string(),
+        activation_epoch: 0,
+    });
+    world.step().expect("activate validator admission");
+
+    let active_registry = world
+        .resolve_governance_effective_finality_signer_registry()
+        .expect("resolve effective registry")
+        .expect("effective registry");
+    assert_eq!(active_registry.signer_bindings.len(), 3);
+    assert_eq!(
+        active_registry
+            .signer_bindings
+            .get("validator-c")
+            .map(String::as_str),
+        Some("3333333333333333333333333333333333333333333333333333333333333333")
+    );
+
+    world.submit_action(Action::RevokeGovernanceValidatorAdmission {
+        controller_account_id: "msig.genesis.v1".to_string(),
+        candidate_id: "candidate-c".to_string(),
+        node_id: "validator-c".to_string(),
+        reason: "operator rotation".to_string(),
+    });
+    world.step().expect("revoke validator admission");
+
+    let revoked_registry = world
+        .resolve_governance_effective_finality_signer_registry()
+        .expect("resolve effective registry after revoke")
+        .expect("effective registry after revoke");
+    assert!(!revoked_registry.signer_bindings.contains_key("validator-c"));
+
+    submit_candidate(
+        &mut world,
+        "candidate-c-reapply",
+        "validator-c",
+        "3333333333333333333333333333333333333333333333333333333333333333",
+    );
+    let reapplied = world
+        .governance_validator_admissions()
+        .get("candidate-c-reapply")
+        .expect("reapplied candidate");
+    assert_eq!(
+        reapplied.status,
+        GovernanceValidatorAdmissionStatus::Applied
+    );
+}
+
+#[test]
+fn validator_admission_probation_becomes_effective_once_activation_epoch_is_due() {
+    let mut world = World::new();
+    seed_governance_world(&mut world);
+
+    submit_candidate(
+        &mut world,
+        "candidate-future",
+        "validator-future",
+        "4444444444444444444444444444444444444444444444444444444444444444",
+    );
+    world.submit_action(Action::ApproveGovernanceValidatorAdmission {
+        controller_account_id: "msig.genesis.v1".to_string(),
+        candidate_id: "candidate-future".to_string(),
+    });
+    world.step().expect("approve future validator admission");
+    world.submit_action(Action::ActivateGovernanceValidatorAdmission {
+        controller_account_id: "msig.genesis.v1".to_string(),
+        candidate_id: "candidate-future".to_string(),
+        activation_epoch: 1,
+    });
+    world.step().expect("schedule future validator admission");
+
+    let probationary = world
+        .governance_validator_admissions()
+        .get("candidate-future")
+        .expect("candidate-future");
+    assert_eq!(
+        probationary.status,
+        GovernanceValidatorAdmissionStatus::ProbationReady
+    );
+    let pre_epoch_registry = world
+        .resolve_governance_effective_finality_signer_registry()
+        .expect("resolve pre-epoch registry")
+        .expect("pre-epoch registry");
+    assert!(!pre_epoch_registry
+        .signer_bindings
+        .contains_key("validator-future"));
+
+    for _ in 0..7 {
+        world.step().expect("advance governance epoch");
+    }
+
+    let post_epoch_registry = world
+        .resolve_governance_effective_finality_signer_registry()
+        .expect("resolve post-epoch registry")
+        .expect("post-epoch registry");
+    assert_eq!(
+        post_epoch_registry
+            .signer_bindings
+            .get("validator-future")
+            .map(String::as_str),
+        Some("4444444444444444444444444444444444444444444444444444444444444444")
+    );
+}

--- a/crates/oasis7/src/runtime/tests/governance_validator_admission.rs
+++ b/crates/oasis7/src/runtime/tests/governance_validator_admission.rs
@@ -135,6 +135,30 @@ fn validator_admission_lifecycle_updates_effective_registry_and_allows_reapply_a
         reapplied.status,
         GovernanceValidatorAdmissionStatus::Applied
     );
+
+    world.submit_action(Action::ApproveGovernanceValidatorAdmission {
+        controller_account_id: "msig.genesis.v1".to_string(),
+        candidate_id: "candidate-c-reapply".to_string(),
+    });
+    world.step().expect("approve reapply validator admission");
+    world.submit_action(Action::ActivateGovernanceValidatorAdmission {
+        controller_account_id: "msig.genesis.v1".to_string(),
+        candidate_id: "candidate-c-reapply".to_string(),
+        activation_epoch: 0,
+    });
+    world.step().expect("activate reapply validator admission");
+
+    let reactivated_registry = world
+        .resolve_governance_effective_finality_signer_registry()
+        .expect("resolve effective registry after reapply")
+        .expect("effective registry after reapply");
+    assert_eq!(
+        reactivated_registry
+            .signer_bindings
+            .get("validator-c")
+            .map(String::as_str),
+        Some("3333333333333333333333333333333333333333333333333333333333333333")
+    );
 }
 
 #[test]
@@ -190,5 +214,57 @@ fn validator_admission_probation_becomes_effective_once_activation_epoch_is_due(
             .get("validator-future")
             .map(String::as_str),
         Some("4444444444444444444444444444444444444444444444444444444444444444")
+    );
+}
+
+#[test]
+fn validator_admission_activate_with_already_due_epoch_becomes_active_immediately() {
+    let mut world = World::new();
+    seed_governance_world(&mut world);
+
+    submit_candidate(
+        &mut world,
+        "candidate-late",
+        "validator-late",
+        "5555555555555555555555555555555555555555555555555555555555555555",
+    );
+    world.submit_action(Action::ApproveGovernanceValidatorAdmission {
+        controller_account_id: "msig.genesis.v1".to_string(),
+        candidate_id: "candidate-late".to_string(),
+    });
+    world.step().expect("approve late validator admission");
+    for _ in 0..15 {
+        world
+            .step()
+            .expect("advance governance epoch before late activation");
+    }
+
+    world.submit_action(Action::ActivateGovernanceValidatorAdmission {
+        controller_account_id: "msig.genesis.v1".to_string(),
+        candidate_id: "candidate-late".to_string(),
+        activation_epoch: 1,
+    });
+    world
+        .step()
+        .expect("activate already-due validator admission");
+
+    let late_record = world
+        .governance_validator_admissions()
+        .get("candidate-late")
+        .expect("late candidate");
+    assert_eq!(
+        late_record.status,
+        GovernanceValidatorAdmissionStatus::Active
+    );
+    let registry = world
+        .resolve_governance_effective_finality_signer_registry()
+        .expect("resolve effective registry for late activation")
+        .expect("effective registry for late activation");
+    assert_eq!(
+        registry
+            .signer_bindings
+            .get("validator-late")
+            .map(String::as_str),
+        Some("5555555555555555555555555555555555555555555555555555555555555555")
     );
 }

--- a/crates/oasis7/src/runtime/tests/mod.rs
+++ b/crates/oasis7/src/runtime/tests/mod.rs
@@ -70,6 +70,7 @@ mod gameplay;
 mod gameplay_bootstrap;
 mod gameplay_protocol;
 mod governance;
+mod governance_validator_admission;
 mod main_token;
 mod main_token_economy_audit;
 mod module_action_loop;

--- a/crates/oasis7/src/runtime/world/event_processing.rs
+++ b/crates/oasis7/src/runtime/world/event_processing.rs
@@ -197,6 +197,10 @@ impl World {
             }
             Action::UpdateGameplayPolicy { .. }
             | Action::UpdateRestrictedStarterClaimAdminRegistry { .. }
+            | Action::SubmitGovernanceValidatorAdmission { .. }
+            | Action::ApproveGovernanceValidatorAdmission { .. }
+            | Action::ActivateGovernanceValidatorAdmission { .. }
+            | Action::RevokeGovernanceValidatorAdmission { .. }
             | Action::OpenEconomicContract { .. }
             | Action::AcceptEconomicContract { .. }
             | Action::SettleEconomicContract { .. } => {

--- a/crates/oasis7/src/runtime/world/event_processing/action_to_event_policy_contract.rs
+++ b/crates/oasis7/src/runtime/world/event_processing/action_to_event_policy_contract.rs
@@ -1,4 +1,7 @@
 use super::*;
+use std::collections::BTreeMap;
+
+use crate::runtime::{GovernanceValidatorAdmissionRecord, GovernanceValidatorAdmissionStatus};
 
 impl World {
     pub(super) fn action_to_event_policy_contract(
@@ -190,6 +193,557 @@ impl World {
                             .cloned()
                             .collect(),
                         next_admin_account_ids: next_admin_account_ids.into_iter().collect(),
+                    },
+                ))
+            }
+            Action::SubmitGovernanceValidatorAdmission {
+                controller_account_id,
+                candidate_id,
+                node_id,
+                finality_signer_public_key,
+                operator_owner,
+                public_manifest_hash,
+            } => {
+                let Some(current_registry) = self.governance_main_token_controller_registry()
+                else {
+                    return Ok(WorldEventBody::Domain(DomainEvent::ActionRejected {
+                        action_id,
+                        reason: RejectReason::RuleDenied {
+                            notes: vec![
+                                "submit validator admission rejected: main token controller registry is not configured"
+                                    .to_string(),
+                            ],
+                        },
+                    }));
+                };
+                let controller_account_id = controller_account_id.trim();
+                let expected_controller_account_id =
+                    match Self::validator_admission_controller_account_id(current_registry) {
+                        Ok(account_id) => account_id,
+                        Err(err) => {
+                            return Ok(WorldEventBody::Domain(DomainEvent::ActionRejected {
+                                action_id,
+                                reason: RejectReason::RuleDenied {
+                                    notes: vec![format!(
+                                        "submit validator admission rejected: {err:?}"
+                                    )],
+                                },
+                            }))
+                        }
+                    };
+                if controller_account_id != expected_controller_account_id {
+                    return Ok(WorldEventBody::Domain(DomainEvent::ActionRejected {
+                        action_id,
+                        reason: RejectReason::RuleDenied {
+                            notes: vec![format!(
+                                "submit validator admission rejected: controller_account_id does not match validator admission controller expected={} actual={}",
+                                expected_controller_account_id, controller_account_id
+                            )],
+                        },
+                    }));
+                }
+                let requested_at_epoch = self.current_governance_epoch();
+                let record = match self.validate_governance_validator_admission_record(
+                    GovernanceValidatorAdmissionRecord {
+                        candidate_id: candidate_id.clone(),
+                        node_id: node_id.clone(),
+                        finality_signer_public_key: finality_signer_public_key.clone(),
+                        operator_owner: operator_owner.clone(),
+                        public_manifest_hash: public_manifest_hash.clone(),
+                        requested_at_epoch,
+                        ..GovernanceValidatorAdmissionRecord::default()
+                    },
+                ) {
+                    Ok(record) => record,
+                    Err(err) => {
+                        return Ok(WorldEventBody::Domain(DomainEvent::ActionRejected {
+                            action_id,
+                            reason: RejectReason::RuleDenied {
+                                notes: vec![format!(
+                                    "submit validator admission rejected: {err:?}"
+                                )],
+                            },
+                        }))
+                    }
+                };
+                if self
+                    .state
+                    .governance_validator_admissions
+                    .contains_key(record.candidate_id.as_str())
+                {
+                    return Ok(WorldEventBody::Domain(DomainEvent::ActionRejected {
+                        action_id,
+                        reason: RejectReason::RuleDenied {
+                            notes: vec![format!(
+                                "submit validator admission rejected: candidate already exists: {}",
+                                record.candidate_id
+                            )],
+                        },
+                    }));
+                }
+                if self
+                    .state
+                    .governance_validator_admissions
+                    .values()
+                    .any(|existing| {
+                        existing.node_id == record.node_id
+                            && existing.status != GovernanceValidatorAdmissionStatus::Revoked
+                    })
+                {
+                    return Ok(WorldEventBody::Domain(DomainEvent::ActionRejected {
+                        action_id,
+                        reason: RejectReason::RuleDenied {
+                            notes: vec![format!(
+                                "submit validator admission rejected: node_id already has an active admission record: {}",
+                                record.node_id
+                            )],
+                        },
+                    }));
+                }
+                match self.resolve_governance_effective_finality_signer_registry() {
+                    Ok(Some(registry))
+                        if registry
+                            .signer_bindings
+                            .contains_key(record.node_id.as_str()) =>
+                    {
+                        return Ok(WorldEventBody::Domain(DomainEvent::ActionRejected {
+                            action_id,
+                            reason: RejectReason::RuleDenied {
+                                notes: vec![format!(
+                                    "submit validator admission rejected: node_id is already active in finality registry: {}",
+                                    record.node_id
+                                )],
+                            },
+                        }));
+                    }
+                    Ok(_) => {}
+                    Err(err) => {
+                        return Ok(WorldEventBody::Domain(DomainEvent::ActionRejected {
+                            action_id,
+                            reason: RejectReason::RuleDenied {
+                                notes: vec![format!(
+                                    "submit validator admission rejected: {err:?}"
+                                )],
+                            },
+                        }));
+                    }
+                }
+                if let Some(existing_public_key) =
+                    self.node_identity_public_key(record.node_id.as_str())
+                {
+                    if existing_public_key != record.finality_signer_public_key {
+                        return Ok(WorldEventBody::Domain(DomainEvent::ActionRejected {
+                            action_id,
+                            reason: RejectReason::RuleDenied {
+                                notes: vec![format!(
+                                    "submit validator admission rejected: node identity binding mismatch node_id={} expected={} actual={}",
+                                    record.node_id, existing_public_key, record.finality_signer_public_key
+                                )],
+                            },
+                        }));
+                    }
+                }
+                if self
+                    .state
+                    .governance_validator_admissions
+                    .values()
+                    .any(|existing| {
+                        existing.finality_signer_public_key == record.finality_signer_public_key
+                            && existing.node_id != record.node_id
+                            && existing.status != GovernanceValidatorAdmissionStatus::Revoked
+                    })
+                    || match self.resolve_governance_effective_finality_signer_registry() {
+                        Ok(Some(registry)) => {
+                            registry
+                                .signer_bindings
+                                .iter()
+                                .any(|(existing_node_id, public_key)| {
+                                    public_key == &record.finality_signer_public_key
+                                        && existing_node_id != &record.node_id
+                                })
+                        }
+                        Ok(None) => false,
+                        Err(err) => {
+                            return Ok(WorldEventBody::Domain(DomainEvent::ActionRejected {
+                                action_id,
+                                reason: RejectReason::RuleDenied {
+                                    notes: vec![format!(
+                                        "submit validator admission rejected: {err:?}"
+                                    )],
+                                },
+                            }));
+                        }
+                    }
+                {
+                    return Ok(WorldEventBody::Domain(DomainEvent::ActionRejected {
+                        action_id,
+                        reason: RejectReason::RuleDenied {
+                            notes: vec![format!(
+                                "submit validator admission rejected: finality signer public key is already assigned to another node"
+                            )],
+                        },
+                    }));
+                }
+                Ok(WorldEventBody::Governance(
+                    GovernanceEvent::ValidatorAdmissionSubmitted {
+                        controller_account_id: controller_account_id.to_string(),
+                        candidate_id: record.candidate_id,
+                        node_id: record.node_id,
+                        finality_signer_public_key: record.finality_signer_public_key,
+                        operator_owner: record.operator_owner,
+                        public_manifest_hash: record.public_manifest_hash,
+                        requested_at_epoch,
+                    },
+                ))
+            }
+            Action::ApproveGovernanceValidatorAdmission {
+                controller_account_id,
+                candidate_id,
+            } => {
+                let Some(current_registry) = self.governance_main_token_controller_registry()
+                else {
+                    return Ok(WorldEventBody::Domain(DomainEvent::ActionRejected {
+                        action_id,
+                        reason: RejectReason::RuleDenied {
+                            notes: vec![
+                                "approve validator admission rejected: main token controller registry is not configured"
+                                    .to_string(),
+                            ],
+                        },
+                    }));
+                };
+                let controller_account_id = controller_account_id.trim();
+                let expected_controller_account_id =
+                    match Self::validator_admission_controller_account_id(current_registry) {
+                        Ok(account_id) => account_id,
+                        Err(err) => {
+                            return Ok(WorldEventBody::Domain(DomainEvent::ActionRejected {
+                                action_id,
+                                reason: RejectReason::RuleDenied {
+                                    notes: vec![format!(
+                                        "approve validator admission rejected: {err:?}"
+                                    )],
+                                },
+                            }))
+                        }
+                    };
+                if controller_account_id != expected_controller_account_id {
+                    return Ok(WorldEventBody::Domain(DomainEvent::ActionRejected {
+                        action_id,
+                        reason: RejectReason::RuleDenied {
+                            notes: vec![format!(
+                                "approve validator admission rejected: controller_account_id does not match validator admission controller expected={} actual={}",
+                                expected_controller_account_id, controller_account_id
+                            )],
+                        },
+                    }));
+                }
+                let candidate_id = candidate_id.trim();
+                let Some(record) = self.state.governance_validator_admissions.get(candidate_id)
+                else {
+                    return Ok(WorldEventBody::Domain(DomainEvent::ActionRejected {
+                        action_id,
+                        reason: RejectReason::RuleDenied {
+                            notes: vec![format!(
+                                "approve validator admission rejected: candidate not found: {candidate_id}"
+                            )],
+                        },
+                    }));
+                };
+                if record.status != GovernanceValidatorAdmissionStatus::Applied {
+                    return Ok(WorldEventBody::Domain(DomainEvent::ActionRejected {
+                        action_id,
+                        reason: RejectReason::RuleDenied {
+                            notes: vec![format!(
+                                "approve validator admission rejected: candidate is not in applied status: {}",
+                                candidate_id
+                            )],
+                        },
+                    }));
+                }
+                Ok(WorldEventBody::Governance(
+                    GovernanceEvent::ValidatorAdmissionApproved {
+                        controller_account_id: controller_account_id.to_string(),
+                        candidate_id: candidate_id.to_string(),
+                        approved_at_epoch: self.current_governance_epoch(),
+                    },
+                ))
+            }
+            Action::ActivateGovernanceValidatorAdmission {
+                controller_account_id,
+                candidate_id,
+                activation_epoch,
+            } => {
+                let Some(current_registry) = self.governance_main_token_controller_registry()
+                else {
+                    return Ok(WorldEventBody::Domain(DomainEvent::ActionRejected {
+                        action_id,
+                        reason: RejectReason::RuleDenied {
+                            notes: vec![
+                                "activate validator admission rejected: main token controller registry is not configured"
+                                    .to_string(),
+                            ],
+                        },
+                    }));
+                };
+                let controller_account_id = controller_account_id.trim();
+                let expected_controller_account_id =
+                    match Self::validator_admission_controller_account_id(current_registry) {
+                        Ok(account_id) => account_id,
+                        Err(err) => {
+                            return Ok(WorldEventBody::Domain(DomainEvent::ActionRejected {
+                                action_id,
+                                reason: RejectReason::RuleDenied {
+                                    notes: vec![format!(
+                                        "activate validator admission rejected: {err:?}"
+                                    )],
+                                },
+                            }))
+                        }
+                    };
+                if controller_account_id != expected_controller_account_id {
+                    return Ok(WorldEventBody::Domain(DomainEvent::ActionRejected {
+                        action_id,
+                        reason: RejectReason::RuleDenied {
+                            notes: vec![format!(
+                                "activate validator admission rejected: controller_account_id does not match validator admission controller expected={} actual={}",
+                                expected_controller_account_id, controller_account_id
+                            )],
+                        },
+                    }));
+                }
+                let current_epoch = self.current_governance_epoch();
+                let candidate_id = candidate_id.trim();
+                let Some(record) = self.state.governance_validator_admissions.get(candidate_id)
+                else {
+                    return Ok(WorldEventBody::Domain(DomainEvent::ActionRejected {
+                        action_id,
+                        reason: RejectReason::RuleDenied {
+                            notes: vec![format!(
+                                "activate validator admission rejected: candidate not found: {candidate_id}"
+                            )],
+                        },
+                    }));
+                };
+                if !matches!(
+                    record.status,
+                    GovernanceValidatorAdmissionStatus::ApprovedCandidate
+                        | GovernanceValidatorAdmissionStatus::ProbationReady
+                ) {
+                    return Ok(WorldEventBody::Domain(DomainEvent::ActionRejected {
+                        action_id,
+                        reason: RejectReason::RuleDenied {
+                            notes: vec![format!(
+                                "activate validator admission rejected: candidate is not in approvable status: {}",
+                                candidate_id
+                            )],
+                        },
+                    }));
+                }
+                let mut preview_admissions = self.state.governance_validator_admissions.clone();
+                let mut preview_record = record.clone();
+                preview_record.activation_epoch = Some(*activation_epoch);
+                preview_record.status = if *activation_epoch == current_epoch {
+                    GovernanceValidatorAdmissionStatus::Active
+                } else {
+                    GovernanceValidatorAdmissionStatus::ProbationReady
+                };
+                preview_admissions.insert(candidate_id.to_string(), preview_record);
+                if let Err(err) = self
+                    .resolve_governance_effective_finality_signer_registry_from_admissions(
+                        &preview_admissions,
+                    )
+                {
+                    return Ok(WorldEventBody::Domain(DomainEvent::ActionRejected {
+                        action_id,
+                        reason: RejectReason::RuleDenied {
+                            notes: vec![format!("activate validator admission rejected: {err:?}")],
+                        },
+                    }));
+                }
+                Ok(WorldEventBody::Governance(
+                    GovernanceEvent::ValidatorAdmissionActivated {
+                        controller_account_id: controller_account_id.to_string(),
+                        candidate_id: candidate_id.to_string(),
+                        activation_epoch: *activation_epoch,
+                    },
+                ))
+            }
+            Action::RevokeGovernanceValidatorAdmission {
+                controller_account_id,
+                candidate_id,
+                node_id,
+                reason,
+            } => {
+                let Some(current_registry) = self.governance_main_token_controller_registry()
+                else {
+                    return Ok(WorldEventBody::Domain(DomainEvent::ActionRejected {
+                        action_id,
+                        reason: RejectReason::RuleDenied {
+                            notes: vec![
+                                "revoke validator admission rejected: main token controller registry is not configured"
+                                    .to_string(),
+                            ],
+                        },
+                    }));
+                };
+                let controller_account_id = controller_account_id.trim();
+                let expected_controller_account_id =
+                    match Self::validator_admission_controller_account_id(current_registry) {
+                        Ok(account_id) => account_id,
+                        Err(err) => {
+                            return Ok(WorldEventBody::Domain(DomainEvent::ActionRejected {
+                                action_id,
+                                reason: RejectReason::RuleDenied {
+                                    notes: vec![format!(
+                                        "revoke validator admission rejected: {err:?}"
+                                    )],
+                                },
+                            }))
+                        }
+                    };
+                if controller_account_id != expected_controller_account_id {
+                    return Ok(WorldEventBody::Domain(DomainEvent::ActionRejected {
+                        action_id,
+                        reason: RejectReason::RuleDenied {
+                            notes: vec![format!(
+                                "revoke validator admission rejected: controller_account_id does not match validator admission controller expected={} actual={}",
+                                expected_controller_account_id, controller_account_id
+                            )],
+                        },
+                    }));
+                }
+                let candidate_id = candidate_id.trim();
+                let node_id = node_id.trim();
+                let reason = reason.trim();
+                if candidate_id.is_empty() || reason.is_empty() {
+                    return Ok(WorldEventBody::Domain(DomainEvent::ActionRejected {
+                        action_id,
+                        reason: RejectReason::RuleDenied {
+                            notes: vec![
+                                "revoke validator admission rejected: candidate_id and reason cannot be empty"
+                                    .to_string(),
+                            ],
+                        },
+                    }));
+                }
+                let current_epoch = self.current_governance_epoch();
+                let existing = self
+                    .state
+                    .governance_validator_admissions
+                    .get(candidate_id)
+                    .cloned();
+                let target_node_id = if let Some(record) = existing.as_ref() {
+                    if !node_id.is_empty() && record.node_id != node_id {
+                        return Ok(WorldEventBody::Domain(DomainEvent::ActionRejected {
+                            action_id,
+                            reason: RejectReason::RuleDenied {
+                                notes: vec![format!(
+                                    "revoke validator admission rejected: node_id mismatch candidate_id={} expected={} actual={}",
+                                    candidate_id, record.node_id, node_id
+                                )],
+                            },
+                        }));
+                    }
+                    record.node_id.clone()
+                } else {
+                    node_id.to_string()
+                };
+                if target_node_id.is_empty() {
+                    return Ok(WorldEventBody::Domain(DomainEvent::ActionRejected {
+                        action_id,
+                        reason: RejectReason::RuleDenied {
+                            notes: vec![
+                                "revoke validator admission rejected: node_id cannot be empty when no candidate record exists"
+                                    .to_string(),
+                            ],
+                        },
+                    }));
+                }
+                let current_public_key = self
+                    .node_identity_public_key(target_node_id.as_str())
+                    .map(str::to_string)
+                    .or_else(|| {
+                        self.resolve_governance_effective_finality_signer_registry()
+                            .ok()
+                            .flatten()
+                            .and_then(|registry| {
+                                registry
+                                    .signer_bindings
+                                    .get(target_node_id.as_str())
+                                    .cloned()
+                            })
+                    });
+                if existing.is_none()
+                    && !self
+                        .resolve_governance_effective_finality_signer_registry()
+                        .ok()
+                        .flatten()
+                        .is_some_and(|registry| {
+                            registry
+                                .signer_bindings
+                                .contains_key(target_node_id.as_str())
+                        })
+                {
+                    return Ok(WorldEventBody::Domain(DomainEvent::ActionRejected {
+                        action_id,
+                        reason: RejectReason::RuleDenied {
+                            notes: vec![format!(
+                                "revoke validator admission rejected: candidate or active validator not found for node_id={}",
+                                target_node_id
+                            )],
+                        },
+                    }));
+                }
+                let Some(current_public_key) = current_public_key else {
+                    return Ok(WorldEventBody::Domain(DomainEvent::ActionRejected {
+                        action_id,
+                        reason: RejectReason::RuleDenied {
+                            notes: vec![format!(
+                                "revoke validator admission rejected: missing node identity binding for node_id={}",
+                                target_node_id
+                            )],
+                        },
+                    }));
+                };
+                let mut preview_admissions: BTreeMap<String, GovernanceValidatorAdmissionRecord> =
+                    self.state.governance_validator_admissions.clone();
+                let mut revoked_record = existing.unwrap_or(GovernanceValidatorAdmissionRecord {
+                    candidate_id: candidate_id.to_string(),
+                    node_id: target_node_id.clone(),
+                    finality_signer_public_key: current_public_key.clone(),
+                    operator_owner: "governance.revocation".to_string(),
+                    public_manifest_hash: "synthetic-revocation".to_string(),
+                    requested_at_epoch: current_epoch,
+                    approved_at_epoch: Some(current_epoch),
+                    activation_epoch: Some(current_epoch),
+                    status: GovernanceValidatorAdmissionStatus::Applied,
+                    revoked_at_epoch: None,
+                    revocation_reason: None,
+                });
+                revoked_record.status = GovernanceValidatorAdmissionStatus::Revoked;
+                revoked_record.revoked_at_epoch = Some(current_epoch);
+                revoked_record.revocation_reason = Some(reason.to_string());
+                preview_admissions.insert(candidate_id.to_string(), revoked_record);
+                if let Err(err) = self
+                    .resolve_governance_effective_finality_signer_registry_from_admissions(
+                        &preview_admissions,
+                    )
+                {
+                    return Ok(WorldEventBody::Domain(DomainEvent::ActionRejected {
+                        action_id,
+                        reason: RejectReason::RuleDenied {
+                            notes: vec![format!("revoke validator admission rejected: {err:?}")],
+                        },
+                    }));
+                }
+                Ok(WorldEventBody::Governance(
+                    GovernanceEvent::ValidatorAdmissionRevoked {
+                        controller_account_id: controller_account_id.to_string(),
+                        candidate_id: candidate_id.to_string(),
+                        node_id: target_node_id,
+                        revoked_at_epoch: current_epoch,
+                        reason: reason.to_string(),
                     },
                 ))
             }

--- a/crates/oasis7/src/runtime/world/event_processing/action_to_event_policy_contract.rs
+++ b/crates/oasis7/src/runtime/world/event_processing/action_to_event_policy_contract.rs
@@ -251,6 +251,7 @@ impl World {
                         operator_owner: operator_owner.clone(),
                         public_manifest_hash: public_manifest_hash.clone(),
                         requested_at_epoch,
+                        last_transition_tick: self.state.time,
                         ..GovernanceValidatorAdmissionRecord::default()
                     },
                 ) {
@@ -543,11 +544,12 @@ impl World {
                 let mut preview_admissions = self.state.governance_validator_admissions.clone();
                 let mut preview_record = record.clone();
                 preview_record.activation_epoch = Some(*activation_epoch);
-                preview_record.status = if *activation_epoch == current_epoch {
-                    GovernanceValidatorAdmissionStatus::Active
-                } else {
-                    GovernanceValidatorAdmissionStatus::ProbationReady
-                };
+                preview_record.status =
+                    Self::governance_validator_admission_status_for_activation_epoch(
+                        current_epoch,
+                        *activation_epoch,
+                    );
+                preview_record.last_transition_tick = self.state.time;
                 preview_admissions.insert(candidate_id.to_string(), preview_record);
                 if let Err(err) = self
                     .resolve_governance_effective_finality_signer_registry_from_admissions(
@@ -628,10 +630,26 @@ impl World {
                     }));
                 }
                 let current_epoch = self.current_governance_epoch();
+                let resolved_candidate_id = if self
+                    .state
+                    .governance_validator_admissions
+                    .contains_key(candidate_id)
+                {
+                    candidate_id.to_string()
+                } else if let Some(existing_key) =
+                    Self::governance_validator_admission_record_key_for_node(
+                        &self.state.governance_validator_admissions,
+                        node_id,
+                    )
+                {
+                    existing_key
+                } else {
+                    format!("legacy-revoked:{node_id}")
+                };
                 let existing = self
                     .state
                     .governance_validator_admissions
-                    .get(candidate_id)
+                    .get(resolved_candidate_id.as_str())
                     .cloned();
                 let target_node_id = if let Some(record) = existing.as_ref() {
                     if !node_id.is_empty() && record.node_id != node_id {
@@ -708,23 +726,41 @@ impl World {
                 };
                 let mut preview_admissions: BTreeMap<String, GovernanceValidatorAdmissionRecord> =
                     self.state.governance_validator_admissions.clone();
+                let duplicate_keys = Self::governance_validator_admission_keys_for_node(
+                    &preview_admissions,
+                    target_node_id.as_str(),
+                );
+                if duplicate_keys.len() > 1 && !duplicate_keys.contains(&resolved_candidate_id) {
+                    return Ok(WorldEventBody::Domain(DomainEvent::ActionRejected {
+                        action_id,
+                        reason: RejectReason::RuleDenied {
+                            notes: vec![format!(
+                                "revoke validator admission rejected: multiple candidate records exist for node_id={} candidate_keys={:?}",
+                                target_node_id, duplicate_keys
+                            )],
+                        },
+                    }));
+                }
                 let mut revoked_record = existing.unwrap_or(GovernanceValidatorAdmissionRecord {
-                    candidate_id: candidate_id.to_string(),
+                    candidate_id: resolved_candidate_id.clone(),
                     node_id: target_node_id.clone(),
                     finality_signer_public_key: current_public_key.clone(),
                     operator_owner: "governance.revocation".to_string(),
                     public_manifest_hash: "synthetic-revocation".to_string(),
                     requested_at_epoch: current_epoch,
+                    last_transition_tick: self.state.time,
                     approved_at_epoch: Some(current_epoch),
                     activation_epoch: Some(current_epoch),
                     status: GovernanceValidatorAdmissionStatus::Applied,
                     revoked_at_epoch: None,
                     revocation_reason: None,
                 });
+                revoked_record.candidate_id = resolved_candidate_id.clone();
                 revoked_record.status = GovernanceValidatorAdmissionStatus::Revoked;
+                revoked_record.last_transition_tick = self.state.time;
                 revoked_record.revoked_at_epoch = Some(current_epoch);
                 revoked_record.revocation_reason = Some(reason.to_string());
-                preview_admissions.insert(candidate_id.to_string(), revoked_record);
+                preview_admissions.insert(resolved_candidate_id.clone(), revoked_record);
                 if let Err(err) = self
                     .resolve_governance_effective_finality_signer_registry_from_admissions(
                         &preview_admissions,
@@ -740,7 +776,7 @@ impl World {
                 Ok(WorldEventBody::Governance(
                     GovernanceEvent::ValidatorAdmissionRevoked {
                         controller_account_id: controller_account_id.to_string(),
-                        candidate_id: candidate_id.to_string(),
+                        candidate_id: resolved_candidate_id,
                         node_id: target_node_id,
                         revoked_at_epoch: current_epoch,
                         reason: reason.to_string(),

--- a/crates/oasis7/src/runtime/world/governance.rs
+++ b/crates/oasis7/src/runtime/world/governance.rs
@@ -13,6 +13,8 @@ use ed25519_dalek::{Signature, Signer, SigningKey, Verifier, VerifyingKey};
 use std::collections::{BTreeMap, BTreeSet};
 #[path = "governance_internal.rs"]
 mod governance_internal;
+#[path = "governance_validator_admission.rs"]
+mod governance_validator_admission;
 
 const LOCAL_GOVERNANCE_FINALITY_SIGNERS: [(&str, &str); 2] = [
     (
@@ -130,6 +132,18 @@ impl World {
         Self::ecosystem_treasury_controller_account_id(registry, "restricted claim admin registry")
     }
 
+    pub(super) fn validator_admission_controller_account_id<'a>(
+        registry: &'a GovernanceMainTokenControllerRegistry,
+    ) -> Result<&'a str, WorldError> {
+        let controller_account_id = registry.genesis_controller_account_id.trim();
+        if controller_account_id.is_empty() {
+            return Err(WorldError::GovernancePolicyInvalid {
+                reason: "validator admission controller account_id cannot be empty".to_string(),
+            });
+        }
+        Ok(controller_account_id)
+    }
+
     // ---------------------------------------------------------------------
     // Manifest and governance
     // ---------------------------------------------------------------------
@@ -233,6 +247,14 @@ impl World {
         let registry = Self::validate_governance_main_token_controller_registry(registry)?;
         self.state.governance_main_token_controller_registry = Some(registry);
         Ok(())
+    }
+
+    pub fn resolve_governance_effective_finality_signer_registry(
+        &self,
+    ) -> Result<Option<GovernanceFinalitySignerRegistry>, WorldError> {
+        self.resolve_governance_effective_finality_signer_registry_from_admissions(
+            &self.state.governance_validator_admissions,
+        )
     }
 
     pub fn governance_effective_finality_epoch_snapshot(

--- a/crates/oasis7/src/runtime/world/governance_internal.rs
+++ b/crates/oasis7/src/runtime/world/governance_internal.rs
@@ -5,7 +5,9 @@ impl World {
         &self,
         epoch_id: u64,
     ) -> Option<GovernanceFinalityEpochSnapshot> {
-        let registry = self.state.governance_finality_signer_registry.as_ref()?;
+        let registry = self
+            .resolve_governance_effective_finality_signer_registry()
+            .ok()??;
         let signer_node_ids: Vec<String> = registry.signer_bindings.keys().cloned().collect();
         let threshold = registry.threshold;
         let threshold_bps = if registry.threshold_bps > 0 {
@@ -986,6 +988,54 @@ impl World {
                 }
                 profile.updated_at = self.state.time;
             }
+            GovernanceEvent::ValidatorAdmissionSubmitted {
+                controller_account_id,
+                candidate_id,
+                node_id,
+                finality_signer_public_key,
+                operator_owner,
+                public_manifest_hash,
+                requested_at_epoch,
+            } => self.apply_governance_validator_admission_submitted(
+                controller_account_id,
+                candidate_id,
+                node_id,
+                finality_signer_public_key,
+                operator_owner,
+                public_manifest_hash,
+                *requested_at_epoch,
+            )?,
+            GovernanceEvent::ValidatorAdmissionApproved {
+                controller_account_id,
+                candidate_id,
+                approved_at_epoch,
+            } => self.apply_governance_validator_admission_approved(
+                controller_account_id,
+                candidate_id,
+                *approved_at_epoch,
+            )?,
+            GovernanceEvent::ValidatorAdmissionActivated {
+                controller_account_id,
+                candidate_id,
+                activation_epoch,
+            } => self.apply_governance_validator_admission_activated(
+                controller_account_id,
+                candidate_id,
+                *activation_epoch,
+            )?,
+            GovernanceEvent::ValidatorAdmissionRevoked {
+                controller_account_id,
+                candidate_id,
+                node_id,
+                revoked_at_epoch,
+                reason,
+            } => self.apply_governance_validator_admission_revoked(
+                controller_account_id,
+                candidate_id,
+                node_id,
+                *revoked_at_epoch,
+                reason,
+            )?,
             GovernanceEvent::RestrictedStarterClaimAdminRegistryUpdated {
                 controller_account_id,
                 previous_admin_account_ids,

--- a/crates/oasis7/src/runtime/world/governance_internal.rs
+++ b/crates/oasis7/src/runtime/world/governance_internal.rs
@@ -5,9 +5,11 @@ impl World {
         &self,
         epoch_id: u64,
     ) -> Option<GovernanceFinalityEpochSnapshot> {
-        let registry = self
-            .resolve_governance_effective_finality_signer_registry()
-            .ok()??;
+        let registry = match self.resolve_governance_effective_finality_signer_registry() {
+            Ok(Some(registry)) => registry,
+            Ok(None) => return None,
+            Err(_) => self.state.governance_finality_signer_registry.clone()?,
+        };
         let signer_node_ids: Vec<String> = registry.signer_bindings.keys().cloned().collect();
         let threshold = registry.threshold;
         let threshold_bps = if registry.threshold_bps > 0 {

--- a/crates/oasis7/src/runtime/world/governance_validator_admission.rs
+++ b/crates/oasis7/src/runtime/world/governance_validator_admission.rs
@@ -3,6 +3,17 @@ use super::*;
 use crate::runtime::{GovernanceValidatorAdmissionRecord, GovernanceValidatorAdmissionStatus};
 
 impl World {
+    pub(crate) fn governance_validator_admission_status_for_activation_epoch(
+        current_epoch: u64,
+        activation_epoch: u64,
+    ) -> GovernanceValidatorAdmissionStatus {
+        if activation_epoch <= current_epoch {
+            GovernanceValidatorAdmissionStatus::Active
+        } else {
+            GovernanceValidatorAdmissionStatus::ProbationReady
+        }
+    }
+
     pub(crate) fn validate_governance_validator_admission_record(
         &self,
         mut record: GovernanceValidatorAdmissionRecord,
@@ -33,6 +44,89 @@ impl World {
         Ok(record)
     }
 
+    pub(crate) fn governance_validator_admission_effective_epoch(
+        record: &GovernanceValidatorAdmissionRecord,
+    ) -> u64 {
+        match record.status {
+            GovernanceValidatorAdmissionStatus::Revoked => record
+                .revoked_at_epoch
+                .or(record.activation_epoch)
+                .or(record.approved_at_epoch)
+                .unwrap_or(record.requested_at_epoch),
+            GovernanceValidatorAdmissionStatus::Active
+            | GovernanceValidatorAdmissionStatus::ProbationReady => record
+                .activation_epoch
+                .or(record.approved_at_epoch)
+                .unwrap_or(record.requested_at_epoch),
+            GovernanceValidatorAdmissionStatus::ApprovedCandidate => record
+                .approved_at_epoch
+                .unwrap_or(record.requested_at_epoch),
+            GovernanceValidatorAdmissionStatus::Applied => record.requested_at_epoch,
+        }
+    }
+
+    pub(crate) fn governance_validator_admission_status_precedence(
+        status: GovernanceValidatorAdmissionStatus,
+    ) -> u8 {
+        match status {
+            GovernanceValidatorAdmissionStatus::Revoked => 5,
+            GovernanceValidatorAdmissionStatus::Active => 4,
+            GovernanceValidatorAdmissionStatus::ProbationReady => 3,
+            GovernanceValidatorAdmissionStatus::ApprovedCandidate => 2,
+            GovernanceValidatorAdmissionStatus::Applied => 1,
+        }
+    }
+
+    pub(crate) fn governance_effective_validator_admission_records<'a>(
+        admissions: &'a BTreeMap<String, GovernanceValidatorAdmissionRecord>,
+    ) -> BTreeMap<String, &'a GovernanceValidatorAdmissionRecord> {
+        let mut effective = BTreeMap::new();
+        for record in admissions.values() {
+            let candidate = effective.entry(record.node_id.clone()).or_insert(record);
+            let candidate_order = (
+                candidate.last_transition_tick,
+                Self::governance_validator_admission_effective_epoch(candidate),
+                Self::governance_validator_admission_status_precedence(candidate.status),
+            );
+            let record_order = (
+                record.last_transition_tick,
+                Self::governance_validator_admission_effective_epoch(record),
+                Self::governance_validator_admission_status_precedence(record.status),
+            );
+            if record_order > candidate_order {
+                *candidate = record;
+            }
+        }
+        effective
+    }
+
+    pub(crate) fn governance_validator_admission_keys_for_node(
+        admissions: &BTreeMap<String, GovernanceValidatorAdmissionRecord>,
+        node_id: &str,
+    ) -> Vec<String> {
+        admissions
+            .iter()
+            .filter_map(|(candidate_id, record)| {
+                (record.node_id == node_id).then(|| candidate_id.clone())
+            })
+            .collect()
+    }
+
+    pub(crate) fn governance_validator_admission_record_key_for_node(
+        admissions: &BTreeMap<String, GovernanceValidatorAdmissionRecord>,
+        node_id: &str,
+    ) -> Option<String> {
+        let per_node = Self::governance_effective_validator_admission_records(admissions);
+        per_node
+            .get(node_id)
+            .map(|record| record.candidate_id.clone())
+            .or_else(|| {
+                admissions.iter().find_map(|(candidate_id, record)| {
+                    (record.node_id == node_id).then(|| candidate_id.clone())
+                })
+            })
+    }
+
     pub(crate) fn resolve_governance_effective_finality_signer_registry_from_admissions(
         &self,
         admissions: &BTreeMap<String, GovernanceValidatorAdmissionRecord>,
@@ -41,7 +135,7 @@ impl World {
             return Ok(None);
         };
         let current_epoch = self.current_governance_epoch();
-        for record in admissions.values() {
+        for record in Self::governance_effective_validator_admission_records(admissions).values() {
             match record.status {
                 GovernanceValidatorAdmissionStatus::Revoked => {
                     registry.signer_bindings.remove(record.node_id.as_str());
@@ -99,6 +193,7 @@ impl World {
                 operator_owner: operator_owner.to_string(),
                 public_manifest_hash: public_manifest_hash.to_string(),
                 requested_at_epoch,
+                last_transition_tick: self.state.time,
                 ..GovernanceValidatorAdmissionRecord::default()
             },
         )?;
@@ -192,6 +287,7 @@ impl World {
         }
         record.status = GovernanceValidatorAdmissionStatus::ApprovedCandidate;
         record.approved_at_epoch = Some(approved_at_epoch);
+        record.last_transition_tick = self.state.time;
         Ok(())
     }
 
@@ -242,11 +338,11 @@ impl World {
                 });
             }
             record.activation_epoch = Some(activation_epoch);
-            record.status = if activation_epoch <= current_epoch {
-                GovernanceValidatorAdmissionStatus::Active
-            } else {
-                GovernanceValidatorAdmissionStatus::ProbationReady
-            };
+            record.status = Self::governance_validator_admission_status_for_activation_epoch(
+                current_epoch,
+                activation_epoch,
+            );
+            record.last_transition_tick = self.state.time;
             admissions
         };
         self.resolve_governance_effective_finality_signer_registry_from_admissions(
@@ -281,6 +377,20 @@ impl World {
                 ),
             });
         }
+        let resolved_candidate_id = if self
+            .state
+            .governance_validator_admissions
+            .contains_key(candidate_id)
+        {
+            candidate_id.to_string()
+        } else if let Some(existing_key) = Self::governance_validator_admission_record_key_for_node(
+            &self.state.governance_validator_admissions,
+            node_id,
+        ) {
+            existing_key
+        } else {
+            format!("legacy-revoked:{node_id}")
+        };
         let preview_admissions = {
             let mut admissions = self.state.governance_validator_admissions.clone();
             let current_public_key = self
@@ -298,15 +408,26 @@ impl World {
                         node_id
                     ),
                 })?;
+            let duplicate_keys =
+                Self::governance_validator_admission_keys_for_node(&admissions, node_id);
+            if duplicate_keys.len() > 1 && !duplicate_keys.contains(&resolved_candidate_id) {
+                return Err(WorldError::GovernancePolicyInvalid {
+                    reason: format!(
+                        "validator admission revoke found multiple candidate records for node_id={} candidate_keys={:?}",
+                        node_id, duplicate_keys
+                    ),
+                });
+            }
             let record = admissions
-                .entry(candidate_id.to_string())
+                .entry(resolved_candidate_id.clone())
                 .or_insert_with(|| GovernanceValidatorAdmissionRecord {
-                    candidate_id: candidate_id.to_string(),
+                    candidate_id: resolved_candidate_id.clone(),
                     node_id: node_id.to_string(),
                     finality_signer_public_key: current_public_key.clone(),
                     operator_owner: "governance.revocation".to_string(),
                     public_manifest_hash: "synthetic-revocation".to_string(),
                     requested_at_epoch: revoked_at_epoch,
+                    last_transition_tick: self.state.time,
                     approved_at_epoch: Some(revoked_at_epoch),
                     activation_epoch: Some(revoked_at_epoch),
                     status: GovernanceValidatorAdmissionStatus::Applied,
@@ -317,11 +438,13 @@ impl World {
                 return Err(WorldError::GovernancePolicyInvalid {
                     reason: format!(
                         "validator admission revoke node_id mismatch candidate_id={} expected={} actual={}",
-                        candidate_id, record.node_id, node_id
+                        resolved_candidate_id, record.node_id, node_id
                     ),
                 });
             }
+            record.candidate_id = resolved_candidate_id.clone();
             record.status = GovernanceValidatorAdmissionStatus::Revoked;
+            record.last_transition_tick = self.state.time;
             record.revoked_at_epoch = Some(revoked_at_epoch);
             record.revocation_reason = Some(reason.to_string());
             admissions

--- a/crates/oasis7/src/runtime/world/governance_validator_admission.rs
+++ b/crates/oasis7/src/runtime/world/governance_validator_admission.rs
@@ -1,0 +1,335 @@
+use super::*;
+
+use crate::runtime::{GovernanceValidatorAdmissionRecord, GovernanceValidatorAdmissionStatus};
+
+impl World {
+    pub(crate) fn validate_governance_validator_admission_record(
+        &self,
+        mut record: GovernanceValidatorAdmissionRecord,
+    ) -> Result<GovernanceValidatorAdmissionRecord, WorldError> {
+        record.candidate_id = record.candidate_id.trim().to_string();
+        record.node_id = record.node_id.trim().to_string();
+        record.finality_signer_public_key = record.finality_signer_public_key.trim().to_string();
+        record.operator_owner = record.operator_owner.trim().to_string();
+        record.public_manifest_hash = record.public_manifest_hash.trim().to_string();
+        if record.candidate_id.is_empty()
+            || record.node_id.is_empty()
+            || record.finality_signer_public_key.is_empty()
+            || record.operator_owner.is_empty()
+            || record.public_manifest_hash.is_empty()
+        {
+            return Err(WorldError::GovernancePolicyInvalid {
+                reason: "validator admission record fields cannot be empty".to_string(),
+            });
+        }
+        decode_hex_array::<32>(
+            record.finality_signer_public_key.as_str(),
+            format!(
+                "validator admission public key candidate_id={} node_id={}",
+                record.candidate_id, record.node_id
+            )
+            .as_str(),
+        )?;
+        Ok(record)
+    }
+
+    pub(crate) fn resolve_governance_effective_finality_signer_registry_from_admissions(
+        &self,
+        admissions: &BTreeMap<String, GovernanceValidatorAdmissionRecord>,
+    ) -> Result<Option<GovernanceFinalitySignerRegistry>, WorldError> {
+        let Some(mut registry) = self.state.governance_finality_signer_registry.clone() else {
+            return Ok(None);
+        };
+        let current_epoch = self.current_governance_epoch();
+        for record in admissions.values() {
+            match record.status {
+                GovernanceValidatorAdmissionStatus::Revoked => {
+                    registry.signer_bindings.remove(record.node_id.as_str());
+                }
+                GovernanceValidatorAdmissionStatus::ProbationReady
+                | GovernanceValidatorAdmissionStatus::Active => {
+                    let activation_epoch = record.activation_epoch.unwrap_or(current_epoch);
+                    if activation_epoch <= current_epoch {
+                        registry.signer_bindings.insert(
+                            record.node_id.clone(),
+                            record.finality_signer_public_key.clone(),
+                        );
+                    }
+                }
+                GovernanceValidatorAdmissionStatus::Applied
+                | GovernanceValidatorAdmissionStatus::ApprovedCandidate => {}
+            }
+        }
+        self.validate_governance_finality_signer_registry(registry)
+            .map(Some)
+    }
+
+    pub(crate) fn apply_governance_validator_admission_submitted(
+        &mut self,
+        controller_account_id: &str,
+        candidate_id: &str,
+        node_id: &str,
+        finality_signer_public_key: &str,
+        operator_owner: &str,
+        public_manifest_hash: &str,
+        requested_at_epoch: u64,
+    ) -> Result<(), WorldError> {
+        let Some(current_registry) = self.state.governance_main_token_controller_registry.clone()
+        else {
+            return Err(WorldError::GovernancePolicyInvalid {
+                reason: "validator admission submit missing main token controller registry"
+                    .to_string(),
+            });
+        };
+        let expected_controller_account_id =
+            Self::validator_admission_controller_account_id(&current_registry)?;
+        if expected_controller_account_id != controller_account_id {
+            return Err(WorldError::GovernancePolicyInvalid {
+                reason: format!(
+                    "validator admission submit controller mismatch expected={} actual={}",
+                    expected_controller_account_id, controller_account_id
+                ),
+            });
+        }
+        let record = self.validate_governance_validator_admission_record(
+            GovernanceValidatorAdmissionRecord {
+                candidate_id: candidate_id.to_string(),
+                node_id: node_id.to_string(),
+                finality_signer_public_key: finality_signer_public_key.to_string(),
+                operator_owner: operator_owner.to_string(),
+                public_manifest_hash: public_manifest_hash.to_string(),
+                requested_at_epoch,
+                ..GovernanceValidatorAdmissionRecord::default()
+            },
+        )?;
+        if self
+            .state
+            .governance_validator_admissions
+            .contains_key(record.candidate_id.as_str())
+        {
+            return Err(WorldError::GovernancePolicyInvalid {
+                reason: format!(
+                    "validator admission candidate already exists candidate_id={}",
+                    record.candidate_id
+                ),
+            });
+        }
+        if self
+            .resolve_governance_effective_finality_signer_registry()?
+            .is_some_and(|registry| {
+                registry
+                    .signer_bindings
+                    .contains_key(record.node_id.as_str())
+            })
+        {
+            return Err(WorldError::GovernancePolicyInvalid {
+                reason: format!(
+                    "validator admission node_id is already active node_id={}",
+                    record.node_id
+                ),
+            });
+        }
+        if let Some(existing_public_key) = self.node_identity_public_key(record.node_id.as_str()) {
+            if existing_public_key != record.finality_signer_public_key {
+                return Err(WorldError::GovernancePolicyInvalid {
+                    reason: format!(
+                        "validator admission node identity binding mismatch node_id={} expected={} actual={}",
+                        record.node_id, existing_public_key, record.finality_signer_public_key
+                    ),
+                });
+            }
+        }
+        self.bind_node_identity(
+            record.node_id.as_str(),
+            record.finality_signer_public_key.as_str(),
+        )?;
+        self.state
+            .governance_validator_admissions
+            .insert(record.candidate_id.clone(), record);
+        Ok(())
+    }
+
+    pub(crate) fn apply_governance_validator_admission_approved(
+        &mut self,
+        controller_account_id: &str,
+        candidate_id: &str,
+        approved_at_epoch: u64,
+    ) -> Result<(), WorldError> {
+        let Some(current_registry) = self.state.governance_main_token_controller_registry.clone()
+        else {
+            return Err(WorldError::GovernancePolicyInvalid {
+                reason: "validator admission approve missing main token controller registry"
+                    .to_string(),
+            });
+        };
+        let expected_controller_account_id =
+            Self::validator_admission_controller_account_id(&current_registry)?;
+        if expected_controller_account_id != controller_account_id {
+            return Err(WorldError::GovernancePolicyInvalid {
+                reason: format!(
+                    "validator admission approve controller mismatch expected={} actual={}",
+                    expected_controller_account_id, controller_account_id
+                ),
+            });
+        }
+        let record = self
+            .state
+            .governance_validator_admissions
+            .get_mut(candidate_id)
+            .ok_or_else(|| WorldError::GovernancePolicyInvalid {
+                reason: format!(
+                    "validator admission candidate not found candidate_id={}",
+                    candidate_id
+                ),
+            })?;
+        if record.status != GovernanceValidatorAdmissionStatus::Applied {
+            return Err(WorldError::GovernancePolicyInvalid {
+                reason: format!(
+                    "validator admission candidate is not in applied status candidate_id={} status={:?}",
+                    candidate_id, record.status
+                ),
+            });
+        }
+        record.status = GovernanceValidatorAdmissionStatus::ApprovedCandidate;
+        record.approved_at_epoch = Some(approved_at_epoch);
+        Ok(())
+    }
+
+    pub(crate) fn apply_governance_validator_admission_activated(
+        &mut self,
+        controller_account_id: &str,
+        candidate_id: &str,
+        activation_epoch: u64,
+    ) -> Result<(), WorldError> {
+        let Some(current_registry) = self.state.governance_main_token_controller_registry.clone()
+        else {
+            return Err(WorldError::GovernancePolicyInvalid {
+                reason: "validator admission activate missing main token controller registry"
+                    .to_string(),
+            });
+        };
+        let expected_controller_account_id =
+            Self::validator_admission_controller_account_id(&current_registry)?;
+        if expected_controller_account_id != controller_account_id {
+            return Err(WorldError::GovernancePolicyInvalid {
+                reason: format!(
+                    "validator admission activate controller mismatch expected={} actual={}",
+                    expected_controller_account_id, controller_account_id
+                ),
+            });
+        }
+        let current_epoch = self.current_governance_epoch();
+        let preview_admissions = {
+            let mut admissions = self.state.governance_validator_admissions.clone();
+            let record = admissions.get_mut(candidate_id).ok_or_else(|| {
+                WorldError::GovernancePolicyInvalid {
+                    reason: format!(
+                        "validator admission candidate not found candidate_id={}",
+                        candidate_id
+                    ),
+                }
+            })?;
+            if !matches!(
+                record.status,
+                GovernanceValidatorAdmissionStatus::ApprovedCandidate
+                    | GovernanceValidatorAdmissionStatus::ProbationReady
+            ) {
+                return Err(WorldError::GovernancePolicyInvalid {
+                    reason: format!(
+                        "validator admission candidate cannot activate from status candidate_id={} status={:?}",
+                        candidate_id, record.status
+                    ),
+                });
+            }
+            record.activation_epoch = Some(activation_epoch);
+            record.status = if activation_epoch <= current_epoch {
+                GovernanceValidatorAdmissionStatus::Active
+            } else {
+                GovernanceValidatorAdmissionStatus::ProbationReady
+            };
+            admissions
+        };
+        self.resolve_governance_effective_finality_signer_registry_from_admissions(
+            &preview_admissions,
+        )?;
+        self.state.governance_validator_admissions = preview_admissions;
+        Ok(())
+    }
+
+    pub(crate) fn apply_governance_validator_admission_revoked(
+        &mut self,
+        controller_account_id: &str,
+        candidate_id: &str,
+        node_id: &str,
+        revoked_at_epoch: u64,
+        reason: &str,
+    ) -> Result<(), WorldError> {
+        let Some(current_registry) = self.state.governance_main_token_controller_registry.clone()
+        else {
+            return Err(WorldError::GovernancePolicyInvalid {
+                reason: "validator admission revoke missing main token controller registry"
+                    .to_string(),
+            });
+        };
+        let expected_controller_account_id =
+            Self::validator_admission_controller_account_id(&current_registry)?;
+        if expected_controller_account_id != controller_account_id {
+            return Err(WorldError::GovernancePolicyInvalid {
+                reason: format!(
+                    "validator admission revoke controller mismatch expected={} actual={}",
+                    expected_controller_account_id, controller_account_id
+                ),
+            });
+        }
+        let preview_admissions = {
+            let mut admissions = self.state.governance_validator_admissions.clone();
+            let current_public_key = self
+                .node_identity_public_key(node_id)
+                .map(str::to_string)
+                .or_else(|| {
+                    self.resolve_governance_effective_finality_signer_registry()
+                        .ok()
+                        .flatten()
+                        .and_then(|registry| registry.signer_bindings.get(node_id).cloned())
+                })
+                .ok_or_else(|| WorldError::GovernancePolicyInvalid {
+                    reason: format!(
+                        "validator admission revoke missing node identity binding node_id={}",
+                        node_id
+                    ),
+                })?;
+            let record = admissions
+                .entry(candidate_id.to_string())
+                .or_insert_with(|| GovernanceValidatorAdmissionRecord {
+                    candidate_id: candidate_id.to_string(),
+                    node_id: node_id.to_string(),
+                    finality_signer_public_key: current_public_key.clone(),
+                    operator_owner: "governance.revocation".to_string(),
+                    public_manifest_hash: "synthetic-revocation".to_string(),
+                    requested_at_epoch: revoked_at_epoch,
+                    approved_at_epoch: Some(revoked_at_epoch),
+                    activation_epoch: Some(revoked_at_epoch),
+                    status: GovernanceValidatorAdmissionStatus::Applied,
+                    revoked_at_epoch: None,
+                    revocation_reason: None,
+                });
+            if record.node_id != node_id {
+                return Err(WorldError::GovernancePolicyInvalid {
+                    reason: format!(
+                        "validator admission revoke node_id mismatch candidate_id={} expected={} actual={}",
+                        candidate_id, record.node_id, node_id
+                    ),
+                });
+            }
+            record.status = GovernanceValidatorAdmissionStatus::Revoked;
+            record.revoked_at_epoch = Some(revoked_at_epoch);
+            record.revocation_reason = Some(reason.to_string());
+            admissions
+        };
+        self.resolve_governance_effective_finality_signer_registry_from_admissions(
+            &preview_admissions,
+        )?;
+        self.state.governance_validator_admissions = preview_admissions;
+        Ok(())
+    }
+}

--- a/crates/oasis7/src/runtime/world/mod.rs
+++ b/crates/oasis7/src/runtime/world/mod.rs
@@ -50,8 +50,9 @@ use super::events::{ActionEnvelope, MaterialTransitPriority};
 use super::governance::{
     GovernanceExecutionPolicy, GovernanceFinalityEpochSnapshot, GovernanceFinalitySignerRegistry,
     GovernanceIdentityPenaltyMonitorStats, GovernanceIdentityPenaltyRecord,
-    GovernanceMainTokenControllerRegistry, Proposal,
+    GovernanceMainTokenControllerRegistry, GovernanceValidatorAdmissionRecord, Proposal,
 };
+use super::main_token::main_token_account_id_from_node_public_key;
 use super::manifest::Manifest;
 use super::modules::{ModuleCache, ModuleLimits, ModuleRegistry};
 use super::policy::PolicySet;
@@ -324,6 +325,25 @@ impl World {
                     .or_insert(public_key_hex);
             }
         }
+        for record in state.governance_validator_admissions.values() {
+            if record.node_id.trim().is_empty()
+                || record.finality_signer_public_key.trim().is_empty()
+            {
+                continue;
+            }
+            state
+                .node_identity_bindings
+                .entry(record.node_id.clone())
+                .or_insert(record.finality_signer_public_key.clone());
+            state
+                .node_main_token_account_bindings
+                .entry(record.node_id.clone())
+                .or_insert_with(|| {
+                    main_token_account_id_from_node_public_key(
+                        record.finality_signer_public_key.as_str(),
+                    )
+                });
+        }
         #[cfg(any(test, feature = "test_tier_required", feature = "test_tier_full"))]
         state
             .node_identity_bindings
@@ -469,6 +489,12 @@ impl World {
 
     pub fn governance_finality_signer_registry(&self) -> Option<&GovernanceFinalitySignerRegistry> {
         self.state.governance_finality_signer_registry.as_ref()
+    }
+
+    pub fn governance_validator_admissions(
+        &self,
+    ) -> &BTreeMap<String, GovernanceValidatorAdmissionRecord> {
+        &self.state.governance_validator_admissions
     }
 
     pub fn governance_main_token_controller_registry(

--- a/crates/oasis7/src/runtime/world/module_runtime_labels.rs
+++ b/crates/oasis7/src/runtime/world/module_runtime_labels.rs
@@ -261,6 +261,18 @@ pub(super) fn action_kind_label(action: &Action) -> &'static str {
         Action::UpdateRestrictedStarterClaimAdminRegistry { .. } => {
             "action.governance.update_restricted_claim_admin_registry"
         }
+        Action::SubmitGovernanceValidatorAdmission { .. } => {
+            "action.governance.submit_validator_admission"
+        }
+        Action::ApproveGovernanceValidatorAdmission { .. } => {
+            "action.governance.approve_validator_admission"
+        }
+        Action::ActivateGovernanceValidatorAdmission { .. } => {
+            "action.governance.activate_validator_admission"
+        }
+        Action::RevokeGovernanceValidatorAdmission { .. } => {
+            "action.governance.revoke_validator_admission"
+        }
         Action::OpenEconomicContract { .. } => "action.gameplay.open_economic_contract",
         Action::AcceptEconomicContract { .. } => "action.gameplay.accept_economic_contract",
         Action::SettleEconomicContract { .. } => "action.gameplay.settle_economic_contract",

--- a/crates/oasis7/src/runtime/world/step.rs
+++ b/crates/oasis7/src/runtime/world/step.rs
@@ -33,6 +33,10 @@ impl World {
                 | Action::GrantMetaProgress { .. }
                 | Action::UpdateGameplayPolicy { .. }
                 | Action::UpdateRestrictedStarterClaimAdminRegistry { .. }
+                | Action::SubmitGovernanceValidatorAdmission { .. }
+                | Action::ApproveGovernanceValidatorAdmission { .. }
+                | Action::ActivateGovernanceValidatorAdmission { .. }
+                | Action::RevokeGovernanceValidatorAdmission { .. }
                 | Action::OpenEconomicContract { .. }
                 | Action::AcceptEconomicContract { .. }
                 | Action::SettleEconomicContract { .. }

--- a/doc/p2p/blockchain/p2p-governance-signer-externalization-2026-03-23.design.md
+++ b/doc/p2p/blockchain/p2p-governance-signer-externalization-2026-03-23.design.md
@@ -7,12 +7,13 @@
 ## 设计目标
 - 把 current governance signer truth 从 local convenience 和 production governance target 两层拆开。
 - 冻结 finality signer 与 controller signer 的长期真值、更新 authority 和失效恢复门禁。
+- 冻结 validator / finality signer 的正式准入流程，避免新节点加入仍依赖人工改 env 或本地 `NodeConfig`。
 
 ## 当前治理 signer 真值
 | Governance scope | 当前来源 | 当前问题 | 生产结论 |
 | --- | --- | --- | --- |
-| `finality signer` | `world/governance` deterministic local seed | 固定 seed label 派生，不具备正式治理更新能力 | preview-only |
-| `controller signer` | `NodeConfig.main_token_controller_binding.controller_signer_policies` | 本地配置承担长期真值，缺 source-of-truth 分层 | partial/block |
+| `finality signer` | execution world `governance_finality_signer_registry`（存在时）; 否则回退 `world/governance` deterministic local seed | runtime 真值入口已切到 world-state registry，但新增/移除 validator 仍缺正式准入/激活流程 | partial |
+| `controller signer` | execution world `governance_main_token_controller_registry`（存在时）; 否则回退 `NodeConfig.main_token_controller_binding.controller_signer_policies` | controller policy 真值也可由 world-state 恢复，但 appointment / freeze / ceremony 仍未闭环 | partial |
 
 ## 目标态
 | Governance scope | 目标真值 | 必需能力 | 禁止项 |
@@ -29,12 +30,59 @@
 2. `GOVSIGN-2 truth boundary`: 冻结长期真值、update authority 与禁止项。
 3. `GOVSIGN-3 ops policy`: 冻结 failover、rotation、revocation 与 operator ownership。
 4. `GOVSIGN-4 release dependency`: 将 governance signer gate 接入 readiness/public-claims/ceremony 前置条件。
+5. `GOVSIGN-5 admission workflow`: 冻结 validator / finality signer 的申请、审核、候选、激活与撤销生命周期。
+
+## 主流公链抽象模式
+| 共同模式 | 主流公链常见做法 | oasis7 设计取向 |
+| --- | --- | --- |
+| 准入不是改节点本地文件 | 通过协议内注册、治理动作或 stake/validator set 更新进入候选/活跃集合 | 新 validator 不再以 `NODE_VALIDATORS_CSV` / `NODE_VALIDATOR_SIGNERS_CSV` 为长期真值入口 |
+| 节点身份和签名职责分离 | operator key、validator consensus key、withdraw/controller key 分角色管理 | 区分 node identity、finality signer、controller signer，禁止把 node identity 当成 finality signer 真值 |
+| 激活有状态机 | 常见 `candidate -> active`，并带 epoch/era 边界 | oasis7 目标态采用 `applied -> approved_candidate -> probation_ready -> active` |
+| 轮换/撤销走治理真值 | 变更通过链上记录或正式 registry 生效，并留下审计痕迹 | 所有 validator/finality signer 激活、轮换、撤销都必须回写 world-state registry |
+| 热路径和高权限路径分层 | 验证出块热签名与金库/控制 signer 分开治理 | 面向外部申请开放的是 validator / finality signer；controller signer 仍是治理内部 appointment |
+
+## oasis7 准入目标流程
+### 范围边界
+- 面向外部运营者开放的只是 `validator operator + finality signer` 准入路径。
+- `main token controller signer` 不走公开申请；它属于治理/金库内部槽位 appointment。
+
+### 目标状态机
+| 状态 | 含义 | 进入条件 | 退出条件 |
+| --- | --- | --- | --- |
+| `applied` | 申请人已提交材料，但未审核 | 提交 node identity、公网/可达性信息、finality signer 公钥、operator ownership、public manifest | 审核驳回或进入 `approved_candidate` |
+| `approved_candidate` | 通过治理审核，但尚未进入活跃 validator set | producer/runtime/QA 联合确认材料完整、角色边界正确 | 进入 `probation_ready` 或撤销 |
+| `probation_ready` | 候选节点已完成 reachability/同步/演练检查，可排期激活 | candidate world / shared network 演练通过，activation epoch 已冻结 | 激活进入 `active` 或回退 |
+| `active` | 已在 world-state registry 内成为正式 validator/finality signer | governance action / world-state registry update 生效 | 轮换、撤销、failover 或退场 |
+| `rotating_out` / `revoked` | 正在退出或已撤销 | compromise、离岗、运维替换或治理决议 | restore/replacement 完成或永久移除 |
+
+### 申请材料
+- `node_id` / `node.public_key`
+- `finality_signer_public_key`
+- network reachability 信息：公开地址、private/hybrid/relay 策略、bootstrap 方案
+- `operator_owner` 与变更审批联系人
+- public-only manifest 摘要
+- 预期 `activation_epoch` 或激活窗口
+
+### 准入流程
+1. 申请人提交 node identity、finality signer 公钥和 public-only manifest，不提交私钥材料。
+2. `producer_system_designer` 冻结角色与容量策略，确认当前 validator set 是否允许扩容或替换。
+3. `runtime_engineer` 校验 signer key 与 node identity 没有混用，且 candidate 配置符合当前 reachability / bootstrap 架构。
+4. `qa_engineer` 在 candidate world、clone-world 或 shared network 上执行 reachability、同步、registry import/audit 与 failover smoke。
+5. 审核通过后，把 candidate 以非活跃形式记录到治理台账或后续 candidate registry；真正激活时再写入 `governance_finality_signer_registry` 并附带 activation epoch。
+6. 到达 activation epoch 后，runtime 通过 world-state registry 恢复新的 validator membership / signer binding；`--node-validator*` 不能再作为正式准入动作。
+7. 若发生 compromise、失联或替换，则走 rotation / revocation / failover，同样通过 world-state registry 留痕并生效。
+
+### 运行时影响
+- active validator set 的唯一长期真值是 execution world 里的 governance registry。
+- local `NodePosConfig` 只负责 bootstrap、测试或显式运维覆盖，不负责长期成员变更。
+- 新节点即使已经拿到二进制与静态配置，只要 governance registry 未激活，也不能自称正式 validator。
 
 ## 通过条件
 - `MAINNET-2` 通过前必须满足：
   - finality/controller signer 都有明确长期真值。
   - local seed/config path 被明确限制在非 production。
   - failover/rotation/revocation/operator ownership 都有 gate。
+  - validator / finality signer admission workflow 已冻结，且与 controller signer appointment 分层。
   - readiness project 与模块主追踪同步更新。
 
 ## 对外口径

--- a/doc/p2p/blockchain/p2p-governance-signer-externalization-2026-03-23.design.md
+++ b/doc/p2p/blockchain/p2p-governance-signer-externalization-2026-03-23.design.md
@@ -12,7 +12,7 @@
 ## 当前治理 signer 真值
 | Governance scope | 当前来源 | 当前问题 | 生产结论 |
 | --- | --- | --- | --- |
-| `finality signer` | execution world `governance_finality_signer_registry`（存在时）; 否则回退 `world/governance` deterministic local seed | runtime 真值入口已切到 world-state registry，但新增/移除 validator 仍缺正式准入/激活流程 | partial |
+| `finality signer` | execution world `governance_finality_signer_registry` + `governance_validator_admissions` 解析出的 effective registry（存在时）; 否则回退 `world/governance` deterministic local seed | runtime admission / activation 已可落到 world-state，但 shared-network probation 与治理证据链仍未完全闭环 | partial |
 | `controller signer` | execution world `governance_main_token_controller_registry`（存在时）; 否则回退 `NodeConfig.main_token_controller_binding.controller_signer_policies` | controller policy 真值也可由 world-state 恢复，但 appointment / freeze / ceremony 仍未闭环 | partial |
 
 ## 目标态
@@ -68,12 +68,13 @@
 2. `producer_system_designer` 冻结角色与容量策略，确认当前 validator set 是否允许扩容或替换。
 3. `runtime_engineer` 校验 signer key 与 node identity 没有混用，且 candidate 配置符合当前 reachability / bootstrap 架构。
 4. `qa_engineer` 在 candidate world、clone-world 或 shared network 上执行 reachability、同步、registry import/audit 与 failover smoke。
-5. 审核通过后，把 candidate 以非活跃形式记录到治理台账或后续 candidate registry；真正激活时再写入 `governance_finality_signer_registry` 并附带 activation epoch。
+5. 审核通过后，把 candidate 以非活跃形式写入 execution world `governance_validator_admissions`；真正激活时，由 `activation_epoch` 驱动 effective `governance_finality_signer_registry` 把该候选并入 active validator set。
 6. 到达 activation epoch 后，runtime 通过 world-state registry 恢复新的 validator membership / signer binding；`--node-validator*` 不能再作为正式准入动作。
 7. 若发生 compromise、失联或替换，则走 rotation / revocation / failover，同样通过 world-state registry 留痕并生效。
 
 ### 运行时影响
 - active validator set 的唯一长期真值是 execution world 里的 governance registry。
+- execution world 会额外持久化 `governance_validator_admissions`；runtime 以 `base governance_finality_signer_registry + due admissions - revoked admissions` 解析 effective finality registry。
 - local `NodePosConfig` 只负责 bootstrap、测试或显式运维覆盖，不负责长期成员变更。
 - 新节点即使已经拿到二进制与静态配置，只要 governance registry 未激活，也不能自称正式 validator。
 

--- a/doc/p2p/blockchain/p2p-governance-signer-externalization-2026-03-23.prd.md
+++ b/doc/p2p/blockchain/p2p-governance-signer-externalization-2026-03-23.prd.md
@@ -5,14 +5,16 @@
 
 审计轮次: 1
 ## 1. Executive Summary
-- Problem Statement: oasis7 当前治理 finality signer 仍由 deterministic local seed 派生，genesis/treasury controller signer policy 也仍停留在 `NodeConfig` 本地真值。即使主链 token action 已签名化、controller threshold 已生效，只要治理 signer 仍依赖 local seed/config，就仍不具备 production governance source of truth。
-- Proposed Solution: 建立 `MAINNET-2` 专题 PRD，把治理 finality signer 与 controller signer 的外部化目标、source-of-truth 边界、failover、rotation、revocation 和 operator ownership 一次性冻结下来，并明确生产真值直接上链，而不是继续停留在本地配置或链下 registry。
+- Problem Statement: oasis7 已经把 execution world 内的 `governance_finality_signer_registry` / `governance_main_token_controller_registry` 接成 runtime 启动/恢复时的真值入口，但治理 signer 仍缺一条正式的 validator / finality signer 准入、激活、轮换和撤销流程。若新增节点仍靠人工改 env、本地 `NodePosConfig` 或口头审批，就仍不具备 production governance source of truth。
+- Proposed Solution: 建立 `MAINNET-2` 专题 PRD，把治理 finality signer 与 controller signer 的外部化目标、source-of-truth 边界、failover、rotation、revocation、operator ownership，以及 validator / finality signer 准入流程一次性冻结下来，并明确生产真值直接上链，而不是继续停留在本地配置或链下 registry。
 - Success Criteria:
   - SC-1: 明确覆盖两类治理 signer：`governance finality signer` 与 `main token controller signer`。
   - SC-2: 明确 deterministic local seed 与 `NodeConfig` 本地 signer policy 只能算 preview/local truth，不算 production governance truth。
   - SC-3: 给出治理 signer 外部化的最小完成定义：`on-chain source of truth`、`rotation`、`revocation`、`failover`、`operator ownership`。
   - SC-4: 形成可执行任务链，至少拆出 `inventory/source-of-truth/failover-policy/QA gate` 四个切片。
   - SC-5: 在本专题完成前，readiness 阶段仍保持 `crypto-hardened preview`。
+  - SC-6: 冻结 validator / finality signer 的目标准入流程，至少覆盖 `apply -> approved_candidate -> probation_ready -> active -> rotate/revoke`。
+  - SC-7: 明确外部开放的是 validator / finality signer 准入路径，controller signer 仍属于治理内部 appointment，不走公开申请。
 
 ## 2. User Experience & Functionality
 - User Personas:
@@ -21,6 +23,7 @@
   - `qa_engineer`：需要把 failover/rotation/revocation 变成可阻断项。
   - `liveops_community`：需要知道 production 环境是否还允许 local governance signer path。
   - 治理/金库维护者：需要明确谁拥有治理 signer、谁负责轮换与失效恢复。
+  - validator 候选运营者：需要知道要提交哪些材料、何时能进入正式 validator set，以及什么情况下会被拒绝或撤销。
 - User Scenarios & Frequency:
   - 每次准备提升治理安全口径时执行。
   - 每次变更 finality signer 或 treasury/genesis controller signer 时复核。
@@ -30,11 +33,13 @@
   - PRD-P2P-GOVSIGN-002: As a `runtime_engineer`, I want externalized source-of-truth boundaries for finality and controller signers, so that future implementation has a single target.
   - PRD-P2P-GOVSIGN-003: As a `qa_engineer`, I want failover/rotation/revocation to be explicit gate conditions, so that governance signer readiness is testable.
   - PRD-P2P-GOVSIGN-004: As a 治理维护者, I want operator ownership and policy authority defined, so that signer updates are auditable.
+  - PRD-P2P-GOVSIGN-005: As a validator 候选运营者, I want a formal apply/approve/activate workflow, so that becoming a validator/finality signer no longer depends on ad hoc env edits or verbal approval.
 - Critical User Flows:
   1. Flow-P2P-GOVSIGN-001: `盘点 finality/controller signer 当前来源 -> 标记 local/config truth -> producer 冻结 production source-of-truth 目标`
   2. Flow-P2P-GOVSIGN-002: `runtime 定义 on-chain signer source -> 把 local seed/config 退出 production path -> QA 复核 failover/rotation/revocation`
   3. Flow-P2P-GOVSIGN-003: `治理 signer 发生 compromise/人员调整/设备替换 -> 按 revocation/rotation/failover 执行 -> 审计留痕`
   4. Flow-P2P-GOVSIGN-004: `准备进入创世 ceremony -> 检查 governance signer gate 是否已过 -> 未过则直接阻断`
+  5. Flow-P2P-GOVSIGN-005: `候选 validator 提交 node identity/finality signer/public manifest -> producer/runtime/QA 审核 -> candidate 演练通过 -> activation epoch 冻结 -> governance registry 激活 -> runtime 通过 world-state registry 恢复有效 validator membership`
 - Functional Specification Matrix:
 | 功能点 | 字段定义 | 动作行为 | 状态转换 | 计算/判定规则 | 权限逻辑 |
 | --- | --- | --- | --- | --- | --- |
@@ -44,15 +49,19 @@
 | Revocation policy | `revocation_trigger/disable_path/recovery_path` | 定义 compromise、离岗、节点失效时的停用与恢复 | `undefined -> planned -> gated` | 无快速 disable path 则 block | `runtime_engineer` 牵头 |
 | Failover policy | `failover_scope/activation_rule/rejoin_rule` | 定义 signer 集合降级、恢复与最小阈值行为 | `undefined -> planned -> gated` | 不能在 signer 失效时保持治理可持续性，则不通过 | `qa_engineer` 联审 |
 | Operator ownership | `operator_group/change_authority/audit_sink` | 冻结谁能改 signer policy、谁能批准轮换 | `draft -> enforced` | 无明确 owner 的治理 signer 不得进入 production | `producer_system_designer` 拍板 |
+| Validator / finality signer admission | `candidate_id/node_id/finality_signer_public_key/operator_owner/public_manifest/activation_epoch` | 受理申请、审核、试运行并决定是否激活进入 validator set | `applied -> approved_candidate -> probation_ready -> active` | 只有进入 world-state registry 且 activation 生效后才能算正式 validator；手工 env 改动不算正式准入 | producer/runtime/QA 联审 |
+| Controller signer appointment boundary | `slot_id/controller_scope/appointment_authority/public_manifest/audit_sink` | 明确 controller signer 只走治理内部 appointment，不走公开 validator 准入 | `draft -> enforced` | 若把 controller slot 当成公开 validator 申请入口，则直接判设计越界 | `producer_system_designer` 拍板 |
 - Acceptance Criteria:
-  - AC-1: 专题必须明确列出当前两类真实治理 signer 路径：`governance finality signer deterministic local seed`、`NodeConfig.main_token_controller_binding.controller_signer_policies`。
-  - AC-2: 必须明确这两类路径当前只允许作为 local/preview 真值，不得作为 production governance truth。
+  - AC-1: 专题必须明确列出当前两类真实治理 signer 路径的 `registry-first + local fallback` 结构：finality 走 `governance_finality_signer_registry -> deterministic local seed fallback`，controller 走 `governance_main_token_controller_registry -> NodeConfig.main_token_controller_binding.controller_signer_policies fallback`。
+  - AC-2: 必须明确其中 local fallback 只允许作为 local/preview 真值，不得作为 production governance truth。
   - AC-3: 必须分别为 `finality signer` 与 `controller signer` 写出长期 source-of-truth 目标与更新 authority；当前统一选定为 `on-chain/world-state registry`。
   - AC-4: 必须定义 `rotation`、`revocation`、`failover`、`operator ownership` 四类 gate；任一缺失则 `MAINNET-2` 不通过。
   - AC-5: 必须明确 production 环境禁止 deterministic local seed 参与治理 finality signer。
   - AC-6: 必须明确 production 环境禁止仅靠 `NodeConfig` 本地 policy 维护 controller signer 真值。
   - AC-7: 必须输出 `GOVSIGN-1~4` 任务链与 owner/test tier 映射。
   - AC-8: 模块主 PRD/project/index/README 与 readiness project 必须接入本专题。
+  - AC-9: 必须冻结 validator / finality signer 的准入状态机、申请材料、审核角色与 activation 规则；`world-state registry` 生效前不得把候选节点算作正式 validator。
+  - AC-10: 必须明确 controller signer 不属于公开 validator 申请路径，只能走治理内部 appointment / freeze / ceremony 流程。
 - Non-Goals:
   - 本轮不直接实现外部治理 signer 服务或 world-state 治理存储。
   - 本轮不直接执行创世 ceremony。
@@ -63,7 +72,7 @@
 - Evaluation Strategy: 不适用。
 
 ## 4. Technical Specifications
-- Architecture Overview: 当前治理 signer 风险分成两层。finality 路径在 `world/governance` 内仍会从 deterministic local seed 派生 signer；controller 路径虽然已经要求 threshold proof，但 policy 真值仍由 `NodeConfig.main_token_controller_binding.controller_signer_policies` 提供。producer 当前已选定 `直接上链`，即长期 governance truth 以 `on-chain/world-state registry` 为目标，而不是链下 registry。`MAINNET-2` 的目标不是一次写完工程实现，而是先冻结这一长期治理真值、更新 authority 与失效恢复门禁。
+- Architecture Overview: 当前治理 signer 风险分成两层。runtime 现在已经支持在 execution world 存在 registry 时优先读取 `governance_finality_signer_registry` 与 `governance_main_token_controller_registry`，并覆盖本地 validator membership / signer binding / controller policy；但新增 validator/finality signer 仍缺少正式准入和 activation 流程。producer 当前已选定 `直接上链`，即长期 governance truth 以 `on-chain/world-state registry` 为目标，而不是链下 registry。`MAINNET-2` 的目标不是一次写完工程实现，而是先冻结长期治理真值、更新 authority、候选准入流程与失效恢复门禁。
 - Integration Points:
   - `crates/oasis7/src/runtime/world/governance.rs`
   - `crates/oasis7_node/src/types.rs`
@@ -74,17 +83,21 @@
   - `doc/p2p/token/mainchain-token-signed-transaction-authorization-2026-03-23.prd.md`
   - `testing-manual.md`
 - Edge Cases & Error Handling:
-  - 若 finality signer 继续由固定 seed label 推导，只能视为 local/test convenience，不得记为外部化完成。
+  - 若 finality signer 在无 registry 场景下仍由固定 seed label 推导，只能视为 local/test convenience，不得记为外部化完成。
   - 若 controller signer policy 仍完全依赖单机 `NodeConfig`，即使 threshold proof 可用，也只能记为 `partial`。
   - 若治理真值仍停留在链下 registry 或单机配置，而不是最终链上状态，也不能记为完成当前选定方案。
   - 若 rotation 有定义但无 revocation/disable path，仍必须判为未完成。
   - 若 failover 会破坏最小阈值或导致治理停摆，则必须 block。
   - 若 operator ownership 不明确，则任何 signer 更新都不得进入 production。
+  - 若候选 validator 把 node identity key 与 finality signer key 混用，必须在审核阶段直接拒绝。
+  - 若 candidate 节点未通过 reachability / sync / registry drill 就直接写入 active registry，必须判为流程越界。
+  - 若有人尝试把 controller signer slot 作为公开 validator 申请入口，必须回退到治理 appointment 流程而不是继续执行。
 - Non-Functional Requirements:
   - NFR-P2P-GOVSIGN-1: production governance signer truth 不得由 deterministic local seed 或单机本地配置单独承担；当前选定目标要求最终 truth 直接上链。
   - NFR-P2P-GOVSIGN-2: finality/controller signer 必须各自定义 rotation、revocation、failover 与 operator ownership。
   - NFR-P2P-GOVSIGN-3: 在本专题完成前，公开安全口径仍保持 `crypto-hardened preview`。
   - NFR-P2P-GOVSIGN-4: 文档与日志只能记录 signer scope、policy、公钥与审计摘要，不得记录私钥、seed 或助记词。
+  - NFR-P2P-GOVSIGN-5: validator / finality signer 准入必须通过 governance registry 的候选/激活流程生效，不能把本地 env 或 `--node-validator*` 参数修改当作长期 admission 机制。
 - Security & Privacy: 本专题只定义治理 signer 的长期真值和治理流程边界；禁止把任何真实 seed、私钥或生产签名材料落入仓库或证据文档。
 
 ## 5. Risks & Roadmap
@@ -105,9 +118,12 @@
 | PRD-P2P-GOVSIGN-002 | GOVSIGN-1/2 | `test_tier_required` | externalized source-of-truth、update authority 与禁止项冻结 | finality/controller signer 长期治理目标 |
 | PRD-P2P-GOVSIGN-003 | GOVSIGN-2/3 | `test_tier_required` | failover/rotation/revocation gate 定义与 QA 审核清单 | 治理 signer 失效恢复能力 |
 | PRD-P2P-GOVSIGN-004 | GOVSIGN-3/4 | `test_tier_required` | operator ownership、release/public-claims 依赖链核对 | 治理运营和变更审计 |
+| PRD-P2P-GOVSIGN-005 | GOVSIGN-5 | `test_tier_required` | validator/finality signer admission 状态机、材料清单、activation 规则与角色边界冻结 | 新 validator 准入路径、world-state registry 激活边界与 controller appointment 分层 |
 - Decision Log:
 | 决策ID | 选定方案 | 备选方案（否决） | 依据 |
 | --- | --- | --- | --- |
 | DEC-P2P-GOVSIGN-001 | 将 finality signer 与 controller signer 一起纳入治理外部化专题 | 只处理 finality signer，把 controller signer 留在 token topic | 两者共同构成治理真值，拆开会继续造成 source-of-truth 分裂。 |
 | DEC-P2P-GOVSIGN-002 | deterministic local seed 与 `NodeConfig` policy 都只能算 preview/local truth | 接受其中一条作为生产过渡方案 | 任何依赖 local seed/config 的路径都缺少正式治理更新与审计能力。 |
 | DEC-P2P-GOVSIGN-003 | 治理长期真值选定为 `on-chain/world-state registry` | 先走链下 external registry 过渡 | 当前制作人决策已经明确要求治理真值直接上链，因此后续实现必须围绕链上 source-of-truth 展开。 |
+| DEC-P2P-GOVSIGN-004 | validator / finality signer 准入采用“申请 -> 审核 -> candidate/probation -> activation -> revoke/rotate”的治理状态机 | 继续依赖人工改 env、改 `NodePosConfig` 或直接把节点拉进活跃集合 | 这更接近主流公链“协议内注册 + 激活边界 + 审计留痕”的通用模式，也与当前 world-state registry 真值方向一致。 |
+| DEC-P2P-GOVSIGN-005 | controller signer 保持治理内部 appointment，不和外部 validator 准入混成一条流程 | 把 treasury/controller slot 也当成公开 validator 申请的一部分 | controller signer 权限更高，职责也不同；若混合流程，会把治理/金库风险错误地下放到节点准入路径。 |

--- a/doc/p2p/blockchain/p2p-governance-signer-externalization-2026-03-23.project.md
+++ b/doc/p2p/blockchain/p2p-governance-signer-externalization-2026-03-23.project.md
@@ -10,6 +10,7 @@
 - [x] GOVSIGN-2 (PRD-P2P-GOVSIGN-002) [test_tier_required]: 冻结两类治理 signer 的长期 source-of-truth、update authority 与禁止项。
 - [x] GOVSIGN-3 (PRD-P2P-GOVSIGN-003) [test_tier_required]: 冻结 failover、rotation、revocation 与 operator ownership gate。
 - [x] GOVSIGN-4 (PRD-P2P-GOVSIGN-004) [test_tier_required]: 冻结 readiness/public-claims/ceremony 对 governance signer 的前置依赖。
+- [x] validator-finality-signer-admission-workflow (PRD-P2P-GOVSIGN-005) [test_tier_required]: 补齐 validator / finality signer 准入目标流程，冻结 `apply -> approved_candidate -> probation_ready -> active -> revoke/rotate` 生命周期，并明确 controller signer 仍为治理内部 appointment。 Trace: .pm/tasks/task_d27fd4eafe4c41bdb046d3fe3765033f.yaml
 
 ## 当前结论
 - 当前阶段:
@@ -22,6 +23,7 @@
   - 默认 execution world `output/chain-runtime/viewer-live-node/reward-runtime-execution-world` 已导入 `governance.finality.v1` 与 8 个 controller slot 的 world-state registry；`chain runtime` 现在已支持在启动/恢复时优先读取该 world registry 来覆盖 validator membership / signer binding 与 controller signer policy，但这仍不等于 rotation / revocation / ceremony / QA gate 全部通过
   - finality signer 的 production signing material 仍由人工离线 custody 持有；runtime 不再把 local seed 视为 registry 存在时的真值，且默认 world 首轮真实 finality drill 已完成，但更大范围 rotation / revocation / ceremony / QA gate 仍未收口
   - controller signer policy 虽已支持由 execution world 注入 `NodeRuntime`，但真实 governance account / recipient binding、genesis ceremony 和最终 QA `pass` 仍未完成
+  - validator / finality signer 的 target admission workflow 虽已在本专题冻结，但 candidate registry、activation action、shared-network probation 和正式 operator runbook 仍待后续实现
 
 ## Transition Freeze Snapshot（public-only）
 - batch id: `oasis7-governance-batch-20260323-01`
@@ -42,6 +44,7 @@
 - [x] `governance_effective_finality_epoch_snapshot` 在 registry 存在时优先使用 world-state signer truth，而不是 deterministic local seed fallback
 - 已完成补充：`oasis7_chain_runtime` 在 execution world 存在 `governance_finality_signer_registry` 时，会用该 world-state registry 覆盖 `NodePosConfig` 的 validator membership / signer binding，并让 replication remote writer allowlist 与 reward runtime node identity binding 继续跟随 effective config
 - [x] chain runtime 启动时可从 execution world 读取 controller signer policy，并覆盖 `NodeConfig.main_token_controller_binding`
+- 已冻结 validator / finality signer 的准入目标流程：申请材料、审核角色、candidate/probation/active 状态机，以及“world-state registry 激活前不算正式 validator”的边界
 - [x] 新增 `oasis7_governance_registry_import`，可把 operator-local `public_manifest.json` 导入 execution world
 - [x] 新增 `oasis7_governance_registry_audit`，可直接读取 world-state registry，输出 slot threshold / signer count / tolerated failures / manifest match 审计结果
 - [x] 已用真实 `public_manifest.json` 在临时 world 目录完成 smoke import，验证 3 个 finality signer + 8 个 controller slot 可落入 world-state registry
@@ -60,6 +63,20 @@
 - [x] 已补 finality baseline rejoin coverage：`signer02` temporary offline 后直接用 baseline manifest rejoin 回到 `ready_for_ops_drill`，证据见 `doc/testing/evidence/governance-registry-live-world-drill-finality-baseline-rejoin-signer02-2026-03-24.md`
 - [ ] 其余 controller slot / additional finality failover / rejoin 变体覆盖仍待继续扩展
 - [ ] genesis address binding / ceremony / QA pass 仍待后续 `MAINNET-3` 收口
+
+## Validator / Finality Signer Admission Target（Spec Gate）
+### 范围边界
+- 公开准入只面向 `validator operator + finality signer`。
+- `controller signer` 继续走治理内部 appointment，不从公开 validator 申请路径进入。
+
+### 目标流程
+1. 申请人提交 `node_id`、`finality_signer_public_key`、reachability 信息、`operator_owner` 和 public-only manifest。
+2. `producer_system_designer` 判断当前 validator set 是否允许扩容或替换，并冻结预期 `activation_epoch` 窗口。
+3. `runtime_engineer` 校验 node identity 与 finality signer 没有混用，且 bootstrap / reachability / registry 结构符合当前网络架构。
+4. `qa_engineer` 在 candidate world、clone-world 或 shared network 对候选节点执行 registry import/audit、同步和 failover smoke。
+5. 通过后先进入 `approved_candidate` / `probation_ready`，只有到达 activation 条件时才写入 active `governance_finality_signer_registry`。
+6. runtime 在启动/恢复时从 world-state registry 恢复生效后的 validator membership / signer binding；`--node-validator*` 不再充当正式 admission 机制。
+7. 退出路径统一走 rotation / revocation / failover，并在 world-state registry 留痕。
 
 ## Operator / QA Runbook（How-to）
 1. 先审计当前 world-state registry，确认所有治理 slot 都符合 manifest 声明的 threshold；若 manifest 未显式声明，则继续按默认 `2-of-3` 且具备单 signer 故障容忍：
@@ -105,7 +122,7 @@
 - `testing-manual.md`
 
 ## 验收命令（本轮）
-- `rg -n "deterministic local seed|controller_signer_policies|NodeConfig|externalized|failover|revocation" doc/p2p/blockchain/p2p-governance-signer-externalization-2026-03-23.prd.md doc/p2p/blockchain/p2p-governance-signer-externalization-2026-03-23.design.md doc/p2p/blockchain/p2p-governance-signer-externalization-2026-03-23.project.md doc/p2p/blockchain/p2p-mainnet-grade-readiness-hardening-2026-03-23.prd.md doc/p2p/project.md`
+- `rg -n "deterministic local seed|controller_signer_policies|NodeConfig|externalized|failover|revocation|approved_candidate|probation_ready|activation_epoch|controller signer 仍为治理内部 appointment" doc/p2p/blockchain/p2p-governance-signer-externalization-2026-03-23.prd.md doc/p2p/blockchain/p2p-governance-signer-externalization-2026-03-23.design.md doc/p2p/blockchain/p2p-governance-signer-externalization-2026-03-23.project.md doc/p2p/blockchain/p2p-mainnet-grade-readiness-hardening-2026-03-23.prd.md doc/p2p/project.md`
 - `env -u RUSTC_WRAPPER cargo test -p oasis7 governance_finality_registry_roundtrip_persists_and_drives_epoch_snapshot -- --nocapture`
 - `env -u RUSTC_WRAPPER cargo test -p oasis7 --bin oasis7_chain_runtime governance_registry -- --nocapture`
 - `env -u RUSTC_WRAPPER cargo test -p oasis7 world_registry_overrides_node_controller_binding -- --nocapture`
@@ -120,5 +137,5 @@
 ## 状态
 - 当前阶段: completed
 - 执行状态: in_progress
-- 下一步: 将真实 drill 从 `msig.foundation_ops.v1` 与当前 finality single-signer / failover / rejoin 样本继续扩到更多 controller slot；finality 侧下一步更适合转去 shared network / release train 或更复杂网络抖动场景，而不是继续堆同类单槽位样本。
-- 最近更新: 2026-03-24（finality baseline rejoin signer02）
+- 下一步: 将真实 drill 从 `msig.foundation_ops.v1` 与当前 finality single-signer / failover / rejoin 样本继续扩到更多 controller slot，并把本次冻结的 validator / finality signer admission workflow 进一步落成 candidate registry、activation action、shared-network probation 与正式 operator runbook。
+- 最近更新: 2026-05-06（world-registry truth bootstrap + validator admission spec）

--- a/doc/p2p/blockchain/p2p-governance-signer-externalization-2026-03-23.project.md
+++ b/doc/p2p/blockchain/p2p-governance-signer-externalization-2026-03-23.project.md
@@ -19,7 +19,7 @@
 - 选定方案:
   - governance truth target: `on-chain/world-state registry`
 - 当前 blocker:
-  - 默认 execution world `output/chain-runtime/viewer-live-node/reward-runtime-execution-world` 已导入 `governance.finality.v1` 与 8 个 controller slot 的 world-state registry，chain runtime 也已支持启动时优先读取 world registry，但这仍不等于 rotation / revocation / ceremony / QA gate 全部通过
+  - 默认 execution world `output/chain-runtime/viewer-live-node/reward-runtime-execution-world` 已导入 `governance.finality.v1` 与 8 个 controller slot 的 world-state registry；`chain runtime` 现在已支持在启动/恢复时优先读取该 world registry 来覆盖 validator membership / signer binding 与 controller signer policy，但这仍不等于 rotation / revocation / ceremony / QA gate 全部通过
   - finality signer 的 production signing material 仍由人工离线 custody 持有；runtime 不再把 local seed 视为 registry 存在时的真值，且默认 world 首轮真实 finality drill 已完成，但更大范围 rotation / revocation / ceremony / QA gate 仍未收口
   - controller signer policy 虽已支持由 execution world 注入 `NodeRuntime`，但真实 governance account / recipient binding、genesis ceremony 和最终 QA `pass` 仍未完成
 
@@ -40,6 +40,7 @@
 ## Execution Workstream Snapshot（2026-03-23）
 - [x] 在 `WorldState` 持久化 `governance_finality_signer_registry` 与 `governance_main_token_controller_registry`
 - [x] `governance_effective_finality_epoch_snapshot` 在 registry 存在时优先使用 world-state signer truth，而不是 deterministic local seed fallback
+- 已完成补充：`oasis7_chain_runtime` 在 execution world 存在 `governance_finality_signer_registry` 时，会用该 world-state registry 覆盖 `NodePosConfig` 的 validator membership / signer binding，并让 replication remote writer allowlist 与 reward runtime node identity binding 继续跟随 effective config
 - [x] chain runtime 启动时可从 execution world 读取 controller signer policy，并覆盖 `NodeConfig.main_token_controller_binding`
 - [x] 新增 `oasis7_governance_registry_import`，可把 operator-local `public_manifest.json` 导入 execution world
 - [x] 新增 `oasis7_governance_registry_audit`，可直接读取 world-state registry，输出 slot threshold / signer count / tolerated failures / manifest match 审计结果
@@ -106,6 +107,7 @@
 ## 验收命令（本轮）
 - `rg -n "deterministic local seed|controller_signer_policies|NodeConfig|externalized|failover|revocation" doc/p2p/blockchain/p2p-governance-signer-externalization-2026-03-23.prd.md doc/p2p/blockchain/p2p-governance-signer-externalization-2026-03-23.design.md doc/p2p/blockchain/p2p-governance-signer-externalization-2026-03-23.project.md doc/p2p/blockchain/p2p-mainnet-grade-readiness-hardening-2026-03-23.prd.md doc/p2p/project.md`
 - `env -u RUSTC_WRAPPER cargo test -p oasis7 governance_finality_registry_roundtrip_persists_and_drives_epoch_snapshot -- --nocapture`
+- `env -u RUSTC_WRAPPER cargo test -p oasis7 --bin oasis7_chain_runtime governance_registry -- --nocapture`
 - `env -u RUSTC_WRAPPER cargo test -p oasis7 world_registry_overrides_node_controller_binding -- --nocapture`
 - `env -u RUSTC_WRAPPER cargo test -p oasis7 import_writes_governance_registries_into_world -- --nocapture`
 - `env -u RUSTC_WRAPPER cargo test -p oasis7 audit_report_passes_for_matching_two_of_three_registry -- --nocapture`

--- a/doc/p2p/blockchain/p2p-governance-signer-externalization-2026-03-23.project.md
+++ b/doc/p2p/blockchain/p2p-governance-signer-externalization-2026-03-23.project.md
@@ -23,7 +23,7 @@
   - 默认 execution world `output/chain-runtime/viewer-live-node/reward-runtime-execution-world` 已导入 `governance.finality.v1` 与 8 个 controller slot 的 world-state registry；`chain runtime` 现在已支持在启动/恢复时优先读取该 world registry 来覆盖 validator membership / signer binding 与 controller signer policy，但这仍不等于 rotation / revocation / ceremony / QA gate 全部通过
   - finality signer 的 production signing material 仍由人工离线 custody 持有；runtime 不再把 local seed 视为 registry 存在时的真值，且默认 world 首轮真实 finality drill 已完成，但更大范围 rotation / revocation / ceremony / QA gate 仍未收口
   - controller signer policy 虽已支持由 execution world 注入 `NodeRuntime`，但真实 governance account / recipient binding、genesis ceremony 和最终 QA `pass` 仍未完成
-  - validator / finality signer 的 target admission workflow 虽已在本专题冻结，但 candidate registry、activation action、shared-network probation 和正式 operator runbook 仍待后续实现
+  - validator / finality signer 的 runtime admission 闭环现已落到 execution world：`WorldState` 持久化 `governance_validator_admissions`，runtime 提供 `submit/approve/activate/revoke` 治理动作，effective finality registry 会在 activation epoch 到期后自动把 `probation_ready` 候选并入正式 validator truth；剩余未收口的是更大范围 shared-network probation 证据、更多 controller/finality drill 变体，以及最终 ceremony / QA `pass`
 
 ## Transition Freeze Snapshot（public-only）
 - batch id: `oasis7-governance-batch-20260323-01`
@@ -41,9 +41,12 @@
 
 ## Execution Workstream Snapshot（2026-03-23）
 - [x] 在 `WorldState` 持久化 `governance_finality_signer_registry` 与 `governance_main_token_controller_registry`
+ - 已完成补充：`WorldState` 现已持久化 `governance_validator_admissions`
 - [x] `governance_effective_finality_epoch_snapshot` 在 registry 存在时优先使用 world-state signer truth，而不是 deterministic local seed fallback
 - 已完成补充：`oasis7_chain_runtime` 在 execution world 存在 `governance_finality_signer_registry` 时，会用该 world-state registry 覆盖 `NodePosConfig` 的 validator membership / signer binding，并让 replication remote writer allowlist 与 reward runtime node identity binding 继续跟随 effective config
 - [x] chain runtime 启动时可从 execution world 读取 controller signer policy，并覆盖 `NodeConfig.main_token_controller_binding`
+- 已完成补充：runtime 已新增 `Submit/Approve/Activate/RevokeGovernanceValidatorAdmission` 治理动作，并把 `apply -> approved_candidate -> probation_ready -> active -> revoked` 生命周期写入 world-state
+- 已完成补充：effective finality registry 会把 activation epoch 到期的 `probation_ready` 候选自动并入正式 validator truth；`oasis7_chain_runtime` 与 `oasis7_governance_registry_audit` 都已切到读取这份 effective registry
 - 已冻结 validator / finality signer 的准入目标流程：申请材料、审核角色、candidate/probation/active 状态机，以及“world-state registry 激活前不算正式 validator”的边界
 - [x] 新增 `oasis7_governance_registry_import`，可把 operator-local `public_manifest.json` 导入 execution world
 - [x] 新增 `oasis7_governance_registry_audit`，可直接读取 world-state registry，输出 slot threshold / signer count / tolerated failures / manifest match 审计结果
@@ -74,7 +77,7 @@
 2. `producer_system_designer` 判断当前 validator set 是否允许扩容或替换，并冻结预期 `activation_epoch` 窗口。
 3. `runtime_engineer` 校验 node identity 与 finality signer 没有混用，且 bootstrap / reachability / registry 结构符合当前网络架构。
 4. `qa_engineer` 在 candidate world、clone-world 或 shared network 对候选节点执行 registry import/audit、同步和 failover smoke。
-5. 通过后先进入 `approved_candidate` / `probation_ready`，只有到达 activation 条件时才写入 active `governance_finality_signer_registry`。
+5. 通过后先把 candidate 写入 execution world `governance_validator_admissions`，状态进入 `approved_candidate` / `probation_ready`；只有到达 activation 条件时，effective `governance_finality_signer_registry` 才会把该候选并入 active validator set。
 6. runtime 在启动/恢复时从 world-state registry 恢复生效后的 validator membership / signer binding；`--node-validator*` 不再充当正式 admission 机制。
 7. 退出路径统一走 rotation / revocation / failover，并在 world-state registry 留痕。
 
@@ -137,5 +140,5 @@
 ## 状态
 - 当前阶段: completed
 - 执行状态: in_progress
-- 下一步: 将真实 drill 从 `msig.foundation_ops.v1` 与当前 finality single-signer / failover / rejoin 样本继续扩到更多 controller slot，并把本次冻结的 validator / finality signer admission workflow 进一步落成 candidate registry、activation action、shared-network probation 与正式 operator runbook。
-- 最近更新: 2026-05-06（world-registry truth bootstrap + validator admission spec）
+- 下一步: 将真实 drill 从 `msig.foundation_ops.v1` 与当前 finality single-signer / failover / rejoin 样本继续扩到更多 controller slot，并补 shared-network probation 与更正式的 governance approval / operator evidence bundle。
+- 最近更新: 2026-05-06（world-registry truth bootstrap + validator admission runtime implementation）

--- a/doc/p2p/blockchain/p2p-mainnet-grade-readiness-hardening-2026-03-23.prd.md
+++ b/doc/p2p/blockchain/p2p-mainnet-grade-readiness-hardening-2026-03-23.prd.md
@@ -33,7 +33,7 @@
 - Critical User Flows:
   1. Flow-P2P-MAINNET-001: `STRAUTH-3 收口 -> producer 复核剩余 blocker -> 拆成 readiness gate -> 进入主模块 project 跟踪`
   2. Flow-P2P-MAINNET-002: `runtime 设计生产 signer custody -> 定义 key source/storage/sign flow -> QA 对照 gate 决定 pass/block`
-  3. Flow-P2P-MAINNET-003: `治理 signer 从 local seed/config 迁出 -> 建立 rotation/revocation/failover 规则 -> 通过后才能进入创世 ceremony`
+  3. Flow-P2P-MAINNET-003: `治理 signer 从 local seed/config 迁出 -> 建立 validator/finality signer 准入/激活流程与 rotation/revocation/failover 规则 -> 通过后才能进入创世 ceremony`
   4. Flow-P2P-MAINNET-004: `冻结 genesis recipient/controller/signer sheet -> 执行 ceremony checklist -> QA 审核证据 -> producer 再做安全阶段重评估`
   5. Flow-P2P-MAINNET-005: `有人提出 mainnet-grade/public-chain-grade 口径 -> liveops 对照 readiness gate -> 任一未过即拒绝`
 - Functional Specification Matrix:
@@ -50,7 +50,7 @@
   - AC-2: 专题必须明确写出：`STRAUTH-3` 的完成只关闭了 signed transaction model 这一类 blocker，不代表 keystore、governance signer 与 genesis ceremony 已完成。
   - AC-3: 必须定义四个 readiness gate，并给出每个 gate 的 `owner/current_state/target_state/test_tier_required`。
   - AC-4: 必须明确生产级 signer custody 的最小完成定义至少包含 `external signer or managed keystore`、`rotation`、`revocation`、`audit trail` 四项。
-  - AC-5: 必须明确治理 finality signer 外部化的最小完成定义至少包含 `no deterministic local seed in production path`、`failover`、`rotation`、`revocation`。
+  - AC-5: 必须明确治理 finality signer 外部化的最小完成定义至少包含 `no deterministic local seed in production path`、`validator/finality signer admission + activation rule`、`failover`、`rotation`、`revocation`。
   - AC-6: 必须明确创世 freeze 真值表在 `recipient/controller/signer policy` 三列全部冻结前，不得进入 mint-ready 判定。
   - AC-7: 必须明确 signer ceremony 的 evidence bundle 至少包含 `public keys/account bindings/threshold policy/operator checklist/QA verdict`，不得记录私钥明文。
   - AC-8: 必须定义 public claims gate，并明确 `mainnet-grade`、`mainstream public-chain-grade security`、`production mint ready` 三类说法在当前阶段全部禁止。

--- a/doc/p2p/blockchain/p2p-mainnet-grade-readiness-hardening-2026-03-23.project.md
+++ b/doc/p2p/blockchain/p2p-mainnet-grade-readiness-hardening-2026-03-23.project.md
@@ -22,7 +22,7 @@
   - genesis/treasury 已有 controller slot binding 与本地 signer allowlist / threshold enforcement。
 - 仍待完成:
   - 生产级 signer custody / keystore 的工程替换仍待后续 runtime 实施，当前只完成规格 gate。
-  - 治理 signer 外部化的 runtime 工程替换仍待后续实现，当前只完成规格 gate；其中 validator / finality signer 的准入/激活流程已冻结目标态，但 candidate registry / activation action / probation runbook 仍未落地。
+  - 治理 signer 外部化已完成 runtime 工程替换：execution world registry 会覆盖 chain runtime validator/controller truth，validator admission 也已具备 world-state candidate lifecycle 和 activation/revoke 动作；剩余未收口的是 shared-network probation 证据、更大范围 rotation/revocation drill 与最终 ceremony / QA `pass`。
   - 创世 freeze/ceremony/QA 的真实地址、公钥、dry-run 与最终 QA `pass` 仍待后续执行，当前只完成规格 gate。
 
 ## 依赖
@@ -42,5 +42,5 @@
 
 ## 状态
 - 当前阶段: completed
-- 下一步: 若继续推进，应进入 execution workstreams，分别落地 signer custody、governance truth externalization、genesis binding/ceremony/QA；在这些项完成前，继续执行当前 preview claims policy。
-- 最近更新: 2026-03-23
+- 下一步: 若继续推进，应重点进入 signer custody 与 genesis binding/ceremony/QA，并把 governance admission 的 shared-network probation / live drill 证据继续补齐；在这些项完成前，继续执行当前 preview claims policy。
+- 最近更新: 2026-05-06

--- a/doc/p2p/blockchain/p2p-mainnet-grade-readiness-hardening-2026-03-23.project.md
+++ b/doc/p2p/blockchain/p2p-mainnet-grade-readiness-hardening-2026-03-23.project.md
@@ -22,7 +22,7 @@
   - genesis/treasury 已有 controller slot binding 与本地 signer allowlist / threshold enforcement。
 - 仍待完成:
   - 生产级 signer custody / keystore 的工程替换仍待后续 runtime 实施，当前只完成规格 gate。
-  - 治理 signer 外部化的 runtime 工程替换仍待后续实现，当前只完成规格 gate。
+  - 治理 signer 外部化的 runtime 工程替换仍待后续实现，当前只完成规格 gate；其中 validator / finality signer 的准入/激活流程已冻结目标态，但 candidate registry / activation action / probation runbook 仍未落地。
   - 创世 freeze/ceremony/QA 的真实地址、公钥、dry-run 与最终 QA `pass` 仍待后续执行，当前只完成规格 gate。
 
 ## 依赖

--- a/doc/p2p/prd.md
+++ b/doc/p2p/prd.md
@@ -48,7 +48,7 @@
   - SC-16: hosted world 网页远程接入具备明确的 `public player plane / private control plane / signer plane` 分层、`guest/player/strong-auth` 授权梯度、公开 join admission control 与 `gui-agent` surface split 策略，且浏览器不再被视为可持有 host 节点长期私钥的受信环境。
   - SC-17: p2p 模块具备一份 public-chain-grade 的“非全公网依赖”覆盖网络目标态，明确 `public/hybrid/private/relay_only/validator_hidden` 多部署模式、`validator core/sentry/relay` 角色分离，以及 `peer record + discovery + reachability + traffic lanes` 的统一框架边界。
   - SC-18: 当前链上代币的正式产品命名、runtime `main_token.symbol` / ticker 与公钥派生账户前缀已统一迁移到“绿洲币 / Oasis Coin” / `OC` / `oc:pk:`；对外 API、viewer/client、脚本与测试不得再把 `AWT` / `awt:pk:` 当作现行真值。
-  - SC-19: 当前本机 + 2 ECS real-env triad 必须具备一条可审计的“三节点等权 validator”落地路径，明确 validator set、signer binding、static bootstrap、same-window snapshot evidence 与 residual legacy service naming 的边界，避免继续把 role-separated `observer + sequencer + storage` 当成唯一真值拓扑。
+  - SC-19: 当前本机 + 2 ECS real-env triad 必须具备一条可审计的“三节点等权 validator”落地路径，明确 validator set、signer binding、static bootstrap、same-window snapshot evidence 与 residual legacy service naming 的边界；当 execution world 已存在 `governance_finality_signer_registry` 时，节点启动/恢复必须优先从该 world-state registry 恢复 validator membership 与 signer binding，而不是继续把 role-separated `observer + sequencer + storage` 或 operator-local env 当成唯一真值拓扑。
   - SC-20: `oasis7` 可以通过独立部署的 bridge-service，把已确认的 `OC` 充值映射为 `New API` 的内部 quota / redeem credit，同时冻结“只支持 one-way service-credit bridge，不是公开兑换所、不是 AMM、也不支持自动提现回 OC”的对外口径。
 
 ## 2. User Experience & Functionality
@@ -180,7 +180,7 @@
   - AC-32: `TASK-P2P-046` 必须把当前链上代币的 runtime `main_token.symbol`、公钥派生账户前缀与签名鉴权前缀统一迁移到 `OC` / `oc:pk:`，并同步 API、viewer/client、liveops、脚本、测试与模块入口文档，不再把 `AWT` / `awt:pk:` 当作现行真值。
   - AC-33: `TASK-P2P-047` 必须把当前链上代币的创世 `initial_supply` 冻结为 `10,000,000,000 OC`，并把 7 个 bucket 的绝对分配额、首年外部释放绝对边界与 formal freeze sheet 的 supply gate 同步回写到 token 专题与模块执行台账。
   - AC-34: `triad-observability-stack` 必须把 real-env triad 的 host/process、chain status、traffic window、wasm window 收敛到统一 repo-owned 监控入口，并在 `testing-manual.md` 冻结 canonical 命令与产物路径。
-  - AC-35: `triad-three-equal-validator-topology` 必须把当前 real-env triad 从“本机 observer + 两台云端 validator”提升为“三节点等权 validator”可审计基线，至少覆盖：`3` 个 validator 的 stake/signer binding、local 节点不再以 observer-only 角色运行、repo-owned snapshot/manual 不再把 `partial_with_observer_blocker` 当成唯一有效 claim，以及 same-window evidence 对 legacy service label 与真实 runtime role 的区分。
+  - AC-35: `triad-three-equal-validator-topology` 必须把当前 real-env triad 从“本机 observer + 两台云端 validator”提升为“三节点等权 validator”可审计基线，至少覆盖：`3` 个 validator 的 stake/signer binding、local 节点不再以 observer-only 角色运行、repo-owned snapshot/manual 不再把 `partial_with_observer_blocker` 当成唯一有效 claim、same-window evidence 对 legacy service label 与真实 runtime role 的区分，以及 `oasis7_chain_runtime` 在 execution world 已落盘 `governance_finality_signer_registry` 时会优先用该 world-state registry 恢复 validator membership / signer binding；`--node-validator*` 只保留为 bootstrap 或显式运维覆盖。
   - AC-36: `mainchain-token-newapi-quota-bridge-2026-05-06` 专题文档落盘并映射任务链，明确 `one-way OC -> New API quota`、bridge-service 独立部署、唯一入账映射、`bridge_ledger` 幂等对账、manual review 风控、`New API` 内部 credit adapter，以及“不支持自动提现/不承诺公开兑换所”边界。
 - Non-Goals:
   - 不在本 PRD 细化 viewer UI 交互。

--- a/doc/p2p/prd.md
+++ b/doc/p2p/prd.md
@@ -50,6 +50,7 @@
   - SC-18: 当前链上代币的正式产品命名、runtime `main_token.symbol` / ticker 与公钥派生账户前缀已统一迁移到“绿洲币 / Oasis Coin” / `OC` / `oc:pk:`；对外 API、viewer/client、脚本与测试不得再把 `AWT` / `awt:pk:` 当作现行真值。
   - SC-19: 当前本机 + 2 ECS real-env triad 必须具备一条可审计的“三节点等权 validator”落地路径，明确 validator set、signer binding、static bootstrap、same-window snapshot evidence 与 residual legacy service naming 的边界；当 execution world 已存在 `governance_finality_signer_registry` 时，节点启动/恢复必须优先从该 world-state registry 恢复 validator membership 与 signer binding，而不是继续把 role-separated `observer + sequencer + storage` 或 operator-local env 当成唯一真值拓扑。
   - SC-20: `oasis7` 可以通过独立部署的 bridge-service，把已确认的 `OC` 充值映射为 `New API` 的内部 quota / redeem credit，同时冻结“只支持 one-way service-credit bridge，不是公开兑换所、不是 AMM、也不支持自动提现回 OC”的对外口径。
+  - SC-21: validator / finality signer 必须具备一条正式的治理准入流程，至少覆盖 `apply -> approved_candidate -> probation_ready -> active -> rotate/revoke`，并明确 world-state registry 才是正式激活真值；`--node-validator*` 与 operator-local env 只能作为 bootstrap 或显式运维覆盖。
 
 ## 2. User Experience & Functionality
 - User Personas:
@@ -61,6 +62,7 @@
   - hosted world host / operator：需要把可公开分享的 join URL 与私有世界控制面拆开，避免分享试玩地址时连控制权一起暴露。
   - hosted world 远程玩家：需要通过网页先建立 session 再游玩，而不是直接继承 host 节点 signer。
   - 私网 / 家宽 / 企业内网节点运营者：需要在没有公网 IP 的前提下，仍能以正式角色加入网络、同步状态或通过 sentry/relay 参与主链。
+  - validator 候选运营者：需要明确提交什么材料、何时从候选转为 active validator，以及哪些 signer/控制权限并不对外开放。
 - User Scenarios & Frequency:
   - 协议演进评审：每次共识或网络协议改动前执行。
   - 多节点长跑：按周执行并记录稳定性与恢复结果。
@@ -116,7 +118,7 @@
   16. Flow-P2P-016: `operator 运行 triad 完整监控 -> snapshot/host/traffic/wasm 产物全部落盘 -> merged summary 输出 overall status + node-level alerts -> evidence doc 引用 canonical 输出路径`
   17. Flow-P2P-017: `STRAUTH-3 收口后复盘剩余安全缺口 -> 冻结 MAINNET-1~4 readiness gate -> signer custody/governance signer/genesis ceremony 逐项过门禁 -> producer 再决定是否重评阶段`
   18. Flow-P2P-018: `盘点 node/viewer/governance signer 来源 -> 冻结 preview-only bootstrap 与 production target backend 边界 -> rotation/revocation/audit policy 入门禁`
-  19. Flow-P2P-019: `盘点 finality/controller signer 真值 -> 冻结 externalized source-of-truth 与 operator ownership -> failover/rotation/revocation 进入治理门禁`
+  19. Flow-P2P-019: `盘点 finality/controller signer 真值 -> 冻结 externalized source-of-truth 与 operator ownership -> 候选 validator 提交 node identity/finality signer/public manifest -> candidate/probation 审核 -> activation 生效后再写入 world-state registry -> failover/rotation/revocation 进入治理门禁`
   20. Flow-P2P-020: `读取 genesis freeze sheet -> 绑定 slot/bucket 真值 -> 执行 ceremony checklist -> QA 审核 evidence bundle -> 决定是否允许 mint-ready 口径`
   21. Flow-P2P-021: `读取 MAINNET-1~3 当前状态 -> 判断哪些仅为 spec gate、哪些已 execution complete -> 冻结 claim allowlist/denylist 与未来升级条件`
   22. Flow-P2P-022: `读取 testing-manual 与安全/readiness 专题 -> 映射 oasis7 当前测试层 -> 对照主流公链 testing benchmark -> 冻结 gap matrix 与下一步验证优先级`
@@ -138,6 +140,7 @@
 | 密码学安全基线评估 | `primitive_status`、`transaction_auth_status`、`account_model_status`、`key_custody_status`、`governance_signer_status`、`genesis_control_status`、`overall_verdict` | 盘点代码/文档真值并输出 system-level verdict；若 blocker 未清零则拒绝高级安全口径 | `unknown -> inventoried -> verdict_frozen` | 只要资产动作缺统一签名交易模型，整体必须保持 `not_mainnet_grade` | `producer_system_designer` 拍板，`runtime_engineer`/`qa_engineer` 联审 |
 | 主链 Token 签名交易鉴权 | `from_account_id/to_account_id/amount/nonce/public_key/signature` | runtime 先验签并校验 `oc:pk:` 账户绑定，再进入既有余额/nonce 预检与 consensus submit | `unsigned_surface -> transfer_signed_surface` | transfer submit 必须带固定版本签名；`from_account_id` 必须等于 `oc:pk:<public_key_hex>`；其他资产动作仍待后续专题 | `runtime_engineer` 牵头实现，`viewer_engineer`/`qa_engineer` 跟进客户端与回归 |
 | 主流公链测试体系对标 | `layer_id/current_coverage/evidence_paths/gap_status/next_action` | 将 oasis7 suites/evidence 对位到主流公链测试分层，并冻结缺口矩阵与执行优先级 | `draft -> mapped -> prioritized` | 若缺共享网络、真实 drill 证据或 fuzz/property gate，则不得宣称“主流公链级测试成熟度” | `producer_system_designer` 拍板，`qa_engineer` 联审 |
+| Validator / finality signer 治理准入 | `candidate_id/node_id/finality_signer_public_key/operator_owner/public_manifest/activation_epoch/admission_status` | 受理申请、审核 reachability/registry/failover 准入条件，并在 activation 生效后把候选节点写入正式 validator truth | `applied -> approved_candidate -> probation_ready -> active -> rotated/revoked` | 只有 world-state registry 生效后才算正式 validator；`--node-validator*` 与本地 env 改动不算长期 admission 完成态 | `producer_system_designer` 拍板，`runtime_engineer`/`qa_engineer` 联审 |
 | Hosted world 玩家接入与 session auth | `deployment_mode/session_id/session_level/capability_set/control_plane_scope/strong_auth_state/admission_policy/player_safe_agent_surface` | 将网页远程玩家面、host 控制面与 signer plane 分层；签发 guest/player session，并对敏感动作要求 strong auth | `specified_not_implemented -> trusted_local_only -> hosted_ready` | 只要浏览器仍依赖 `node.private_key` bootstrap、可命中 host 控制面路由或未冻结 admission / `gui-agent` split，就不得判为 hosted-ready | `producer_system_designer` 拍板，`runtime_engineer`/`viewer_engineer`/`qa_engineer`/`liveops_community` 联审 |
 - 三线联合验收清单（TASK-P2P-002）:
 | 线别 | 必跑命令（基线） | 联合验收门禁 | 阻断条件（任一命中即 fail） | 证据产物 |
@@ -169,7 +172,7 @@
   - AC-21: `mainchain-token-signed-transaction-authorization-2026-03-23` 专题文档落盘并映射任务链 `TASK-P2P-033`；`POST /v1/chain/transfer/submit` 必须新增 `public_key/signature` 鉴权、绑定 `oc:pk:<public_key_hex>` 并完成 required 回归。
   - AC-22: `p2p-mainnet-grade-readiness-hardening-2026-03-23` 专题文档落盘并映射任务链 `TASK-P2P-034`，明确当前阶段只可称为 `limited playable technical preview` + `crypto-hardened preview`，并冻结 `MAINNET-1~4` readiness gate。
   - AC-23: `p2p-production-signer-custody-keystore-2026-03-23` 专题文档落盘并映射任务链 `TASK-P2P-035`，明确 `config.toml` 明文 key、HTML 私钥注入与 env 私钥 bootstrap 只属于 preview-only signer path，不得作为 production custody 完成态。
-  - AC-24: `p2p-governance-signer-externalization-2026-03-23` 专题文档落盘并映射任务链 `TASK-P2P-036`，明确 deterministic local seed 与 `NodeConfig` 本地 controller signer policy 只属于 preview/local truth，不得作为 production governance truth。
+  - AC-24: `p2p-governance-signer-externalization-2026-03-23` 专题文档落盘并映射任务链 `TASK-P2P-036`，明确 governance registry 优先、deterministic local seed / `NodeConfig` local fallback 只属于 preview/local truth，不得作为 production governance truth，并冻结 validator / finality signer 的治理准入目标流程。
   - AC-25: `p2p-genesis-freeze-ceremony-qa-gate-2026-03-23` 专题文档落盘并映射任务链 `TASK-P2P-037`，明确 `logic_frozen_address_binding_pending`、`TBD_BEFORE_MINT`、`pending_binding` 与 `ready_pending_address_binding` 都属于 mint-ready blocker。
   - AC-26: `p2p-mainnet-public-claims-policy-2026-03-23` 专题文档落盘并映射任务链 `TASK-P2P-038`，明确 `MAINNET-1~3` 当前仅完成 spec gate、整体 verdict 仍为 `not_mainnet_grade`，并冻结 allowlist/denylist 与 future upgrade conditions。
   - AC-27: `p2p-mainstream-public-chain-testing-benchmark-2026-03-24` 专题文档落盘并映射任务链 `TASK-P2P-039`，明确主流公链测试分层模型、oasis7 当前映射、`fuzz/property` 与 `shared network/release train` 缺口，以及真实 governance drill 证据的当前优先级。
@@ -266,7 +269,7 @@
   - NFR-P2P-18: 公开 `transfer submit` 面不得存在无签名旁路；请求级鉴权必须在余额/nonce 预检之前完成，且 `oasis7_web_launcher` 代理结构与 runtime 保持同一字段集合。
   - NFR-P2P-19: 在 `MAINNET-1~4` readiness gate 全部通过前，公开口径最多只能使用 `limited playable technical preview` 与 `crypto-hardened preview`，不得升级到 `production mint ready`。
   - NFR-P2P-20: 生产 signer custody 未外部化前，任何本地 `config.toml`、HTML bootstrap 或长期 env 私钥路径都不得进入 production release allowlist。
-  - NFR-P2P-21: 生产 governance truth 未外部化前，任何 deterministic local seed 或单机 `NodeConfig` signer policy 路径都不得进入 production governance allowlist。
+  - NFR-P2P-21: 生产 governance truth 未外部化前，任何 deterministic local seed、单机 `NodeConfig` signer policy、手工 env 改动或 `--node-validator*` 参数注入都不得进入 production governance allowlist 或被视为正式 validator admission 完成态。
   - NFR-P2P-22: 在 genesis slot/bucket 真值、ceremony evidence bundle 与 QA `pass` 完成前，任何 `mint_ready` 或 `production mint ready` 口径都不得进入 public claims allowlist。
   - NFR-P2P-23: 在 `MAINNET-1~3` 仍停留于 spec gate 而 execution blockers 未清零时，任何高于 `crypto-hardened preview` 的 public claims 都必须被 denylist 拒绝。
   - NFR-P2P-24: 在 `shared_devnet/staging/canary` 仍未形成正式 shared-network evidence 前，任何 `release train established`、`shared network validated` 或“对标主流公链测试成熟度已完成”的表述都必须被 denylist 拒绝。
@@ -311,7 +314,7 @@
 | PRD-P2P-015 | TASK-P2P-033 | `test_tier_required` | 签名交易鉴权专题 PRD/project/design 建档、transfer submit 鉴权实现、control-plane schema 同步与定向回归 | 主链 Token 首个公开资产面签名化 |
 | PRD-P2P-016 | TASK-P2P-034 | `test_tier_required` | mainnet-grade readiness 硬化专题 PRD/project/design 建档、剩余 P1/P2 gate 冻结、模块入口映射与文档门禁 | signer custody、治理 signer、创世 ceremony 与 public claims gate |
 | PRD-P2P-017 | TASK-P2P-035 | `test_tier_required` | 生产级 signer custody / keystore 专题 PRD/project/design 建档、signer inventory、环境门禁与 readiness project 回写 | signer source boundary、rotation/revocation/audit 与 release policy |
-| PRD-P2P-018 | TASK-P2P-036 | `test_tier_required` | 治理 signer 外部化专题 PRD/project/design 建档、governance signer inventory、source-of-truth 门禁与 readiness project 回写 | governance truth、failover/rotation/revocation 与 operator ownership |
+| PRD-P2P-018 | TASK-P2P-036 | `test_tier_required` | 治理 signer 外部化专题 PRD/project/design 建档、governance signer inventory、source-of-truth 门禁、validator/finality signer admission target workflow 与 readiness project 回写 | governance truth、validator admission、failover/rotation/revocation 与 operator ownership |
 | PRD-P2P-019 | TASK-P2P-037 | `test_tier_required` + `test_tier_full` | 创世 freeze/ceremony/QA gate 专题 PRD/project/design 建档、freeze sheet blocker 冻结、QA evidence bundle 与 claim gate 回写 | mint readiness、创世执行与对外口径 |
 | PRD-P2P-020 | TASK-P2P-038 | `test_tier_required` | public claims policy 复评专题 PRD/project/design 建档、allowlist/denylist 冻结、future upgrade condition 与 readiness 完结回写 | 对外口径、阶段复评与后续升级条件 |
 | PRD-P2P-021 | TASK-P2P-039 | `test_tier_required` | 主流公链测试体系 benchmark 专题 PRD/project/design 建档、testing-manual 映射、gap matrix 与执行优先级冻结 | 测试成熟度口径、QA 证据体系与后续 hardening 排序 |

--- a/doc/p2p/project.md
+++ b/doc/p2p/project.md
@@ -650,6 +650,19 @@
     - `P2PARCH6_SEQ_SSH_PASSWORD='***' P2PARCH6_STORAGE_SSH_PASSWORD='***' ./scripts/p2p-real-env-triad-snapshot.sh --samples 4 --interval-secs 5 --out-dir .tmp/p2p_real_env_triad`
     - `./scripts/doc-governance-check.sh`
     - `git diff --check`
+- [x] world-registry-validator-truth-bootstrap (PRD-P2P-003/026) [test_tier_required]: 让 `oasis7_chain_runtime` 在 execution world 已存在 `governance_finality_signer_registry` 时，用 world-state registry 覆盖本地 PoS validator membership / signer binding，并把 replication remote writer allowlist 与 reward runtime node identity binding 统一切到这份 effective config；`--node-validator*` 退回为 bootstrap 或显式运维覆盖。 Trace: .pm/tasks/task_d27fd4eafe4c41bdb046d3fe3765033f.yaml
+  - 产物文件:
+    - `crates/oasis7/src/bin/oasis7_chain_runtime.rs`
+    - `crates/oasis7/src/bin/oasis7_chain_runtime/governance_registry.rs`
+    - `doc/p2p/prd.md`
+    - `doc/p2p/project.md`
+    - `doc/p2p/blockchain/p2p-governance-signer-externalization-2026-03-23.project.md`
+    - `.pm/tasks/task_d27fd4eafe4c41bdb046d3fe3765033f.execution.md`
+  - 验收命令 (`test_tier_required`):
+    - `env -u RUSTC_WRAPPER cargo test -p oasis7 --bin oasis7_chain_runtime governance_registry -- --nocapture`
+    - `env -u RUSTC_WRAPPER cargo check -p oasis7 --bin oasis7_chain_runtime`
+    - `./scripts/doc-governance-check.sh`
+    - `git diff --check`
 - [x] libp2p-hotpath-perf (PRD-P2P-002) [test_tier_required]: 收敛 `libp2p` 请求热路和 peer-manager active-set 刷新中的性能放大路径，移除请求选 peer 对 `debug_snapshot()` 的依赖，把 active peer 准入从“每候选一次全量重算”收敛为基于计数的增量判定，并将 replication 的 connection-gap 失败从 protocol 级短冷却继续推进到 peer-level transport cooldown；`unsupported` 与 `fetch_commit` 的 `ErrNotFound` 保持 protocol-scoped，同时把 protocol/transport cooldown 状态透出到 chain status 与 triad observability。后续已继续把 `oasis7_net` 生命周期事件面改成基于 peer/语义 key 的短窗去重，并在 `ConnectionEstablished` 后立即裁剪同一 peer 的冗余已建立连接，实测将 `sequencer_ecs` 的 `transport.connection_closed` 从四位数压回两位数、runtime CPU 从 `173.0%` 压到 `122.0%`。 Trace: .pm/tasks/task_e7f70a29287e4fe9a23467ba04ebf2ed.yaml
 - [x] TASK-P2P-048 (PRD-P2P-001/024) [test_tier_required]: 修复 2026-04-14 p2p provider-routing / discovery retry / remote error propagation / replication peer-selection 回归，确保 provider 子集请求不再越界 fallback、discovery 拨号失败后仍可重试、request-response 保留远端错误码，且 replication peer 选择优先避开已知 blocked peer。
   - 产物文件:

--- a/doc/p2p/project.md
+++ b/doc/p2p/project.md
@@ -650,15 +650,18 @@
     - `P2PARCH6_SEQ_SSH_PASSWORD='***' P2PARCH6_STORAGE_SSH_PASSWORD='***' ./scripts/p2p-real-env-triad-snapshot.sh --samples 4 --interval-secs 5 --out-dir .tmp/p2p_real_env_triad`
     - `./scripts/doc-governance-check.sh`
     - `git diff --check`
-- [x] world-registry-validator-truth-bootstrap (PRD-P2P-003/026) [test_tier_required]: 让 `oasis7_chain_runtime` 在 execution world 已存在 `governance_finality_signer_registry` 时，用 world-state registry 覆盖本地 PoS validator membership / signer binding，并把 replication remote writer allowlist 与 reward runtime node identity binding 统一切到这份 effective config；`--node-validator*` 退回为 bootstrap 或显式运维覆盖。 Trace: .pm/tasks/task_d27fd4eafe4c41bdb046d3fe3765033f.yaml
+- [x] world-registry-validator-truth-bootstrap (PRD-P2P-003/018/026) [test_tier_required]: 让 `oasis7_chain_runtime` 在 execution world 已存在 `governance_finality_signer_registry` 时，用 world-state registry 覆盖本地 PoS validator membership / signer binding，并把 replication remote writer allowlist 与 reward runtime node identity binding 统一切到这份 effective config；`--node-validator*` 退回为 bootstrap 或显式运维覆盖，同时补齐 validator / finality signer 的治理准入目标流程文档。 Trace: .pm/tasks/task_d27fd4eafe4c41bdb046d3fe3765033f.yaml
   - 产物文件:
     - `crates/oasis7/src/bin/oasis7_chain_runtime.rs`
     - `crates/oasis7/src/bin/oasis7_chain_runtime/governance_registry.rs`
     - `doc/p2p/prd.md`
     - `doc/p2p/project.md`
+    - `doc/p2p/blockchain/p2p-governance-signer-externalization-2026-03-23.prd.md`
+    - `doc/p2p/blockchain/p2p-governance-signer-externalization-2026-03-23.design.md`
     - `doc/p2p/blockchain/p2p-governance-signer-externalization-2026-03-23.project.md`
     - `.pm/tasks/task_d27fd4eafe4c41bdb046d3fe3765033f.execution.md`
   - 验收命令 (`test_tier_required`):
+    - `rg -n "approved_candidate|probation_ready|activation_epoch|formal validator admission|governance registry" doc/p2p/prd.md doc/p2p/blockchain/p2p-governance-signer-externalization-2026-03-23.prd.md doc/p2p/blockchain/p2p-governance-signer-externalization-2026-03-23.design.md doc/p2p/blockchain/p2p-governance-signer-externalization-2026-03-23.project.md`
     - `env -u RUSTC_WRAPPER cargo test -p oasis7 --bin oasis7_chain_runtime governance_registry -- --nocapture`
     - `env -u RUSTC_WRAPPER cargo check -p oasis7 --bin oasis7_chain_runtime`
     - `./scripts/doc-governance-check.sh`

--- a/doc/p2p/project.md
+++ b/doc/p2p/project.md
@@ -654,6 +654,8 @@
   - 产物文件:
     - `crates/oasis7/src/bin/oasis7_chain_runtime.rs`
     - `crates/oasis7/src/bin/oasis7_chain_runtime/governance_registry.rs`
+    - `crates/oasis7/src/bin/oasis7_governance_registry_audit.rs`
+    - `crates/oasis7/src/runtime/tests/governance_validator_admission.rs`
     - `doc/p2p/prd.md`
     - `doc/p2p/project.md`
     - `doc/p2p/blockchain/p2p-governance-signer-externalization-2026-03-23.prd.md`
@@ -663,7 +665,8 @@
   - 验收命令 (`test_tier_required`):
     - `rg -n "approved_candidate|probation_ready|activation_epoch|formal validator admission|governance registry" doc/p2p/prd.md doc/p2p/blockchain/p2p-governance-signer-externalization-2026-03-23.prd.md doc/p2p/blockchain/p2p-governance-signer-externalization-2026-03-23.design.md doc/p2p/blockchain/p2p-governance-signer-externalization-2026-03-23.project.md`
     - `env -u RUSTC_WRAPPER cargo test -p oasis7 --bin oasis7_chain_runtime governance_registry -- --nocapture`
-    - `env -u RUSTC_WRAPPER cargo check -p oasis7 --bin oasis7_chain_runtime`
+    - `env -u RUSTC_WRAPPER cargo test -p oasis7 governance_validator_admission -- --nocapture`
+    - `env -u RUSTC_WRAPPER cargo test -p oasis7 audit_report_ -- --nocapture`
     - `./scripts/doc-governance-check.sh`
     - `git diff --check`
 - [x] libp2p-hotpath-perf (PRD-P2P-002) [test_tier_required]: 收敛 `libp2p` 请求热路和 peer-manager active-set 刷新中的性能放大路径，移除请求选 peer 对 `debug_snapshot()` 的依赖，把 active peer 准入从“每候选一次全量重算”收敛为基于计数的增量判定，并将 replication 的 connection-gap 失败从 protocol 级短冷却继续推进到 peer-level transport cooldown；`unsupported` 与 `fetch_commit` 的 `ErrNotFound` 保持 protocol-scoped，同时把 protocol/transport cooldown 状态透出到 chain status 与 triad observability。后续已继续把 `oasis7_net` 生命周期事件面改成基于 peer/语义 key 的短窗去重，并在 `ConnectionEstablished` 后立即裁剪同一 peer 的冗余已建立连接，实测将 `sequencer_ecs` 的 `transport.connection_closed` 从四位数压回两位数、runtime CPU 从 `173.0%` 压到 `122.0%`。 Trace: .pm/tasks/task_e7f70a29287e4fe9a23467ba04ebf2ed.yaml


### PR DESCRIPTION
Closes #181

## Summary
- prefer execution world governance_finality_signer_registry over local validator CLI when registry truth exists
- propagate the effective validator signer bindings into replication remote writer allowlist and reward runtime identity bindings
- document the staged boundary: world-state registry is canonical for validator membership and signer bindings, while --node-validator* remains bootstrap or explicit ops override

## Validation
- env -u RUSTC_WRAPPER cargo test -p oasis7 --bin oasis7_chain_runtime governance_registry -- --nocapture
- env -u RUSTC_WRAPPER cargo check -p oasis7 --bin oasis7_chain_runtime
- env OASIS7_CI_RUN_OASIS7_REQUIRED_TESTS=true OASIS7_CI_RUN_CONSENSUS_TESTS=false OASIS7_CI_RUN_DISTFS_TESTS=false OASIS7_CI_RUN_VIEWER_TESTS=false OASIS7_CI_RUN_VIEWER_CONTRACT_TESTS=false OASIS7_CI_RUN_VIEWER_WASM_CHECK=false OASIS7_CI_RUN_LAUNCHER_WEB_BUILD=true ./scripts/ci-tests.sh required
