### PR TITLE
testing/runtime: formalize playability stack and runnable L4B evidence

### DIFF
--- a/.pm/tasks/task_5fdd00b00f024743a6878e8687a9e22e.execution.md
+++ b/.pm/tasks/task_5fdd00b00f024743a6878e8687a9e22e.execution.md
@@ -1,0 +1,17 @@
+# task_5fdd00b00f024743a6878e8687a9e22e Execution Log
+
+- task_uid: task_5fdd00b00f024743a6878e8687a9e22e
+- title: collapse stacked playability docs prs into one
+- owner_role: producer_system_designer
+- worktree_hint: /home/scc/worktrees/oasis7-testing-playability-pr-stack-collapse-2026-05-06
+
+<!-- Append entries using:
+Example:
+  ## YYYY-MM-DD HH:MM:SS CST / role_name
+  - 完成内容: ...
+  - 遗留事项: ...
+-->
+
+## 2026-05-06 19:54:00 CST / producer_system_designer
+- 完成内容: 新建整合 worktree，把 stacked playability 文档分支线性并回一条链，基于最新顶部提交重放到 `origin/main` 之上，准备将 `#187`、`#188`、`#192` 的内容统一收口到 `#186` 对应分支，并关闭多余 stacked PR。
+- 遗留事项: 需把整合结果推回 `task/testing-playability-evidence-stack-2026-05-06`，关闭多余 stacked PR，并确认最终仅保留一条对 `main` 的 PR。

--- a/.pm/tasks/task_5fdd00b00f024743a6878e8687a9e22e.yaml
+++ b/.pm/tasks/task_5fdd00b00f024743a6878e8687a9e22e.yaml
@@ -1,0 +1,23 @@
+task_uid: task_5fdd00b00f024743a6878e8687a9e22e
+title: "collapse stacked playability docs prs into one"
+owner_role: producer_system_designer
+worktree_hint: /home/scc/worktrees/oasis7-testing-playability-pr-stack-collapse-2026-05-06
+execution_log_path: .pm/tasks/task_5fdd00b00f024743a6878e8687a9e22e.execution.md
+status: done
+priority: P2
+source_signal: null
+source_refs:
+  - doc/testing/governance/playability-evidence-stack-2026-05-06.prd.md
+  - doc/testing/project.md
+doc_refs:
+  - doc/testing/prd.md
+related_prd:
+  - PRD-TESTING-007
+  - PRD-TESTING-008
+  - PRD-TESTING-009
+  - PRD-TESTING-010
+acceptance: []
+handoff_to: []
+updated_at: 2026-05-06T19:54:16+08:00
+last_started_at: 2026-05-06T19:52:10+08:00
+last_closed_at: 2026-05-06T19:54:16+08:00

--- a/.pm/tasks/task_9a6bbbc3022f4d4e8a3f5f99fab4d1b2.execution.md
+++ b/.pm/tasks/task_9a6bbbc3022f4d4e8a3f5f99fab4d1b2.execution.md
@@ -1,0 +1,17 @@
+# task_9a6bbbc3022f4d4e8a3f5f99fab4d1b2 Execution Log
+
+- task_uid: task_9a6bbbc3022f4d4e8a3f5f99fab4d1b2
+- title: design role-based playability review subagents
+- owner_role: producer_system_designer
+- worktree_hint: /home/scc/worktrees/oasis7-testing-playability-subagent-review-system-2026-05-06
+
+<!-- Append entries using:
+Example:
+  ## YYYY-MM-DD HH:MM:SS CST / role_name
+  - 完成内容: ...
+  - 遗留事项: ...
+-->
+## 2026-05-06 12:57:23 CST / producer_system_designer
+- 完成内容: 新增 `doc/testing/governance/playability-subagent-review-system-2026-05-06.{prd,design,project}.md`，把多角色内部人工评审设计成标准角色 subagent 系统，明确七类角色 subagent、review packet / output card、trigger matrix、调度顺序与 stop conditions。
+- 完成内容: 同步 `doc/testing/prd.md`、`doc/testing/project.md`、`doc/testing/README.md`、`doc/testing/prd.index.md` 与上一条 `playability evidence stack` 专题的互链，确保根入口能回答“这些 subagent 怎么设计、什么时候该开哪些角色”。
+- 遗留事项: 当前只完成系统设计，没有实现自动 orchestration wrapper；若后续要把 review packet / output card 真正串成工具链，还需要单独 runbook 或脚本专题。

--- a/.pm/tasks/task_9a6bbbc3022f4d4e8a3f5f99fab4d1b2.yaml
+++ b/.pm/tasks/task_9a6bbbc3022f4d4e8a3f5f99fab4d1b2.yaml
@@ -1,0 +1,21 @@
+task_uid: task_9a6bbbc3022f4d4e8a3f5f99fab4d1b2
+title: "design role-based playability review subagents"
+owner_role: producer_system_designer
+worktree_hint: /home/scc/worktrees/oasis7-testing-playability-subagent-review-system-2026-05-06
+execution_log_path: .pm/tasks/task_9a6bbbc3022f4d4e8a3f5f99fab4d1b2.execution.md
+status: done
+priority: P2
+source_signal: null
+source_refs:
+  - doc/testing/prd.md
+  - doc/testing/project.md
+doc_refs: []
+related_prd:
+  - PRD-TESTING-007
+acceptance:
+  - "testing governance defines the standard role subagents for internal playability review"
+  - "docs specify role inputs outputs review order and evidence boundaries for subagent-based review"
+handoff_to: []
+updated_at: 2026-05-06T13:02:58+08:00
+last_started_at: 2026-05-06T12:55:47+08:00
+last_closed_at: 2026-05-06T13:02:58+08:00

--- a/.pm/tasks/task_a68decb0a2c8460aa7d989df7370c901.execution.md
+++ b/.pm/tasks/task_a68decb0a2c8460aa7d989df7370c901.execution.md
@@ -1,0 +1,17 @@
+# task_a68decb0a2c8460aa7d989df7370c901 Execution Log
+
+- task_uid: task_a68decb0a2c8460aa7d989df7370c901
+- title: split playability L4 into synthetic and human layers
+- owner_role: producer_system_designer
+- worktree_hint: /home/scc/worktrees/oasis7-testing-playability-l4-synthetic-human-split-2026-05-06
+
+<!-- Append entries using:
+Example:
+  ## YYYY-MM-DD HH:MM:SS CST / role_name
+  - 完成内容: ...
+  - 遗留事项: ...
+-->
+
+## 2026-05-06 14:08:00 CST / producer_system_designer
+- 完成内容: 新增 `playability-l4-synthetic-human-split-2026-05-06` 专题 PRD/design/project，把 evidence stack 中的 `L4` 正式拆成 `L4A synthetic` 与 `L4B human`，并同步回写 `playability-evidence-stack`、`playability-simulated-player-persona-panel`、`playability-subagent-review-system`、`testing-manual` 与 `doc/testing/{prd,project,README,prd.index}.md`。
+- 遗留事项: 需继续运行 doc-governance / diff 校验，完成 task closeout、commit 与 PR 收口。

--- a/.pm/tasks/task_a68decb0a2c8460aa7d989df7370c901.yaml
+++ b/.pm/tasks/task_a68decb0a2c8460aa7d989df7370c901.yaml
@@ -1,0 +1,23 @@
+task_uid: task_a68decb0a2c8460aa7d989df7370c901
+title: "split playability L4 into synthetic and human layers"
+owner_role: producer_system_designer
+worktree_hint: /home/scc/worktrees/oasis7-testing-playability-l4-synthetic-human-split-2026-05-06
+execution_log_path: .pm/tasks/task_a68decb0a2c8460aa7d989df7370c901.execution.md
+status: done
+priority: P2
+source_signal: null
+source_refs:
+  - doc/testing/governance/playability-evidence-stack-2026-05-06.prd.md
+  - doc/testing/governance/playability-simulated-player-persona-panel-2026-05-06.prd.md
+doc_refs:
+  - doc/testing/prd.md
+  - doc/testing/project.md
+related_prd:
+  - PRD-TESTING-007
+  - PRD-TESTING-009
+  - PRD-TESTING-010
+acceptance: []
+handoff_to: []
+updated_at: 2026-05-06T19:41:37+08:00
+last_started_at: 2026-05-06T13:37:54+08:00
+last_closed_at: 2026-05-06T19:41:37+08:00

--- a/.pm/tasks/task_a9d3c884a3074ab2b0f3b10dab7bb86e.execution.md
+++ b/.pm/tasks/task_a9d3c884a3074ab2b0f3b10dab7bb86e.execution.md
@@ -1,0 +1,17 @@
+# task_a9d3c884a3074ab2b0f3b10dab7bb86e Execution Log
+
+- task_uid: task_a9d3c884a3074ab2b0f3b10dab7bb86e
+- title: design simulated player personas for playability review
+- owner_role: producer_system_designer
+- worktree_hint: /home/scc/worktrees/oasis7-testing-playability-player-persona-panel-2026-05-06
+
+<!-- Append entries using:
+Example:
+  ## YYYY-MM-DD HH:MM:SS CST / role_name
+  - 完成内容: ...
+  - 遗留事项: ...
+-->
+
+## 2026-05-06 13:26:00 CST / producer_system_designer
+- 完成内容: 新增 `playability-simulated-player-persona-panel-2026-05-06` 专题 PRD/design/project，定义五类 simulated personas、persona review packet / card、与标准角色 subagent 的回流边界，并同步回写 `playability-evidence-stack`、`playability-subagent-review-system`、`doc/testing/{prd,project,README,prd.index}.md`。
+- 遗留事项: 需继续运行 doc-governance / diff 校验，完成 task closeout、commit 与 PR 收口。

--- a/.pm/tasks/task_a9d3c884a3074ab2b0f3b10dab7bb86e.yaml
+++ b/.pm/tasks/task_a9d3c884a3074ab2b0f3b10dab7bb86e.yaml
@@ -1,0 +1,21 @@
+task_uid: task_a9d3c884a3074ab2b0f3b10dab7bb86e
+title: "design simulated player personas for playability review"
+owner_role: producer_system_designer
+worktree_hint: /home/scc/worktrees/oasis7-testing-playability-player-persona-panel-2026-05-06
+execution_log_path: .pm/tasks/task_a9d3c884a3074ab2b0f3b10dab7bb86e.execution.md
+status: done
+priority: P2
+source_signal: null
+source_refs:
+  - doc/testing/prd.md
+  - doc/testing/governance/playability-subagent-review-system-2026-05-06.prd.md
+doc_refs:
+  - doc/testing/project.md
+related_prd:
+  - PRD-TESTING-008
+  - PRD-TESTING-009
+acceptance: []
+handoff_to: []
+updated_at: 2026-05-06T13:21:07+08:00
+last_started_at: 2026-05-06T13:09:44+08:00
+last_closed_at: 2026-05-06T13:21:07+08:00

--- a/.pm/tasks/task_af43b79f8f054117877d5c0d8ce33817.execution.md
+++ b/.pm/tasks/task_af43b79f8f054117877d5c0d8ce33817.execution.md
@@ -1,0 +1,17 @@
+# task_af43b79f8f054117877d5c0d8ce33817 Execution Log
+
+- task_uid: task_af43b79f8f054117877d5c0d8ce33817
+- title: compact PR186 playability project task view
+- owner_role: producer_system_designer
+- worktree_hint: /home/scc/worktrees/oasis7-testing-playability-project-view-bundle-pr186-2026-05-06
+
+<!-- Append entries using:
+Example:
+  ## YYYY-MM-DD HH:MM:SS CST / role_name
+  - 完成内容: ...
+  - 遗留事项: ...
+-->
+
+## 2026-05-06 20:17:58 CST / producer_system_designer
+- 完成内容: 基于 PR `#186` 分支把 `doc/testing/project.md` 顶部 4 条 playability governance 平铺任务折叠为 1 条 bundle 视图，并同步把状态区的 2 条 playability 窗口摘要合并为 1 条聚合摘要，保留四个正式专题与对应 `.pm` trace 不变。
+- 遗留事项: 需要完成文档检查、task closeout，并把该展示层修正回灌到保留的 `#186` 头分支。

--- a/.pm/tasks/task_af43b79f8f054117877d5c0d8ce33817.yaml
+++ b/.pm/tasks/task_af43b79f8f054117877d5c0d8ce33817.yaml
@@ -1,0 +1,23 @@
+task_uid: task_af43b79f8f054117877d5c0d8ce33817
+title: "compact PR186 playability project task view"
+owner_role: producer_system_designer
+worktree_hint: /home/scc/worktrees/oasis7-testing-playability-project-view-bundle-pr186-2026-05-06
+execution_log_path: .pm/tasks/task_af43b79f8f054117877d5c0d8ce33817.execution.md
+status: done
+priority: P2
+source_signal: null
+source_refs:
+  - doc/testing/project.md
+  - doc/testing/prd.md
+doc_refs: []
+related_prd:
+  - PRD-TESTING-007
+  - PRD-TESTING-008
+  - PRD-TESTING-009
+  - PRD-TESTING-010
+acceptance:
+  - "PR186 project page collapses four playability governance rows into one bundle while preserving trace"
+handoff_to: []
+updated_at: 2026-05-06T20:18:52+08:00
+last_started_at: 2026-05-06T20:15:58+08:00
+last_closed_at: 2026-05-06T20:18:52+08:00

--- a/.pm/tasks/task_ecc83f9e16e44916a527314ff522b6cf.execution.md
+++ b/.pm/tasks/task_ecc83f9e16e44916a527314ff522b6cf.execution.md
@@ -18,3 +18,9 @@ Example:
 - 完成内容: 已验证 `bash -n scripts/prepare-playability-l4-review.sh`、`bash -n scripts/run-producer-playtest.sh`、`./scripts/prepare-playability-l4-review.sh --run-id smoke-20260506c --output-dir .tmp/l4-smoke-20260506c --json`、`git diff --check`、`./scripts/doc-governance-check.sh` 全部通过；smoke 产物包含 packet、role cards、persona cards、summary、`L4B` 卡片副本、`commands.sh` 与 `manifest.json`，且 README / `commands.sh` 已显式要求回填 `l4b-playability-test-card.md` 与 `L4B` verdict。
 - 完成内容: 已实际尝试 `./scripts/prepare-playability-l4-review.sh --with-l4a-stack --run-id smoke-with-stack-20260506b --output-dir .tmp/l4-smoke-with-stack-20260506b --json`。结果证明主路径会真实继承 formal gameplay 的 active LLM provider preflight；当前环境因缺少 `OASIS7_LLM_MODEL` / 等价 `config.toml` 在 launcher 启动前 fail-fast，阻断签名为 `error: active LLM provider preflight failed before launcher startup`，因此这轮只能确认“repo-side scaffold 完整 + 环境前置条件真实生效”，不能声称“当前 shell 已跑通完整 formal L4 session”。
 - 遗留事项: 需在提交前完成 subagent review；现有 PR `#186` 本体分支 `task/testing-playability-evidence-stack-2026-05-06` 在另一 worktree 中与远端分叉（origin only 10 / local only 2），回灌到 retained PR head 前需要先确认是否要在该分支上 rebase/cherry-pick，避免覆盖用户既有分支状态。
+
+## 2026-05-07 21:52:46 CST / producer_system_designer
+- 完成内容: 针对 PR `#186` review comments 补齐两类收口修复：一是修正 3 份 playability governance PRD 中的嵌套反引号 / 多余反引号 Markdown 语法；二是为 `GeoPos` 增加 legacy float centimeter 反序列化兼容，仅接受旧快照里 `.0` 形式的整数坐标编码，不再让非整数浮点静默舍入进世界状态。
+- 完成内容: 新增 `GeoPos` 与 `WorldSnapshot` 的正反向回归测试，锁定“旧整数浮点快照可加载、非整数浮点快照必须失败”的边界；在提交前按用户既有要求启动 subagent review，并据 review 结论收紧实现与负例测试。
+- 完成内容: 已验证 `env -u RUSTC_WRAPPER cargo test -p oasis7 float --lib`、`git diff --check`、`./scripts/doc-governance-check.sh` 通过，确认 comment fix 本身不引入新的 loader 宽松接受面或文档治理问题。
+- 遗留事项: 仍需把本次 comment fix commit/push 到 PR head，更新 PR 标题/描述以匹配当前实际 scope，并在 push 后显式 resolve 现有 unresolved threads，再复核 `mergeStateStatus` / `reviewDecision`。

--- a/.pm/tasks/task_ecc83f9e16e44916a527314ff522b6cf.execution.md
+++ b/.pm/tasks/task_ecc83f9e16e44916a527314ff522b6cf.execution.md
@@ -1,0 +1,20 @@
+# task_ecc83f9e16e44916a527314ff522b6cf Execution Log
+
+- task_uid: task_ecc83f9e16e44916a527314ff522b6cf
+- title: make PR186 runnable for complete L4 validation
+- owner_role: producer_system_designer
+- worktree_hint: /home/scc/worktrees/oasis7-testing-playability-l4-execution-closure-pr186-2026-05-06
+
+<!-- Append entries using:
+Example:
+  ## YYYY-MM-DD HH:MM:SS CST / role_name
+  - 完成内容: ...
+  - 遗留事项: ...
+-->
+
+## 2026-05-06 21:58:49 CST / producer_system_designer
+- 完成内容: 新增 `scripts/prepare-playability-l4-review.sh` 与 4 个 `playability-l4-*` 模板，补齐单 worktree 内完整 `L4` scaffold；同步对齐 `testing-manual.md`、`doc/testing/{README,prd.index,prd,project}.md` 与 4 份 playability governance PRD/design，把“repo-local scaffold 已存在，但不替代 L4B 真人验证”的边界写成正式真值。
+- 完成内容: 修复 scaffold 脚本运行缺陷，包括 role/persona/card 循环中的函数外 `local` 用法、bullet 输出中的反引号命令替换噪音，并补上脚本执行位。
+- 完成内容: 已验证 `bash -n scripts/prepare-playability-l4-review.sh`、`bash -n scripts/run-producer-playtest.sh`、`./scripts/prepare-playability-l4-review.sh --run-id smoke-20260506c --output-dir .tmp/l4-smoke-20260506c --json`、`git diff --check`、`./scripts/doc-governance-check.sh` 全部通过；smoke 产物包含 packet、role cards、persona cards、summary、`L4B` 卡片副本、`commands.sh` 与 `manifest.json`，且 README / `commands.sh` 已显式要求回填 `l4b-playability-test-card.md` 与 `L4B` verdict。
+- 完成内容: 已实际尝试 `./scripts/prepare-playability-l4-review.sh --with-l4a-stack --run-id smoke-with-stack-20260506b --output-dir .tmp/l4-smoke-with-stack-20260506b --json`。结果证明主路径会真实继承 formal gameplay 的 active LLM provider preflight；当前环境因缺少 `OASIS7_LLM_MODEL` / 等价 `config.toml` 在 launcher 启动前 fail-fast，阻断签名为 `error: active LLM provider preflight failed before launcher startup`，因此这轮只能确认“repo-side scaffold 完整 + 环境前置条件真实生效”，不能声称“当前 shell 已跑通完整 formal L4 session”。
+- 遗留事项: 需在提交前完成 subagent review；现有 PR `#186` 本体分支 `task/testing-playability-evidence-stack-2026-05-06` 在另一 worktree 中与远端分叉（origin only 10 / local only 2），回灌到 retained PR head 前需要先确认是否要在该分支上 rebase/cherry-pick，避免覆盖用户既有分支状态。

--- a/.pm/tasks/task_ecc83f9e16e44916a527314ff522b6cf.yaml
+++ b/.pm/tasks/task_ecc83f9e16e44916a527314ff522b6cf.yaml
@@ -1,0 +1,26 @@
+task_uid: task_ecc83f9e16e44916a527314ff522b6cf
+title: "make PR186 runnable for complete L4 validation"
+owner_role: producer_system_designer
+worktree_hint: /home/scc/worktrees/oasis7-testing-playability-l4-execution-closure-pr186-2026-05-06
+execution_log_path: .pm/tasks/task_ecc83f9e16e44916a527314ff522b6cf.execution.md
+status: done
+priority: P2
+source_signal: null
+source_refs:
+  - doc/testing/project.md
+  - doc/testing/prd.md
+  - testing-manual.md
+  - doc/playability_test_result/README.md
+doc_refs: []
+related_prd:
+  - PRD-TESTING-007
+  - PRD-TESTING-008
+  - PRD-TESTING-009
+  - PRD-TESTING-010
+acceptance:
+  - "PR186 provides runnable L4A and L4B execution scaffolds, not only policy docs"
+  - "operators can produce a complete L4 artifact set inside one worktree without inventing ad hoc packet/card files"
+handoff_to: []
+updated_at: 2026-05-06T22:27:44+08:00
+last_started_at: 2026-05-06T21:08:40+08:00
+last_closed_at: 2026-05-06T22:27:43+08:00

--- a/.pm/tasks/task_efe1a5f949e84160a1237302c9064168.execution.md
+++ b/.pm/tasks/task_efe1a5f949e84160a1237302c9064168.execution.md
@@ -15,3 +15,7 @@ Example:
 - 完成内容: 新增 `doc/testing/governance/playability-evidence-stack-2026-05-06.{prd,design,project}.md`，把“自动化不能单独保证好玩”正式写成 testing/governance 专题，并定义 L1-L5 证据栈、`go/watch/hold/block` 组合规则，以及 `software_safe` / `pure_api` / `--no-llm` / playability card / limited preview 的现有映射。
 - 完成内容: 同步 `doc/testing/prd.md`、`doc/testing/project.md`、`doc/testing/README.md` 与 `doc/testing/prd.index.md`，让模块根入口能够直接回答“自动化能证明什么、不能证明什么”。
 - 遗留事项: 当前只完成治理口径和文档互链，尚未新增 L3 遥测字段或 L5 受控外部信号的新采集系统；后续如要升级 external claim envelope，需要按专题定义继续补证据，而不是重复堆自动化。
+## 2026-05-06 12:44:20 CST / producer_system_designer
+- 完成内容: 按 follow-up 决策补充“多角色 subagent internal review”治理规则，明确所有内部人工评审环节都可优先由对应标准角色 subagent 补齐，并把 `qa_engineer` / `producer_system_designer` / `viewer_engineer` / `agent_engineer` / `liveops_community` / `runtime_engineer` / `wasm_platform_engineer` 的评审职责映射进专题。
+- 完成内容: 明确 `player` 不是标准正式角色；若需要玩家视角，只能作为内部启发式批评，不能写成正式角色，也不能替代 L5 真实外部玩家验证。
+- 遗留事项: 若后续要把多角色 subagent review 变成默认流水线，还需要单独新增 runbook，固定各角色的输入、输出和汇总模板。

--- a/.pm/tasks/task_efe1a5f949e84160a1237302c9064168.execution.md
+++ b/.pm/tasks/task_efe1a5f949e84160a1237302c9064168.execution.md
@@ -1,0 +1,17 @@
+# task_efe1a5f949e84160a1237302c9064168 Execution Log
+
+- task_uid: task_efe1a5f949e84160a1237302c9064168
+- title: formalize oasis7 playability evidence stack
+- owner_role: producer_system_designer
+- worktree_hint: /home/scc/worktrees/oasis7-testing-playability-evidence-stack-2026-05-06
+
+<!-- Append entries using:
+Example:
+  ## YYYY-MM-DD HH:MM:SS CST / role_name
+  - 完成内容: ...
+  - 遗留事项: ...
+-->
+## 2026-05-06 12:21:55 CST / producer_system_designer
+- 完成内容: 新增 `doc/testing/governance/playability-evidence-stack-2026-05-06.{prd,design,project}.md`，把“自动化不能单独保证好玩”正式写成 testing/governance 专题，并定义 L1-L5 证据栈、`go/watch/hold/block` 组合规则，以及 `software_safe` / `pure_api` / `--no-llm` / playability card / limited preview 的现有映射。
+- 完成内容: 同步 `doc/testing/prd.md`、`doc/testing/project.md`、`doc/testing/README.md` 与 `doc/testing/prd.index.md`，让模块根入口能够直接回答“自动化能证明什么、不能证明什么”。
+- 遗留事项: 当前只完成治理口径和文档互链，尚未新增 L3 遥测字段或 L5 受控外部信号的新采集系统；后续如要升级 external claim envelope，需要按专题定义继续补证据，而不是重复堆自动化。

--- a/.pm/tasks/task_efe1a5f949e84160a1237302c9064168.yaml
+++ b/.pm/tasks/task_efe1a5f949e84160a1237302c9064168.yaml
@@ -1,0 +1,21 @@
+task_uid: task_efe1a5f949e84160a1237302c9064168
+title: "formalize oasis7 playability evidence stack"
+owner_role: producer_system_designer
+worktree_hint: /home/scc/worktrees/oasis7-testing-playability-evidence-stack-2026-05-06
+execution_log_path: .pm/tasks/task_efe1a5f949e84160a1237302c9064168.execution.md
+status: done
+priority: P2
+source_signal: null
+source_refs:
+  - doc/testing/project.md
+  - doc/game/prd.md
+doc_refs: []
+related_prd:
+  - PRD-TESTING-003
+acceptance:
+  - "testing docs define what automation can and cannot prove about gameplay fun"
+  - "oasis7 gets a layered playability evidence stack covering automation, telemetry, and human playtests"
+handoff_to: []
+updated_at: 2026-05-06T12:29:51+08:00
+last_started_at: 2026-05-06T12:20:34+08:00
+last_closed_at: 2026-05-06T12:29:50+08:00

--- a/crates/oasis7/src/bin/oasis7_game_launcher.rs
+++ b/crates/oasis7/src/bin/oasis7_game_launcher.rs
@@ -274,6 +274,11 @@ fn run_launcher(options: &CliOptions) -> Result<(), String> {
         options.viewer_host.as_str(),
         options.viewer_port,
         viewer_static_dir.as_path(),
+        if options.chain_enabled {
+            Some(options.chain_node_id.as_str())
+        } else {
+            None
+        },
     ) {
         Ok(server) => server,
         Err(err) => {
@@ -450,6 +455,7 @@ fn start_static_http_server(
     host: &str,
     port: u16,
     root_dir: &Path,
+    default_viewer_player_id: Option<&str>,
 ) -> Result<StaticHttpServer, String> {
     let listener = TcpListener::bind((host, port))
         .map_err(|err| format!("failed to bind static HTTP server at {host}:{port}: {err}"))?;
@@ -462,6 +468,7 @@ fn start_static_http_server(
     let stop_requested = Arc::new(AtomicBool::new(false));
     let root_dir = Arc::new(root_dir.to_path_buf());
     let live_bind = Arc::new(live_bind.to_string());
+    let default_viewer_player_id = Arc::new(default_viewer_player_id.map(ToOwned::to_owned));
     let hosted_session_issuer = Arc::new(Mutex::new(HostedPlayerSessionIssuer::default()));
     let runtime_presence_join_handle = if deployment_mode == DeploymentMode::HostedPublicJoin {
         let stop_requested = Arc::clone(&stop_requested);
@@ -479,6 +486,7 @@ fn start_static_http_server(
             deployment_mode,
             root_dir,
             live_bind,
+            default_viewer_player_id,
             hosted_session_issuer,
             stop_rx,
         ) {
@@ -500,6 +508,7 @@ fn run_static_http_loop(
     deployment_mode: DeploymentMode,
     root_dir: Arc<PathBuf>,
     live_bind: Arc<String>,
+    default_viewer_player_id: Arc<Option<String>>,
     hosted_session_issuer: Arc<Mutex<HostedPlayerSessionIssuer>>,
     stop_rx: Receiver<()>,
 ) -> Result<(), String> {
@@ -513,6 +522,7 @@ fn run_static_http_loop(
             Ok((stream, _addr)) => {
                 let root_dir = Arc::clone(&root_dir);
                 let live_bind = Arc::clone(&live_bind);
+                let default_viewer_player_id = Arc::clone(&default_viewer_player_id);
                 let deployment_mode = deployment_mode;
                 let hosted_session_issuer = Arc::clone(&hosted_session_issuer);
                 thread::spawn(move || {
@@ -520,6 +530,7 @@ fn run_static_http_loop(
                         stream,
                         root_dir.as_path(),
                         live_bind.as_str(),
+                        default_viewer_player_id.as_deref(),
                         deployment_mode,
                         &hosted_session_issuer,
                     ) {
@@ -537,10 +548,19 @@ fn run_static_http_loop(
     }
 }
 
-fn resolve_viewer_player_id_override(value: Option<String>) -> String {
+fn resolve_viewer_player_id_override(
+    value: Option<String>,
+    fallback_player_id: Option<&str>,
+) -> String {
     value
         .map(|raw| raw.trim().to_string())
         .filter(|value| !value.is_empty())
+        .or_else(|| {
+            fallback_player_id
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .map(ToOwned::to_owned)
+        })
         .unwrap_or_else(|| DEFAULT_VIEWER_PLAYER_ID.to_string())
 }
 

--- a/crates/oasis7/src/bin/oasis7_game_launcher/oasis7_game_launcher_tests.rs
+++ b/crates/oasis7/src/bin/oasis7_game_launcher/oasis7_game_launcher_tests.rs
@@ -886,10 +886,28 @@ fn resolve_viewer_auth_bootstrap_from_path_reads_node_keypair() {
     .expect("write config");
 
     let auth =
-        resolve_viewer_auth_bootstrap_from_path(config_path.as_path()).expect("resolve auth");
+        resolve_viewer_auth_bootstrap_from_path(config_path.as_path(), None).expect("resolve auth");
     assert_eq!(auth.public_key, "public-key-hex");
     assert_eq!(auth.private_key, "private-key-hex");
     assert!(!auth.player_id.trim().is_empty());
+    let _ = fs::remove_dir_all(temp_dir);
+}
+
+#[test]
+fn resolve_viewer_auth_bootstrap_from_path_uses_chain_node_id_fallback() {
+    let temp_dir = make_temp_dir("viewer_auth_bootstrap_chain_player");
+    let config_path = temp_dir.join("config.toml");
+    fs::write(
+        &config_path,
+        "[node]\nprivate_key = \"private-key-hex\"\npublic_key = \"public-key-hex\"\n",
+    )
+    .expect("write config");
+
+    let auth = resolve_viewer_auth_bootstrap_from_path(config_path.as_path(), Some("chain-a"))
+        .expect("resolve auth");
+    assert_eq!(auth.player_id, "chain-a");
+    assert_eq!(auth.public_key, "public-key-hex");
+    assert_eq!(auth.private_key, "private-key-hex");
     let _ = fs::remove_dir_all(temp_dir);
 }
 
@@ -905,8 +923,10 @@ fn hosted_public_join_disables_viewer_auth_bootstrap_resolution() {
 
     let old_cwd = env::current_dir().expect("cwd");
     env::set_current_dir(&temp_dir).expect("chdir");
-    let auth =
-        resolve_viewer_auth_bootstrap_for_embedded_server(super::DeploymentMode::HostedPublicJoin);
+    let auth = resolve_viewer_auth_bootstrap_for_embedded_server(
+        super::DeploymentMode::HostedPublicJoin,
+        Some("chain-a"),
+    );
     env::set_current_dir(old_cwd).expect("restore cwd");
 
     assert!(auth.is_none());

--- a/crates/oasis7/src/bin/oasis7_game_launcher/static_http.rs
+++ b/crates/oasis7/src/bin/oasis7_game_launcher/static_http.rs
@@ -22,6 +22,7 @@ pub(super) fn handle_http_connection(
     mut stream: TcpStream,
     root_dir: &Path,
     live_bind: &str,
+    default_viewer_player_id: Option<&str>,
     deployment_mode: DeploymentMode,
     hosted_session_issuer: &Arc<Mutex<HostedPlayerSessionIssuer>>,
 ) -> Result<(), String> {
@@ -147,8 +148,10 @@ pub(super) fn handle_http_connection(
             let body = fs::read(&path).map_err(|err| {
                 format!("failed to read static asset `{}`: {err}", path.display())
             })?;
-            let viewer_auth_bootstrap =
-                resolve_viewer_auth_bootstrap_for_embedded_server(deployment_mode);
+            let viewer_auth_bootstrap = resolve_viewer_auth_bootstrap_for_embedded_server(
+                deployment_mode,
+                default_viewer_player_id,
+            );
             let body = sanitize_index_html_for_embedded_server(
                 path.as_path(),
                 body.as_slice(),
@@ -489,6 +492,7 @@ fn write_http_response(
 
 pub(super) fn resolve_viewer_auth_bootstrap_from_path(
     path: &Path,
+    default_viewer_player_id: Option<&str>,
 ) -> Result<ViewerAuthBootstrap, String> {
     let content =
         fs::read_to_string(path).map_err(|err| format!("read {} failed: {err}", path.display()))?;
@@ -501,7 +505,10 @@ pub(super) fn resolve_viewer_auth_bootstrap_from_path(
     let private_key =
         resolve_required_toml_string(node, NODE_PRIVATE_KEY_FIELD, "node.private_key")?;
     let public_key = resolve_required_toml_string(node, NODE_PUBLIC_KEY_FIELD, "node.public_key")?;
-    let player_id = resolve_viewer_player_id_override(env::var(VIEWER_PLAYER_ID_ENV).ok());
+    let player_id = resolve_viewer_player_id_override(
+        env::var(VIEWER_PLAYER_ID_ENV).ok(),
+        default_viewer_player_id,
+    );
     Ok(ViewerAuthBootstrap {
         player_id,
         public_key,
@@ -511,10 +518,15 @@ pub(super) fn resolve_viewer_auth_bootstrap_from_path(
 
 pub(super) fn resolve_viewer_auth_bootstrap_for_embedded_server(
     deployment_mode: DeploymentMode,
+    default_viewer_player_id: Option<&str>,
 ) -> Option<ViewerAuthBootstrap> {
     if deployment_mode.disables_browser_signer_bootstrap() {
         None
     } else {
-        resolve_viewer_auth_bootstrap_from_path(Path::new(NODE_CONFIG_FILE_NAME)).ok()
+        resolve_viewer_auth_bootstrap_from_path(
+            Path::new(NODE_CONFIG_FILE_NAME),
+            default_viewer_player_id,
+        )
+        .ok()
     }
 }

--- a/crates/oasis7/src/geometry.rs
+++ b/crates/oasis7/src/geometry.rs
@@ -1,6 +1,7 @@
+use serde::de::{self, Deserializer};
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Serialize)]
 pub struct GeoPos {
     pub x_cm: i64,
     pub y_cm: i64,
@@ -10,6 +11,60 @@ pub struct GeoPos {
 impl GeoPos {
     pub fn new(x_cm: i64, y_cm: i64, z_cm: i64) -> Self {
         Self { x_cm, y_cm, z_cm }
+    }
+}
+
+#[derive(Deserialize)]
+struct GeoPosRepr {
+    x_cm: GeoCoordValue,
+    y_cm: GeoCoordValue,
+    z_cm: GeoCoordValue,
+}
+
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum GeoCoordValue {
+    Integer(i64),
+    Float(f64),
+}
+
+impl GeoCoordValue {
+    fn into_i64<E: de::Error>(self, field: &str) -> Result<i64, E> {
+        match self {
+            Self::Integer(value) => Ok(value),
+            Self::Float(value) => {
+                if !value.is_finite() {
+                    return Err(E::custom(format!(
+                        "GeoPos field `{field}` must be finite, got {value}"
+                    )));
+                }
+                if value < i64::MIN as f64 || value > i64::MAX as f64 {
+                    return Err(E::custom(format!(
+                        "GeoPos field `{field}` is out of i64 range: {value}"
+                    )));
+                }
+                if value.trunc() != value {
+                    return Err(E::custom(format!(
+                        "GeoPos field `{field}` must be an integer centimeter value, got {value}"
+                    )));
+                }
+                Ok(value as i64)
+            }
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for GeoPos {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let repr = GeoPosRepr::deserialize(deserializer)?;
+        Ok(Self {
+            x_cm: repr.x_cm.into_i64("x_cm")?,
+            y_cm: repr.y_cm.into_i64("y_cm")?,
+            z_cm: repr.z_cm.into_i64("z_cm")?,
+        })
     }
 }
 
@@ -44,5 +99,21 @@ mod tests {
         assert_eq!(pos.x_cm, 10);
         assert_eq!(pos.y_cm, -3);
         assert_eq!(pos.z_cm, 4);
+    }
+
+    #[test]
+    fn geo_pos_deserializes_legacy_float_centimeter_coordinates() {
+        let decoded: GeoPos = serde_json::from_str(r#"{"x_cm":10.0,"y_cm":-3.0,"z_cm":4.0}"#)
+            .expect("decode legacy float geopo");
+
+        assert_eq!(decoded, GeoPos::new(10, -3, 4));
+    }
+
+    #[test]
+    fn geo_pos_rejects_non_integral_float_coordinates() {
+        let err = serde_json::from_str::<GeoPos>(r#"{"x_cm":10.5,"y_cm":-3.0,"z_cm":4.0}"#)
+            .expect_err("non-integral coordinates should fail");
+
+        assert!(err.to_string().contains("integer centimeter value"));
     }
 }

--- a/crates/oasis7/src/simulator/tests/persist.rs
+++ b/crates/oasis7/src/simulator/tests/persist.rs
@@ -277,6 +277,79 @@ fn snapshot_version_validation_accepts_legacy_and_defaults_chunk_schema() {
 }
 
 #[test]
+fn snapshot_loads_legacy_float_geo_positions() {
+    let mut kernel = WorldKernel::new();
+    kernel.submit_action(Action::RegisterLocation {
+        location_id: "loc-legacy".to_string(),
+        name: "legacy".to_string(),
+        pos: GeoPos::new(10, 20, 30),
+        profile: LocationProfile::default(),
+    });
+    kernel.step_until_empty();
+
+    let mut value: serde_json::Value =
+        serde_json::from_str(&kernel.snapshot().to_json().expect("snapshot to json"))
+            .expect("parse snapshot json");
+
+    let pos = value
+        .get_mut("model")
+        .and_then(|model| model.get_mut("locations"))
+        .and_then(|locations| locations.get_mut("loc-legacy"))
+        .and_then(|location| location.get_mut("pos"))
+        .and_then(|pos| pos.as_object_mut())
+        .expect("legacy location position");
+    pos.insert("x_cm".to_string(), serde_json::json!(10.0));
+    pos.insert("y_cm".to_string(), serde_json::json!(20.0));
+    pos.insert("z_cm".to_string(), serde_json::json!(30.0));
+
+    let migrated = WorldSnapshot::from_json(
+        &serde_json::to_string(&value).expect("serialize migrated snapshot"),
+    )
+    .expect("load legacy float snapshot");
+
+    let location = migrated
+        .model
+        .locations
+        .get("loc-legacy")
+        .expect("restored legacy location");
+    assert_eq!(location.pos, GeoPos::new(10, 20, 30));
+}
+
+#[test]
+fn snapshot_rejects_non_integral_legacy_float_geo_positions() {
+    let mut kernel = WorldKernel::new();
+    kernel.submit_action(Action::RegisterLocation {
+        location_id: "loc-invalid".to_string(),
+        name: "invalid".to_string(),
+        pos: GeoPos::new(10, 20, 30),
+        profile: LocationProfile::default(),
+    });
+    kernel.step_until_empty();
+
+    let mut value: serde_json::Value =
+        serde_json::from_str(&kernel.snapshot().to_json().expect("snapshot to json"))
+            .expect("parse snapshot json");
+
+    let pos = value
+        .get_mut("model")
+        .and_then(|model| model.get_mut("locations"))
+        .and_then(|locations| locations.get_mut("loc-invalid"))
+        .and_then(|location| location.get_mut("pos"))
+        .and_then(|pos| pos.as_object_mut())
+        .expect("invalid location position");
+    pos.insert("x_cm".to_string(), serde_json::json!(10.5));
+
+    let err = WorldSnapshot::from_json(
+        &serde_json::to_string(&value).expect("serialize migrated snapshot"),
+    )
+    .expect_err("non-integral legacy float snapshot should fail");
+
+    assert!(
+        matches!(err, PersistError::Serde(message) if message.contains("integer centimeter value"))
+    );
+}
+
+#[test]
 fn snapshot_agent_kinematics_defaults_when_legacy_field_is_missing() {
     let mut kernel = WorldKernel::new();
     kernel.submit_action(Action::RegisterLocation {

--- a/doc/testing/README.md
+++ b/doc/testing/README.md
@@ -1,10 +1,11 @@
 # testing 文档索引
 
-审计轮次: 9
+审计轮次: 10
 
 ## 从这里开始
 - 想先理解 testing 模块覆盖哪些测试层级、门禁和证据边界：`doc/testing/prd.md`
 - 想先回答“自动化测试能不能证明游戏好玩、还缺哪层证据”：`doc/testing/governance/playability-evidence-stack-2026-05-06.prd.md`
+- 想先回答“为什么 `L4` 需要拆成 `L4A synthetic` 和 `L4B human`，以及 agent 为什么还不能直接冒充真人试玩”：`doc/testing/governance/playability-l4-synthetic-human-split-2026-05-06.prd.md`
 - 想先回答“这些标准角色 subagent 到底怎么设计、怎么组合成 review 流程”：`doc/testing/governance/playability-subagent-review-system-2026-05-06.prd.md`
 - 想先回答“agent 如何模拟多个不同风格的玩家视角，但又不把 `player` 写成正式角色”：`doc/testing/governance/playability-simulated-player-persona-panel-2026-05-06.prd.md`
 - 想看当前活跃任务、阻断与最新完成项：`doc/testing/project.md`
@@ -43,14 +44,14 @@
 - `ci/`（33）：CI、wasm determinism、tiering 与 gate 保护。
 - `longrun/`（24）：长稳、chaos、soak 与在线稳定性。
 - `launcher/`（18）：启动器链路测试、playtest 与配置自动接线。
-- `governance/`（25）：质量趋势、release-gate 指标、审计检查、好玩性证据栈、subagent 评审系统与 simulated player personas。
+- `governance/`（28）：质量趋势、release-gate 指标、审计检查、好玩性证据栈、L4 synthetic/human 分层、subagent 评审系统与 simulated player personas。
 - `templates/`（12）：证据包、报告与检查清单模板；默认按需进入。
 - `performance/`（12）：runtime / viewer 性能观测与方法学。
 - `manual/`（7）：系统测试手册分册与 Web UI 闭环 manual。
 - `chaos-plans/`（1）：专项 chaos plan 入口。
 
 ## 高密度提示
-- `doc/testing/` 当前共有 187 份文件；这一层入口不再尝试把热点专题直接摊平展示。
+- `doc/testing/` 当前共有 190 份文件；这一层入口不再尝试把热点专题直接摊平展示。
 - 需要完整活跃专题清单时，进入 `doc/testing/prd.index.md`；进入 `evidence/` 时，优先先读 `doc/testing/evidence/README.md` 再继续下钻；需要 template / blocker 留痕时，再按具体子域进入。
 
 ## 共享约定

--- a/doc/testing/README.md
+++ b/doc/testing/README.md
@@ -5,6 +5,7 @@
 ## 从这里开始
 - 想先理解 testing 模块覆盖哪些测试层级、门禁和证据边界：`doc/testing/prd.md`
 - 想先回答“自动化测试能不能证明游戏好玩、还缺哪层证据”：`doc/testing/governance/playability-evidence-stack-2026-05-06.prd.md`
+- 想先回答“这些标准角色 subagent 到底怎么设计、怎么组合成 review 流程”：`doc/testing/governance/playability-subagent-review-system-2026-05-06.prd.md`
 - 想看当前活跃任务、阻断与最新完成项：`doc/testing/project.md`
 - 想先判断要跑哪套测试或查操作步骤：`testing-manual.md`、`doc/testing/manual/web-ui-agent-browser-closure-manual.manual.md`
 - 想先进入 `evidence` 热点子域，并按 release gate / hosted-world / p2p-shared-network / governance drill / claim-audit 问题分流：`doc/testing/evidence/README.md`
@@ -41,7 +42,7 @@
 - `ci/`（33）：CI、wasm determinism、tiering 与 gate 保护。
 - `longrun/`（24）：长稳、chaos、soak 与在线稳定性。
 - `launcher/`（18）：启动器链路测试、playtest 与配置自动接线。
-- `governance/`（19）：质量趋势、release-gate 指标、审计检查与好玩性证据栈。
+- `governance/`（22）：质量趋势、release-gate 指标、审计检查、好玩性证据栈与 subagent 评审系统。
 - `templates/`（12）：证据包、报告与检查清单模板；默认按需进入。
 - `performance/`（12）：runtime / viewer 性能观测与方法学。
 - `manual/`（7）：系统测试手册分册与 Web UI 闭环 manual。

--- a/doc/testing/README.md
+++ b/doc/testing/README.md
@@ -4,6 +4,7 @@
 
 ## 从这里开始
 - 想先理解 testing 模块覆盖哪些测试层级、门禁和证据边界：`doc/testing/prd.md`
+- 想先回答“自动化测试能不能证明游戏好玩、还缺哪层证据”：`doc/testing/governance/playability-evidence-stack-2026-05-06.prd.md`
 - 想看当前活跃任务、阻断与最新完成项：`doc/testing/project.md`
 - 想先判断要跑哪套测试或查操作步骤：`testing-manual.md`、`doc/testing/manual/web-ui-agent-browser-closure-manual.manual.md`
 - 想先进入 `evidence` 热点子域，并按 release gate / hosted-world / p2p-shared-network / governance drill / claim-audit 问题分流：`doc/testing/evidence/README.md`
@@ -40,7 +41,7 @@
 - `ci/`（33）：CI、wasm determinism、tiering 与 gate 保护。
 - `longrun/`（24）：长稳、chaos、soak 与在线稳定性。
 - `launcher/`（18）：启动器链路测试、playtest 与配置自动接线。
-- `governance/`（16）：质量趋势、release-gate 指标与审计检查。
+- `governance/`（19）：质量趋势、release-gate 指标、审计检查与好玩性证据栈。
 - `templates/`（12）：证据包、报告与检查清单模板；默认按需进入。
 - `performance/`（12）：runtime / viewer 性能观测与方法学。
 - `manual/`（7）：系统测试手册分册与 Web UI 闭环 manual。

--- a/doc/testing/README.md
+++ b/doc/testing/README.md
@@ -5,8 +5,8 @@
 ## 从这里开始
 - 想先理解 testing 模块覆盖哪些测试层级、门禁和证据边界：`doc/testing/prd.md`
 - 想先回答“自动化测试能不能证明游戏好玩、还缺哪层证据”：`doc/testing/governance/playability-evidence-stack-2026-05-06.prd.md`
-- 想先回答“为什么 `L4` 需要拆成 `L4A synthetic` 和 `L4B human`，以及 agent 为什么还不能直接冒充真人试玩”：`doc/testing/governance/playability-l4-synthetic-human-split-2026-05-06.prd.md`
-- 想在一个 worktree 里直接准备一轮完整 `L4A + L4B` 验证产物：先读 `testing-manual.md` 的 `L4A/L4B` 章节，再执行 `./scripts/prepare-playability-l4-review.sh`
+- 想先回答“为什么 `L4` 现在只保留 `L4A synthetic`、`L4B embodied-agent` 两个正式内部层，并把内部真人试玩降为 `L4B` 可选佐证”：`doc/testing/governance/playability-l4-synthetic-human-split-2026-05-06.prd.md`
+- 想在一个 worktree 里直接准备一轮完整 `L4A + L4B` 验证产物：先读 `testing-manual.md` 的 `L4A/L4B/L5` 章节，再执行 `./scripts/prepare-playability-l4-review.sh`；正式 `L4B` embodied-agent run 再由 `./scripts/run-playability-l4b-agent.sh --l4-manifest <artifact>/manifest.json` 收口。
 - 想先回答“这些标准角色 subagent 到底怎么设计、怎么组合成 review 流程”：`doc/testing/governance/playability-subagent-review-system-2026-05-06.prd.md`
 - 想先回答“agent 如何模拟多个不同风格的玩家视角，但又不把 `player` 写成正式角色”：`doc/testing/governance/playability-simulated-player-persona-panel-2026-05-06.prd.md`
 - 想看当前活跃任务、阻断与最新完成项：`doc/testing/project.md`

--- a/doc/testing/README.md
+++ b/doc/testing/README.md
@@ -6,6 +6,7 @@
 - 想先理解 testing 模块覆盖哪些测试层级、门禁和证据边界：`doc/testing/prd.md`
 - 想先回答“自动化测试能不能证明游戏好玩、还缺哪层证据”：`doc/testing/governance/playability-evidence-stack-2026-05-06.prd.md`
 - 想先回答“为什么 `L4` 需要拆成 `L4A synthetic` 和 `L4B human`，以及 agent 为什么还不能直接冒充真人试玩”：`doc/testing/governance/playability-l4-synthetic-human-split-2026-05-06.prd.md`
+- 想在一个 worktree 里直接准备一轮完整 `L4A + L4B` 验证产物：先读 `testing-manual.md` 的 `L4A/L4B` 章节，再执行 `./scripts/prepare-playability-l4-review.sh`
 - 想先回答“这些标准角色 subagent 到底怎么设计、怎么组合成 review 流程”：`doc/testing/governance/playability-subagent-review-system-2026-05-06.prd.md`
 - 想先回答“agent 如何模拟多个不同风格的玩家视角，但又不把 `player` 写成正式角色”：`doc/testing/governance/playability-simulated-player-persona-panel-2026-05-06.prd.md`
 - 想看当前活跃任务、阻断与最新完成项：`doc/testing/project.md`
@@ -45,13 +46,13 @@
 - `longrun/`（24）：长稳、chaos、soak 与在线稳定性。
 - `launcher/`（18）：启动器链路测试、playtest 与配置自动接线。
 - `governance/`（28）：质量趋势、release-gate 指标、审计检查、好玩性证据栈、L4 synthetic/human 分层、subagent 评审系统与 simulated player personas。
-- `templates/`（12）：证据包、报告与检查清单模板；默认按需进入。
+- `templates/`（16）：证据包、报告与检查清单模板；默认按需进入。
 - `performance/`（12）：runtime / viewer 性能观测与方法学。
 - `manual/`（7）：系统测试手册分册与 Web UI 闭环 manual。
 - `chaos-plans/`（1）：专项 chaos plan 入口。
 
 ## 高密度提示
-- `doc/testing/` 当前共有 190 份文件；这一层入口不再尝试把热点专题直接摊平展示。
+- `doc/testing/` 当前共有 194 份文件；这一层入口不再尝试把热点专题直接摊平展示。
 - 需要完整活跃专题清单时，进入 `doc/testing/prd.index.md`；进入 `evidence/` 时，优先先读 `doc/testing/evidence/README.md` 再继续下钻；需要 template / blocker 留痕时，再按具体子域进入。
 
 ## 共享约定

--- a/doc/testing/README.md
+++ b/doc/testing/README.md
@@ -1,11 +1,12 @@
 # testing 文档索引
 
-审计轮次: 8
+审计轮次: 9
 
 ## 从这里开始
 - 想先理解 testing 模块覆盖哪些测试层级、门禁和证据边界：`doc/testing/prd.md`
 - 想先回答“自动化测试能不能证明游戏好玩、还缺哪层证据”：`doc/testing/governance/playability-evidence-stack-2026-05-06.prd.md`
 - 想先回答“这些标准角色 subagent 到底怎么设计、怎么组合成 review 流程”：`doc/testing/governance/playability-subagent-review-system-2026-05-06.prd.md`
+- 想先回答“agent 如何模拟多个不同风格的玩家视角，但又不把 `player` 写成正式角色”：`doc/testing/governance/playability-simulated-player-persona-panel-2026-05-06.prd.md`
 - 想看当前活跃任务、阻断与最新完成项：`doc/testing/project.md`
 - 想先判断要跑哪套测试或查操作步骤：`testing-manual.md`、`doc/testing/manual/web-ui-agent-browser-closure-manual.manual.md`
 - 想先进入 `evidence` 热点子域，并按 release gate / hosted-world / p2p-shared-network / governance drill / claim-audit 问题分流：`doc/testing/evidence/README.md`
@@ -37,19 +38,19 @@
 - 汇总 CI、启动器、长稳、性能、人工手册与治理专题。
 - 承接跨模块测试范围定义、证据归档与趋势基线建设。
 
-## 热点子域导航（2026-04-10 快照）
+## 热点子域导航（2026-05-06 快照）
 - `evidence/`（49）：发布证据、趋势基线与审计留痕；当前已补 `evidence/README.md` 作为热点子域入口。
 - `ci/`（33）：CI、wasm determinism、tiering 与 gate 保护。
 - `longrun/`（24）：长稳、chaos、soak 与在线稳定性。
 - `launcher/`（18）：启动器链路测试、playtest 与配置自动接线。
-- `governance/`（22）：质量趋势、release-gate 指标、审计检查、好玩性证据栈与 subagent 评审系统。
+- `governance/`（25）：质量趋势、release-gate 指标、审计检查、好玩性证据栈、subagent 评审系统与 simulated player personas。
 - `templates/`（12）：证据包、报告与检查清单模板；默认按需进入。
 - `performance/`（12）：runtime / viewer 性能观测与方法学。
 - `manual/`（7）：系统测试手册分册与 Web UI 闭环 manual。
 - `chaos-plans/`（1）：专项 chaos plan 入口。
 
 ## 高密度提示
-- `doc/testing/` 当前共有 178 份文件；这一层入口不再尝试把热点专题直接摊平展示。
+- `doc/testing/` 当前共有 187 份文件；这一层入口不再尝试把热点专题直接摊平展示。
 - 需要完整活跃专题清单时，进入 `doc/testing/prd.index.md`；进入 `evidence/` 时，优先先读 `doc/testing/evidence/README.md` 再继续下钻；需要 template / blocker 留痕时，再按具体子域进入。
 
 ## 共享约定

--- a/doc/testing/governance/playability-evidence-stack-2026-05-06.design.md
+++ b/doc/testing/governance/playability-evidence-stack-2026-05-06.design.md
@@ -26,6 +26,7 @@
 - 专题 Project: `doc/testing/governance/playability-evidence-stack-2026-05-06.project.md`
 - 模块根入口: `doc/testing/prd.md`、`doc/testing/project.md`
 - 操作手册入口: `testing-manual.md`
+- repo-local `L4` scaffold 入口: `scripts/prepare-playability-l4-review.sh`
 - 真人试玩 / 玩法结果入口: `doc/playability_test_result/*`
 
 ## 4. 约束与边界

--- a/doc/testing/governance/playability-evidence-stack-2026-05-06.design.md
+++ b/doc/testing/governance/playability-evidence-stack-2026-05-06.design.md
@@ -3,7 +3,7 @@
 - 对应需求文档: `doc/testing/governance/playability-evidence-stack-2026-05-06.prd.md`
 - 对应项目管理文档: `doc/testing/governance/playability-evidence-stack-2026-05-06.project.md`
 
-审计轮次: 1
+审计轮次: 2
 
 ## 1. 设计定位
 把 testing 模块里与“是否好玩”相关的治理口径统一成一个解释层专题，明确证据层级、证明边界、组合规则和现有脚本/文档锚点。
@@ -13,12 +13,13 @@
   - L1 自动化基线
   - L2 Agent/fixture probe
   - L3 遥测与实验
-  - L4 结构化真人试玩
+  - L4A synthetic internal playability review
+  - L4B structured human playtest
   - L5 受控外部信号
 - 组合层:
   - `block / hold / watch / go`
 - 映射层:
-  - 把 `software_safe`、`pure_api`、`--no-llm`、playability card、`run-producer-playtest.sh`、limited preview 等现有入口挂到具体层级。
+  - 把 `software_safe`、`pure_api`、`--no-llm`、subagent/persona outputs、playability card、`run-producer-playtest.sh`、limited preview 等现有入口挂到具体层级。
 
 ## 3. 关键接口 / 入口
 - 专题 PRD: `doc/testing/governance/playability-evidence-stack-2026-05-06.prd.md`
@@ -31,8 +32,10 @@
 - 不新增 SDK、服务端遥测管线或实验平台实现。
 - 不重写现有 trust gate / capability gate 证据，只统一它们在更大证据栈中的位置。
 - 不允许低层证据替代高层证据作出更强 claim。
+- 不允许 `L4A` synthetic 结论直接冒充 `L4B` human 结论。
 
 ## 5. 设计演进计划
 - 先建立专题和根入口互链。
 - 再把正式 evidence packet 的分层结论逐步补齐。
-- 后续若引入真实实验/遥测系统，也只作为 L3 能力扩展，不改变 L4/L5 的必要性。
+- 后续若引入真实实验/遥测系统，也只作为 L3 能力扩展，不改变 `L4B/L5` 的必要性。
+- 若未来建立 synthetic-to-human calibration，再评估是否上调 `L4A` 的决策权重。

--- a/doc/testing/governance/playability-evidence-stack-2026-05-06.design.md
+++ b/doc/testing/governance/playability-evidence-stack-2026-05-06.design.md
@@ -14,7 +14,7 @@
   - L2 Agent/fixture probe
   - L3 遥测与实验
   - L4A synthetic internal playability review
-  - L4B structured human playtest
+  - L4B embodied agent playtest
   - L5 受控外部信号
 - 组合层:
   - `block / hold / watch / go`
@@ -27,16 +27,17 @@
 - 模块根入口: `doc/testing/prd.md`、`doc/testing/project.md`
 - 操作手册入口: `testing-manual.md`
 - repo-local `L4` scaffold 入口: `scripts/prepare-playability-l4-review.sh`
-- 真人试玩 / 玩法结果入口: `doc/playability_test_result/*`
+- agent / 真人试玩 / 玩法结果入口: `doc/playability_test_result/*`
 
 ## 4. 约束与边界
 - 不新增 SDK、服务端遥测管线或实验平台实现。
 - 不重写现有 trust gate / capability gate 证据，只统一它们在更大证据栈中的位置。
 - 不允许低层证据替代高层证据作出更强 claim。
-- 不允许 `L4A` synthetic 结论直接冒充 `L4B` human 结论。
+- 不允许 `L4A` synthetic 结论直接冒充 `L4B` agentic 结论。
+- 不允许把 `L4B` 的可选内部真人校准误写成独立正式层或 `L5` 结论。
 
 ## 5. 设计演进计划
 - 先建立专题和根入口互链。
 - 再把正式 evidence packet 的分层结论逐步补齐。
 - 后续若引入真实实验/遥测系统，也只作为 L3 能力扩展，不改变 `L4B/L5` 的必要性。
-- 若未来建立 synthetic-to-human calibration，再评估是否上调 `L4A` 的决策权重。
+- 若未来建立 calibration，再评估是否上调 `L4A` 或 `L4B` 的决策权重。

--- a/doc/testing/governance/playability-evidence-stack-2026-05-06.design.md
+++ b/doc/testing/governance/playability-evidence-stack-2026-05-06.design.md
@@ -1,0 +1,38 @@
+# oasis7: 好玩性证据栈（2026-05-06）设计
+
+- 对应需求文档: `doc/testing/governance/playability-evidence-stack-2026-05-06.prd.md`
+- 对应项目管理文档: `doc/testing/governance/playability-evidence-stack-2026-05-06.project.md`
+
+审计轮次: 1
+
+## 1. 设计定位
+把 testing 模块里与“是否好玩”相关的治理口径统一成一个解释层专题，明确证据层级、证明边界、组合规则和现有脚本/文档锚点。
+
+## 2. 设计结构
+- 证据层:
+  - L1 自动化基线
+  - L2 Agent/fixture probe
+  - L3 遥测与实验
+  - L4 结构化真人试玩
+  - L5 受控外部信号
+- 组合层:
+  - `block / hold / watch / go`
+- 映射层:
+  - 把 `software_safe`、`pure_api`、`--no-llm`、playability card、`run-producer-playtest.sh`、limited preview 等现有入口挂到具体层级。
+
+## 3. 关键接口 / 入口
+- 专题 PRD: `doc/testing/governance/playability-evidence-stack-2026-05-06.prd.md`
+- 专题 Project: `doc/testing/governance/playability-evidence-stack-2026-05-06.project.md`
+- 模块根入口: `doc/testing/prd.md`、`doc/testing/project.md`
+- 操作手册入口: `testing-manual.md`
+- 真人试玩 / 玩法结果入口: `doc/playability_test_result/*`
+
+## 4. 约束与边界
+- 不新增 SDK、服务端遥测管线或实验平台实现。
+- 不重写现有 trust gate / capability gate 证据，只统一它们在更大证据栈中的位置。
+- 不允许低层证据替代高层证据作出更强 claim。
+
+## 5. 设计演进计划
+- 先建立专题和根入口互链。
+- 再把正式 evidence packet 的分层结论逐步补齐。
+- 后续若引入真实实验/遥测系统，也只作为 L3 能力扩展，不改变 L4/L5 的必要性。

--- a/doc/testing/governance/playability-evidence-stack-2026-05-06.prd.md
+++ b/doc/testing/governance/playability-evidence-stack-2026-05-06.prd.md
@@ -95,6 +95,7 @@
 - Integration Points:
   - `doc/testing/prd.md`
   - `doc/testing/project.md`
+  - `doc/testing/governance/playability-subagent-review-system-2026-05-06.prd.md`
   - `testing-manual.md`
   - `doc/testing/manual/web-ui-agent-browser-closure-manual.manual.md`
   - `doc/testing/evidence/gameplay-ten-minute-trust-gate-2026-04-09.md`

--- a/doc/testing/governance/playability-evidence-stack-2026-05-06.prd.md
+++ b/doc/testing/governance/playability-evidence-stack-2026-05-06.prd.md
@@ -45,7 +45,7 @@
 - Success Criteria:
   - SC-1: 专题文档明确声明“没有单一自动化方案能够保证游戏好玩”。
   - SC-2: 至少定义 `automation baseline / agent probe / telemetry & experiments / L4A synthetic / L4B embodied agent / limited preview live signals`，并为每层列出可证明与不可证明边界。
-  - SC-3: `software_safe`、`pure_api`、`--no-llm observer/debug only`、`run-producer-playtest.sh`、playability card、`player leverage` rubric 和 limited preview 现有治理口径都被映射进同一套证据栈。
+  - SC-3: `software_safe`、`pure_api`、`--no-llm observer/debug only`、`run-producer-playtest.sh`、playability card、`player leverage` rubric，以及 limited preview 现有治理口径都被映射进同一套证据栈。
   - SC-4: 模块根入口 `doc/testing/prd.md` / `project.md` / `README.md` / `prd.index.md` 能把读者导向该专题。
   - SC-5: 专题文档明确声明“所有内部评审环节都可以优先由对应标准角色 subagent 补齐”，同时保留“这不等价于真实外部玩家验证”的硬边界。
   - SC-6: 专题文档明确声明 simulated player personas 与标准角色 subagents 属于 `L4A` 的核心输入，不新增正式角色，也不替代 `L4B` 或 `L5`。

--- a/doc/testing/governance/playability-evidence-stack-2026-05-06.prd.md
+++ b/doc/testing/governance/playability-evidence-stack-2026-05-06.prd.md
@@ -1,0 +1,120 @@
+# oasis7: 好玩性证据栈（2026-05-06）
+
+- 对应设计文档: `doc/testing/governance/playability-evidence-stack-2026-05-06.design.md`
+- 对应项目管理文档: `doc/testing/governance/playability-evidence-stack-2026-05-06.project.md`
+
+审计轮次: 1
+
+## 1. Executive Summary
+- Problem Statement: 自动化测试已经能稳定覆盖回归、协议、性能、长稳和部分玩家路径，但“自动化绿灯”仍不等于“游戏已经好玩”。如果没有一套明确的证据栈把自动化、遥测、A/B 与真人试玩分层，团队很容易把“没坏”“世界在动”“玩家真的想继续玩”混写成同一种结论。
+- Proposed Solution: 建立 `playability evidence stack` 专题，正式定义 oasis7 的五层好玩性证据体系，明确每一层能证明什么、不能证明什么、如何组合成阶段性 go/hold/block 结论，以及当前仓库已有脚本/文档应挂在哪一层。
+- Success Criteria:
+  - SC-1: 专题文档明确声明“没有单一自动化方案能够保证游戏好玩”，且给出 oasis7 的正式替代口径。
+  - SC-2: 至少定义 `automation baseline / agent probe / telemetry & experiments / structured human playtests / limited preview live signals` 五层证据，并为每层列出可证明与不可证明边界。
+  - SC-3: `software_safe`、`pure_api`、`--no-llm observer/debug only`、`run-producer-playtest.sh`、playability card、`player leverage` rubric 和 limited preview 现有治理口径都被映射进同一套证据栈。
+  - SC-4: 模块根入口 `doc/testing/prd.md` / `project.md` / `README.md` / `prd.index.md` 能把读者导向该专题。
+
+## 2. User Experience & Functionality
+- User Personas:
+  - `producer_system_designer`: 需要知道哪些信号只是在证明“没坏”，哪些信号才足以支撑“值得继续玩”。
+  - `qa_engineer`: 需要统一地给出 `pass/watch/block` 结论，而不是让每次 playability 讨论都临时换标准。
+  - `runtime_engineer` / `viewer_engineer` / `agent_engineer`: 需要知道自己补的是“可靠性证据”还是“玩法证据”，避免做了自动化就误以为好玩问题已关闭。
+  - `liveops_community`: 需要知道 limited preview 和真实玩家反馈在整套证据栈里的位置，不把少量外部正反馈误写成全面放行。
+- User Scenarios & Frequency:
+  - 新玩法或关键体验切片收口前：先判断当前证据只到哪一层。
+  - 发布评审或阶段升级前：检查是否已经具备跨层证据组合，而不是只看 required/full。
+  - 玩法争议复盘时：把“自动化已通过但人类觉得无聊”拆成可定位的问题。
+- User Stories:
+  - PRD-TESTING-PLAYABILITY-001: As a `producer_system_designer`, I want a canonical evidence stack for gameplay fun, so that I can make stage decisions without conflating reliability with fun.
+  - PRD-TESTING-PLAYABILITY-002: As a `qa_engineer`, I want each evidence layer to have explicit proof boundaries, so that I can block overclaims early.
+  - PRD-TESTING-PLAYABILITY-003: As an implementation owner, I want existing scripts and reports mapped into that stack, so that I know what evidence gap is still open.
+  - PRD-TESTING-PLAYABILITY-004: As a release reviewer, I want a clear combination rule for go/hold/block, so that no single metric or single playtest overrides the rest of the stack.
+- Critical User Flows:
+  1. `识别体验目标 -> 选择对应玩家 surface -> 先跑自动化基线 -> 判断是否已具备继续收集更高层证据的前置条件`
+  2. `收集 agent probe / telemetry / 真人试玩 / limited preview 信号 -> 填写统一 evidence packet -> 标记每层结论`
+  3. `producer_system_designer` 汇总多层结论 -> 输出 `go/watch/hold/block`，并明确“当前只证明了什么”
+- Functional Specification Matrix:
+| 证据层 | 主要输入 | 可以证明 | 不能证明 | oasis7 当前锚点 | 默认 owner |
+| --- | --- | --- | --- | --- | --- |
+| L1 自动化基线 | `required/full`、协议回归、Web 闭环脚本、长稳 smoke | 没坏、可重复、主链路能走通、阻断签名稳定可复现 | 玩家是否觉得有趣、是否愿意继续玩 | `testing-manual.md`、`scripts/ci-tests.sh`、`viewer-software-safe-step-regression.sh` | `qa_engineer` |
+| L2 Agent/fixture probe | 脚本化 step/chat/progression、场景推进、受控 bot/fixture 探针 | 可达性、卡点、节奏断点、是否存在“玩家动作后世界无响应” | 情绪价值、审美、长期动机 | `player leverage` rubric、`world_activity_only`、`snapshot.player_gameplay` | `qa_engineer` + 实现 owner |
+| L3 遥测与实验 | progression funnel、停留时长、回流率、A/B、行为事件 | 某方案是否比另一方案更好；玩家在哪些环节退出 | 指标提升是否真的等于“更好玩”；样本外原因解释 | 本专题先冻结字段与决策口径，不在本轮实现采集系统 | `qa_engineer` + `producer_system_designer` |
+| L4 结构化真人试玩 | playability 卡片、制作人试玩、QA headed rerun、受控访谈 | 是否看得懂、是否感到有杠杆、是否想继续玩、阻塞点是否可解释 | 大规模外部市场反应 | `run-producer-playtest.sh`、`doc/playability_test_result/card_*.md` | `producer_system_designer` + `qa_engineer` |
+| L5 受控外部信号 | limited preview、liveops 反馈、真实玩家 session | 在真实环境下，当前 claim envelope 是否成立 | 广泛市场成功、长期留存已被证明 | `technical preview` / limited preview 口径、liveops signal 回流 | `liveops_community` + `producer_system_designer` |
+- Layer rules:
+  - L1/L2 是“能否继续验证”的前置层，不得单独给出“已证明好玩”。
+  - L3 可以证明“方案 A 比方案 B 更有效”，但仍不能跳过 L4 的玩家主观验证。
+  - L4 是当前仓库内最接近“是否好玩”的正式内部判断层，但仍属于内部证据，不自动等价于外部市场验证。
+  - L5 只允许在受控 claim envelope 内升级信心，不允许把少量反馈写成“已完成普适验证”。
+- Combination rules:
+  - `block`: 任何一个 formal 玩家 surface 在 L1 就不稳定，或 L2 证明玩家动作没有稳定杠杆。
+  - `hold`: L1/L2 通过，但 L4 仍无法证明“玩家想继续玩”，或 L5 尚未收集到足够受控信号。
+  - `watch`: L1-L4 基本成立，但 L5 样本量小、或 L3 仍显示某些分段掉队风险。
+  - `go`: 只在目标 claim envelope 下，L1-L4 全部通过，且 L5 没有出现新的高价值反证时给出。
+- Current oasis7 policy bindings:
+  - active LLM access 才是正式游玩 lane；`--no-llm` 只允许记为 observer/debug。
+  - `software_safe` 与 `pure_api` 都属于 formal 玩家 surface，必须回答同一组 `snapshot.player_gameplay` 问题。
+  - `world_activity_only=yes` 的样本不得支撑“玩家已有 meaningful participation”。
+  - 即使自动化通过、世界时间推进，只要 L4 仍不能证明玩家拥有稳定杠杆和继续动机，就不能把项目升级成“已证明好玩”。
+- Acceptance Criteria:
+  - AC-1: 专题文档明确写出五层证据栈与组合规则。
+  - AC-2: 至少列出 `software_safe`、`pure_api`、`--no-llm`、`run-producer-playtest.sh`、playability card、`player leverage` rubric、limited preview 这 7 个现有锚点。
+  - AC-3: 明确声明“自动化只能保证没坏/可回归，不能单独保证好玩”。
+  - AC-4: `doc/testing/prd.md` 与 `doc/testing/project.md` 映射该专题，并给出模块级追踪条目。
+  - AC-5: `doc/testing/README.md` 与 `doc/testing/prd.index.md` 把“如何判断自动化是否足以支撑好玩结论”的读者导向该专题。
+- Non-Goals:
+  - 不在本轮实现新的遥测 SDK、实验平台或外部问卷系统。
+  - 不把该专题写成某一个玩法切片的结果报告。
+  - 不宣称当前仓库已经满足 `go`。
+
+## 3. AI System Requirements (If Applicable)
+- Tool Requirements: 不适用。
+- Evaluation Strategy: 不适用。
+
+## 4. Technical Specifications
+- Architecture Overview: 本专题是 testing/governance 层的判断框架，不直接新增测试代码；它把现有自动化、playability 文档、信任门/留存门、制作人试玩和 limited preview 信号统一到一个 evidence stack。
+- Integration Points:
+  - `doc/testing/prd.md`
+  - `doc/testing/project.md`
+  - `testing-manual.md`
+  - `doc/testing/manual/web-ui-agent-browser-closure-manual.manual.md`
+  - `doc/testing/evidence/gameplay-ten-minute-trust-gate-2026-04-09.md`
+  - `doc/playability_test_result/README.md`
+  - `doc/playability_test_result/playability_test_card.md`
+  - `doc/game/prd.md`
+  - `doc/game/gameplay/gameplay-closed-beta-readiness-2026-03-21.prd.md`
+- Edge Cases & Error Handling:
+  - 自动化全绿，但真人试玩仍觉得无聊或缺乏目标：必须记为 L1 pass / L4 hold，不能回退成“待观察的小问题”。
+  - 世界很活跃，但玩家动作没有造成稳定可解释的后果：必须标记 `world_activity_only` 或 `player_leverage=block`。
+  - 某个 A/B 指标更优，但真人试玩反馈更差：优先记为“L3 与 L4 冲突”，要求补充解释，而不是直接按指标放行。
+  - 少量外部正反馈与内部留存门冲突：仍以 formal lane 的门禁与 blocker 为准，外部反馈只作为 L5 旁证。
+- Non-Functional Requirements:
+  - NFR-PES-1: 审查者必须能在 60 秒内看懂每层证据的证明边界。
+  - NFR-PES-2: 所有正式玩法结论都必须能指出“当前到达了哪一层、还缺哪一层”。
+  - NFR-PES-3: 模块根文档与该专题之间的互链必须可达，且通过 `doc-governance-check`。
+- Security & Privacy: 真人试玩与外部信号的记录应继续遵循现有脱敏与最小化采集原则。
+
+## 5. Risks & Roadmap
+- Phased Rollout:
+  - MVP (`PES-1`): 建立五层证据栈、组合规则与 oasis7 当前锚点映射。
+  - v1.1 (`PES-2`): 把正式 evidence packet 字段进一步补齐到 L3/L5，避免只有 narrative 没有层级结论。
+  - v2.0 (`PES-3`): 视需要再引入实验/遥测自动汇总，但仍保持 L4/L5 不被自动化替代。
+- Technical Risks:
+  - 风险-1: 团队可能继续把“自动化全绿”简写成“已经好玩”，导致该专题只写不执行。
+  - 风险-2: 若 L3 迟迟没有统一字段，后续仍会靠零散指标做过度解释。
+  - 风险-3: 若 L4 真人试玩卡片质量不稳，证据栈会在最关键一层失真。
+
+## 6. Validation & Decision Record
+- Test Plan & Traceability:
+| PRD-ID | 对应任务 | 测试层级 | 验证方法 | 回归影响范围 |
+| --- | --- | --- | --- | --- |
+| PRD-TESTING-PLAYABILITY-001 | `playability-evidence-stack-2026-05-06` / `PES-1` | `test_tier_required` | `rg` 检查五层证据、自动化边界与组合规则 | testing/governance 玩法结论口径 |
+| PRD-TESTING-PLAYABILITY-002 | `playability-evidence-stack-2026-05-06` / `PES-1/2` | `test_tier_required` | 抽查 `software_safe` / `pure_api` / `--no-llm` / `player leverage` / limited preview 是否已映射 | formal surface 与门禁边界 |
+| PRD-TESTING-PLAYABILITY-003 | `playability-evidence-stack-2026-05-06` / `PES-1/2` | `test_tier_required` | 检查模块根入口、索引与专题互链 | 文档导航与追溯一致性 |
+| PRD-TESTING-PLAYABILITY-004 | `playability-evidence-stack-2026-05-06` / `PES-2/3` | `test_tier_required` | 抽样检查 project/README/prd.index/current window summary 是否同步 | 模块级治理执行力 |
+- Decision Log:
+| 决策ID | 选定方案 | 备选方案（否决） | 依据 |
+| --- | --- | --- | --- |
+| `DEC-PES-001` | 明确写成“没有单一自动化方案能保证好玩” | 把自动化继续包装成足以证明玩法质量 | 这会持续混淆可靠性结论和玩法结论。 |
+| `DEC-PES-002` | 用五层证据栈表达从内部到外部、从客观到主观的递进关系 | 把所有信号平铺成同权 checklist | 平铺 checklist 容易让低层证据越权替代高层证据。 |
+| `DEC-PES-003` | 保留 L4 真人试玩作为当前仓内最高权重内部判断层 | 试图用 L3 实验或 L2 bot probe 替代人类体验判断 | 当前工具链可以辅助判断，但不能代替“玩家是否觉得值得继续玩”。 |

--- a/doc/testing/governance/playability-evidence-stack-2026-05-06.prd.md
+++ b/doc/testing/governance/playability-evidence-stack-2026-05-06.prd.md
@@ -3,60 +3,92 @@
 - 对应设计文档: `doc/testing/governance/playability-evidence-stack-2026-05-06.design.md`
 - 对应项目管理文档: `doc/testing/governance/playability-evidence-stack-2026-05-06.project.md`
 
-审计轮次: 3
+审计轮次: 4
+
+## 目标
+- 建立 oasis7 的正式好玩性证据栈，明确每层能证明什么、不能证明什么。
+- 把 `L4` 正式收口为 `L4A synthetic`、`L4B embodied agent` 两层，并把内部真人试玩降为 `L4B` 可选校准。
+- 为当前仓库脚本、卡片、subagent 评审和外部信号提供统一映射口径。
+
+## 范围
+- 覆盖自动化、agent probe、遥测/实验、synthetic review、agent 实玩、内部真人校准、limited preview 信号的组合规则。
+- 覆盖 `software_safe`、`pure_api`、`run-producer-playtest.sh`、`prepare-playability-l4-review.sh`、`run-playability-l4b-agent.sh` 等现有仓库入口。
+- 不覆盖新的遥测 SDK、外部招募平台或“自动替代真人”的自治系统实现。
+
+## 接口 / 数据
+- 专题 PRD: `doc/testing/governance/playability-evidence-stack-2026-05-06.prd.md`
+- 专题设计文档: `doc/testing/governance/playability-evidence-stack-2026-05-06.design.md`
+- 专题项目管理文档: `doc/testing/governance/playability-evidence-stack-2026-05-06.project.md`
+- 关联专题:
+  - `doc/testing/governance/playability-subagent-review-system-2026-05-06.prd.md`
+  - `doc/testing/governance/playability-simulated-player-persona-panel-2026-05-06.prd.md`
+  - `doc/testing/governance/playability-l4-synthetic-human-split-2026-05-06.prd.md`
+- operator 入口:
+  - `testing-manual.md`
+  - `scripts/prepare-playability-l4-review.sh`
+  - `scripts/run-producer-playtest.sh`
+  - `scripts/run-playability-l4b-agent.sh`
+
+## 里程碑
+- M1 (2026-05-06): 冻结证据层级、组合规则与当前脚本映射。
+- M2: 继续补齐 evidence packet 字段与更严格的层级回填。
+- M3: 若需要，再引入 calibration ledger 讨论低层到高层的权重升级。
+
+## 风险
+- 团队继续把“自动化全绿”简写成“已经好玩”。
+- 团队继续混用 `L4A/L4B/L5` 的术语，导致 release/stage 结论失真。
+- `L4B` 卡片或其可选内部真人校准质量不稳，导致高层证据失真。
 
 ## 1. Executive Summary
-- Problem Statement: 自动化测试已经能稳定覆盖回归、协议、性能、长稳和部分玩家路径，但“自动化绿灯”仍不等于“游戏已经好玩”。如果没有一套明确的证据栈把自动化、遥测、A/B、synthetic 角色扮演与真人试玩分层，团队很容易把“没坏”“世界在动”“agent 预测会继续玩”“真人真的想继续玩”混写成同一种结论。
-- Proposed Solution: 建立 `playability evidence stack` 专题，正式定义 oasis7 的分层好玩性证据体系，明确每一层能证明什么、不能证明什么、如何组合成阶段性 go/hold/block 结论，以及当前仓库已有脚本/文档应挂在哪一层；其中当前 `L4` 正式拆成 `L4A synthetic internal playability review` 与 `L4B structured human playtest`。
+- Problem Statement: 自动化测试已经能稳定覆盖回归、协议、性能、长稳和部分玩家路径，但“自动化绿灯”仍不等于“游戏已经好玩”。如果没有一套明确的证据栈把自动化、遥测、A/B、synthetic 角色扮演、agent 实际试玩，以及真实人类 / 真实环境验证分层，团队很容易把“没坏”“世界在动”“agent 预测会继续玩”“agent 真玩了一轮”“真人真的想继续玩”混写成同一种结论。
+- Proposed Solution: 建立 `playability evidence stack` 专题，正式定义 oasis7 的分层好玩性证据体系，明确每一层能证明什么、不能证明什么、如何组合成阶段性 `go/watch/hold/block` 结论，以及当前仓库已有脚本/文档应挂在哪一层；其中当前 `L4` 正式收口为 `L4A synthetic internal playability review` 与 `L4B embodied agent playtest`，内部真人试玩只作为 `L4B` 的可选校准证据，`L5` 保留给真实人类 / 受控外部信号。
 - Success Criteria:
-  - SC-1: 专题文档明确声明“没有单一自动化方案能够保证游戏好玩”，且给出 oasis7 的正式替代口径。
-  - SC-2: 至少定义 `automation baseline / agent probe / telemetry & experiments / L4A synthetic internal playability review / L4B structured human playtests / limited preview live signals`，并为每层列出可证明与不可证明边界。
+  - SC-1: 专题文档明确声明“没有单一自动化方案能够保证游戏好玩”。
+  - SC-2: 至少定义 `automation baseline / agent probe / telemetry & experiments / L4A synthetic / L4B embodied agent / limited preview live signals`，并为每层列出可证明与不可证明边界。
   - SC-3: `software_safe`、`pure_api`、`--no-llm observer/debug only`、`run-producer-playtest.sh`、playability card、`player leverage` rubric 和 limited preview 现有治理口径都被映射进同一套证据栈。
   - SC-4: 模块根入口 `doc/testing/prd.md` / `project.md` / `README.md` / `prd.index.md` 能把读者导向该专题。
-  - SC-5: 专题文档明确声明“所有内部人工评审环节都可以优先由对应标准角色 subagent 补齐”，同时保留“这不等价于真实外部玩家验证”的硬边界。
-  - SC-6: 专题文档明确声明 simulated player personas 与标准角色 subagents 属于 `L4A` 的核心输入，不新增正式角色，也不替代 `L4B` 真人试玩。
-  - SC-7: 专题文档明确写出 `L4A != L4B`，并保留未来 calibration 扩展位，但当前不宣称 `L4A` 已可替代 `L4B`。
-  - SC-8: 专题文档明确当前已经提供 repo-local `L4` scaffold 入口 `./scripts/prepare-playability-l4-review.sh`，可以在单个 worktree 内生成 `L4A` packet / role cards / persona cards / `L4B` 卡片副本 / summary，而不是继续依赖临时手写文件。
+  - SC-5: 专题文档明确声明“所有内部评审环节都可以优先由对应标准角色 subagent 补齐”，同时保留“这不等价于真实外部玩家验证”的硬边界。
+  - SC-6: 专题文档明确声明 simulated player personas 与标准角色 subagents 属于 `L4A` 的核心输入，不新增正式角色，也不替代 `L4B` 或 `L5`。
+  - SC-7: 专题文档明确写出 `L4A != L4B != L5`，并保留未来 calibration 扩展位，但当前不宣称低层已可替代高层。
+  - SC-8: 专题文档明确当前已经提供 repo-local `L4` scaffold 入口 `./scripts/prepare-playability-l4-review.sh`，可以在单个 worktree 内生成 `L4A` packet / role cards / persona cards / `L4B` agent 卡副本 / 可选内部真人佐证 notes / summary。
+  - SC-9: 专题文档明确当前已经提供 repo-local `L4B` 执行入口 `./scripts/run-playability-l4b-agent.sh`，可以在同一 artifact 目录内实际执行 embodied-agent run 并落盘状态/截图/summary/card prefill。
 
 ## 2. User Experience & Functionality
 - User Personas:
   - `producer_system_designer`: 需要知道哪些信号只是在证明“没坏”，哪些信号才足以支撑“值得继续玩”。
   - `qa_engineer`: 需要统一地给出 `pass/watch/block` 结论，而不是让每次 playability 讨论都临时换标准。
-  - `runtime_engineer` / `viewer_engineer` / `agent_engineer`: 需要知道自己补的是“可靠性证据”还是“玩法证据”，避免做了自动化就误以为好玩问题已关闭。
+  - `runtime_engineer` / `viewer_engineer` / `agent_engineer`: 需要知道自己补的是“可靠性证据”还是“玩法证据”。
   - `liveops_community`: 需要知道 limited preview 和真实玩家反馈在整套证据栈里的位置，不把少量外部正反馈误写成全面放行。
-- User Scenarios & Frequency:
-  - 新玩法或关键体验切片收口前：先判断当前证据只到哪一层。
-  - 发布评审或阶段升级前：检查是否已经具备跨层证据组合，而不是只看 required/full。
-  - 玩法争议复盘时：把“自动化已通过但人类觉得无聊”拆成可定位的问题。
-  - 需要多人内部评审时：按 `qa_engineer` / `producer_system_designer` / `viewer_engineer` / `agent_engineer` / `liveops_community` 角色分别开 subagent 补齐内部评审意见。
-  - 需要模拟多个玩家风格时：开启 `simulated player persona panel` 产出风格化体验假设，完成 `L4A`。
-  - 需要回答“真人会不会继续玩”时：升级到 `L4B structured human playtest`。
 - User Stories:
   - PRD-TESTING-PLAYABILITY-001: As a `producer_system_designer`, I want a canonical evidence stack for gameplay fun, so that I can make stage decisions without conflating reliability with fun.
   - PRD-TESTING-PLAYABILITY-002: As a `qa_engineer`, I want each evidence layer to have explicit proof boundaries, so that I can block overclaims early.
   - PRD-TESTING-PLAYABILITY-003: As an implementation owner, I want existing scripts and reports mapped into that stack, so that I know what evidence gap is still open.
-  - PRD-TESTING-PLAYABILITY-004: As a release reviewer, I want a clear combination rule for go/hold/block, so that no single metric or single playtest overrides the rest of the stack.
-  - PRD-TESTING-PLAYABILITY-005: As a workflow owner, I want each internal human-review step to be delegatable to the matching standard-role subagent, so that multi-role review can scale without weakening the evidence boundary.
+  - PRD-TESTING-PLAYABILITY-004: As a release reviewer, I want a clear combination rule for `go/watch/hold/block`, so that no single metric or single playtest overrides the rest of the stack.
+  - PRD-TESTING-PLAYABILITY-005: As a workflow owner, I want each internal review step to be delegatable to the matching standard-role subagent, so that multi-role review can scale without weakening the evidence boundary.
   - PRD-TESTING-PLAYABILITY-006: As a gameplay reviewer, I want a reusable simulated player persona panel, so that internal review can test more than one player mindset without inventing new formal roles.
-  - PRD-TESTING-PLAYABILITY-007: As a stage owner, I want `L4A` and `L4B` split explicitly, so that synthetic roleplay and human willingness claims stop being conflated.
+  - PRD-TESTING-PLAYABILITY-007: As a stage owner, I want `L4A/L4B/L5` boundaries written explicitly, so that synthetic roleplay, embodied agent play, and real-human willingness claims stop being conflated.
 - Critical User Flows:
   1. `识别体验目标 -> 选择对应玩家 surface -> 先跑自动化基线 -> 判断是否已具备继续收集更高层证据的前置条件`
-  2. `收集 agent probe / telemetry / synthetic review / 真人试玩 / limited preview 信号 -> 填写统一 evidence packet -> 标记每层结论`
-  3. `producer_system_designer` 汇总多层结论 -> 输出 `go/watch/hold/block`，并明确“当前只证明了什么”
-  4. `识别需要人工内部评审的环节 -> 按标准角色开对应 subagent`
+  2. `收集 agent probe / telemetry / synthetic review / embodied agent playtest / human playtest / limited preview 信号 -> 填写统一 evidence packet -> 标记每层结论`
+  3. `producer_system_designer` 汇总多层结论 -> 输出 `go/watch/hold/block`，并明确“当前只证明了什么”`
+  4. `识别需要内部评审的环节 -> 按标准角色开对应 subagent`
   5. `若需要多风格主观体验假设 -> 开 simulated player persona panel + 标准角色 subagent -> 形成 L4A`
-  6. `若需要真人主观继续游玩证据 -> 执行 `run-producer-playtest.sh` + playability card -> 形成 L4B`
-  7. `若需要一轮完整 L4 -> 先运行 `prepare-playability-l4-review.sh` 生成 packet / cards / summary scaffold，再把 L4A 与 L4B 证据收口到同一 artifact 目录`
-  8. `汇总各角色评审 -> 保留外部真实验证边界`
-- Functional Specification Matrix:
+  6. `若需要 agent 真的进游戏操作一轮 -> 执行 run-playability-l4b-agent.sh（内部调用 run-producer-playtest）+ agent card -> 形成 L4B`
+  7. `若需要内部人类校准 -> 复用同一入口，把结果写成 L4B corroboration / contradiction，而不是新层`
+  8. `若需要真实人类 / 真实环境证据 -> 升级到 L5`
+  9. `若需要一轮完整 L4 -> 先运行 prepare-playability-l4-review.sh 生成 packet / cards / summary scaffold，再把 L4A/L4B 证据收口到同一 artifact 目录`
+
+## 3. Functional Specification Matrix
 | 证据层 | 主要输入 | 可以证明 | 不能证明 | oasis7 当前锚点 | 默认 owner |
 | --- | --- | --- | --- | --- | --- |
 | L1 自动化基线 | `required/full`、协议回归、Web 闭环脚本、长稳 smoke | 没坏、可重复、主链路能走通、阻断签名稳定可复现 | 玩家是否觉得有趣、是否愿意继续玩 | `testing-manual.md`、`scripts/ci-tests.sh`、`viewer-software-safe-step-regression.sh` | `qa_engineer` |
 | L2 Agent/fixture probe | 脚本化 step/chat/progression、场景推进、受控 bot/fixture 探针 | 可达性、卡点、节奏断点、是否存在“玩家动作后世界无响应” | 情绪价值、审美、长期动机 | `player leverage` rubric、`world_activity_only`、`snapshot.player_gameplay` | `qa_engineer` + 实现 owner |
 | L3 遥测与实验 | progression funnel、停留时长、回流率、A/B、行为事件 | 某方案是否比另一方案更好；玩家在哪些环节退出 | 指标提升是否真的等于“更好玩”；样本外原因解释 | 本专题先冻结字段与决策口径，不在本轮实现采集系统 | `qa_engineer` + `producer_system_designer` |
-| L4A synthetic internal playability review | 标准角色 subagent review、simulated persona panel、formal player surface 上的 scripted/UI closure、synthetic continuation prediction | 以当前内部模型看，哪些风格玩家可能想继续玩、会在哪掉线、哪些 claim 只在 synthetic 里成立 | 真人在真实时间/耐心/机会成本下是否真的愿意继续玩 | `prepare-playability-l4-review.sh`、`worktree-harness.sh`、S6 Web UI 闭环、role review cards、persona cards | `producer_system_designer` + `qa_engineer` |
-| L4B structured human playtest | playability 卡片、制作人试玩、QA headed rerun、受控访谈 | 真实人类是否看得懂、是否感到有杠杆、是否想继续玩、阻塞点是否可解释 | 大规模外部市场反应 | `prepare-playability-l4-review.sh`、`run-producer-playtest.sh`、`doc/playability_test_result/card_*.md` | `producer_system_designer` + `qa_engineer` |
+| L4A synthetic internal playability review | 标准角色 subagent review、simulated persona panel、formal player surface 上的 scripted/UI closure、synthetic continuation prediction | 以当前内部模型看，哪些风格玩家可能想继续玩、会在哪掉线、哪些 claim 只在 synthetic 里成立 | agent 是否真的在真实操作链路中继续玩；真人是否真的愿意继续玩 | `prepare-playability-l4-review.sh`、`worktree-harness.sh`、S6 Web UI 闭环、role review cards、persona cards | `producer_system_designer` + `qa_engineer` |
+| L4B embodied agent playtest | agent playtest 卡、agent 实际操作链路、session 证据、可选内部真人校准 notes | agent 是否在真实游玩入口中执行了实际操作，并表现出继续玩的倾向与可解释杠杆判断；内部真人 spot-check 是否 corroborate 该判断 | 真实外部人类在真实时间/耐心/机会成本下是否真的愿意继续玩 | `prepare-playability-l4-review.sh`、`run-playability-l4b-agent.sh`、`run-producer-playtest.sh`、`l4b-agent-playtest-card.md`、`optional-internal-human-corroboration.md` | `producer_system_designer` + `qa_engineer` |
 | L5 受控外部信号 | limited preview、liveops 反馈、真实玩家 session | 在真实环境下，当前 claim envelope 是否成立 | 广泛市场成功、长期留存已被证明 | `technical preview` / limited preview 口径、liveops signal 回流 | `liveops_community` + `producer_system_designer` |
+
+## 4. Governance Rules
 - Internal role-subagent mapping:
   - `qa_engineer` subagent: 负责回归、阻断、`player leverage` / `world_activity_only` 审查。
   - `producer_system_designer` subagent: 负责玩法目标、claim envelope 与“当前证据是否足以声称值得继续玩”。
@@ -67,54 +99,48 @@
 - Simulated player persona panel:
   - `new_player_confused` / `impatient_action_player` / `systems_optimizer` / `narrative_curiosity_player` / `chaos_tester`
   - 作为 `L4A` 的核心输入之一，不是正式组织角色。
-  - persona cards 必须先回流到标准角色 review，不能直接成为 `L4B` 或最终 stage verdict。
-- Subagent governance rules:
-  - 所有内部人工评审环节，默认都可以优先委托给对应标准角色 subagent。
-  - 正式 execution log、handoff 和结论只允许使用 `.agents/roles/*.md` 中已存在的标准角色名，不新增 `player` 这类非标准角色。
-  - 若需要“玩家视角”批评，应进入 `simulated player persona panel`，并继续由标准角色 subagent 收口，不得写成正式独立角色。
-  - subagent + persona panel 可共同构成 `L4A`，但不得冒充 `L4B` 或 L5 真实外部信号。
+  - persona cards 必须先回流到标准角色 review，不能直接成为 `L4B`、`L5` 或最终 stage verdict。
 - Layer rules:
   - L1/L2 是“能否继续验证”的前置层，不得单独给出“已证明好玩”。
-  - L3 可以证明“方案 A 比方案 B 更有效”，但仍不能跳过 `L4A/L4B` 的主观体验判断。
-  - `L4A` 是当前仓库内最强的 synthetic 内部判断层，可以表达“内部高强度模拟预测会继续玩”，但不等价于真人继续游玩意愿。
-  - `L4B` 是当前仓库内最强的人类内部判断层，可以表达“真人实际继续游玩已被观察到”，但仍不自动等价于外部市场验证。
-  - L5 只允许在受控 claim envelope 内升级信心，不允许把少量反馈写成“已完成普适验证”。
-- Combination rules:
-  - `block`: 任何一个 formal 玩家 surface 在 L1 就不稳定，或 L2 证明玩家动作没有稳定杠杆。
-  - `hold`: L1-L3 通过，但 `L4A` 仍无法证明 synthetic continue，或 `L4B` 明确显示真人不想继续玩。
-  - `watch`: `L4A` 基本成立，但 `L4B` 尚未执行、样本薄，或 `L4A/L4B` 对部分节点仍有分歧。
-  - `go`: 只在目标 claim envelope 下，L1-L3 通过、`L4A` 与 `L4B` 都没有高价值反证，且 L5 没有出现新的高价值反证时给出。
+  - L3 可以证明“方案 A 比方案 B 更有效”，但仍不能跳过 `L4A/L4B/L5` 的主观体验判断。
+  - `L4A` 是当前仓库内最强的 synthetic 内部判断层，可以表达“内部高强度模拟预测会继续玩”，但不等价于真实操作链路中的继续行为。
+  - `L4B` 是当前仓库内最强的正式内部判断层，可以表达“agent 实际继续游玩已被观察到”，并应尽量逼近真人评审效果；内部真人试玩如果存在，只能作为 `L4B` 的校准或反证。
 - Current oasis7 policy bindings:
   - active LLM access 才是正式游玩 lane；`--no-llm` 只允许记为 observer/debug。
   - `software_safe` 与 `pure_api` 都属于 formal 玩家 surface，必须回答同一组 `snapshot.player_gameplay` 问题。
   - `world_activity_only=yes` 的样本不得支撑“玩家已有 meaningful participation”。
-  - 即使自动化通过、世界时间推进，只要 `L4A/L4B` 仍不能证明玩家拥有稳定杠杆和继续动机，就不能把项目升级成“已证明好玩”。
-  - 对应标准角色的 subagent 可以补齐所有内部 synthetic 评审环节，形成 `L4A`，但不能被记作真人 `L4B` 或真实外部玩家。
-  - simulated player personas 只能帮助解释“哪类玩家可能掉线 / 困惑 / 无聊”，属于 `L4A`，不能替代 `L4B` 真人试玩卡片或外部会话。
+  - 即使自动化通过、世界时间推进，只要 `L4A/L4B/L5` 仍不能证明玩家拥有稳定杠杆和继续动机，就不能把项目升级成“已证明好玩”。
+  - 对应标准角色的 subagent 可以补齐所有内部 synthetic 评审环节，形成 `L4A`，但不能被记作 `L4B`、`L5` 或真实外部玩家。
+  - simulated player personas 只能帮助解释“哪类玩家可能掉线 / 困惑 / 无聊”，属于 `L4A`，不能替代 `L4B` agent 试玩卡、可选内部真人校准或外部会话。
   - `prepare-playability-l4-review.sh` 只负责把完整 `L4` packet / cards / summary / commands 固定到同一 worktree；生成 scaffold 不等于 `L4A` 或 `L4B` 已完成。
-- Acceptance Criteria:
-  - AC-1: 专题文档明确写出 `L4A/L4B` 在内的证据栈与组合规则。
-  - AC-2: 至少列出 `software_safe`、`pure_api`、`--no-llm`、`run-producer-playtest.sh`、playability card、`player leverage` rubric、limited preview 这 7 个现有锚点。
-  - AC-3: 明确声明“自动化只能保证没坏/可回归，不能单独保证好玩”。
-  - AC-4: `doc/testing/prd.md` 与 `doc/testing/project.md` 映射该专题，并给出模块级追踪条目。
-  - AC-5: `doc/testing/README.md` 与 `doc/testing/prd.index.md` 把“如何判断自动化是否足以支撑好玩结论”的读者导向该专题。
-  - AC-6: 明确写出标准角色 subagent 的适用范围、`player` 非标准角色限制，以及“subagent review != 真实外部玩家验证”的硬边界。
-  - AC-7: 明确 simulated player persona panel 的定位、固定 persona 清单，以及其与 `L4A/L4B/L5` 的边界。
-  - AC-8: 明确 `L4A` 与 `L4B` 的 operator 入口、claim 名称与当前非替代边界。
-  - AC-9: 明确写出 `./scripts/prepare-playability-l4-review.sh` 是当前 repo-local 的完整 `L4` scaffold 入口，只负责产物准备与命令收口，不等于自动完成评审。
-- Non-Goals:
-  - 不在本轮实现新的遥测 SDK、实验平台或外部问卷系统。
-  - 不把该专题写成某一个玩法切片的结果报告。
-  - 不宣称当前仓库已经满足 `go`。
-  - 不宣称当前 `L4A` 已可替代 `L4B`。
-  - 不为内部评审新增 `player` 这类非标准正式角色。
+  - `run-playability-l4b-agent.sh` 负责在上述 scaffold 内执行一轮最小正式 `L4B` embodied-agent run，并把关键观测点回填成稳定 evidence；它减少手工拼装，但仍不自动替代 `L4A` 角色/persona 评审或 `L5` 真实人类验证。
 
-## 3. AI System Requirements (If Applicable)
-- Tool Requirements: 不适用。
-- Evaluation Strategy: 不适用。
+## 5. Combination Rules
+- `block`: 任何一个 formal 玩家 surface 在 L1 就不稳定，或 L2 证明玩家动作没有稳定杠杆。
+- `hold`: L1-L3 通过，但 `L4A` 仍无法证明 synthetic continue，或 `L4B` 明确给出高价值反证。
+- `watch`: `L4A` 基本成立，但 `L4B` 尚未执行、样本薄，或 `L4B` 与可选内部真人校准对部分节点仍有分歧。
+- `go`: 只在目标 claim envelope 下，L1-L3 通过、目标层所需的 `L4A/L4B` 都没有高价值反证，且 L5 没有出现新的高价值反证时给出。
 
-## 4. Technical Specifications
-- Architecture Overview: 本专题是 testing/governance 层的判断框架，不直接新增测试代码；它把现有自动化、playability 文档、信任门/留存门、制作人试玩和 limited preview 信号统一到一个 evidence stack。
+## 6. Acceptance Criteria
+- AC-1: 专题文档明确写出 `L4A/L4B/L5` 在内的证据栈与组合规则。
+- AC-2: 至少列出 `software_safe`、`pure_api`、`--no-llm`、`run-producer-playtest.sh`、playability card、`player leverage` rubric、limited preview 这 7 个现有锚点。
+- AC-3: 明确声明“自动化只能保证没坏/可回归，不能单独保证好玩”。
+- AC-4: `doc/testing/prd.md` 与 `doc/testing/project.md` 映射该专题，并给出模块级追踪条目。
+- AC-5: `doc/testing/README.md` 与 `doc/testing/prd.index.md` 把“如何判断自动化是否足以支撑好玩结论”的读者导向该专题。
+- AC-6: 明确写出标准角色 subagent 的适用范围、`player` 非标准角色限制，以及“subagent review != 真实外部玩家验证”的硬边界。
+- AC-7: 明确 simulated player persona panel 的定位、固定 persona 清单，以及其与 `L4A/L4B/L5` 的边界。
+- AC-8: 明确 `L4A`、`L4B` 与可选内部真人校准的 operator 入口、claim 名称与当前非替代边界。
+- AC-9: 明确写出 `./scripts/prepare-playability-l4-review.sh` 是当前 repo-local 的完整 `L4` scaffold 入口，只负责产物准备与命令收口，不等于自动完成评审。
+- AC-10: 明确写出 `./scripts/run-playability-l4b-agent.sh` 是当前 repo-local 的正式 `L4B` embodied-agent 执行入口，会在同一 artifact 目录内落 `summary/state/screenshot/card prefill`，但不自动替代 `L4A` 评审或 `L5` 真实验证。
+
+## 7. Non-Goals
+- 不在本轮实现新的遥测 SDK、实验平台或外部问卷系统。
+- 不把该专题写成某一个玩法切片的结果报告。
+- 不宣称当前仓库已经满足 `go`。
+- 不宣称当前 `L4A` 已可替代 `L4B`，也不宣称 `L4B` 已可替代 `L5`。
+- 不为内部评审新增 `player` 这类非标准正式角色。
+
+## 8. Technical Specifications
 - Integration Points:
   - `doc/testing/prd.md`
   - `doc/testing/project.md`
@@ -124,55 +150,51 @@
   - `testing-manual.md`
   - `scripts/prepare-playability-l4-review.sh`
   - `doc/testing/manual/web-ui-agent-browser-closure-manual.manual.md`
-  - `doc/testing/evidence/gameplay-ten-minute-trust-gate-2026-04-09.md`
   - `doc/playability_test_result/README.md`
   - `doc/playability_test_result/playability_test_card.md`
-  - `doc/game/prd.md`
-  - `doc/game/gameplay/gameplay-closed-beta-readiness-2026-03-21.prd.md`
 - Edge Cases & Error Handling:
-  - 自动化全绿，但真人试玩仍觉得无聊或缺乏目标：必须记为 `L1 pass / L4A maybe-pass / L4B hold`，不能回退成“待观察的小问题”。
+  - 自动化全绿，但 `L4B` agent 试玩仍觉得无聊或缺乏目标：必须记为“低层 pass / 高层 hold”，不能回退成“待观察的小问题”。
   - 世界很活跃，但玩家动作没有造成稳定可解释的后果：必须标记 `world_activity_only` 或 `player_leverage=block`。
-  - 某个 A/B 指标更优，但真人试玩反馈更差：优先记为“L3 与 L4B 冲突”，要求补充解释，而不是直接按指标放行。
-  - 少量外部正反馈与内部留存门冲突：仍以 formal lane 的门禁与 blocker 为准，外部反馈只作为 L5 旁证。
-  - 多个角色 subagent 都给出正面结论，但还没有真实外部反馈：仍只能停留在内部证据完成，不得上抬成外部验证完成。
-  - 多个 simulated personas 与 role subagents 都给出正面反应，但没有任何真人试玩：仍只能记为 `L4A pass / L4B missing`，不得替代 `L4B`。
+  - 某个 A/B 指标更优，但内部真人校准或 `L5` 反馈更差：优先记为“L3 与高层主观证据冲突”，要求补充解释，而不是直接按指标放行。
+  - 多个 simulated personas 与 role subagents 都给出正面反应，但没有任何 agent 实玩：仍只能记为 `L4A pass / L4B missing`，不得替代 `L4B`。
+  - `L4B` 已正面，但没有任何 `L5` 样本：仍只能记为 `L4B pass / L5 missing`，不得替代 `L5`。
   - 只生成了 `L4` scaffold，但 packet / role cards / persona cards / summary 仍未填写：只能记为“operator 准备完成”，不能记为 `L4A` 或 `L4B` 已完成。
 - Non-Functional Requirements:
   - NFR-PES-1: 审查者必须能在 60 秒内看懂每层证据的证明边界。
   - NFR-PES-2: 所有正式玩法结论都必须能指出“当前到达了哪一层、还缺哪一层”。
   - NFR-PES-3: 模块根文档与该专题之间的互链必须可达，且通过 `doc-governance-check`。
-- Security & Privacy: 真人试玩与外部信号的记录应继续遵循现有脱敏与最小化采集原则。
+- Security & Privacy: agent 试玩、真人试玩与外部信号的记录应继续遵循现有脱敏与最小化采集原则。
 
-## 5. Risks & Roadmap
+## 9. Risks & Roadmap
 - Phased Rollout:
-  - MVP (`PES-1`): 建立五层证据栈、组合规则与 oasis7 当前锚点映射。
+  - MVP (`PES-1`): 建立七层证据栈、组合规则与 oasis7 当前锚点映射。
   - v1.1 (`PES-2`): 把正式 evidence packet 字段进一步补齐到 L3/L5，避免只有 narrative 没有层级结论。
   - v2.0 (`PES-3`): 视需要再引入实验/遥测自动汇总，但仍保持 `L4B/L5` 不被自动化替代。
-  - v2.1 (`PES-4`): 若未来建立 calibration ledger，再讨论是否提升 `L4A` 的决策权重。
+  - v2.1 (`PES-4`): 若未来建立 calibration ledger，再讨论是否提升 `L4A` 或 `L4B` 的决策权重。
 - Technical Risks:
   - 风险-1: 团队可能继续把“自动化全绿”简写成“已经好玩”，导致该专题只写不执行。
   - 风险-2: 若 L3 迟迟没有统一字段，后续仍会靠零散指标做过度解释。
-  - 风险-3: 若 `L4B` 真人试玩卡片质量不稳，证据栈会在最关键一层失真。
-  - 风险-4: 若团队偷换 `L4A` 和 `L4B` 的用词，split 会流于纸面。
+  - 风险-3: 若 `L4B` agent 试玩卡或其可选内部真人校准质量不稳，证据栈会在关键层失真。
+  - 风险-4: 若团队偷换 `L4A`、`L4B` 和 `L5` 的用词，split 会流于纸面。
 
-## 6. Validation & Decision Record
+## 10. Validation & Decision Record
 - Test Plan & Traceability:
 | PRD-ID | 对应任务 | 测试层级 | 验证方法 | 回归影响范围 |
 | --- | --- | --- | --- | --- |
-| PRD-TESTING-PLAYABILITY-001 | `playability-evidence-stack-2026-05-06` / `PES-1` | `test_tier_required` | `rg` 检查五层证据、自动化边界与组合规则 | testing/governance 玩法结论口径 |
+| PRD-TESTING-PLAYABILITY-001 | `playability-evidence-stack-2026-05-06` / `PES-1` | `test_tier_required` | `rg` 检查证据层、自动化边界与组合规则 | testing/governance 玩法结论口径 |
 | PRD-TESTING-PLAYABILITY-002 | `playability-evidence-stack-2026-05-06` / `PES-1/2` | `test_tier_required` | 抽查 `software_safe` / `pure_api` / `--no-llm` / `player leverage` / limited preview 是否已映射 | formal surface 与门禁边界 |
 | PRD-TESTING-PLAYABILITY-003 | `playability-evidence-stack-2026-05-06` / `PES-1/2` | `test_tier_required` | 检查模块根入口、索引与专题互链 | 文档导航与追溯一致性 |
 | PRD-TESTING-PLAYABILITY-004 | `playability-evidence-stack-2026-05-06` / `PES-2/3` | `test_tier_required` | 抽样检查 project/README/prd.index/current window summary 是否同步 | 模块级治理执行力 |
 | PRD-TESTING-PLAYABILITY-005 | `playability-evidence-stack-2026-05-06` / `PES-3/4` | `test_tier_required` | 抽查标准角色 subagent 映射、非标准 `player` 限制与 L5 边界说明 | 多角色内部评审治理边界 |
 | PRD-TESTING-PLAYABILITY-006 | `playability-evidence-stack-2026-05-06` / `PES-4` | `test_tier_required` | 抽查 simulated persona panel 定位、persona 清单与 L4-supporting 边界 | 内部玩家视角治理边界 |
-| PRD-TESTING-PLAYABILITY-007 | `playability-evidence-stack-2026-05-06` / `PES-4/5` | `test_tier_required` | 抽查 `L4A/L4B` 分层、operator 入口与非替代边界 | synthetic/human 证据拆分 |
+| PRD-TESTING-PLAYABILITY-007 | `playability-evidence-stack-2026-05-06` / `PES-4/5` | `test_tier_required` | 抽查 `L4A/L4B/L5` 边界、operator 入口与非替代边界 | synthetic/agent/real-human 证据拆分 |
 - Decision Log:
 | 决策ID | 选定方案 | 备选方案（否决） | 依据 |
 | --- | --- | --- | --- |
 | `DEC-PES-001` | 明确写成“没有单一自动化方案能保证好玩” | 把自动化继续包装成足以证明玩法质量 | 这会持续混淆可靠性结论和玩法结论。 |
-| `DEC-PES-002` | 用五层证据栈表达从内部到外部、从客观到主观的递进关系 | 把所有信号平铺成同权 checklist | 平铺 checklist 容易让低层证据越权替代高层证据。 |
-| `DEC-PES-003` | 保留 L4 真人试玩作为当前仓内最高权重内部判断层 | 试图用 L3 实验或 L2 bot probe 替代人类体验判断 | 当前工具链可以辅助判断，但不能代替“玩家是否觉得值得继续玩”。 |
-| `DEC-PES-004` | 所有内部人工评审默认可委托给对应标准角色 subagent | 为每个“玩家视角”额外创造非标准正式角色 | 当前仓库已有标准角色体系，新增非标准角色会破坏 execution log / handoff / PM 约束。 |
-| `DEC-PES-005` | simulated personas 只作为 L4-supporting 的内部假设面板 | 把 simulated persona panel 升格为独立证据层或正式角色 | 这样会模糊 persona 假设与真人试玩之间的证明强度差异。 |
-| `DEC-PES-006` | 把 `L4` 拆成 `L4A synthetic` 与 `L4B human` | 继续把 synthetic 与 human 共用一个 `L4` 标签 | 不拆层会持续混淆“agent 预测继续玩”和“真人实际继续玩”。 |
+| `DEC-PES-002` | 用多层证据栈表达从内部到外部、从客观到主观的递进关系 | 把所有信号平铺成同权 checklist | 平铺 checklist 容易让低层证据越权替代高层证据。 |
+| `DEC-PES-003` | 保留 `L4B` agent 实操作为最高正式内部判断层，并把内部真人试玩降为其可选校准；真实人类验证留在 `L5` | 试图用 L3 实验、L2 bot probe，或单次内部真人试玩重新发明独立层级 | 当前工具链可以辅助判断，但不能代替“真实玩过之后是否还想继续玩”。 |
+| `DEC-PES-004` | 所有内部评审默认可委托给对应标准角色 subagent | 为每个“玩家视角”额外创造非标准正式角色 | 当前仓库已有标准角色体系，新增非标准角色会破坏 execution log / handoff / PM 约束。 |
+| `DEC-PES-005` | simulated personas 只作为 L4-supporting 的内部假设面板 | 把 simulated persona panel 升格为独立证据层或正式角色 | 这样会模糊 persona 假设与 agent/human 实玩之间的证明强度差异。 |
+| `DEC-PES-006` | 把 `L4` 收口为 `L4A synthetic` 与 `L4B agent`，并把内部真人试玩降为 `L4B` 校准、把真实人类验证留在 `L5` | 继续把 synthetic、agentic、内部真人试玩与真实人类验证共用模糊标签 | 不拆边界会持续混淆“agent 预测继续玩”“agent 实际继续玩”和“真实人类实际继续玩”。 |
 | `DEC-PES-007` | 当前先提供 repo-local `L4` scaffold，把 packet/card/summary 入口固定下来 | 继续依赖每次临时手写文件名和执行顺序 | 没有稳定入口就无法说当前 PR 已能在单个 worktree 内完整执行 `L4`。 |

--- a/doc/testing/governance/playability-evidence-stack-2026-05-06.prd.md
+++ b/doc/testing/governance/playability-evidence-stack-2026-05-06.prd.md
@@ -16,6 +16,7 @@
   - SC-5: 专题文档明确声明“所有内部人工评审环节都可以优先由对应标准角色 subagent 补齐”，同时保留“这不等价于真实外部玩家验证”的硬边界。
   - SC-6: 专题文档明确声明 simulated player personas 与标准角色 subagents 属于 `L4A` 的核心输入，不新增正式角色，也不替代 `L4B` 真人试玩。
   - SC-7: 专题文档明确写出 `L4A != L4B`，并保留未来 calibration 扩展位，但当前不宣称 `L4A` 已可替代 `L4B`。
+  - SC-8: 专题文档明确当前已经提供 repo-local `L4` scaffold 入口 `./scripts/prepare-playability-l4-review.sh`，可以在单个 worktree 内生成 `L4A` packet / role cards / persona cards / `L4B` 卡片副本 / summary，而不是继续依赖临时手写文件。
 
 ## 2. User Experience & Functionality
 - User Personas:
@@ -45,15 +46,16 @@
   4. `识别需要人工内部评审的环节 -> 按标准角色开对应 subagent`
   5. `若需要多风格主观体验假设 -> 开 simulated player persona panel + 标准角色 subagent -> 形成 L4A`
   6. `若需要真人主观继续游玩证据 -> 执行 `run-producer-playtest.sh` + playability card -> 形成 L4B`
-  7. `汇总各角色评审 -> 保留外部真实验证边界`
+  7. `若需要一轮完整 L4 -> 先运行 `prepare-playability-l4-review.sh` 生成 packet / cards / summary scaffold，再把 L4A 与 L4B 证据收口到同一 artifact 目录`
+  8. `汇总各角色评审 -> 保留外部真实验证边界`
 - Functional Specification Matrix:
 | 证据层 | 主要输入 | 可以证明 | 不能证明 | oasis7 当前锚点 | 默认 owner |
 | --- | --- | --- | --- | --- | --- |
 | L1 自动化基线 | `required/full`、协议回归、Web 闭环脚本、长稳 smoke | 没坏、可重复、主链路能走通、阻断签名稳定可复现 | 玩家是否觉得有趣、是否愿意继续玩 | `testing-manual.md`、`scripts/ci-tests.sh`、`viewer-software-safe-step-regression.sh` | `qa_engineer` |
 | L2 Agent/fixture probe | 脚本化 step/chat/progression、场景推进、受控 bot/fixture 探针 | 可达性、卡点、节奏断点、是否存在“玩家动作后世界无响应” | 情绪价值、审美、长期动机 | `player leverage` rubric、`world_activity_only`、`snapshot.player_gameplay` | `qa_engineer` + 实现 owner |
 | L3 遥测与实验 | progression funnel、停留时长、回流率、A/B、行为事件 | 某方案是否比另一方案更好；玩家在哪些环节退出 | 指标提升是否真的等于“更好玩”；样本外原因解释 | 本专题先冻结字段与决策口径，不在本轮实现采集系统 | `qa_engineer` + `producer_system_designer` |
-| L4A synthetic internal playability review | 标准角色 subagent review、simulated persona panel、formal player surface 上的 scripted/UI closure、synthetic continuation prediction | 以当前内部模型看，哪些风格玩家可能想继续玩、会在哪掉线、哪些 claim 只在 synthetic 里成立 | 真人在真实时间/耐心/机会成本下是否真的愿意继续玩 | `worktree-harness.sh`、S6 Web UI 闭环、role review cards、persona cards | `producer_system_designer` + `qa_engineer` |
-| L4B structured human playtest | playability 卡片、制作人试玩、QA headed rerun、受控访谈 | 真实人类是否看得懂、是否感到有杠杆、是否想继续玩、阻塞点是否可解释 | 大规模外部市场反应 | `run-producer-playtest.sh`、`doc/playability_test_result/card_*.md` | `producer_system_designer` + `qa_engineer` |
+| L4A synthetic internal playability review | 标准角色 subagent review、simulated persona panel、formal player surface 上的 scripted/UI closure、synthetic continuation prediction | 以当前内部模型看，哪些风格玩家可能想继续玩、会在哪掉线、哪些 claim 只在 synthetic 里成立 | 真人在真实时间/耐心/机会成本下是否真的愿意继续玩 | `prepare-playability-l4-review.sh`、`worktree-harness.sh`、S6 Web UI 闭环、role review cards、persona cards | `producer_system_designer` + `qa_engineer` |
+| L4B structured human playtest | playability 卡片、制作人试玩、QA headed rerun、受控访谈 | 真实人类是否看得懂、是否感到有杠杆、是否想继续玩、阻塞点是否可解释 | 大规模外部市场反应 | `prepare-playability-l4-review.sh`、`run-producer-playtest.sh`、`doc/playability_test_result/card_*.md` | `producer_system_designer` + `qa_engineer` |
 | L5 受控外部信号 | limited preview、liveops 反馈、真实玩家 session | 在真实环境下，当前 claim envelope 是否成立 | 广泛市场成功、长期留存已被证明 | `technical preview` / limited preview 口径、liveops signal 回流 | `liveops_community` + `producer_system_designer` |
 - Internal role-subagent mapping:
   - `qa_engineer` subagent: 负责回归、阻断、`player leverage` / `world_activity_only` 审查。
@@ -89,6 +91,7 @@
   - 即使自动化通过、世界时间推进，只要 `L4A/L4B` 仍不能证明玩家拥有稳定杠杆和继续动机，就不能把项目升级成“已证明好玩”。
   - 对应标准角色的 subagent 可以补齐所有内部 synthetic 评审环节，形成 `L4A`，但不能被记作真人 `L4B` 或真实外部玩家。
   - simulated player personas 只能帮助解释“哪类玩家可能掉线 / 困惑 / 无聊”，属于 `L4A`，不能替代 `L4B` 真人试玩卡片或外部会话。
+  - `prepare-playability-l4-review.sh` 只负责把完整 `L4` packet / cards / summary / commands 固定到同一 worktree；生成 scaffold 不等于 `L4A` 或 `L4B` 已完成。
 - Acceptance Criteria:
   - AC-1: 专题文档明确写出 `L4A/L4B` 在内的证据栈与组合规则。
   - AC-2: 至少列出 `software_safe`、`pure_api`、`--no-llm`、`run-producer-playtest.sh`、playability card、`player leverage` rubric、limited preview 这 7 个现有锚点。
@@ -98,6 +101,7 @@
   - AC-6: 明确写出标准角色 subagent 的适用范围、`player` 非标准角色限制，以及“subagent review != 真实外部玩家验证”的硬边界。
   - AC-7: 明确 simulated player persona panel 的定位、固定 persona 清单，以及其与 `L4A/L4B/L5` 的边界。
   - AC-8: 明确 `L4A` 与 `L4B` 的 operator 入口、claim 名称与当前非替代边界。
+  - AC-9: 明确写出 `./scripts/prepare-playability-l4-review.sh` 是当前 repo-local 的完整 `L4` scaffold 入口，只负责产物准备与命令收口，不等于自动完成评审。
 - Non-Goals:
   - 不在本轮实现新的遥测 SDK、实验平台或外部问卷系统。
   - 不把该专题写成某一个玩法切片的结果报告。
@@ -118,6 +122,7 @@
   - `doc/testing/governance/playability-simulated-player-persona-panel-2026-05-06.prd.md`
   - `doc/testing/governance/playability-l4-synthetic-human-split-2026-05-06.prd.md`
   - `testing-manual.md`
+  - `scripts/prepare-playability-l4-review.sh`
   - `doc/testing/manual/web-ui-agent-browser-closure-manual.manual.md`
   - `doc/testing/evidence/gameplay-ten-minute-trust-gate-2026-04-09.md`
   - `doc/playability_test_result/README.md`
@@ -131,6 +136,7 @@
   - 少量外部正反馈与内部留存门冲突：仍以 formal lane 的门禁与 blocker 为准，外部反馈只作为 L5 旁证。
   - 多个角色 subagent 都给出正面结论，但还没有真实外部反馈：仍只能停留在内部证据完成，不得上抬成外部验证完成。
   - 多个 simulated personas 与 role subagents 都给出正面反应，但没有任何真人试玩：仍只能记为 `L4A pass / L4B missing`，不得替代 `L4B`。
+  - 只生成了 `L4` scaffold，但 packet / role cards / persona cards / summary 仍未填写：只能记为“operator 准备完成”，不能记为 `L4A` 或 `L4B` 已完成。
 - Non-Functional Requirements:
   - NFR-PES-1: 审查者必须能在 60 秒内看懂每层证据的证明边界。
   - NFR-PES-2: 所有正式玩法结论都必须能指出“当前到达了哪一层、还缺哪一层”。
@@ -169,3 +175,4 @@
 | `DEC-PES-004` | 所有内部人工评审默认可委托给对应标准角色 subagent | 为每个“玩家视角”额外创造非标准正式角色 | 当前仓库已有标准角色体系，新增非标准角色会破坏 execution log / handoff / PM 约束。 |
 | `DEC-PES-005` | simulated personas 只作为 L4-supporting 的内部假设面板 | 把 simulated persona panel 升格为独立证据层或正式角色 | 这样会模糊 persona 假设与真人试玩之间的证明强度差异。 |
 | `DEC-PES-006` | 把 `L4` 拆成 `L4A synthetic` 与 `L4B human` | 继续把 synthetic 与 human 共用一个 `L4` 标签 | 不拆层会持续混淆“agent 预测继续玩”和“真人实际继续玩”。 |
+| `DEC-PES-007` | 当前先提供 repo-local `L4` scaffold，把 packet/card/summary 入口固定下来 | 继续依赖每次临时手写文件名和执行顺序 | 没有稳定入口就无法说当前 PR 已能在单个 worktree 内完整执行 `L4`。 |

--- a/doc/testing/governance/playability-evidence-stack-2026-05-06.prd.md
+++ b/doc/testing/governance/playability-evidence-stack-2026-05-06.prd.md
@@ -13,6 +13,7 @@
   - SC-2: 至少定义 `automation baseline / agent probe / telemetry & experiments / structured human playtests / limited preview live signals` 五层证据，并为每层列出可证明与不可证明边界。
   - SC-3: `software_safe`、`pure_api`、`--no-llm observer/debug only`、`run-producer-playtest.sh`、playability card、`player leverage` rubric 和 limited preview 现有治理口径都被映射进同一套证据栈。
   - SC-4: 模块根入口 `doc/testing/prd.md` / `project.md` / `README.md` / `prd.index.md` 能把读者导向该专题。
+  - SC-5: 专题文档明确声明“所有内部人工评审环节都可以优先由对应标准角色 subagent 补齐”，同时保留“这不等价于真实外部玩家验证”的硬边界。
 
 ## 2. User Experience & Functionality
 - User Personas:
@@ -24,15 +25,18 @@
   - 新玩法或关键体验切片收口前：先判断当前证据只到哪一层。
   - 发布评审或阶段升级前：检查是否已经具备跨层证据组合，而不是只看 required/full。
   - 玩法争议复盘时：把“自动化已通过但人类觉得无聊”拆成可定位的问题。
+  - 需要多人内部评审时：按 `qa_engineer` / `producer_system_designer` / `viewer_engineer` / `agent_engineer` / `liveops_community` 角色分别开 subagent 补齐内部评审意见。
 - User Stories:
   - PRD-TESTING-PLAYABILITY-001: As a `producer_system_designer`, I want a canonical evidence stack for gameplay fun, so that I can make stage decisions without conflating reliability with fun.
   - PRD-TESTING-PLAYABILITY-002: As a `qa_engineer`, I want each evidence layer to have explicit proof boundaries, so that I can block overclaims early.
   - PRD-TESTING-PLAYABILITY-003: As an implementation owner, I want existing scripts and reports mapped into that stack, so that I know what evidence gap is still open.
   - PRD-TESTING-PLAYABILITY-004: As a release reviewer, I want a clear combination rule for go/hold/block, so that no single metric or single playtest overrides the rest of the stack.
+  - PRD-TESTING-PLAYABILITY-005: As a workflow owner, I want each internal human-review step to be delegatable to the matching standard-role subagent, so that multi-role review can scale without weakening the evidence boundary.
 - Critical User Flows:
   1. `识别体验目标 -> 选择对应玩家 surface -> 先跑自动化基线 -> 判断是否已具备继续收集更高层证据的前置条件`
   2. `收集 agent probe / telemetry / 真人试玩 / limited preview 信号 -> 填写统一 evidence packet -> 标记每层结论`
   3. `producer_system_designer` 汇总多层结论 -> 输出 `go/watch/hold/block`，并明确“当前只证明了什么”
+  4. `识别需要人工内部评审的环节 -> 按标准角色开对应 subagent -> 汇总各角色评审 -> 保留外部真实验证边界`
 - Functional Specification Matrix:
 | 证据层 | 主要输入 | 可以证明 | 不能证明 | oasis7 当前锚点 | 默认 owner |
 | --- | --- | --- | --- | --- | --- |
@@ -41,6 +45,18 @@
 | L3 遥测与实验 | progression funnel、停留时长、回流率、A/B、行为事件 | 某方案是否比另一方案更好；玩家在哪些环节退出 | 指标提升是否真的等于“更好玩”；样本外原因解释 | 本专题先冻结字段与决策口径，不在本轮实现采集系统 | `qa_engineer` + `producer_system_designer` |
 | L4 结构化真人试玩 | playability 卡片、制作人试玩、QA headed rerun、受控访谈 | 是否看得懂、是否感到有杠杆、是否想继续玩、阻塞点是否可解释 | 大规模外部市场反应 | `run-producer-playtest.sh`、`doc/playability_test_result/card_*.md` | `producer_system_designer` + `qa_engineer` |
 | L5 受控外部信号 | limited preview、liveops 反馈、真实玩家 session | 在真实环境下，当前 claim envelope 是否成立 | 广泛市场成功、长期留存已被证明 | `technical preview` / limited preview 口径、liveops signal 回流 | `liveops_community` + `producer_system_designer` |
+- Internal role-subagent mapping:
+  - `qa_engineer` subagent: 负责回归、阻断、`player leverage` / `world_activity_only` 审查。
+  - `producer_system_designer` subagent: 负责玩法目标、claim envelope 与“当前证据是否足以声称值得继续玩”。
+  - `viewer_engineer` subagent: 负责交互可读性、首屏信息负担、反馈是否可见。
+  - `agent_engineer` subagent: 负责 agent 行为是否真的支撑玩家体验，而不只是让世界自己运转。
+  - `liveops_community` subagent: 负责 limited preview 口径、外部反馈归档与风险回流。
+  - `runtime_engineer` / `wasm_platform_engineer` subagent: 负责实现约束、determinism、平台限制是否让高层体验结论失真。
+- Subagent governance rules:
+  - 所有内部人工评审环节，默认都可以优先委托给对应标准角色 subagent。
+  - 正式 execution log、handoff 和结论只允许使用 `.agents/roles/*.md` 中已存在的标准角色名，不新增 `player` 这类非标准角色。
+  - 若需要“玩家视角”批评，只能作为 `qa_engineer` 或 `producer_system_designer` 名下的启发式内部视角，不得写成正式独立角色。
+  - subagent 评审可补 L1-L4 的内部证据，不得单独替代 L5 真实外部信号。
 - Layer rules:
   - L1/L2 是“能否继续验证”的前置层，不得单独给出“已证明好玩”。
   - L3 可以证明“方案 A 比方案 B 更有效”，但仍不能跳过 L4 的玩家主观验证。
@@ -56,16 +72,19 @@
   - `software_safe` 与 `pure_api` 都属于 formal 玩家 surface，必须回答同一组 `snapshot.player_gameplay` 问题。
   - `world_activity_only=yes` 的样本不得支撑“玩家已有 meaningful participation”。
   - 即使自动化通过、世界时间推进，只要 L4 仍不能证明玩家拥有稳定杠杆和继续动机，就不能把项目升级成“已证明好玩”。
+  - 对应标准角色的 subagent 可以补齐所有内部人工评审环节，但不能被记作真实外部玩家，也不能单独把项目推进到 L5 `go`。
 - Acceptance Criteria:
   - AC-1: 专题文档明确写出五层证据栈与组合规则。
   - AC-2: 至少列出 `software_safe`、`pure_api`、`--no-llm`、`run-producer-playtest.sh`、playability card、`player leverage` rubric、limited preview 这 7 个现有锚点。
   - AC-3: 明确声明“自动化只能保证没坏/可回归，不能单独保证好玩”。
   - AC-4: `doc/testing/prd.md` 与 `doc/testing/project.md` 映射该专题，并给出模块级追踪条目。
   - AC-5: `doc/testing/README.md` 与 `doc/testing/prd.index.md` 把“如何判断自动化是否足以支撑好玩结论”的读者导向该专题。
+  - AC-6: 明确写出标准角色 subagent 的适用范围、`player` 非标准角色限制，以及“subagent review != 真实外部玩家验证”的硬边界。
 - Non-Goals:
   - 不在本轮实现新的遥测 SDK、实验平台或外部问卷系统。
   - 不把该专题写成某一个玩法切片的结果报告。
   - 不宣称当前仓库已经满足 `go`。
+  - 不为内部评审新增 `player` 这类非标准正式角色。
 
 ## 3. AI System Requirements (If Applicable)
 - Tool Requirements: 不适用。
@@ -88,6 +107,7 @@
   - 世界很活跃，但玩家动作没有造成稳定可解释的后果：必须标记 `world_activity_only` 或 `player_leverage=block`。
   - 某个 A/B 指标更优，但真人试玩反馈更差：优先记为“L3 与 L4 冲突”，要求补充解释，而不是直接按指标放行。
   - 少量外部正反馈与内部留存门冲突：仍以 formal lane 的门禁与 blocker 为准，外部反馈只作为 L5 旁证。
+  - 多个角色 subagent 都给出正面结论，但还没有真实外部反馈：仍只能停留在内部证据完成，不得上抬成外部验证完成。
 - Non-Functional Requirements:
   - NFR-PES-1: 审查者必须能在 60 秒内看懂每层证据的证明边界。
   - NFR-PES-2: 所有正式玩法结论都必须能指出“当前到达了哪一层、还缺哪一层”。
@@ -112,9 +132,11 @@
 | PRD-TESTING-PLAYABILITY-002 | `playability-evidence-stack-2026-05-06` / `PES-1/2` | `test_tier_required` | 抽查 `software_safe` / `pure_api` / `--no-llm` / `player leverage` / limited preview 是否已映射 | formal surface 与门禁边界 |
 | PRD-TESTING-PLAYABILITY-003 | `playability-evidence-stack-2026-05-06` / `PES-1/2` | `test_tier_required` | 检查模块根入口、索引与专题互链 | 文档导航与追溯一致性 |
 | PRD-TESTING-PLAYABILITY-004 | `playability-evidence-stack-2026-05-06` / `PES-2/3` | `test_tier_required` | 抽样检查 project/README/prd.index/current window summary 是否同步 | 模块级治理执行力 |
+| PRD-TESTING-PLAYABILITY-005 | `playability-evidence-stack-2026-05-06` / `PES-3/4` | `test_tier_required` | 抽查标准角色 subagent 映射、非标准 `player` 限制与 L5 边界说明 | 多角色内部评审治理边界 |
 - Decision Log:
 | 决策ID | 选定方案 | 备选方案（否决） | 依据 |
 | --- | --- | --- | --- |
 | `DEC-PES-001` | 明确写成“没有单一自动化方案能保证好玩” | 把自动化继续包装成足以证明玩法质量 | 这会持续混淆可靠性结论和玩法结论。 |
 | `DEC-PES-002` | 用五层证据栈表达从内部到外部、从客观到主观的递进关系 | 把所有信号平铺成同权 checklist | 平铺 checklist 容易让低层证据越权替代高层证据。 |
 | `DEC-PES-003` | 保留 L4 真人试玩作为当前仓内最高权重内部判断层 | 试图用 L3 实验或 L2 bot probe 替代人类体验判断 | 当前工具链可以辅助判断，但不能代替“玩家是否觉得值得继续玩”。 |
+| `DEC-PES-004` | 所有内部人工评审默认可委托给对应标准角色 subagent | 为每个“玩家视角”额外创造非标准正式角色 | 当前仓库已有标准角色体系，新增非标准角色会破坏 execution log / handoff / PM 约束。 |

--- a/doc/testing/governance/playability-evidence-stack-2026-05-06.prd.md
+++ b/doc/testing/governance/playability-evidence-stack-2026-05-06.prd.md
@@ -3,18 +3,19 @@
 - 对应设计文档: `doc/testing/governance/playability-evidence-stack-2026-05-06.design.md`
 - 对应项目管理文档: `doc/testing/governance/playability-evidence-stack-2026-05-06.project.md`
 
-审计轮次: 2
+审计轮次: 3
 
 ## 1. Executive Summary
-- Problem Statement: 自动化测试已经能稳定覆盖回归、协议、性能、长稳和部分玩家路径，但“自动化绿灯”仍不等于“游戏已经好玩”。如果没有一套明确的证据栈把自动化、遥测、A/B 与真人试玩分层，团队很容易把“没坏”“世界在动”“玩家真的想继续玩”混写成同一种结论。
-- Proposed Solution: 建立 `playability evidence stack` 专题，正式定义 oasis7 的五层好玩性证据体系，明确每一层能证明什么、不能证明什么、如何组合成阶段性 go/hold/block 结论，以及当前仓库已有脚本/文档应挂在哪一层。
+- Problem Statement: 自动化测试已经能稳定覆盖回归、协议、性能、长稳和部分玩家路径，但“自动化绿灯”仍不等于“游戏已经好玩”。如果没有一套明确的证据栈把自动化、遥测、A/B、synthetic 角色扮演与真人试玩分层，团队很容易把“没坏”“世界在动”“agent 预测会继续玩”“真人真的想继续玩”混写成同一种结论。
+- Proposed Solution: 建立 `playability evidence stack` 专题，正式定义 oasis7 的分层好玩性证据体系，明确每一层能证明什么、不能证明什么、如何组合成阶段性 go/hold/block 结论，以及当前仓库已有脚本/文档应挂在哪一层；其中当前 `L4` 正式拆成 `L4A synthetic internal playability review` 与 `L4B structured human playtest`。
 - Success Criteria:
   - SC-1: 专题文档明确声明“没有单一自动化方案能够保证游戏好玩”，且给出 oasis7 的正式替代口径。
-  - SC-2: 至少定义 `automation baseline / agent probe / telemetry & experiments / structured human playtests / limited preview live signals` 五层证据，并为每层列出可证明与不可证明边界。
+  - SC-2: 至少定义 `automation baseline / agent probe / telemetry & experiments / L4A synthetic internal playability review / L4B structured human playtests / limited preview live signals`，并为每层列出可证明与不可证明边界。
   - SC-3: `software_safe`、`pure_api`、`--no-llm observer/debug only`、`run-producer-playtest.sh`、playability card、`player leverage` rubric 和 limited preview 现有治理口径都被映射进同一套证据栈。
   - SC-4: 模块根入口 `doc/testing/prd.md` / `project.md` / `README.md` / `prd.index.md` 能把读者导向该专题。
   - SC-5: 专题文档明确声明“所有内部人工评审环节都可以优先由对应标准角色 subagent 补齐”，同时保留“这不等价于真实外部玩家验证”的硬边界。
-  - SC-6: 专题文档明确声明 simulated player personas 只属于 L4-supporting 的内部假设层，不新增正式角色，也不替代真人试玩。
+  - SC-6: 专题文档明确声明 simulated player personas 与标准角色 subagents 属于 `L4A` 的核心输入，不新增正式角色，也不替代 `L4B` 真人试玩。
+  - SC-7: 专题文档明确写出 `L4A != L4B`，并保留未来 calibration 扩展位，但当前不宣称 `L4A` 已可替代 `L4B`。
 
 ## 2. User Experience & Functionality
 - User Personas:
@@ -27,7 +28,8 @@
   - 发布评审或阶段升级前：检查是否已经具备跨层证据组合，而不是只看 required/full。
   - 玩法争议复盘时：把“自动化已通过但人类觉得无聊”拆成可定位的问题。
   - 需要多人内部评审时：按 `qa_engineer` / `producer_system_designer` / `viewer_engineer` / `agent_engineer` / `liveops_community` 角色分别开 subagent 补齐内部评审意见。
-  - 需要模拟多个玩家风格时：开启 `simulated player persona panel` 产出风格化体验假设，再回流标准角色收口。
+  - 需要模拟多个玩家风格时：开启 `simulated player persona panel` 产出风格化体验假设，完成 `L4A`。
+  - 需要回答“真人会不会继续玩”时：升级到 `L4B structured human playtest`。
 - User Stories:
   - PRD-TESTING-PLAYABILITY-001: As a `producer_system_designer`, I want a canonical evidence stack for gameplay fun, so that I can make stage decisions without conflating reliability with fun.
   - PRD-TESTING-PLAYABILITY-002: As a `qa_engineer`, I want each evidence layer to have explicit proof boundaries, so that I can block overclaims early.
@@ -35,20 +37,23 @@
   - PRD-TESTING-PLAYABILITY-004: As a release reviewer, I want a clear combination rule for go/hold/block, so that no single metric or single playtest overrides the rest of the stack.
   - PRD-TESTING-PLAYABILITY-005: As a workflow owner, I want each internal human-review step to be delegatable to the matching standard-role subagent, so that multi-role review can scale without weakening the evidence boundary.
   - PRD-TESTING-PLAYABILITY-006: As a gameplay reviewer, I want a reusable simulated player persona panel, so that internal review can test more than one player mindset without inventing new formal roles.
+  - PRD-TESTING-PLAYABILITY-007: As a stage owner, I want `L4A` and `L4B` split explicitly, so that synthetic roleplay and human willingness claims stop being conflated.
 - Critical User Flows:
   1. `识别体验目标 -> 选择对应玩家 surface -> 先跑自动化基线 -> 判断是否已具备继续收集更高层证据的前置条件`
-  2. `收集 agent probe / telemetry / 真人试玩 / limited preview 信号 -> 填写统一 evidence packet -> 标记每层结论`
+  2. `收集 agent probe / telemetry / synthetic review / 真人试玩 / limited preview 信号 -> 填写统一 evidence packet -> 标记每层结论`
   3. `producer_system_designer` 汇总多层结论 -> 输出 `go/watch/hold/block`，并明确“当前只证明了什么”
   4. `识别需要人工内部评审的环节 -> 按标准角色开对应 subagent`
-  5. `若需要多风格主观体验假设 -> 开 simulated player persona panel -> persona cards 回流标准角色`
-  6. `汇总各角色评审 -> 保留外部真实验证边界`
+  5. `若需要多风格主观体验假设 -> 开 simulated player persona panel + 标准角色 subagent -> 形成 L4A`
+  6. `若需要真人主观继续游玩证据 -> 执行 `run-producer-playtest.sh` + playability card -> 形成 L4B`
+  7. `汇总各角色评审 -> 保留外部真实验证边界`
 - Functional Specification Matrix:
 | 证据层 | 主要输入 | 可以证明 | 不能证明 | oasis7 当前锚点 | 默认 owner |
 | --- | --- | --- | --- | --- | --- |
 | L1 自动化基线 | `required/full`、协议回归、Web 闭环脚本、长稳 smoke | 没坏、可重复、主链路能走通、阻断签名稳定可复现 | 玩家是否觉得有趣、是否愿意继续玩 | `testing-manual.md`、`scripts/ci-tests.sh`、`viewer-software-safe-step-regression.sh` | `qa_engineer` |
 | L2 Agent/fixture probe | 脚本化 step/chat/progression、场景推进、受控 bot/fixture 探针 | 可达性、卡点、节奏断点、是否存在“玩家动作后世界无响应” | 情绪价值、审美、长期动机 | `player leverage` rubric、`world_activity_only`、`snapshot.player_gameplay` | `qa_engineer` + 实现 owner |
 | L3 遥测与实验 | progression funnel、停留时长、回流率、A/B、行为事件 | 某方案是否比另一方案更好；玩家在哪些环节退出 | 指标提升是否真的等于“更好玩”；样本外原因解释 | 本专题先冻结字段与决策口径，不在本轮实现采集系统 | `qa_engineer` + `producer_system_designer` |
-| L4 结构化真人试玩 | playability 卡片、制作人试玩、QA headed rerun、受控访谈 | 是否看得懂、是否感到有杠杆、是否想继续玩、阻塞点是否可解释 | 大规模外部市场反应 | `run-producer-playtest.sh`、`doc/playability_test_result/card_*.md` | `producer_system_designer` + `qa_engineer` |
+| L4A synthetic internal playability review | 标准角色 subagent review、simulated persona panel、formal player surface 上的 scripted/UI closure、synthetic continuation prediction | 以当前内部模型看，哪些风格玩家可能想继续玩、会在哪掉线、哪些 claim 只在 synthetic 里成立 | 真人在真实时间/耐心/机会成本下是否真的愿意继续玩 | `worktree-harness.sh`、S6 Web UI 闭环、role review cards、persona cards | `producer_system_designer` + `qa_engineer` |
+| L4B structured human playtest | playability 卡片、制作人试玩、QA headed rerun、受控访谈 | 真实人类是否看得懂、是否感到有杠杆、是否想继续玩、阻塞点是否可解释 | 大规模外部市场反应 | `run-producer-playtest.sh`、`doc/playability_test_result/card_*.md` | `producer_system_designer` + `qa_engineer` |
 | L5 受控外部信号 | limited preview、liveops 反馈、真实玩家 session | 在真实环境下，当前 claim envelope 是否成立 | 广泛市场成功、长期留存已被证明 | `technical preview` / limited preview 口径、liveops signal 回流 | `liveops_community` + `producer_system_designer` |
 - Internal role-subagent mapping:
   - `qa_engineer` subagent: 负责回归、阻断、`player leverage` / `world_activity_only` 审查。
@@ -59,42 +64,45 @@
   - `runtime_engineer` / `wasm_platform_engineer` subagent: 负责实现约束、determinism、平台限制是否让高层体验结论失真。
 - Simulated player persona panel:
   - `new_player_confused` / `impatient_action_player` / `systems_optimizer` / `narrative_curiosity_player` / `chaos_tester`
-  - 只用于补充 L4-supporting 的内部体验假设，不是新的证据层，也不是正式组织角色。
-  - persona cards 必须先回流到标准角色 review，不能直接成为最终 stage verdict。
+  - 作为 `L4A` 的核心输入之一，不是正式组织角色。
+  - persona cards 必须先回流到标准角色 review，不能直接成为 `L4B` 或最终 stage verdict。
 - Subagent governance rules:
   - 所有内部人工评审环节，默认都可以优先委托给对应标准角色 subagent。
   - 正式 execution log、handoff 和结论只允许使用 `.agents/roles/*.md` 中已存在的标准角色名，不新增 `player` 这类非标准角色。
   - 若需要“玩家视角”批评，应进入 `simulated player persona panel`，并继续由标准角色 subagent 收口，不得写成正式独立角色。
-  - subagent 评审可补 L1-L4 的内部证据，不得单独替代 L5 真实外部信号。
+  - subagent + persona panel 可共同构成 `L4A`，但不得冒充 `L4B` 或 L5 真实外部信号。
 - Layer rules:
   - L1/L2 是“能否继续验证”的前置层，不得单独给出“已证明好玩”。
-  - L3 可以证明“方案 A 比方案 B 更有效”，但仍不能跳过 L4 的玩家主观验证。
-  - L4 是当前仓库内最接近“是否好玩”的正式内部判断层，但仍属于内部证据，不自动等价于外部市场验证。
+  - L3 可以证明“方案 A 比方案 B 更有效”，但仍不能跳过 `L4A/L4B` 的主观体验判断。
+  - `L4A` 是当前仓库内最强的 synthetic 内部判断层，可以表达“内部高强度模拟预测会继续玩”，但不等价于真人继续游玩意愿。
+  - `L4B` 是当前仓库内最强的人类内部判断层，可以表达“真人实际继续游玩已被观察到”，但仍不自动等价于外部市场验证。
   - L5 只允许在受控 claim envelope 内升级信心，不允许把少量反馈写成“已完成普适验证”。
 - Combination rules:
   - `block`: 任何一个 formal 玩家 surface 在 L1 就不稳定，或 L2 证明玩家动作没有稳定杠杆。
-  - `hold`: L1/L2 通过，但 L4 仍无法证明“玩家想继续玩”，或 L5 尚未收集到足够受控信号。
-  - `watch`: L1-L4 基本成立，但 L5 样本量小、或 L3 仍显示某些分段掉队风险。
-  - `go`: 只在目标 claim envelope 下，L1-L4 全部通过，且 L5 没有出现新的高价值反证时给出。
+  - `hold`: L1-L3 通过，但 `L4A` 仍无法证明 synthetic continue，或 `L4B` 明确显示真人不想继续玩。
+  - `watch`: `L4A` 基本成立，但 `L4B` 尚未执行、样本薄，或 `L4A/L4B` 对部分节点仍有分歧。
+  - `go`: 只在目标 claim envelope 下，L1-L3 通过、`L4A` 与 `L4B` 都没有高价值反证，且 L5 没有出现新的高价值反证时给出。
 - Current oasis7 policy bindings:
   - active LLM access 才是正式游玩 lane；`--no-llm` 只允许记为 observer/debug。
   - `software_safe` 与 `pure_api` 都属于 formal 玩家 surface，必须回答同一组 `snapshot.player_gameplay` 问题。
   - `world_activity_only=yes` 的样本不得支撑“玩家已有 meaningful participation”。
-  - 即使自动化通过、世界时间推进，只要 L4 仍不能证明玩家拥有稳定杠杆和继续动机，就不能把项目升级成“已证明好玩”。
-  - 对应标准角色的 subagent 可以补齐所有内部人工评审环节，但不能被记作真实外部玩家，也不能单独把项目推进到 L5 `go`。
-  - simulated player personas 只能帮助解释“哪类玩家可能掉线 / 困惑 / 无聊”，不能替代真人试玩卡片或外部会话。
+  - 即使自动化通过、世界时间推进，只要 `L4A/L4B` 仍不能证明玩家拥有稳定杠杆和继续动机，就不能把项目升级成“已证明好玩”。
+  - 对应标准角色的 subagent 可以补齐所有内部 synthetic 评审环节，形成 `L4A`，但不能被记作真人 `L4B` 或真实外部玩家。
+  - simulated player personas 只能帮助解释“哪类玩家可能掉线 / 困惑 / 无聊”，属于 `L4A`，不能替代 `L4B` 真人试玩卡片或外部会话。
 - Acceptance Criteria:
-  - AC-1: 专题文档明确写出五层证据栈与组合规则。
+  - AC-1: 专题文档明确写出 `L4A/L4B` 在内的证据栈与组合规则。
   - AC-2: 至少列出 `software_safe`、`pure_api`、`--no-llm`、`run-producer-playtest.sh`、playability card、`player leverage` rubric、limited preview 这 7 个现有锚点。
   - AC-3: 明确声明“自动化只能保证没坏/可回归，不能单独保证好玩”。
   - AC-4: `doc/testing/prd.md` 与 `doc/testing/project.md` 映射该专题，并给出模块级追踪条目。
   - AC-5: `doc/testing/README.md` 与 `doc/testing/prd.index.md` 把“如何判断自动化是否足以支撑好玩结论”的读者导向该专题。
   - AC-6: 明确写出标准角色 subagent 的适用范围、`player` 非标准角色限制，以及“subagent review != 真实外部玩家验证”的硬边界。
-  - AC-7: 明确 simulated player persona panel 的定位、固定 persona 清单，以及其与 L4/L5 的边界。
+  - AC-7: 明确 simulated player persona panel 的定位、固定 persona 清单，以及其与 `L4A/L4B/L5` 的边界。
+  - AC-8: 明确 `L4A` 与 `L4B` 的 operator 入口、claim 名称与当前非替代边界。
 - Non-Goals:
   - 不在本轮实现新的遥测 SDK、实验平台或外部问卷系统。
   - 不把该专题写成某一个玩法切片的结果报告。
   - 不宣称当前仓库已经满足 `go`。
+  - 不宣称当前 `L4A` 已可替代 `L4B`。
   - 不为内部评审新增 `player` 这类非标准正式角色。
 
 ## 3. AI System Requirements (If Applicable)
@@ -108,6 +116,7 @@
   - `doc/testing/project.md`
   - `doc/testing/governance/playability-subagent-review-system-2026-05-06.prd.md`
   - `doc/testing/governance/playability-simulated-player-persona-panel-2026-05-06.prd.md`
+  - `doc/testing/governance/playability-l4-synthetic-human-split-2026-05-06.prd.md`
   - `testing-manual.md`
   - `doc/testing/manual/web-ui-agent-browser-closure-manual.manual.md`
   - `doc/testing/evidence/gameplay-ten-minute-trust-gate-2026-04-09.md`
@@ -116,12 +125,12 @@
   - `doc/game/prd.md`
   - `doc/game/gameplay/gameplay-closed-beta-readiness-2026-03-21.prd.md`
 - Edge Cases & Error Handling:
-  - 自动化全绿，但真人试玩仍觉得无聊或缺乏目标：必须记为 L1 pass / L4 hold，不能回退成“待观察的小问题”。
+  - 自动化全绿，但真人试玩仍觉得无聊或缺乏目标：必须记为 `L1 pass / L4A maybe-pass / L4B hold`，不能回退成“待观察的小问题”。
   - 世界很活跃，但玩家动作没有造成稳定可解释的后果：必须标记 `world_activity_only` 或 `player_leverage=block`。
-  - 某个 A/B 指标更优，但真人试玩反馈更差：优先记为“L3 与 L4 冲突”，要求补充解释，而不是直接按指标放行。
+  - 某个 A/B 指标更优，但真人试玩反馈更差：优先记为“L3 与 L4B 冲突”，要求补充解释，而不是直接按指标放行。
   - 少量外部正反馈与内部留存门冲突：仍以 formal lane 的门禁与 blocker 为准，外部反馈只作为 L5 旁证。
   - 多个角色 subagent 都给出正面结论，但还没有真实外部反馈：仍只能停留在内部证据完成，不得上抬成外部验证完成。
-  - 多个 simulated personas 都给出正面反应，但没有任何真人试玩：仍只能记为内部假设增强，不得替代 L4。
+  - 多个 simulated personas 与 role subagents 都给出正面反应，但没有任何真人试玩：仍只能记为 `L4A pass / L4B missing`，不得替代 `L4B`。
 - Non-Functional Requirements:
   - NFR-PES-1: 审查者必须能在 60 秒内看懂每层证据的证明边界。
   - NFR-PES-2: 所有正式玩法结论都必须能指出“当前到达了哪一层、还缺哪一层”。
@@ -132,11 +141,13 @@
 - Phased Rollout:
   - MVP (`PES-1`): 建立五层证据栈、组合规则与 oasis7 当前锚点映射。
   - v1.1 (`PES-2`): 把正式 evidence packet 字段进一步补齐到 L3/L5，避免只有 narrative 没有层级结论。
-  - v2.0 (`PES-3`): 视需要再引入实验/遥测自动汇总，但仍保持 L4/L5 不被自动化替代。
+  - v2.0 (`PES-3`): 视需要再引入实验/遥测自动汇总，但仍保持 `L4B/L5` 不被自动化替代。
+  - v2.1 (`PES-4`): 若未来建立 calibration ledger，再讨论是否提升 `L4A` 的决策权重。
 - Technical Risks:
   - 风险-1: 团队可能继续把“自动化全绿”简写成“已经好玩”，导致该专题只写不执行。
   - 风险-2: 若 L3 迟迟没有统一字段，后续仍会靠零散指标做过度解释。
-  - 风险-3: 若 L4 真人试玩卡片质量不稳，证据栈会在最关键一层失真。
+  - 风险-3: 若 `L4B` 真人试玩卡片质量不稳，证据栈会在最关键一层失真。
+  - 风险-4: 若团队偷换 `L4A` 和 `L4B` 的用词，split 会流于纸面。
 
 ## 6. Validation & Decision Record
 - Test Plan & Traceability:
@@ -148,6 +159,7 @@
 | PRD-TESTING-PLAYABILITY-004 | `playability-evidence-stack-2026-05-06` / `PES-2/3` | `test_tier_required` | 抽样检查 project/README/prd.index/current window summary 是否同步 | 模块级治理执行力 |
 | PRD-TESTING-PLAYABILITY-005 | `playability-evidence-stack-2026-05-06` / `PES-3/4` | `test_tier_required` | 抽查标准角色 subagent 映射、非标准 `player` 限制与 L5 边界说明 | 多角色内部评审治理边界 |
 | PRD-TESTING-PLAYABILITY-006 | `playability-evidence-stack-2026-05-06` / `PES-4` | `test_tier_required` | 抽查 simulated persona panel 定位、persona 清单与 L4-supporting 边界 | 内部玩家视角治理边界 |
+| PRD-TESTING-PLAYABILITY-007 | `playability-evidence-stack-2026-05-06` / `PES-4/5` | `test_tier_required` | 抽查 `L4A/L4B` 分层、operator 入口与非替代边界 | synthetic/human 证据拆分 |
 - Decision Log:
 | 决策ID | 选定方案 | 备选方案（否决） | 依据 |
 | --- | --- | --- | --- |
@@ -156,3 +168,4 @@
 | `DEC-PES-003` | 保留 L4 真人试玩作为当前仓内最高权重内部判断层 | 试图用 L3 实验或 L2 bot probe 替代人类体验判断 | 当前工具链可以辅助判断，但不能代替“玩家是否觉得值得继续玩”。 |
 | `DEC-PES-004` | 所有内部人工评审默认可委托给对应标准角色 subagent | 为每个“玩家视角”额外创造非标准正式角色 | 当前仓库已有标准角色体系，新增非标准角色会破坏 execution log / handoff / PM 约束。 |
 | `DEC-PES-005` | simulated personas 只作为 L4-supporting 的内部假设面板 | 把 simulated persona panel 升格为独立证据层或正式角色 | 这样会模糊 persona 假设与真人试玩之间的证明强度差异。 |
+| `DEC-PES-006` | 把 `L4` 拆成 `L4A synthetic` 与 `L4B human` | 继续把 synthetic 与 human 共用一个 `L4` 标签 | 不拆层会持续混淆“agent 预测继续玩”和“真人实际继续玩”。 |

--- a/doc/testing/governance/playability-evidence-stack-2026-05-06.prd.md
+++ b/doc/testing/governance/playability-evidence-stack-2026-05-06.prd.md
@@ -3,7 +3,7 @@
 - 对应设计文档: `doc/testing/governance/playability-evidence-stack-2026-05-06.design.md`
 - 对应项目管理文档: `doc/testing/governance/playability-evidence-stack-2026-05-06.project.md`
 
-审计轮次: 1
+审计轮次: 2
 
 ## 1. Executive Summary
 - Problem Statement: 自动化测试已经能稳定覆盖回归、协议、性能、长稳和部分玩家路径，但“自动化绿灯”仍不等于“游戏已经好玩”。如果没有一套明确的证据栈把自动化、遥测、A/B 与真人试玩分层，团队很容易把“没坏”“世界在动”“玩家真的想继续玩”混写成同一种结论。
@@ -14,6 +14,7 @@
   - SC-3: `software_safe`、`pure_api`、`--no-llm observer/debug only`、`run-producer-playtest.sh`、playability card、`player leverage` rubric 和 limited preview 现有治理口径都被映射进同一套证据栈。
   - SC-4: 模块根入口 `doc/testing/prd.md` / `project.md` / `README.md` / `prd.index.md` 能把读者导向该专题。
   - SC-5: 专题文档明确声明“所有内部人工评审环节都可以优先由对应标准角色 subagent 补齐”，同时保留“这不等价于真实外部玩家验证”的硬边界。
+  - SC-6: 专题文档明确声明 simulated player personas 只属于 L4-supporting 的内部假设层，不新增正式角色，也不替代真人试玩。
 
 ## 2. User Experience & Functionality
 - User Personas:
@@ -26,17 +27,21 @@
   - 发布评审或阶段升级前：检查是否已经具备跨层证据组合，而不是只看 required/full。
   - 玩法争议复盘时：把“自动化已通过但人类觉得无聊”拆成可定位的问题。
   - 需要多人内部评审时：按 `qa_engineer` / `producer_system_designer` / `viewer_engineer` / `agent_engineer` / `liveops_community` 角色分别开 subagent 补齐内部评审意见。
+  - 需要模拟多个玩家风格时：开启 `simulated player persona panel` 产出风格化体验假设，再回流标准角色收口。
 - User Stories:
   - PRD-TESTING-PLAYABILITY-001: As a `producer_system_designer`, I want a canonical evidence stack for gameplay fun, so that I can make stage decisions without conflating reliability with fun.
   - PRD-TESTING-PLAYABILITY-002: As a `qa_engineer`, I want each evidence layer to have explicit proof boundaries, so that I can block overclaims early.
   - PRD-TESTING-PLAYABILITY-003: As an implementation owner, I want existing scripts and reports mapped into that stack, so that I know what evidence gap is still open.
   - PRD-TESTING-PLAYABILITY-004: As a release reviewer, I want a clear combination rule for go/hold/block, so that no single metric or single playtest overrides the rest of the stack.
   - PRD-TESTING-PLAYABILITY-005: As a workflow owner, I want each internal human-review step to be delegatable to the matching standard-role subagent, so that multi-role review can scale without weakening the evidence boundary.
+  - PRD-TESTING-PLAYABILITY-006: As a gameplay reviewer, I want a reusable simulated player persona panel, so that internal review can test more than one player mindset without inventing new formal roles.
 - Critical User Flows:
   1. `识别体验目标 -> 选择对应玩家 surface -> 先跑自动化基线 -> 判断是否已具备继续收集更高层证据的前置条件`
   2. `收集 agent probe / telemetry / 真人试玩 / limited preview 信号 -> 填写统一 evidence packet -> 标记每层结论`
   3. `producer_system_designer` 汇总多层结论 -> 输出 `go/watch/hold/block`，并明确“当前只证明了什么”
-  4. `识别需要人工内部评审的环节 -> 按标准角色开对应 subagent -> 汇总各角色评审 -> 保留外部真实验证边界`
+  4. `识别需要人工内部评审的环节 -> 按标准角色开对应 subagent`
+  5. `若需要多风格主观体验假设 -> 开 simulated player persona panel -> persona cards 回流标准角色`
+  6. `汇总各角色评审 -> 保留外部真实验证边界`
 - Functional Specification Matrix:
 | 证据层 | 主要输入 | 可以证明 | 不能证明 | oasis7 当前锚点 | 默认 owner |
 | --- | --- | --- | --- | --- | --- |
@@ -52,10 +57,14 @@
   - `agent_engineer` subagent: 负责 agent 行为是否真的支撑玩家体验，而不只是让世界自己运转。
   - `liveops_community` subagent: 负责 limited preview 口径、外部反馈归档与风险回流。
   - `runtime_engineer` / `wasm_platform_engineer` subagent: 负责实现约束、determinism、平台限制是否让高层体验结论失真。
+- Simulated player persona panel:
+  - `new_player_confused` / `impatient_action_player` / `systems_optimizer` / `narrative_curiosity_player` / `chaos_tester`
+  - 只用于补充 L4-supporting 的内部体验假设，不是新的证据层，也不是正式组织角色。
+  - persona cards 必须先回流到标准角色 review，不能直接成为最终 stage verdict。
 - Subagent governance rules:
   - 所有内部人工评审环节，默认都可以优先委托给对应标准角色 subagent。
   - 正式 execution log、handoff 和结论只允许使用 `.agents/roles/*.md` 中已存在的标准角色名，不新增 `player` 这类非标准角色。
-  - 若需要“玩家视角”批评，只能作为 `qa_engineer` 或 `producer_system_designer` 名下的启发式内部视角，不得写成正式独立角色。
+  - 若需要“玩家视角”批评，应进入 `simulated player persona panel`，并继续由标准角色 subagent 收口，不得写成正式独立角色。
   - subagent 评审可补 L1-L4 的内部证据，不得单独替代 L5 真实外部信号。
 - Layer rules:
   - L1/L2 是“能否继续验证”的前置层，不得单独给出“已证明好玩”。
@@ -73,6 +82,7 @@
   - `world_activity_only=yes` 的样本不得支撑“玩家已有 meaningful participation”。
   - 即使自动化通过、世界时间推进，只要 L4 仍不能证明玩家拥有稳定杠杆和继续动机，就不能把项目升级成“已证明好玩”。
   - 对应标准角色的 subagent 可以补齐所有内部人工评审环节，但不能被记作真实外部玩家，也不能单独把项目推进到 L5 `go`。
+  - simulated player personas 只能帮助解释“哪类玩家可能掉线 / 困惑 / 无聊”，不能替代真人试玩卡片或外部会话。
 - Acceptance Criteria:
   - AC-1: 专题文档明确写出五层证据栈与组合规则。
   - AC-2: 至少列出 `software_safe`、`pure_api`、`--no-llm`、`run-producer-playtest.sh`、playability card、`player leverage` rubric、limited preview 这 7 个现有锚点。
@@ -80,6 +90,7 @@
   - AC-4: `doc/testing/prd.md` 与 `doc/testing/project.md` 映射该专题，并给出模块级追踪条目。
   - AC-5: `doc/testing/README.md` 与 `doc/testing/prd.index.md` 把“如何判断自动化是否足以支撑好玩结论”的读者导向该专题。
   - AC-6: 明确写出标准角色 subagent 的适用范围、`player` 非标准角色限制，以及“subagent review != 真实外部玩家验证”的硬边界。
+  - AC-7: 明确 simulated player persona panel 的定位、固定 persona 清单，以及其与 L4/L5 的边界。
 - Non-Goals:
   - 不在本轮实现新的遥测 SDK、实验平台或外部问卷系统。
   - 不把该专题写成某一个玩法切片的结果报告。
@@ -96,6 +107,7 @@
   - `doc/testing/prd.md`
   - `doc/testing/project.md`
   - `doc/testing/governance/playability-subagent-review-system-2026-05-06.prd.md`
+  - `doc/testing/governance/playability-simulated-player-persona-panel-2026-05-06.prd.md`
   - `testing-manual.md`
   - `doc/testing/manual/web-ui-agent-browser-closure-manual.manual.md`
   - `doc/testing/evidence/gameplay-ten-minute-trust-gate-2026-04-09.md`
@@ -109,6 +121,7 @@
   - 某个 A/B 指标更优，但真人试玩反馈更差：优先记为“L3 与 L4 冲突”，要求补充解释，而不是直接按指标放行。
   - 少量外部正反馈与内部留存门冲突：仍以 formal lane 的门禁与 blocker 为准，外部反馈只作为 L5 旁证。
   - 多个角色 subagent 都给出正面结论，但还没有真实外部反馈：仍只能停留在内部证据完成，不得上抬成外部验证完成。
+  - 多个 simulated personas 都给出正面反应，但没有任何真人试玩：仍只能记为内部假设增强，不得替代 L4。
 - Non-Functional Requirements:
   - NFR-PES-1: 审查者必须能在 60 秒内看懂每层证据的证明边界。
   - NFR-PES-2: 所有正式玩法结论都必须能指出“当前到达了哪一层、还缺哪一层”。
@@ -134,6 +147,7 @@
 | PRD-TESTING-PLAYABILITY-003 | `playability-evidence-stack-2026-05-06` / `PES-1/2` | `test_tier_required` | 检查模块根入口、索引与专题互链 | 文档导航与追溯一致性 |
 | PRD-TESTING-PLAYABILITY-004 | `playability-evidence-stack-2026-05-06` / `PES-2/3` | `test_tier_required` | 抽样检查 project/README/prd.index/current window summary 是否同步 | 模块级治理执行力 |
 | PRD-TESTING-PLAYABILITY-005 | `playability-evidence-stack-2026-05-06` / `PES-3/4` | `test_tier_required` | 抽查标准角色 subagent 映射、非标准 `player` 限制与 L5 边界说明 | 多角色内部评审治理边界 |
+| PRD-TESTING-PLAYABILITY-006 | `playability-evidence-stack-2026-05-06` / `PES-4` | `test_tier_required` | 抽查 simulated persona panel 定位、persona 清单与 L4-supporting 边界 | 内部玩家视角治理边界 |
 - Decision Log:
 | 决策ID | 选定方案 | 备选方案（否决） | 依据 |
 | --- | --- | --- | --- |
@@ -141,3 +155,4 @@
 | `DEC-PES-002` | 用五层证据栈表达从内部到外部、从客观到主观的递进关系 | 把所有信号平铺成同权 checklist | 平铺 checklist 容易让低层证据越权替代高层证据。 |
 | `DEC-PES-003` | 保留 L4 真人试玩作为当前仓内最高权重内部判断层 | 试图用 L3 实验或 L2 bot probe 替代人类体验判断 | 当前工具链可以辅助判断，但不能代替“玩家是否觉得值得继续玩”。 |
 | `DEC-PES-004` | 所有内部人工评审默认可委托给对应标准角色 subagent | 为每个“玩家视角”额外创造非标准正式角色 | 当前仓库已有标准角色体系，新增非标准角色会破坏 execution log / handoff / PM 约束。 |
+| `DEC-PES-005` | simulated personas 只作为 L4-supporting 的内部假设面板 | 把 simulated persona panel 升格为独立证据层或正式角色 | 这样会模糊 persona 假设与真人试玩之间的证明强度差异。 |

--- a/doc/testing/governance/playability-evidence-stack-2026-05-06.project.md
+++ b/doc/testing/governance/playability-evidence-stack-2026-05-06.project.md
@@ -9,6 +9,7 @@
 - [x] playability-evidence-stack-definition (PRD-TESTING-PLAYABILITY-001) [test_tier_required]: 建立专题 PRD / Design / Project，冻结“自动化不能单独保证好玩”的正式口径，以及五层证据栈与 `go/watch/hold/block` 组合规则。 Trace: .pm/tasks/task_efe1a5f949e84160a1237302c9064168.yaml
 - [x] playability-evidence-stack-surface-mapping (PRD-TESTING-PLAYABILITY-002) [test_tier_required]: 把 `software_safe`、`pure_api`、`--no-llm`、playability card、`run-producer-playtest.sh`、`player leverage` rubric 和 limited preview 现有入口映射进统一证据栈。 Trace: .pm/tasks/task_efe1a5f949e84160a1237302c9064168.yaml
 - [x] playability-evidence-stack-root-entry-sync (PRD-TESTING-PLAYABILITY-003) [test_tier_required]: 同步模块根入口 `doc/testing/prd.md`、`doc/testing/project.md`、`doc/testing/README.md` 与 `doc/testing/prd.index.md`，保证首读分流可达。 Trace: .pm/tasks/task_efe1a5f949e84160a1237302c9064168.yaml
+- [x] playability-evidence-stack-subagent-governance (PRD-TESTING-PLAYABILITY-005) [test_tier_required]: 补充“所有内部人工评审默认可由对应标准角色 subagent 补齐”的治理规则，并写明非标准 `player` 角色限制，以及 `subagent review != 真实外部玩家验证` 的边界。 Trace: .pm/tasks/task_efe1a5f949e84160a1237302c9064168.yaml
 
 ## 依赖
 - `doc/testing/prd.md`
@@ -25,3 +26,4 @@
 - 下一步:
   - 若后续新增实验/遥测系统，按 L3 能力扩展补字段，不改低层/高层边界。
   - 若后续要升级 external claim envelope，先补 L5 受控外部信号样本，而不是重复堆自动化。
+  - 若后续真的把多角色 subagent review 变成默认流水线，再追加一份 execution-oriented runbook，把各角色输入输出模板固定下来。

--- a/doc/testing/governance/playability-evidence-stack-2026-05-06.project.md
+++ b/doc/testing/governance/playability-evidence-stack-2026-05-06.project.md
@@ -1,0 +1,27 @@
+# oasis7: 好玩性证据栈（2026-05-06）（项目管理）
+
+- 对应设计文档: `doc/testing/governance/playability-evidence-stack-2026-05-06.design.md`
+- 对应需求文档: `doc/testing/governance/playability-evidence-stack-2026-05-06.prd.md`
+
+审计轮次: 1
+
+## 任务拆解（含 PRD-ID 映射）
+- [x] playability-evidence-stack-definition (PRD-TESTING-PLAYABILITY-001) [test_tier_required]: 建立专题 PRD / Design / Project，冻结“自动化不能单独保证好玩”的正式口径，以及五层证据栈与 `go/watch/hold/block` 组合规则。 Trace: .pm/tasks/task_efe1a5f949e84160a1237302c9064168.yaml
+- [x] playability-evidence-stack-surface-mapping (PRD-TESTING-PLAYABILITY-002) [test_tier_required]: 把 `software_safe`、`pure_api`、`--no-llm`、playability card、`run-producer-playtest.sh`、`player leverage` rubric 和 limited preview 现有入口映射进统一证据栈。 Trace: .pm/tasks/task_efe1a5f949e84160a1237302c9064168.yaml
+- [x] playability-evidence-stack-root-entry-sync (PRD-TESTING-PLAYABILITY-003) [test_tier_required]: 同步模块根入口 `doc/testing/prd.md`、`doc/testing/project.md`、`doc/testing/README.md` 与 `doc/testing/prd.index.md`，保证首读分流可达。 Trace: .pm/tasks/task_efe1a5f949e84160a1237302c9064168.yaml
+
+## 依赖
+- `doc/testing/prd.md`
+- `doc/testing/project.md`
+- `testing-manual.md`
+- `doc/testing/evidence/gameplay-ten-minute-trust-gate-2026-04-09.md`
+- `doc/playability_test_result/playability_test_card.md`
+- `doc/game/prd.md`
+
+## 状态
+- 更新日期: 2026-05-06
+- 当前阶段: 已完成
+- 阻塞项: 无
+- 下一步:
+  - 若后续新增实验/遥测系统，按 L3 能力扩展补字段，不改低层/高层边界。
+  - 若后续要升级 external claim envelope，先补 L5 受控外部信号样本，而不是重复堆自动化。

--- a/doc/testing/governance/playability-l4-synthetic-human-split-2026-05-06.design.md
+++ b/doc/testing/governance/playability-l4-synthetic-human-split-2026-05-06.design.md
@@ -1,12 +1,14 @@
-# oasis7: 好玩性 L4 synthetic/human 分层（2026-05-06）设计
+# oasis7: 好玩性 L4 synthetic/agent/human 分层（2026-05-06）设计
 
 - 对应需求文档: `doc/testing/governance/playability-l4-synthetic-human-split-2026-05-06.prd.md`
 - 对应项目管理文档: `doc/testing/governance/playability-l4-synthetic-human-split-2026-05-06.project.md`
 
-审计轮次: 1
+审计轮次: 2
 
 ## 1. 设计定位
-把 `L4` 从单一标签改成双层内部证据：`L4A synthetic` 负责内部高强度模拟，`L4B human` 负责真人继续游玩意愿。
+把 `L4` 收口成两层正式内部证据，并把内部真人试玩降为 `L4B` 可选校准：
+- `L4A synthetic`: 内部高强度模拟
+- `L4B embodied-agent`: agent 实际进入产品并操作
 
 ## 2. 结构
 - `L4A`:
@@ -15,23 +17,31 @@
   - formal player surface 上的 synthetic continuation prediction
 - `L4B`:
   - `run-producer-playtest.sh`
-  - playability test card
-  - headed human rerun / 受控访谈
+  - agent-browser / GUI Agent 实际操作
+  - `l4b-agent-playtest-card.md`
+- `L4B` optional corroboration:
+  - `run-producer-playtest.sh`
+  - headed internal human rerun / playability test card
+  - `optional-internal-human-corroboration.md`
 
 ## 3. 数据流
 - `L4A outputs`:
   - `synthetic_continue_likely/unclear/unlikely`
 - `L4B outputs`:
-  - `human_continue_observed/mixed/not_observed`
+  - `agent_continue_observed/mixed/not_observed`
+- `L4B optional corroboration outputs`:
+  - `corroborates_l4b/mixed/contradicts_l4b`
 - 汇总:
   - `synthetic_ready`
-  - `human_ready`
+  - `agent_ready`
   - `external_ready`
 - Current scaffold:
-  - `scripts/prepare-playability-l4-review.sh` 负责把 `L4A` packet/cards、`L4B` 卡片副本、summary 和推荐命令固定到同一 artifact 目录。
-  - 该 scaffold 只收口 operator 入口，不改变 `L4A` 不能替代 `L4B` 的边界。
+  - `scripts/prepare-playability-l4-review.sh` 负责把 `L4A` packet/cards、`L4B` agent 卡、可选内部真人佐证 notes、summary 和推荐命令固定到同一 artifact 目录。
+  - 该 scaffold 只收口 operator 入口，不改变 `L4A` 不能替代 `L4B`、`L4B` 不能替代 `L5` 的边界。
 
 ## 4. 约束
 - `L4A` 不能直接替代 `L4B`。
+- `L4B` 不能直接替代 `L5`。
 - 若 `L4A` 与 `L4B` 冲突，必须显式记录 divergence。
+- 若内部真人校准与 `L4B` 冲突，必须显式记录 divergence，并保留 `L5` 缺失状态。
 - calibration 只保留为未来扩展，不属于本轮可用能力。

--- a/doc/testing/governance/playability-l4-synthetic-human-split-2026-05-06.design.md
+++ b/doc/testing/governance/playability-l4-synthetic-human-split-2026-05-06.design.md
@@ -1,0 +1,34 @@
+# oasis7: 好玩性 L4 synthetic/human 分层（2026-05-06）设计
+
+- 对应需求文档: `doc/testing/governance/playability-l4-synthetic-human-split-2026-05-06.prd.md`
+- 对应项目管理文档: `doc/testing/governance/playability-l4-synthetic-human-split-2026-05-06.project.md`
+
+审计轮次: 1
+
+## 1. 设计定位
+把 `L4` 从单一标签改成双层内部证据：`L4A synthetic` 负责内部高强度模拟，`L4B human` 负责真人继续游玩意愿。
+
+## 2. 结构
+- `L4A`:
+  - 标准角色 subagent
+  - simulated player personas
+  - formal player surface 上的 synthetic continuation prediction
+- `L4B`:
+  - `run-producer-playtest.sh`
+  - playability test card
+  - headed human rerun / 受控访谈
+
+## 3. 数据流
+- `L4A outputs`:
+  - `synthetic_continue_likely/unclear/unlikely`
+- `L4B outputs`:
+  - `human_continue_observed/mixed/not_observed`
+- 汇总:
+  - `synthetic_ready`
+  - `human_ready`
+  - `external_ready`
+
+## 4. 约束
+- `L4A` 不能直接替代 `L4B`。
+- 若 `L4A` 与 `L4B` 冲突，必须显式记录 divergence。
+- calibration 只保留为未来扩展，不属于本轮可用能力。

--- a/doc/testing/governance/playability-l4-synthetic-human-split-2026-05-06.design.md
+++ b/doc/testing/governance/playability-l4-synthetic-human-split-2026-05-06.design.md
@@ -27,6 +27,9 @@
   - `synthetic_ready`
   - `human_ready`
   - `external_ready`
+- Current scaffold:
+  - `scripts/prepare-playability-l4-review.sh` 负责把 `L4A` packet/cards、`L4B` 卡片副本、summary 和推荐命令固定到同一 artifact 目录。
+  - 该 scaffold 只收口 operator 入口，不改变 `L4A` 不能替代 `L4B` 的边界。
 
 ## 4. 约束
 - `L4A` 不能直接替代 `L4B`。

--- a/doc/testing/governance/playability-l4-synthetic-human-split-2026-05-06.prd.md
+++ b/doc/testing/governance/playability-l4-synthetic-human-split-2026-05-06.prd.md
@@ -11,7 +11,8 @@
 
 ## 范围
 - 覆盖 `L4A/L4B` 的定义、输入、输出、组合规则、升级边界和 operator 入口。
-- 不覆盖新的真人招募平台、外部用户研究系统或自动 orchestration 工具实现。
+- 覆盖当前 repo-local `L4` scaffold 入口如何把 `L4A` packet / cards、`L4B` 卡片副本、summary 与推荐命令收口到同一 worktree。
+- 不覆盖新的真人招募平台、外部用户研究系统或“自动替代真人”的自治 orchestration 实现。
 
 ## 接口 / 数据
 - 专题 PRD: `doc/testing/governance/playability-l4-synthetic-human-split-2026-05-06.prd.md`
@@ -23,11 +24,12 @@
   - `doc/testing/governance/playability-simulated-player-persona-panel-2026-05-06.prd.md`
 - operator 入口:
   - `testing-manual.md`
+  - `scripts/prepare-playability-l4-review.sh`
   - `scripts/run-producer-playtest.sh`
   - `doc/playability_test_result/playability_test_card.md`
 
 ## 里程碑
-- M1 (2026-05-06): 冻结 `L4A/L4B` 定义、claim boundary 和组合规则。
+- M1 (2026-05-06): 冻结 `L4A/L4B` 定义、claim boundary、组合规则，以及 repo-local scaffold 入口。
 - M2: 若后续要提升 `L4A` 权重，再补 synthetic-to-human calibration 方案。
 
 ## 风险
@@ -43,6 +45,7 @@
   - SC-3: `playability evidence stack`、`persona panel`、`subagent review system` 与 `testing-manual` 都同步改成同一口径。
   - SC-4: `L4A` 可以成为内部高强度模拟完成的正式 verdict，但不能冒充 `L4B`。
   - SC-5: 文档明确保留未来“做 synthetic-to-human calibration 后再提升 L4A 权重”的扩展位，但当前不宣称已经完成。
+  - SC-6: 当前仓库提供 `./scripts/prepare-playability-l4-review.sh`，可以在单个 worktree 内稳定生成完整 `L4` scaffold，并把 `L4A` 与 `L4B` 证据路径对齐到同一 artifact 目录。
 
 ## 2. User Experience & Functionality
 - User Personas:
@@ -61,15 +64,16 @@
   - PRD-TESTING-L4SPLIT-004: As a future workflow owner, I want a documented path for calibration-based promotion, so that stronger synthetic evidence can be discussed without prematurely changing current claims.
 - Critical User Flows:
   1. `识别当前要回答的问题是 synthetic 预测，还是 human 实际继续游玩意愿`
-  2. `若先跑内部模拟 -> 执行 L4A -> 输出 synthetic verdict`
-  3. `若需要真人主观证据 -> 升级到 L4B -> 输出 human verdict`
-  4. `producer_system_designer` 汇总 L4A/L4B -> 决定当前是 synthetic_ready / human_ready / external_ready`
+  2. `若要在一个 worktree 内准备完整 L4 -> 先执行 `prepare-playability-l4-review.sh` 生成 packet / cards / summary / commands scaffold`
+  3. `若先跑内部模拟 -> 执行 L4A -> 输出 synthetic verdict`
+  4. `若需要真人主观证据 -> 升级到 L4B -> 输出 human verdict`
+  5. `producer_system_designer` 汇总 L4A/L4B -> 决定当前是 synthetic_ready / human_ready / external_ready`
 
 ## 3. Functional Specification Matrix
 | 层级 | 主要输入 | 可以证明 | 不能证明 | 默认入口 | 默认 owner |
 | --- | --- | --- | --- | --- | --- |
-| `L4A synthetic internal playability review` | 标准角色 subagent review cards、simulated persona cards、formal player surface 上的 scripted/UI closure、synthetic continuation prediction | 以当前内部模型看，哪些风格玩家大概率想继续玩，哪些断点会掉线，哪些 claim 只在 synthetic 里成立 | 真人在真实时间/耐心成本下是否真的愿意继续玩 | `testing-manual.md`、`worktree-harness.sh`、S6 Web UI 闭环、subagent/persona panel 输出 | `producer_system_designer` + `qa_engineer` |
-| `L4B structured human playtest` | 制作人试玩、QA headed rerun、playability card、受控访谈 | 真实人类是否看懂、是否感到有杠杆、是否想继续玩、阻塞是否可解释 | 广泛外部市场反应 | `run-producer-playtest.sh`、`doc/playability_test_result/playability_test_card.md` | `producer_system_designer` + `qa_engineer` |
+| `L4A synthetic internal playability review` | 标准角色 subagent review cards、simulated persona cards、formal player surface 上的 scripted/UI closure、synthetic continuation prediction | 以当前内部模型看，哪些风格玩家大概率想继续玩，哪些断点会掉线，哪些 claim 只在 synthetic 里成立 | 真人在真实时间/耐心成本下是否真的愿意继续玩 | `prepare-playability-l4-review.sh`、`testing-manual.md`、`worktree-harness.sh`、S6 Web UI 闭环、subagent/persona panel 输出 | `producer_system_designer` + `qa_engineer` |
+| `L4B structured human playtest` | 制作人试玩、QA headed rerun、playability card、受控访谈 | 真实人类是否看懂、是否感到有杠杆、是否想继续玩、阻塞是否可解释 | 广泛外部市场反应 | `prepare-playability-l4-review.sh`、`run-producer-playtest.sh`、`doc/playability_test_result/playability_test_card.md` | `producer_system_designer` + `qa_engineer` |
 
 ## 4. Claim Rules
 - 允许的 `L4A` 结论:
@@ -91,6 +95,9 @@
   - release / stage 结论需要比 `synthetic_ready` 更强
 - 当前不允许的推断:
   - `L4A pass => L4B pass`
+- 当前 repo-local scaffold 的边界:
+  - `prepare-playability-l4-review.sh` 只负责生成 packet / cards / summary / commands / manifest。
+  - 生成了 scaffold 不等于 `L4A` 或 `L4B` 已完成，更不等于真人替代已经发生。
 - 保留的未来扩展:
   - 若未来建立 synthetic-to-human calibration ledger，且长期证明 `L4A` 对 `L4B` 具备可接受预测力，才可讨论提升 `L4A` 的决策权重；本轮不做此 claim。
 
@@ -100,6 +107,7 @@
 - AC-3: `testing-manual.md` 的 L4 operator 入口同步区分 `L4A` 与 `L4B`。
 - AC-4: `simulated player persona panel` 与 `subagent review system` 都改成显式服务 `L4A`。
 - AC-5: 文档明确保留 calibration 扩展位，但不宣称当前已完成。
+- AC-6: 文档明确写出 `./scripts/prepare-playability-l4-review.sh` 是当前完整 `L4` scaffold 入口，以及“scaffold != 替代真人”的硬边界。
 
 ## 7. Non-Goals
 - 不在本轮让 `L4A` 直接替代 `L4B`。
@@ -116,10 +124,14 @@
   - `doc/testing/README.md`
   - `doc/testing/prd.index.md`
   - `testing-manual.md`
+  - `scripts/prepare-playability-l4-review.sh`
+  - `doc/testing/templates/playability-l4-review-packet-template.md`
+  - `doc/testing/templates/playability-l4-summary-template.md`
 - Edge Cases:
   - `L4A` 全正面、`L4B` 未执行：只能写 `synthetic_ready`，不能写 `human_ready`。
   - `L4A` 与 `L4B` 冲突：优先记为“synthetic-human divergence”，不得直接用 `L4A` 覆盖真人反馈。
   - `L4B` 样本很少：可以提升到 `human_continue_mixed`，但不能直接把它扩展成 `L5` 结论。
+  - 已生成 `L4` scaffold，但 `commands.sh` 未执行且卡片仍为空：只能写 operator scaffold ready，不能写任何 layer verdict。
 - Non-Functional Requirements:
   - NFR-L4SPLIT-1: 审查者必须能在 60 秒内看懂当前结论是 `L4A` 还是 `L4B`。
   - NFR-L4SPLIT-2: operator 必须能在 5 分钟内知道该跑 `worktree-harness/S6` 还是 `run-producer-playtest/playability card`。
@@ -139,3 +151,4 @@
 | `DEC-L4S-001` | 把当前 `L4` 拆成 `L4A/L4B` | 继续维持单层 `L4` | 单层会持续混淆 synthetic 与 human 证据。 |
 | `DEC-L4S-002` | `L4A` 允许高权重 synthetic 结论，但不冒充 `L4B` | 把 agent 角色扮演直接记成真人试玩 | 角色扮演仍缺真人时间/耐心/机会成本约束。 |
 | `DEC-L4S-003` | 为未来 calibration 留扩展位，但当前不宣称已完成 | 现在就把 `L4A` 提升为 `L4B` 替代品 | 当前仓库没有 synthetic-to-human 校准证据。 |
+| `DEC-L4S-004` | 当前先提供 repo-local scaffold，把 `L4A` 与 `L4B` 产物放进同一 artifact 目录 | 继续让 operator 临时拼接 packet / cards / summary / playtest card | 没有统一入口就无法把“完整 L4 可执行”作为当前 PR 的正式能力。 |

--- a/doc/testing/governance/playability-l4-synthetic-human-split-2026-05-06.prd.md
+++ b/doc/testing/governance/playability-l4-synthetic-human-split-2026-05-06.prd.md
@@ -1,18 +1,18 @@
-# oasis7: 好玩性 L4 synthetic/human 分层（2026-05-06）
+# oasis7: 好玩性 L4 synthetic/agent/human 分层（2026-05-06）
 
 - 对应设计文档: `doc/testing/governance/playability-l4-synthetic-human-split-2026-05-06.design.md`
 - 对应项目管理文档: `doc/testing/governance/playability-l4-synthetic-human-split-2026-05-06.project.md`
 
-审计轮次: 1
+审计轮次: 2
 
 ## 目标
-- 把当前 evidence stack 中过于宽泛的 `L4` 拆成 `L4A synthetic internal playability review` 与 `L4B structured human playtest`。
-- 明确 agent 完整角色扮演、标准角色 subagent 和 simulated personas 能提升到什么强度，以及为什么仍不能直接与真人试玩 claim 混写。
+- 把当前 evidence stack 中过于宽泛的 `L4` 收口成 `L4A synthetic internal playability review` 与 `L4B embodied agent playtest` 两层正式内部证据，并把内部真人试玩降为 `L4B` 可选校准。
+- 明确 agent 完整角色扮演、标准角色 subagent、simulated personas、agent 实际进游戏操作、内部真人校准、以及 `L5` 真实人类 / 外部验证分别能证明什么，避免继续混写。
 
 ## 范围
-- 覆盖 `L4A/L4B` 的定义、输入、输出、组合规则、升级边界和 operator 入口。
-- 覆盖当前 repo-local `L4` scaffold 入口如何把 `L4A` packet / cards、`L4B` 卡片副本、summary 与推荐命令收口到同一 worktree。
-- 不覆盖新的真人招募平台、外部用户研究系统或“自动替代真人”的自治 orchestration 实现。
+- 覆盖 `L4A/L4B` 的定义、输入、输出、组合规则、升级边界和 operator 入口，以及内部真人校准与 `L5` 的关系。
+- 覆盖当前 repo-local `L4` scaffold 入口如何把 `L4A` packet / cards、`L4B` agent 卡、可选内部真人佐证 notes、summary 与推荐命令收口到同一 worktree。
+- 不覆盖新的真人招募平台、外部用户研究系统或“完全自动替代真人”的自治 orchestration 实现。
 
 ## 接口 / 数据
 - 专题 PRD: `doc/testing/governance/playability-l4-synthetic-human-split-2026-05-06.prd.md`
@@ -29,51 +29,49 @@
   - `doc/playability_test_result/playability_test_card.md`
 
 ## 里程碑
-- M1 (2026-05-06): 冻结 `L4A/L4B` 定义、claim boundary、组合规则，以及 repo-local scaffold 入口。
-- M2: 若后续要提升 `L4A` 权重，再补 synthetic-to-human calibration 方案。
+- M1 (2026-05-06): 冻结 `L4A/L4B/L5` 边界、内部真人校准定位、组合规则，以及 repo-local scaffold 入口。
+- M2: 若后续要提升 `L4B` 或 `L4A` 的替代权重，再补 calibration 方案。
 
 ## 风险
-- 若继续把 `L4` 写成单层，agent 结果和真人结果会持续混写。
-- 若把 `L4A` 直接包装成真人试玩替代品，会污染 go/hold/watch/block 结论。
+- 若继续把 `L4` 写成单层，synthetic、agentic、real-human 结果会持续混写。
+- 若把 `L4B` 具身 agent 试玩或内部真人校准直接包装成 `L5` 真人替代品，会污染 go/hold/watch/block 结论。
 
 ## 1. Executive Summary
-- Problem Statement: 当前 evidence stack 已经明确“自动化不能单独证明好玩”，但 `L4` 仍把两种本质不同的证据混在一起：一类是由 subagent、simulated personas 和 scripted/UI closure 组成的高强度内部模拟；另一类是真实人类在有时间、耐心和机会成本约束下的主观继续游玩意愿。如果继续共用一个 `L4` 标签，团队会反复争论“agent 说想继续玩，到底算不算真人试玩”。
-- Proposed Solution: 把 `L4` 正式拆成两层：`L4A synthetic internal playability review` 与 `L4B structured human playtest`。前者收纳标准角色 subagent、simulated personas、真实 formal surface 上的 synthetic continuation prediction；后者只收纳真人试玩卡、制作人/QA 人类实际继续游玩与主观反馈。
+- Problem Statement: 当前 evidence stack 已经明确“自动化不能单独证明好玩”，但旧 `L4` 仍把三种不同强度的证据混在一起：`L4A` 的高强度内部模拟、agent 实际进游戏操作后的 `L4B`，以及内部真人 spot-check。若继续共用一个 `L4` 标签，团队会反复争论“agent 真的玩了一轮，到底算不算比 synthetic 更强”“内部真人试玩到底是不是新的正式层”“真人没玩之前能不能收口”。
+- Proposed Solution: 把 `L4` 正式收口成两层：`L4A synthetic internal playability review` 与 `L4B embodied agent playtest`。`L4A` 收纳标准角色 subagent、simulated personas、formal surface 上的 synthetic continuation prediction；`L4B` 收纳 agent 真实进入产品并执行操作链路后的继续游玩判断，并允许内部真人试玩只作为 `L4B` 的可选校准；真实人类 / 真实环境验证统一归 `L5`。
 - Success Criteria:
-  - SC-1: 文档明确给出 `L4A` 与 `L4B` 的输入、输出、证明边界和 operator 入口。
-  - SC-2: 文档明确写出 `agent 完整角色扮演 != 真人继续游玩意愿已被证明`。
+  - SC-1: 文档明确给出 `L4A/L4B/L5` 的输入、输出、证明边界和 operator 入口。
+  - SC-2: 文档明确写出 `agent 完整角色扮演 != agent 实际试玩 != 真实人类继续游玩意愿已被证明`。
   - SC-3: `playability evidence stack`、`persona panel`、`subagent review system` 与 `testing-manual` 都同步改成同一口径。
-  - SC-4: `L4A` 可以成为内部高强度模拟完成的正式 verdict，但不能冒充 `L4B`。
-  - SC-5: 文档明确保留未来“做 synthetic-to-human calibration 后再提升 L4A 权重”的扩展位，但当前不宣称已经完成。
-  - SC-6: 当前仓库提供 `./scripts/prepare-playability-l4-review.sh`，可以在单个 worktree 内稳定生成完整 `L4` scaffold，并把 `L4A` 与 `L4B` 证据路径对齐到同一 artifact 目录。
+  - SC-4: `L4B` 可以成为“agent 实际试玩已经发生”的正式 verdict，并应尽量逼近真人评审效果，但不能冒充 `L5`。
+  - SC-5: 文档明确保留未来 calibration 扩展位，但当前不宣称 `L4A` 或 `L4B` 已可替代更高层。
+  - SC-6: 当前仓库提供 `./scripts/prepare-playability-l4-review.sh`，可以在单个 worktree 内稳定生成完整 `L4` scaffold，并把 `L4A`、`L4B` 与可选内部真人校准证据路径对齐到同一 artifact 目录。
 
 ## 2. User Experience & Functionality
 - User Personas:
-  - `producer_system_designer`: 需要知道当前结论是“模拟上看起来想继续玩”还是“真人真的想继续玩”。
-  - `qa_engineer`: 需要阻止团队把 synthetic 结果写成 human-validated claim。
-  - `viewer_engineer` / `agent_engineer` / `runtime_engineer`: 需要知道自己补的是 `L4A` 还是 `L4B` 的证据。
-  - `liveops_community`: 需要知道哪些内部正面结论还不能拿去对外表达成“已被玩家验证”。
-- User Scenarios & Frequency:
-  - 玩法争议集中在“agent 都说会继续玩，为什么还要人测”时。
-  - 日常迭代希望尽量减少人参与，但仍要保持证据边界时。
-  - 发布前需要解释当前到底只到 `L4A`，还是已经到 `L4B` 时。
+  - `producer_system_designer`: 需要知道当前结论是“模拟上看起来想继续玩”“agent 真的继续操作了”“真实人类真的想继续玩”中的哪一层。
+  - `qa_engineer`: 需要阻止团队把 `L4A` 写成 `L4B`，或把 `L4B` / 内部真人校准写成 `L5`。
+  - `viewer_engineer` / `agent_engineer` / `runtime_engineer`: 需要知道自己补的是 `L4A`、`L4B` 还是 `L5` 前的内部校准证据。
+  - `liveops_community`: 需要知道哪些内部正面结论还不能拿去对外表达成“已被真实玩家验证”。
 - User Stories:
-  - PRD-TESTING-L4SPLIT-001: As a `producer_system_designer`, I want `L4A/L4B` split explicitly, so that synthetic and human claims stop collapsing into one label.
-  - PRD-TESTING-L4SPLIT-002: As a `qa_engineer`, I want synthetic roleplay evidence bounded below human playtest evidence, so that overclaiming can be blocked.
-  - PRD-TESTING-L4SPLIT-003: As an operator, I want clear entrypoints for `L4A` and `L4B`, so that I know which command and artifact set belongs to which layer.
-  - PRD-TESTING-L4SPLIT-004: As a future workflow owner, I want a documented path for calibration-based promotion, so that stronger synthetic evidence can be discussed without prematurely changing current claims.
+  - PRD-TESTING-L4SPLIT-001: As a `producer_system_designer`, I want `L4A/L4B/L5` boundaries written explicitly, so that synthetic、agentic、real-human claims stop collapsing into one label.
+  - PRD-TESTING-L4SPLIT-002: As a `qa_engineer`, I want synthetic roleplay evidence bounded below embodied agent playtest, and embodied agent playtest bounded below `L5` real-human validation, so that overclaiming can be blocked.
+  - PRD-TESTING-L4SPLIT-003: As an operator, I want clear entrypoints for `L4A` / `L4B`, plus optional internal human calibration notes, so that I know which command and artifact set belongs to which layer.
+  - PRD-TESTING-L4SPLIT-004: As a future workflow owner, I want a documented path for calibration-based promotion, so that stronger synthetic or embodied-agent evidence can be discussed without prematurely changing current claims.
 - Critical User Flows:
-  1. `识别当前要回答的问题是 synthetic 预测，还是 human 实际继续游玩意愿`
-  2. `若要在一个 worktree 内准备完整 L4 -> 先执行 `prepare-playability-l4-review.sh` 生成 packet / cards / summary / commands scaffold`
+  1. `识别当前要回答的问题是 synthetic 预测、agent 实际试玩，还是 human 实际继续游玩意愿`
+  2. `若要在一个 worktree 内准备完整 L4 -> 先执行 prepare-playability-l4-review.sh 生成 packet / cards / summary / commands scaffold`
   3. `若先跑内部模拟 -> 执行 L4A -> 输出 synthetic verdict`
-  4. `若需要真人主观证据 -> 升级到 L4B -> 输出 human verdict`
-  5. `producer_system_designer` 汇总 L4A/L4B -> 决定当前是 synthetic_ready / human_ready / external_ready`
+  4. `若需要 agent 真的进游戏操作一轮 -> 升级到 L4B -> 输出 embodied-agent verdict`
+  5. `若需要内部真人校准 -> 复用同一入口记录 corroboration / contradiction`
+  6. `若需要真实人类 / 真实环境证据 -> 升级到 L5`
+  7. `producer_system_designer` 汇总 L4A/L4B 与可选校准 -> 决定当前是 `synthetic_ready` / `agent_ready` / `external_ready`
 
 ## 3. Functional Specification Matrix
 | 层级 | 主要输入 | 可以证明 | 不能证明 | 默认入口 | 默认 owner |
 | --- | --- | --- | --- | --- | --- |
-| `L4A synthetic internal playability review` | 标准角色 subagent review cards、simulated persona cards、formal player surface 上的 scripted/UI closure、synthetic continuation prediction | 以当前内部模型看，哪些风格玩家大概率想继续玩，哪些断点会掉线，哪些 claim 只在 synthetic 里成立 | 真人在真实时间/耐心成本下是否真的愿意继续玩 | `prepare-playability-l4-review.sh`、`testing-manual.md`、`worktree-harness.sh`、S6 Web UI 闭环、subagent/persona panel 输出 | `producer_system_designer` + `qa_engineer` |
-| `L4B structured human playtest` | 制作人试玩、QA headed rerun、playability card、受控访谈 | 真实人类是否看懂、是否感到有杠杆、是否想继续玩、阻塞是否可解释 | 广泛外部市场反应 | `prepare-playability-l4-review.sh`、`run-producer-playtest.sh`、`doc/playability_test_result/playability_test_card.md` | `producer_system_designer` + `qa_engineer` |
+| `L4A synthetic internal playability review` | 标准角色 subagent review cards、simulated persona cards、formal player surface 上的 scripted/UI closure、synthetic continuation prediction | 以当前内部模型看，哪些风格玩家大概率想继续玩，哪些断点会掉线，哪些 claim 只在 synthetic 里成立 | agent 是否真的在真实操作链路中继续玩；真人是否真的愿意继续玩 | `prepare-playability-l4-review.sh`、`testing-manual.md`、`worktree-harness.sh`、S6 Web UI 闭环、subagent/persona panel 输出 | `producer_system_designer` + `qa_engineer` |
+| `L4B embodied agent playtest` | agent 实际打开产品、执行真实操作链路、agent playtest card、play session 证据、可选内部真人校准 notes | agent 是否在真实游玩入口中执行了实际操作，并表现出继续玩的倾向与可解释杠杆判断；内部真人 spot-check 是否 corroborate 该判断 | 真实外部人类是否真的愿意继续玩 | `prepare-playability-l4-review.sh`、`run-producer-playtest.sh`、`l4b-agent-playtest-card.md`、`optional-internal-human-corroboration.md` / `doc/playability_test_result/playability_test_card.md` | `producer_system_designer` + `qa_engineer` |
 
 ## 4. Claim Rules
 - 允许的 `L4A` 结论:
@@ -81,36 +79,45 @@
   - `synthetic_continue_unclear`
   - `synthetic_continue_unlikely`
 - 允许的 `L4B` 结论:
-  - `human_continue_observed`
-  - `human_continue_mixed`
-  - `human_continue_not_observed`
+  - `agent_continue_observed`
+  - `agent_continue_mixed`
+  - `agent_continue_not_observed`
+- 允许的内部真人校准结论:
+  - `corroborates_l4b`
+  - `mixed`
+  - `contradicts_l4b`
 - 禁止写法:
-  - 只有 `L4A` 结果，却写成“玩家已经证明想继续玩”
-  - 只有 persona/subagent 结果，却写成“真人试玩已通过”
+  - 只有 `L4A` 结果，却写成“agent 已经试玩通过”或“真人试玩已通过”
+  - 只有 `L4B` 或内部真人校准结果，却写成“真实玩家验证已通过”
+  - 只有 persona/subagent 结果，却写成“真实玩家验证已通过”
 
 ## 5. Escalation And Calibration Boundary
 - 必须从 `L4A` 升级到 `L4B` 的情况:
-  - 玩法 claim 需要使用“真人想继续玩”这类措辞
-  - `L4A` 内部分歧很大，或 synthetic 结果高度依赖 persona 假设
-  - release / stage 结论需要比 `synthetic_ready` 更强
+  - 玩法 claim 需要使用“agent 真实进游戏操作后仍想继续”这类措辞
+  - 仅靠 synthetic 无法说明第一条真实操作链路是否成立
+- 必须从 `L4B` 升级到 `L5` 的情况:
+  - 玩法 claim 需要使用“真实人类想继续玩”这类措辞
+  - release / stage 结论需要比 `agent_ready` 更强
 - 当前不允许的推断:
   - `L4A pass => L4B pass`
+  - `L4B pass => L5 pass`
 - 当前 repo-local scaffold 的边界:
   - `prepare-playability-l4-review.sh` 只负责生成 packet / cards / summary / commands / manifest。
-  - 生成了 scaffold 不等于 `L4A` 或 `L4B` 已完成，更不等于真人替代已经发生。
+  - 生成了 scaffold 不等于 `L4A` 或 `L4B` 已完成。
 - 保留的未来扩展:
-  - 若未来建立 synthetic-to-human calibration ledger，且长期证明 `L4A` 对 `L4B` 具备可接受预测力，才可讨论提升 `L4A` 的决策权重；本轮不做此 claim。
+  - 若未来建立 calibration ledger，且长期证明 `L4A` 对 `L4B`、或 `L4B` 对 `L5` 具备可接受预测力，才可讨论提升低层的决策权重；本轮不做此 claim。
 
 ## 6. Acceptance Criteria
-- AC-1: 新专题明确写出 `L4A` 与 `L4B` 的定义、输入、输出和 claim 边界。
-- AC-2: `playability evidence stack` 专题正式拆出 `L4A/L4B`。
-- AC-3: `testing-manual.md` 的 L4 operator 入口同步区分 `L4A` 与 `L4B`。
-- AC-4: `simulated player persona panel` 与 `subagent review system` 都改成显式服务 `L4A`。
+- AC-1: 新专题明确写出 `L4A/L4B/L5` 的定义、输入、输出和 claim 边界。
+- AC-2: `playability evidence stack` 专题正式拆出 `L4A/L4B/L5` 边界。
+- AC-3: `testing-manual.md` 的 L4/L5 operator 入口同步区分 `L4A`、`L4B` 与 `L5`。
+- AC-4: `simulated player persona panel` 与 `subagent review system` 都改成显式服务 `L4A`，但允许它们把结果升级到 `L4B`。
 - AC-5: 文档明确保留 calibration 扩展位，但不宣称当前已完成。
-- AC-6: 文档明确写出 `./scripts/prepare-playability-l4-review.sh` 是当前完整 `L4` scaffold 入口，以及“scaffold != 替代真人”的硬边界。
+- AC-6: 文档明确写出 `./scripts/prepare-playability-l4-review.sh` 是当前完整 `L4` scaffold 入口，以及“scaffold != 已完成更高层”的硬边界。
 
 ## 7. Non-Goals
 - 不在本轮让 `L4A` 直接替代 `L4B`。
+- 不在本轮让 `L4B` 直接替代 `L5`。
 - 不实现 calibration ledger、统计模型或外部研究平台。
 - 不改变 `L5` 的定义。
 
@@ -128,27 +135,29 @@
   - `doc/testing/templates/playability-l4-review-packet-template.md`
   - `doc/testing/templates/playability-l4-summary-template.md`
 - Edge Cases:
-  - `L4A` 全正面、`L4B` 未执行：只能写 `synthetic_ready`，不能写 `human_ready`。
-  - `L4A` 与 `L4B` 冲突：优先记为“synthetic-human divergence”，不得直接用 `L4A` 覆盖真人反馈。
-  - `L4B` 样本很少：可以提升到 `human_continue_mixed`，但不能直接把它扩展成 `L5` 结论。
+  - `L4A` 全正面、`L4B` 未执行：只能写 `synthetic_ready`，不能写 `agent_ready`。
+  - `L4B` 全正面、`L5` 未执行：只能写 `agent_ready`，不能写 `external_ready`。
+  - `L4A` 与 `L4B` 冲突：必须显式记录 divergence。
+  - 内部真人校准与 `L4B` 冲突：必须显式记录 divergence，并保持 `L5 missing`。
   - 已生成 `L4` scaffold，但 `commands.sh` 未执行且卡片仍为空：只能写 operator scaffold ready，不能写任何 layer verdict。
 - Non-Functional Requirements:
-  - NFR-L4SPLIT-1: 审查者必须能在 60 秒内看懂当前结论是 `L4A` 还是 `L4B`。
-  - NFR-L4SPLIT-2: operator 必须能在 5 分钟内知道该跑 `worktree-harness/S6` 还是 `run-producer-playtest/playability card`。
-  - NFR-L4SPLIT-3: 任何正式玩法结论都不能再把 `synthetic` 与 `human` 混写成一个未分层的 `L4` verdict。
+  - NFR-L4SPLIT-1: 审查者必须能在 60 秒内看懂当前结论是 `L4A`、`L4B` 还是 `L5` 前的内部校准。
+  - NFR-L4SPLIT-2: operator 必须能在 5 分钟内知道该跑 `worktree-harness/S6`、`run-producer-playtest + agent card`，还是补一份可选内部真人校准 notes。
+  - NFR-L4SPLIT-3: 任何正式玩法结论都不能再把 `synthetic`、`agentic` 与 `real-human` 混写成一个未分层的 `L4` verdict。
 
 ## 9. Validation & Decision Record
 - Test Plan & Traceability:
 | PRD-ID | 对应任务 | 测试层级 | 验证方法 | 回归影响范围 |
 | --- | --- | --- | --- | --- |
-| PRD-TESTING-L4SPLIT-001 | `playability-l4-synthetic-human-split-2026-05-06` / `L4S-1` | `test_tier_required` | 抽查 `L4A/L4B` 定义、输入输出与 claim 规则 | 玩法证据分层口径 |
+| PRD-TESTING-L4SPLIT-001 | `playability-l4-synthetic-human-split-2026-05-06` / `L4S-1` | `test_tier_required` | 抽查 `L4A/L4B/L5` 边界、输入输出与 claim 规则 | 玩法证据分层口径 |
 | PRD-TESTING-L4SPLIT-002 | `playability-l4-synthetic-human-split-2026-05-06` / `L4S-1/2` | `test_tier_required` | 抽查 evidence stack / subagent / persona / manual 互相引用 | 文档真值一致性 |
 | PRD-TESTING-L4SPLIT-003 | `playability-l4-synthetic-human-split-2026-05-06` / `L4S-2` | `test_tier_required` | 抽查 operator 入口与边界说明 | operator 执行清晰度 |
-| PRD-TESTING-L4SPLIT-004 | `playability-l4-synthetic-human-split-2026-05-06` / `L4S-2/3` | `test_tier_required` | 抽查 calibration 扩展位与当前非承诺边界 | synthetic 替代 claim 边界 |
+| PRD-TESTING-L4SPLIT-004 | `playability-l4-synthetic-human-split-2026-05-06` / `L4S-2/3` | `test_tier_required` | 抽查 calibration 扩展位与当前非承诺边界 | synthetic/agent/human 替代 claim 边界 |
 - Decision Log:
 | 决策ID | 选定方案 | 备选方案（否决） | 依据 |
 | --- | --- | --- | --- |
-| `DEC-L4S-001` | 把当前 `L4` 拆成 `L4A/L4B` | 继续维持单层 `L4` | 单层会持续混淆 synthetic 与 human 证据。 |
-| `DEC-L4S-002` | `L4A` 允许高权重 synthetic 结论，但不冒充 `L4B` | 把 agent 角色扮演直接记成真人试玩 | 角色扮演仍缺真人时间/耐心/机会成本约束。 |
-| `DEC-L4S-003` | 为未来 calibration 留扩展位，但当前不宣称已完成 | 现在就把 `L4A` 提升为 `L4B` 替代品 | 当前仓库没有 synthetic-to-human 校准证据。 |
-| `DEC-L4S-004` | 当前先提供 repo-local scaffold，把 `L4A` 与 `L4B` 产物放进同一 artifact 目录 | 继续让 operator 临时拼接 packet / cards / summary / playtest card | 没有统一入口就无法把“完整 L4 可执行”作为当前 PR 的正式能力。 |
+| `DEC-L4S-001` | 把当前 `L4` 收口成 `L4A/L4B`，并把真实人类验证留在 `L5` | 继续维持单层 `L4` | 单层会持续混淆 synthetic、agentic 与 real-human 证据。 |
+| `DEC-L4S-002` | `L4B` 定义为具身 agent 试玩，不再等同真人试玩 | 继续把 agent 实操也记成 `L4A` | 用户当前产品口径要求“agent 实际玩游戏”成为独立更强层。 |
+| `DEC-L4S-003` | 内部真人试玩只保留为 `L4B` 可选校准，真实人类验证统一归 `L5` | 把内部真人试玩继续升格成独立正式层 | 用户当前口径要求 `L4B` 成为最高正式内部层，同时保留 `L5` 真实验证边界。 |
+| `DEC-L4S-004` | 为未来 calibration 留扩展位，但当前不宣称已完成 | 现在就把 `L4A` 或 `L4B` 提升为更高层替代品 | 当前仓库没有跨层校准证据。 |
+| `DEC-L4S-005` | 当前先提供 repo-local scaffold，把 `L4A`、`L4B` 与可选内部真人校准产物放进同一 artifact 目录 | 继续让 operator 临时拼接 packet / cards / summary / playtest card | 没有统一入口就无法把“完整 L4 可执行”作为当前 PR 的正式能力。 |

--- a/doc/testing/governance/playability-l4-synthetic-human-split-2026-05-06.prd.md
+++ b/doc/testing/governance/playability-l4-synthetic-human-split-2026-05-06.prd.md
@@ -1,0 +1,141 @@
+# oasis7: 好玩性 L4 synthetic/human 分层（2026-05-06）
+
+- 对应设计文档: `doc/testing/governance/playability-l4-synthetic-human-split-2026-05-06.design.md`
+- 对应项目管理文档: `doc/testing/governance/playability-l4-synthetic-human-split-2026-05-06.project.md`
+
+审计轮次: 1
+
+## 目标
+- 把当前 evidence stack 中过于宽泛的 `L4` 拆成 `L4A synthetic internal playability review` 与 `L4B structured human playtest`。
+- 明确 agent 完整角色扮演、标准角色 subagent 和 simulated personas 能提升到什么强度，以及为什么仍不能直接与真人试玩 claim 混写。
+
+## 范围
+- 覆盖 `L4A/L4B` 的定义、输入、输出、组合规则、升级边界和 operator 入口。
+- 不覆盖新的真人招募平台、外部用户研究系统或自动 orchestration 工具实现。
+
+## 接口 / 数据
+- 专题 PRD: `doc/testing/governance/playability-l4-synthetic-human-split-2026-05-06.prd.md`
+- 专题设计文档: `doc/testing/governance/playability-l4-synthetic-human-split-2026-05-06.design.md`
+- 专题项目管理文档: `doc/testing/governance/playability-l4-synthetic-human-split-2026-05-06.project.md`
+- 上游专题:
+  - `doc/testing/governance/playability-evidence-stack-2026-05-06.prd.md`
+  - `doc/testing/governance/playability-subagent-review-system-2026-05-06.prd.md`
+  - `doc/testing/governance/playability-simulated-player-persona-panel-2026-05-06.prd.md`
+- operator 入口:
+  - `testing-manual.md`
+  - `scripts/run-producer-playtest.sh`
+  - `doc/playability_test_result/playability_test_card.md`
+
+## 里程碑
+- M1 (2026-05-06): 冻结 `L4A/L4B` 定义、claim boundary 和组合规则。
+- M2: 若后续要提升 `L4A` 权重，再补 synthetic-to-human calibration 方案。
+
+## 风险
+- 若继续把 `L4` 写成单层，agent 结果和真人结果会持续混写。
+- 若把 `L4A` 直接包装成真人试玩替代品，会污染 go/hold/watch/block 结论。
+
+## 1. Executive Summary
+- Problem Statement: 当前 evidence stack 已经明确“自动化不能单独证明好玩”，但 `L4` 仍把两种本质不同的证据混在一起：一类是由 subagent、simulated personas 和 scripted/UI closure 组成的高强度内部模拟；另一类是真实人类在有时间、耐心和机会成本约束下的主观继续游玩意愿。如果继续共用一个 `L4` 标签，团队会反复争论“agent 说想继续玩，到底算不算真人试玩”。
+- Proposed Solution: 把 `L4` 正式拆成两层：`L4A synthetic internal playability review` 与 `L4B structured human playtest`。前者收纳标准角色 subagent、simulated personas、真实 formal surface 上的 synthetic continuation prediction；后者只收纳真人试玩卡、制作人/QA 人类实际继续游玩与主观反馈。
+- Success Criteria:
+  - SC-1: 文档明确给出 `L4A` 与 `L4B` 的输入、输出、证明边界和 operator 入口。
+  - SC-2: 文档明确写出 `agent 完整角色扮演 != 真人继续游玩意愿已被证明`。
+  - SC-3: `playability evidence stack`、`persona panel`、`subagent review system` 与 `testing-manual` 都同步改成同一口径。
+  - SC-4: `L4A` 可以成为内部高强度模拟完成的正式 verdict，但不能冒充 `L4B`。
+  - SC-5: 文档明确保留未来“做 synthetic-to-human calibration 后再提升 L4A 权重”的扩展位，但当前不宣称已经完成。
+
+## 2. User Experience & Functionality
+- User Personas:
+  - `producer_system_designer`: 需要知道当前结论是“模拟上看起来想继续玩”还是“真人真的想继续玩”。
+  - `qa_engineer`: 需要阻止团队把 synthetic 结果写成 human-validated claim。
+  - `viewer_engineer` / `agent_engineer` / `runtime_engineer`: 需要知道自己补的是 `L4A` 还是 `L4B` 的证据。
+  - `liveops_community`: 需要知道哪些内部正面结论还不能拿去对外表达成“已被玩家验证”。
+- User Scenarios & Frequency:
+  - 玩法争议集中在“agent 都说会继续玩，为什么还要人测”时。
+  - 日常迭代希望尽量减少人参与，但仍要保持证据边界时。
+  - 发布前需要解释当前到底只到 `L4A`，还是已经到 `L4B` 时。
+- User Stories:
+  - PRD-TESTING-L4SPLIT-001: As a `producer_system_designer`, I want `L4A/L4B` split explicitly, so that synthetic and human claims stop collapsing into one label.
+  - PRD-TESTING-L4SPLIT-002: As a `qa_engineer`, I want synthetic roleplay evidence bounded below human playtest evidence, so that overclaiming can be blocked.
+  - PRD-TESTING-L4SPLIT-003: As an operator, I want clear entrypoints for `L4A` and `L4B`, so that I know which command and artifact set belongs to which layer.
+  - PRD-TESTING-L4SPLIT-004: As a future workflow owner, I want a documented path for calibration-based promotion, so that stronger synthetic evidence can be discussed without prematurely changing current claims.
+- Critical User Flows:
+  1. `识别当前要回答的问题是 synthetic 预测，还是 human 实际继续游玩意愿`
+  2. `若先跑内部模拟 -> 执行 L4A -> 输出 synthetic verdict`
+  3. `若需要真人主观证据 -> 升级到 L4B -> 输出 human verdict`
+  4. `producer_system_designer` 汇总 L4A/L4B -> 决定当前是 synthetic_ready / human_ready / external_ready`
+
+## 3. Functional Specification Matrix
+| 层级 | 主要输入 | 可以证明 | 不能证明 | 默认入口 | 默认 owner |
+| --- | --- | --- | --- | --- | --- |
+| `L4A synthetic internal playability review` | 标准角色 subagent review cards、simulated persona cards、formal player surface 上的 scripted/UI closure、synthetic continuation prediction | 以当前内部模型看，哪些风格玩家大概率想继续玩，哪些断点会掉线，哪些 claim 只在 synthetic 里成立 | 真人在真实时间/耐心成本下是否真的愿意继续玩 | `testing-manual.md`、`worktree-harness.sh`、S6 Web UI 闭环、subagent/persona panel 输出 | `producer_system_designer` + `qa_engineer` |
+| `L4B structured human playtest` | 制作人试玩、QA headed rerun、playability card、受控访谈 | 真实人类是否看懂、是否感到有杠杆、是否想继续玩、阻塞是否可解释 | 广泛外部市场反应 | `run-producer-playtest.sh`、`doc/playability_test_result/playability_test_card.md` | `producer_system_designer` + `qa_engineer` |
+
+## 4. Claim Rules
+- 允许的 `L4A` 结论:
+  - `synthetic_continue_likely`
+  - `synthetic_continue_unclear`
+  - `synthetic_continue_unlikely`
+- 允许的 `L4B` 结论:
+  - `human_continue_observed`
+  - `human_continue_mixed`
+  - `human_continue_not_observed`
+- 禁止写法:
+  - 只有 `L4A` 结果，却写成“玩家已经证明想继续玩”
+  - 只有 persona/subagent 结果，却写成“真人试玩已通过”
+
+## 5. Escalation And Calibration Boundary
+- 必须从 `L4A` 升级到 `L4B` 的情况:
+  - 玩法 claim 需要使用“真人想继续玩”这类措辞
+  - `L4A` 内部分歧很大，或 synthetic 结果高度依赖 persona 假设
+  - release / stage 结论需要比 `synthetic_ready` 更强
+- 当前不允许的推断:
+  - `L4A pass => L4B pass`
+- 保留的未来扩展:
+  - 若未来建立 synthetic-to-human calibration ledger，且长期证明 `L4A` 对 `L4B` 具备可接受预测力，才可讨论提升 `L4A` 的决策权重；本轮不做此 claim。
+
+## 6. Acceptance Criteria
+- AC-1: 新专题明确写出 `L4A` 与 `L4B` 的定义、输入、输出和 claim 边界。
+- AC-2: `playability evidence stack` 专题正式拆出 `L4A/L4B`。
+- AC-3: `testing-manual.md` 的 L4 operator 入口同步区分 `L4A` 与 `L4B`。
+- AC-4: `simulated player persona panel` 与 `subagent review system` 都改成显式服务 `L4A`。
+- AC-5: 文档明确保留 calibration 扩展位，但不宣称当前已完成。
+
+## 7. Non-Goals
+- 不在本轮让 `L4A` 直接替代 `L4B`。
+- 不实现 calibration ledger、统计模型或外部研究平台。
+- 不改变 `L5` 的定义。
+
+## 8. Technical Specifications
+- Integration Points:
+  - `doc/testing/governance/playability-evidence-stack-2026-05-06.prd.md`
+  - `doc/testing/governance/playability-subagent-review-system-2026-05-06.prd.md`
+  - `doc/testing/governance/playability-simulated-player-persona-panel-2026-05-06.prd.md`
+  - `doc/testing/prd.md`
+  - `doc/testing/project.md`
+  - `doc/testing/README.md`
+  - `doc/testing/prd.index.md`
+  - `testing-manual.md`
+- Edge Cases:
+  - `L4A` 全正面、`L4B` 未执行：只能写 `synthetic_ready`，不能写 `human_ready`。
+  - `L4A` 与 `L4B` 冲突：优先记为“synthetic-human divergence”，不得直接用 `L4A` 覆盖真人反馈。
+  - `L4B` 样本很少：可以提升到 `human_continue_mixed`，但不能直接把它扩展成 `L5` 结论。
+- Non-Functional Requirements:
+  - NFR-L4SPLIT-1: 审查者必须能在 60 秒内看懂当前结论是 `L4A` 还是 `L4B`。
+  - NFR-L4SPLIT-2: operator 必须能在 5 分钟内知道该跑 `worktree-harness/S6` 还是 `run-producer-playtest/playability card`。
+  - NFR-L4SPLIT-3: 任何正式玩法结论都不能再把 `synthetic` 与 `human` 混写成一个未分层的 `L4` verdict。
+
+## 9. Validation & Decision Record
+- Test Plan & Traceability:
+| PRD-ID | 对应任务 | 测试层级 | 验证方法 | 回归影响范围 |
+| --- | --- | --- | --- | --- |
+| PRD-TESTING-L4SPLIT-001 | `playability-l4-synthetic-human-split-2026-05-06` / `L4S-1` | `test_tier_required` | 抽查 `L4A/L4B` 定义、输入输出与 claim 规则 | 玩法证据分层口径 |
+| PRD-TESTING-L4SPLIT-002 | `playability-l4-synthetic-human-split-2026-05-06` / `L4S-1/2` | `test_tier_required` | 抽查 evidence stack / subagent / persona / manual 互相引用 | 文档真值一致性 |
+| PRD-TESTING-L4SPLIT-003 | `playability-l4-synthetic-human-split-2026-05-06` / `L4S-2` | `test_tier_required` | 抽查 operator 入口与边界说明 | operator 执行清晰度 |
+| PRD-TESTING-L4SPLIT-004 | `playability-l4-synthetic-human-split-2026-05-06` / `L4S-2/3` | `test_tier_required` | 抽查 calibration 扩展位与当前非承诺边界 | synthetic 替代 claim 边界 |
+- Decision Log:
+| 决策ID | 选定方案 | 备选方案（否决） | 依据 |
+| --- | --- | --- | --- |
+| `DEC-L4S-001` | 把当前 `L4` 拆成 `L4A/L4B` | 继续维持单层 `L4` | 单层会持续混淆 synthetic 与 human 证据。 |
+| `DEC-L4S-002` | `L4A` 允许高权重 synthetic 结论，但不冒充 `L4B` | 把 agent 角色扮演直接记成真人试玩 | 角色扮演仍缺真人时间/耐心/机会成本约束。 |
+| `DEC-L4S-003` | 为未来 calibration 留扩展位，但当前不宣称已完成 | 现在就把 `L4A` 提升为 `L4B` 替代品 | 当前仓库没有 synthetic-to-human 校准证据。 |

--- a/doc/testing/governance/playability-l4-synthetic-human-split-2026-05-06.project.md
+++ b/doc/testing/governance/playability-l4-synthetic-human-split-2026-05-06.project.md
@@ -1,14 +1,14 @@
-# oasis7: 好玩性 L4 synthetic/human 分层（2026-05-06）（项目管理）
+# oasis7: 好玩性 L4 synthetic/agent/human 分层（2026-05-06）（项目管理）
 
 - 对应设计文档: `doc/testing/governance/playability-l4-synthetic-human-split-2026-05-06.design.md`
 - 对应需求文档: `doc/testing/governance/playability-l4-synthetic-human-split-2026-05-06.prd.md`
 
-审计轮次: 1
+审计轮次: 2
 
 ## 任务拆解（含 PRD-ID 映射）
-- [x] l4-split-boundary (PRD-TESTING-L4SPLIT-001/002) [test_tier_required]: 把 evidence stack 中的 `L4` 正式拆成 `L4A synthetic` 与 `L4B human`，并同步根模块入口。 Trace: .pm/tasks/task_a68decb0a2c8460aa7d989df7370c901.yaml
-- [x] l4-split-operator-entry (PRD-TESTING-L4SPLIT-003) [test_tier_required]: 同步 `testing-manual` 的 operator 入口，把 `worktree-harness/S6` 与 `run-producer-playtest/playability card` 分到不同子层。 Trace: .pm/tasks/task_a68decb0a2c8460aa7d989df7370c901.yaml
-- [x] l4-split-calibration-boundary (PRD-TESTING-L4SPLIT-004) [test_tier_required]: 明确未来 calibration 扩展位存在，但当前不宣称 `L4A` 已可替代 `L4B`。 Trace: .pm/tasks/task_a68decb0a2c8460aa7d989df7370c901.yaml
+- [x] l4-split-boundary (PRD-TESTING-L4SPLIT-001/002) [test_tier_required]: 把 evidence stack 中的 `L4` 正式收口成 `L4A synthetic` 与 `L4B agent`，并把内部真人试玩降为 `L4B` 可选校准、把真实人类验证留在 `L5`，同步根模块入口。 Trace: .pm/tasks/task_a68decb0a2c8460aa7d989df7370c901.yaml
+- [x] l4-split-operator-entry (PRD-TESTING-L4SPLIT-003) [test_tier_required]: 同步 `testing-manual` 的 operator 入口，把 `worktree-harness/S6`、`run-producer-playtest + agent card` 与可选内部真人校准 notes 分到不同职责边界。 Trace: .pm/tasks/task_a68decb0a2c8460aa7d989df7370c901.yaml
+- [x] l4-split-calibration-boundary (PRD-TESTING-L4SPLIT-004) [test_tier_required]: 明确未来 calibration 扩展位存在，但当前不宣称 `L4A` 已可替代 `L4B`，也不宣称 `L4B` 已可替代 `L5`。 Trace: .pm/tasks/task_a68decb0a2c8460aa7d989df7370c901.yaml
 
 ## 依赖
 - `doc/testing/governance/playability-evidence-stack-2026-05-06.prd.md`
@@ -18,8 +18,8 @@
 - `doc/playability_test_result/playability_test_card.md`
 
 ## 状态
-- 更新日期: 2026-05-06
+- 更新日期: 2026-05-07
 - 当前阶段: 已完成
 - 阻塞项: 无
 - 下一步:
-  - 若未来要提升 `L4A` 权重，先新增 calibration ledger/topic，再决定是否调整 claim envelope。
+  - 若未来要提升 `L4A` 或 `L4B` 权重，先新增 calibration ledger/topic，再决定是否调整 claim envelope。

--- a/doc/testing/governance/playability-l4-synthetic-human-split-2026-05-06.project.md
+++ b/doc/testing/governance/playability-l4-synthetic-human-split-2026-05-06.project.md
@@ -1,0 +1,25 @@
+# oasis7: 好玩性 L4 synthetic/human 分层（2026-05-06）（项目管理）
+
+- 对应设计文档: `doc/testing/governance/playability-l4-synthetic-human-split-2026-05-06.design.md`
+- 对应需求文档: `doc/testing/governance/playability-l4-synthetic-human-split-2026-05-06.prd.md`
+
+审计轮次: 1
+
+## 任务拆解（含 PRD-ID 映射）
+- [x] l4-split-boundary (PRD-TESTING-L4SPLIT-001/002) [test_tier_required]: 把 evidence stack 中的 `L4` 正式拆成 `L4A synthetic` 与 `L4B human`，并同步根模块入口。 Trace: .pm/tasks/task_a68decb0a2c8460aa7d989df7370c901.yaml
+- [x] l4-split-operator-entry (PRD-TESTING-L4SPLIT-003) [test_tier_required]: 同步 `testing-manual` 的 operator 入口，把 `worktree-harness/S6` 与 `run-producer-playtest/playability card` 分到不同子层。 Trace: .pm/tasks/task_a68decb0a2c8460aa7d989df7370c901.yaml
+- [x] l4-split-calibration-boundary (PRD-TESTING-L4SPLIT-004) [test_tier_required]: 明确未来 calibration 扩展位存在，但当前不宣称 `L4A` 已可替代 `L4B`。 Trace: .pm/tasks/task_a68decb0a2c8460aa7d989df7370c901.yaml
+
+## 依赖
+- `doc/testing/governance/playability-evidence-stack-2026-05-06.prd.md`
+- `doc/testing/governance/playability-subagent-review-system-2026-05-06.prd.md`
+- `doc/testing/governance/playability-simulated-player-persona-panel-2026-05-06.prd.md`
+- `testing-manual.md`
+- `doc/playability_test_result/playability_test_card.md`
+
+## 状态
+- 更新日期: 2026-05-06
+- 当前阶段: 已完成
+- 阻塞项: 无
+- 下一步:
+  - 若未来要提升 `L4A` 权重，先新增 calibration ledger/topic，再决定是否调整 claim envelope。

--- a/doc/testing/governance/playability-simulated-player-persona-panel-2026-05-06.design.md
+++ b/doc/testing/governance/playability-simulated-player-persona-panel-2026-05-06.design.md
@@ -1,0 +1,42 @@
+# oasis7: 模拟玩家 persona 评审面板（2026-05-06）设计
+
+- 对应需求文档: `doc/testing/governance/playability-simulated-player-persona-panel-2026-05-06.prd.md`
+- 对应项目管理文档: `doc/testing/governance/playability-simulated-player-persona-panel-2026-05-06.project.md`
+
+审计轮次: 1
+
+## 1. 设计定位
+把“agent 扮演多个不同风格玩家”从临时灵感收口成 testing/governance 层的固定面板设计，专门补内部主观体验假设。
+
+## 2. 系统结构
+- Orchestrator:
+  - `producer_system_designer`
+- Gatekeeper:
+  - `qa_engineer`
+- Persona panel:
+  - `new_player_confused`
+  - `impatient_action_player`
+  - `systems_optimizer`
+  - `narrative_curiosity_player`
+  - `chaos_tester`
+- Role handoff:
+  - persona cards 不能直接成为最终 verdict，必须回流到标准角色 review card。
+
+## 3. 数据契约
+- Input:
+  - `persona review packet`
+- Output:
+  - `persona card`
+- Aggregation:
+  - `persona divergence summary`
+  - `role review card`
+
+## 4. 调度策略
+- 先由 `producer_system_designer` / `qa_engineer` 判断本次改动是否值得开启 persona panel。
+- 再按 changed surface 选择最小 persona 子集并行执行。
+- 最后把 persona cards 交给命中的标准角色 subagent 收口。
+
+## 5. 约束
+- persona panel 不是 `.agents/roles/` 正式角色。
+- persona panel 只能产出内部体验假设、分歧和风险线索。
+- persona panel 不能直接替代 L4 结构化真人试玩或 L5 外部信号。

--- a/doc/testing/governance/playability-simulated-player-persona-panel-2026-05-06.design.md
+++ b/doc/testing/governance/playability-simulated-player-persona-panel-2026-05-06.design.md
@@ -30,6 +30,9 @@
 - Aggregation:
   - `persona divergence summary`
   - `role review card`
+- Current scaffold:
+  - `scripts/prepare-playability-l4-review.sh` 负责在单个 worktree 内预置 persona cards、summary 与统一路径。
+  - 该 scaffold 不自动替代 persona 分析或标准角色 handoff。
 
 ## 4. 调度策略
 - 先由 `producer_system_designer` / `qa_engineer` 判断本次改动是否值得开启 persona panel。

--- a/doc/testing/governance/playability-simulated-player-persona-panel-2026-05-06.prd.md
+++ b/doc/testing/governance/playability-simulated-player-persona-panel-2026-05-06.prd.md
@@ -11,7 +11,8 @@
 
 ## 范围
 - 覆盖 simulated player personas 的清单、输入输出 contract、触发方式、与标准角色 subagent 的协作边界。
-- 不覆盖真实外部玩家招募、问卷平台或自动 orchestration 工具实现。
+- 覆盖当前 repo-local scaffold 入口如何稳定生成 persona packet 与 persona cards。
+- 不覆盖真实外部玩家招募、问卷平台或“自动完成 persona verdict”的自治 orchestration 实现。
 
 ## 接口 / 数据
 - 专题 PRD: `doc/testing/governance/playability-simulated-player-persona-panel-2026-05-06.prd.md`
@@ -23,8 +24,8 @@
 - 角色真值入口: `.agents/roles/*.md`
 
 ## 里程碑
-- M1 (2026-05-06): 冻结 simulated player persona panel 的固定 persona 清单、输入输出 contract 与越权边界。
-- M2: 若后续需要自动执行，再补 panel runbook / wrapper 层设计。
+- M1 (2026-05-06): 冻结 simulated player persona panel 的固定 persona 清单、输入输出 contract、越权边界，以及 repo-local scaffold 入口。
+- M2: 若后续需要更强自动化，再补 persona 执行/聚合自动化扩展设计。
 
 ## 风险
 - 若 persona 定义模糊，评审输出会退回泛泛而谈的“像玩家一样看看”。
@@ -39,6 +40,7 @@
   - SC-3: persona panel 被明确写成“内部体验假设层”，而不是新的正式 `.agents/roles/` 角色。
   - SC-4: 专题定义 persona panel 与标准角色 subagent 的协作方式、触发矩阵和 stop conditions。
   - SC-5: 专题明确 `persona simulation != 真实玩家验证`，不得替代 L5 外部信号。
+  - SC-6: 当前仓库提供 `./scripts/prepare-playability-l4-review.sh`，能在单个 worktree 内稳定生成 persona packet 上下文和固定 persona cards。
 
 ## 2. User Experience & Functionality
 - User Personas:
@@ -57,7 +59,7 @@
   - PRD-TESTING-PERSONA-004: As an implementation owner, I want a trigger matrix for when persona simulation is worth running, so that this panel does not become cargo-cult overhead.
   - PRD-TESTING-PERSONA-005: As a workflow owner, I want persona panel outputs to plug into role-based subagent review, so that internal review still closes through standard roles.
 - Critical User Flows:
-  1. `识别是否存在显著主观体验风险 -> 选择默认或定制 persona 子集 -> 组装 persona review packet`
+  1. `识别是否存在显著主观体验风险 -> 运行 `prepare-playability-l4-review.sh` 或按同一 contract 组装 persona review packet -> 选择默认或定制 persona 子集`
   2. `并行执行多个 persona 模拟 -> 回收 persona cards -> 标记共性断点 / 风格分歧`
   3. `qa_engineer` / `producer_system_designer` / 命中的工程角色读取 persona cards -> 回写正式 role review card`
   4. `若需要更高信度 -> 从 `L4A` 升级到 `L4B structured human playtest` 或 L5 受控外部信号`
@@ -94,6 +96,14 @@
   - `what_this_persona_does_not_prove`
   - `followup_questions`
   - `handoff_recommended_to`
+- Current repo-local scaffold:
+  - `./scripts/prepare-playability-l4-review.sh` 会一次性生成：
+    - `l4-review-packet.md`
+    - `persona-cards/*.md`
+    - `l4-summary.md`
+    - `commands.sh`
+    - `manifest.json`
+  - 该脚本只负责固定 persona 卡位和统一路径，不自动产出 persona 结论。
 
 ## 5. Trigger Matrix
 - Default-open:
@@ -144,6 +154,7 @@
 - AC-3: persona panel 与标准角色 subagent 的协作方式、触发矩阵和升级条件写清。
 - AC-4: 文档明确写出“persona panel 不是正式角色，不进入 `.agents/roles/`”。
 - AC-5: 文档明确写出“persona simulation != 真实玩家验证”的硬边界。
+- AC-6: 文档明确写出当前 repo-local scaffold 入口与其边界: 能生成 persona cards，但不会自动替代 persona 分析与 role handoff。
 
 ## 9. Non-Goals
 - 不在本轮新增正式 `player` 角色。
@@ -157,10 +168,13 @@
   - `doc/testing/governance/playability-evidence-stack-2026-05-06.prd.md`
   - `doc/testing/governance/playability-subagent-review-system-2026-05-06.prd.md`
   - `.agents/roles/*.md`
+  - `scripts/prepare-playability-l4-review.sh`
+  - `doc/testing/templates/playability-l4-persona-card-template.md`
 - Edge Cases:
   - 若 persona card 没有一手证据，只是转述 role review：必须标 `secondary_review_only`。
   - 若 selected personas 未覆盖本次改动最关键风险面：必须记为 `panel_incomplete`。
   - 若 persona panel 全正面，但没有任何真人试玩：仍只能记为 `L4A` 完成，不能宣称 `L4B` 已完成。
+  - 若 scaffold 已生成，但 persona cards 仍为空白模板：只能记为 panel scaffold 完成，不能记为 persona panel 已执行。
 - Non-Functional Requirements:
   - NFR-SPP-1: 新读者应在 5 分钟内知道何时需要开 persona panel。
   - NFR-SPP-2: 每张 persona card 必须在 30 秒内看出“这个风格的玩家会在哪掉线”。
@@ -181,3 +195,4 @@
 | `DEC-SPP-002` | 固定 5 类高复用 persona | 每次临时想象不同玩家 | 临时脑补不可比较，也无法沉淀治理规范。 |
 | `DEC-SPP-003` | persona 输出先汇入标准角色 review | persona panel 直接给最终放行结论 | 玩家主观模拟不应绕过 QA / producer / 工程角色收口。 |
 | `DEC-SPP-004` | persona panel 只作为 `L4A` 内部体验假设层 | 把 persona simulation 当成真实玩家测试 | 证明强度不够，会污染 `L4B/L5` 边界。 |
+| `DEC-SPP-005` | 当前先提供 repo-local scaffold 固定 persona card 路径与汇总接口 | 等未来自动模拟器成熟后再提供 operator 入口 | 没有稳定 scaffold，persona panel 仍停留在一次性手写流程。 |

--- a/doc/testing/governance/playability-simulated-player-persona-panel-2026-05-06.prd.md
+++ b/doc/testing/governance/playability-simulated-player-persona-panel-2026-05-06.prd.md
@@ -1,0 +1,183 @@
+# oasis7: 模拟玩家 persona 评审面板（2026-05-06）
+
+- 对应设计文档: `doc/testing/governance/playability-simulated-player-persona-panel-2026-05-06.design.md`
+- 对应项目管理文档: `doc/testing/governance/playability-simulated-player-persona-panel-2026-05-06.project.md`
+
+审计轮次: 1
+
+## 目标
+- 把“agent 可以扮演多个不同风格的 player 视角”正式设计成一套可复用的 testing/governance 专题。
+- 让内部 playability review 在不新增正式 `player` 角色的前提下，稳定补齐多种玩家主观反应假设。
+
+## 范围
+- 覆盖 simulated player personas 的清单、输入输出 contract、触发方式、与标准角色 subagent 的协作边界。
+- 不覆盖真实外部玩家招募、问卷平台或自动 orchestration 工具实现。
+
+## 接口 / 数据
+- 专题 PRD: `doc/testing/governance/playability-simulated-player-persona-panel-2026-05-06.prd.md`
+- 专题设计文档: `doc/testing/governance/playability-simulated-player-persona-panel-2026-05-06.design.md`
+- 专题项目管理文档: `doc/testing/governance/playability-simulated-player-persona-panel-2026-05-06.project.md`
+- 上游专题:
+  - `doc/testing/governance/playability-evidence-stack-2026-05-06.prd.md`
+  - `doc/testing/governance/playability-subagent-review-system-2026-05-06.prd.md`
+- 角色真值入口: `.agents/roles/*.md`
+
+## 里程碑
+- M1 (2026-05-06): 冻结 simulated player persona panel 的固定 persona 清单、输入输出 contract 与越权边界。
+- M2: 若后续需要自动执行，再补 panel runbook / wrapper 层设计。
+
+## 风险
+- 若 persona 定义模糊，评审输出会退回泛泛而谈的“像玩家一样看看”。
+- 若 persona panel 边界写不清，内部模拟视角会被误当成真实外部玩家验证。
+
+## 1. Executive Summary
+- Problem Statement: 标准角色 subagent 已经能覆盖专业判断，但它们不天然等于多样化玩家主观反应。若没有一层固定的 simulated player personas，团队还是会在“新手会不会迷路”“急性子玩家会不会立刻退出”“系统党会不会刷出无聊最优解”这些问题上临时想象，导致内部 playability review 缺乏可比较的玩家视角。
+- Proposed Solution: 新增 `simulated player persona panel` 专题，把多种玩家风格设计成可复用的内部评审面板。它不新增正式组织角色，而是作为 `producer_system_designer` / `qa_engineer` / 相关角色 subagent 可调用的体验假设层，输出结构化 persona cards，供标准角色 subagent 汇总。
+- Success Criteria:
+  - SC-1: 至少定义 5 类固定 simulated personas，覆盖新手困惑、急性子行动派、系统优化派、叙事好奇派和混沌破坏派。
+  - SC-2: 每个 persona 都有明确的输入、偏好/容忍度、必答问题、输出字段和不得越权边界。
+  - SC-3: persona panel 被明确写成“内部体验假设层”，而不是新的正式 `.agents/roles/` 角色。
+  - SC-4: 专题定义 persona panel 与标准角色 subagent 的协作方式、触发矩阵和 stop conditions。
+  - SC-5: 专题明确 `persona simulation != 真实玩家验证`，不得替代 L5 外部信号。
+
+## 2. User Experience & Functionality
+- User Personas:
+  - `producer_system_designer`: 需要把“玩家可能怎么想”从临时脑补变成结构化内部假设。
+  - `qa_engineer`: 需要知道 persona panel 能证明什么、不能证明什么，避免把模拟主观反应误当 blocker 真值。
+  - `viewer_engineer`: 需要快速知道不同风格玩家在 UI / onboarding / feedback 上会卡在哪里。
+  - `agent_engineer` / `runtime_engineer`: 需要判断不同玩家风格到底有没有真实杠杆，还是只是在看世界自己运转。
+- User Scenarios & Frequency:
+  - 新 onboarding / 首次体验 / retention 改动准备提交或发 PR 时。
+  - 玩法争议集中在“有的人会觉得无聊/迷路/太慢/太吵”这类主观差异时。
+  - 标准角色 review 已经齐全，但还需要补多种玩家视角假设时。
+- User Stories:
+  - PRD-TESTING-PERSONA-001: As a `producer_system_designer`, I want a reusable panel of simulated player personas, so that internal playability review can cover more than one player mindset.
+  - PRD-TESTING-PERSONA-002: As a `qa_engineer`, I want persona outputs to be normalized and explicitly bounded, so that they remain hypotheses instead of fake validation.
+  - PRD-TESTING-PERSONA-003: As a `viewer_engineer`, I want personas with distinct reading tolerance and feedback expectations, so that UI readability risks become concrete.
+  - PRD-TESTING-PERSONA-004: As an implementation owner, I want a trigger matrix for when persona simulation is worth running, so that this panel does not become cargo-cult overhead.
+  - PRD-TESTING-PERSONA-005: As a workflow owner, I want persona panel outputs to plug into role-based subagent review, so that internal review still closes through standard roles.
+- Critical User Flows:
+  1. `识别是否存在显著主观体验风险 -> 选择默认或定制 persona 子集 -> 组装 persona review packet`
+  2. `并行执行多个 persona 模拟 -> 回收 persona cards -> 标记共性断点 / 风格分歧`
+  3. `qa_engineer` / `producer_system_designer` / 命中的工程角色读取 persona cards -> 回写正式 role review card`
+  4. `若需要更高信度 -> 升级到 L4 结构化真人试玩或 L5 受控外部信号`
+
+## 3. Persona Catalog
+| persona_id | 核心风格 | 高敏感项 | 低容忍项 | 最关注的问题 | 默认使用场景 |
+| --- | --- | --- | --- | --- | --- |
+| `new_player_confused` | 首次进入、目标感弱、需要明确引导 | 首屏目标、下一步提示、反馈解释性 | 长文案、隐含规则、需要猜的交互 | “我现在到底该做什么？” | onboarding、首屏、首次 10 分钟 |
+| `impatient_action_player` | 想立刻行动并看到结果 | 操作后反馈速度、结果可见性、节奏 | 等待、绕路、说明文字 | “我点了之后，世界马上因我而变了吗？” | retention、首个可用回路、快节奏玩法 |
+| `systems_optimizer` | 会找最优解、刷法和漏洞 | 策略深度、可优化空间、资源 loop | 假选择、单一最优、无效 grind | “这里有没有值得我推敲的系统杠杆？” | 经济、资源、工艺、策略系统 |
+| `narrative_curiosity_player` | 在意世界意义、角色动机和反馈语义 | 世界回应、后果解释、叙事 hooks | 冷冰冰反馈、无意义噪音 | “这个世界为什么值得我继续观察或介入？” | narrative、world feedback、agent drama |
+| `chaos_tester` | 专门跳步骤、乱点、试边界 | 断路恢复、异常反馈、状态一致性 | 静默失败、假成功、软锁 | “如果我不按设计来，会发生什么坏事？” | 边界条件、恢复、容错、anti-softlock |
+
+## 4. Persona Review Packet Contract
+- Required fields:
+  - `change_scope`
+  - `target_experience_claim`
+  - `formal_surfaces`
+  - `artifact_paths`
+  - `known_blockers`
+  - `selected_personas`
+  - `questions_to_probe`
+- Optional fields:
+  - `current_role_reviews`
+  - `telemetry_hypothesis`
+  - `outside_scope`
+  - `expected_player_leverage`
+- Persona card schema:
+  - `persona_id`
+  - `verdict`: `engaged/confused/bored/frustrated/exploitable`
+  - `top_reactions`
+  - `moment_of_dropoff`
+  - `evidence_used`
+  - `what_this_persona_does_not_prove`
+  - `followup_questions`
+  - `handoff_recommended_to`
+
+## 5. Trigger Matrix
+- Default-open:
+  - 不默认强制每次都开 persona panel；只有当体验 claim 含明显主观差异风险时才建议开启。
+- Open when changed surface includes:
+  - onboarding / first-time comprehension / first-session retention:
+    - `new_player_confused`
+    - `impatient_action_player`
+  - progression payoff / responsiveness / first reward loop:
+    - `impatient_action_player`
+  - economy / optimization / exploitability / dominant strategy:
+    - `systems_optimizer`
+    - `chaos_tester`
+  - narrative hooks / world reactivity / agent meaning:
+    - `narrative_curiosity_player`
+  - recovery / edge-case navigation / softlock risk:
+    - `chaos_tester`
+
+## 6. Collaboration With Standard Role Subagents
+- `producer_system_designer`:
+  - 读取 persona panel 的共性断点和风格分歧，决定是否影响 `target_claim`。
+- `qa_engineer`:
+  - 判断 persona panel 是不是只提出假设，还是已经指出必须升级到真人试玩的高风险断点。
+- `viewer_engineer`:
+  - 吸收 `new_player_confused` / `impatient_action_player` / `narrative_curiosity_player` 的可读性和反馈问题。
+- `agent_engineer`:
+  - 吸收 `narrative_curiosity_player` / `impatient_action_player` 对 agent reactivity 的质疑。
+- `runtime_engineer`:
+  - 吸收 `chaos_tester` / `systems_optimizer` 暴露出的软锁、节奏塌陷或 contract 风险。
+- `liveops_community`:
+  - 只在需要准备对外说法时读取 persona panel 的 claim-risk，不把它当成外部反馈。
+
+## 7. Escalation And Stop Conditions
+- 必须立即升级到更高层验证的情况:
+  - 多个 persona 都在同一关键节点给出 `confused` / `bored` / `frustrated`
+  - `systems_optimizer` 或 `chaos_tester` 指出明显 exploit / dominant strategy / softlock 风险
+  - `persona panel` 与标准角色 review 对“玩家是否拥有杠杆”得出相反结论
+- 必须写明但不直接阻断的情况:
+  - 只有单一 persona 负面，其余 persona 正常
+  - persona 之间对同一节点出现明显风格分歧
+- 永远不能越过的边界:
+  - persona panel 只能输出内部体验假设与风险线索，不能写成“玩家已经验证喜欢”
+  - persona panel 不能单独替代 L4 结构化真人试玩或 L5 外部信号
+
+## 8. Acceptance Criteria
+- AC-1: 专题定义至少 5 类固定 persona，并写清各自偏好与低容忍项。
+- AC-2: persona review packet 与 persona card schema 明确可复用。
+- AC-3: persona panel 与标准角色 subagent 的协作方式、触发矩阵和升级条件写清。
+- AC-4: 文档明确写出“persona panel 不是正式角色，不进入 `.agents/roles/`”。
+- AC-5: 文档明确写出“persona simulation != 真实玩家验证”的硬边界。
+
+## 9. Non-Goals
+- 不在本轮新增正式 `player` 角色。
+- 不把 persona panel 包装成外部用户研究平台。
+- 不在本轮实现自动化执行器或评分模型。
+
+## 10. Technical Specifications
+- Integration Points:
+  - `doc/testing/prd.md`
+  - `doc/testing/project.md`
+  - `doc/testing/governance/playability-evidence-stack-2026-05-06.prd.md`
+  - `doc/testing/governance/playability-subagent-review-system-2026-05-06.prd.md`
+  - `.agents/roles/*.md`
+- Edge Cases:
+  - 若 persona card 没有一手证据，只是转述 role review：必须标 `secondary_review_only`。
+  - 若 selected personas 未覆盖本次改动最关键风险面：必须记为 `panel_incomplete`。
+  - 若 persona panel 全正面，但没有任何真人试玩：仍只能记为内部假设完成。
+- Non-Functional Requirements:
+  - NFR-SPP-1: 新读者应在 5 分钟内知道何时需要开 persona panel。
+  - NFR-SPP-2: 每张 persona card 必须在 30 秒内看出“这个风格的玩家会在哪掉线”。
+  - NFR-SPP-3: persona panel 的所有结论都必须能无歧义回接到标准角色 review。
+
+## 11. Validation & Decision Record
+- Test Plan & Traceability:
+| PRD-ID | 对应任务 | 测试层级 | 验证方法 | 回归影响范围 |
+| --- | --- | --- | --- | --- |
+| PRD-TESTING-PERSONA-001 | `playability-simulated-player-persona-panel-2026-05-06` / `SPP-1` | `test_tier_required` | `rg` 检查 persona catalog 与边界定义 | 内部玩家视角设计完整性 |
+| PRD-TESTING-PERSONA-002 | `playability-simulated-player-persona-panel-2026-05-06` / `SPP-1/2` | `test_tier_required` | 抽查 persona packet / card schema | 输入输出一致性 |
+| PRD-TESTING-PERSONA-003 | `playability-simulated-player-persona-panel-2026-05-06` / `SPP-2` | `test_tier_required` | 抽查 trigger matrix 与 role handoff 规则 | persona panel 调度可执行性 |
+| PRD-TESTING-PERSONA-004 | `playability-simulated-player-persona-panel-2026-05-06` / `SPP-2/3` | `test_tier_required` | 抽查非正式角色限制与 L4/L5 边界说明 | 内外部验证边界 |
+- Decision Log:
+| 决策ID | 选定方案 | 备选方案（否决） | 依据 |
+| --- | --- | --- | --- |
+| `DEC-SPP-001` | 用 non-role persona panel 表达玩家视角 | 新增正式 `player` 角色 | 会破坏现有标准角色治理与 PM 约束。 |
+| `DEC-SPP-002` | 固定 5 类高复用 persona | 每次临时想象不同玩家 | 临时脑补不可比较，也无法沉淀治理规范。 |
+| `DEC-SPP-003` | persona 输出先汇入标准角色 review | persona panel 直接给最终放行结论 | 玩家主观模拟不应绕过 QA / producer / 工程角色收口。 |
+| `DEC-SPP-004` | persona panel 只作为内部体验假设层 | 把 persona simulation 当成真实玩家测试 | 证明强度不够，会污染 L4/L5 边界。 |

--- a/doc/testing/governance/playability-simulated-player-persona-panel-2026-05-06.prd.md
+++ b/doc/testing/governance/playability-simulated-player-persona-panel-2026-05-06.prd.md
@@ -3,11 +3,11 @@
 - 对应设计文档: `doc/testing/governance/playability-simulated-player-persona-panel-2026-05-06.design.md`
 - 对应项目管理文档: `doc/testing/governance/playability-simulated-player-persona-panel-2026-05-06.project.md`
 
-审计轮次: 1
+审计轮次: 2
 
 ## 目标
 - 把“agent 可以扮演多个不同风格的 player 视角”正式设计成一套可复用的 testing/governance 专题。
-- 让内部 playability review 在不新增正式 `player` 角色的前提下，稳定补齐多种玩家主观反应假设。
+- 让内部 playability review 在不新增正式 `player` 角色的前提下，稳定补齐多种玩家主观反应假设，并作为 `L4A synthetic internal playability review` 的核心输入。
 
 ## 范围
 - 覆盖 simulated player personas 的清单、输入输出 contract、触发方式、与标准角色 subagent 的协作边界。
@@ -60,7 +60,7 @@
   1. `识别是否存在显著主观体验风险 -> 选择默认或定制 persona 子集 -> 组装 persona review packet`
   2. `并行执行多个 persona 模拟 -> 回收 persona cards -> 标记共性断点 / 风格分歧`
   3. `qa_engineer` / `producer_system_designer` / 命中的工程角色读取 persona cards -> 回写正式 role review card`
-  4. `若需要更高信度 -> 升级到 L4 结构化真人试玩或 L5 受控外部信号`
+  4. `若需要更高信度 -> 从 `L4A` 升级到 `L4B structured human playtest` 或 L5 受控外部信号`
 
 ## 3. Persona Catalog
 | persona_id | 核心风格 | 高敏感项 | 低容忍项 | 最关注的问题 | 默认使用场景 |
@@ -136,7 +136,7 @@
   - persona 之间对同一节点出现明显风格分歧
 - 永远不能越过的边界:
   - persona panel 只能输出内部体验假设与风险线索，不能写成“玩家已经验证喜欢”
-  - persona panel 不能单独替代 L4 结构化真人试玩或 L5 外部信号
+  - persona panel 不能单独替代 `L4B structured human playtest` 或 L5 外部信号
 
 ## 8. Acceptance Criteria
 - AC-1: 专题定义至少 5 类固定 persona，并写清各自偏好与低容忍项。
@@ -160,7 +160,7 @@
 - Edge Cases:
   - 若 persona card 没有一手证据，只是转述 role review：必须标 `secondary_review_only`。
   - 若 selected personas 未覆盖本次改动最关键风险面：必须记为 `panel_incomplete`。
-  - 若 persona panel 全正面，但没有任何真人试玩：仍只能记为内部假设完成。
+  - 若 persona panel 全正面，但没有任何真人试玩：仍只能记为 `L4A` 完成，不能宣称 `L4B` 已完成。
 - Non-Functional Requirements:
   - NFR-SPP-1: 新读者应在 5 分钟内知道何时需要开 persona panel。
   - NFR-SPP-2: 每张 persona card 必须在 30 秒内看出“这个风格的玩家会在哪掉线”。
@@ -180,4 +180,4 @@
 | `DEC-SPP-001` | 用 non-role persona panel 表达玩家视角 | 新增正式 `player` 角色 | 会破坏现有标准角色治理与 PM 约束。 |
 | `DEC-SPP-002` | 固定 5 类高复用 persona | 每次临时想象不同玩家 | 临时脑补不可比较，也无法沉淀治理规范。 |
 | `DEC-SPP-003` | persona 输出先汇入标准角色 review | persona panel 直接给最终放行结论 | 玩家主观模拟不应绕过 QA / producer / 工程角色收口。 |
-| `DEC-SPP-004` | persona panel 只作为内部体验假设层 | 把 persona simulation 当成真实玩家测试 | 证明强度不够，会污染 L4/L5 边界。 |
+| `DEC-SPP-004` | persona panel 只作为 `L4A` 内部体验假设层 | 把 persona simulation 当成真实玩家测试 | 证明强度不够，会污染 `L4B/L5` 边界。 |

--- a/doc/testing/governance/playability-simulated-player-persona-panel-2026-05-06.prd.md
+++ b/doc/testing/governance/playability-simulated-player-persona-panel-2026-05-06.prd.md
@@ -62,7 +62,7 @@
   1. `识别是否存在显著主观体验风险 -> 运行 `prepare-playability-l4-review.sh` 或按同一 contract 组装 persona review packet -> 选择默认或定制 persona 子集`
   2. `并行执行多个 persona 模拟 -> 回收 persona cards -> 标记共性断点 / 风格分歧`
   3. `qa_engineer` / `producer_system_designer` / 命中的工程角色读取 persona cards -> 回写正式 role review card`
-  4. `若需要更高信度 -> 从 `L4A` 升级到 `L4B structured human playtest` 或 L5 受控外部信号`
+  4. `若需要更高信度 -> 从 `L4A` 升级到 `L4B embodied agent playtest`；若仍需真实人类 / 真实环境结论，再升级到 L5 受控外部信号；内部真人试玩只作为 `L4B` 可选校准`
 
 ## 3. Persona Catalog
 | persona_id | 核心风格 | 高敏感项 | 低容忍项 | 最关注的问题 | 默认使用场景 |
@@ -126,7 +126,7 @@
 - `producer_system_designer`:
   - 读取 persona panel 的共性断点和风格分歧，决定是否影响 `target_claim`。
 - `qa_engineer`:
-  - 判断 persona panel 是不是只提出假设，还是已经指出必须升级到真人试玩的高风险断点。
+  - 判断 persona panel 是不是只提出假设，还是已经指出必须升级到 `L4B` agent 实玩或 `L5` 真实人类 / 线上验证的高风险断点。
 - `viewer_engineer`:
   - 吸收 `new_player_confused` / `impatient_action_player` / `narrative_curiosity_player` 的可读性和反馈问题。
 - `agent_engineer`:
@@ -146,7 +146,7 @@
   - persona 之间对同一节点出现明显风格分歧
 - 永远不能越过的边界:
   - persona panel 只能输出内部体验假设与风险线索，不能写成“玩家已经验证喜欢”
-  - persona panel 不能单独替代 `L4B structured human playtest` 或 L5 外部信号
+  - persona panel 不能单独替代 `L4B embodied agent playtest` 或 L5 外部信号
 
 ## 8. Acceptance Criteria
 - AC-1: 专题定义至少 5 类固定 persona，并写清各自偏好与低容忍项。
@@ -173,7 +173,8 @@
 - Edge Cases:
   - 若 persona card 没有一手证据，只是转述 role review：必须标 `secondary_review_only`。
   - 若 selected personas 未覆盖本次改动最关键风险面：必须记为 `panel_incomplete`。
-  - 若 persona panel 全正面，但没有任何真人试玩：仍只能记为 `L4A` 完成，不能宣称 `L4B` 已完成。
+  - 若 persona panel 全正面，但没有任何 agent 实玩：仍只能记为 `L4A` 完成，不能宣称 `L4B` 已完成。
+  - 若 `L4B` 已完成，但没有任何 `L5` 样本：仍不能宣称真实人类验证已完成。
   - 若 scaffold 已生成，但 persona cards 仍为空白模板：只能记为 panel scaffold 完成，不能记为 persona panel 已执行。
 - Non-Functional Requirements:
   - NFR-SPP-1: 新读者应在 5 分钟内知道何时需要开 persona panel。

--- a/doc/testing/governance/playability-simulated-player-persona-panel-2026-05-06.prd.md
+++ b/doc/testing/governance/playability-simulated-player-persona-panel-2026-05-06.prd.md
@@ -59,10 +59,10 @@
   - PRD-TESTING-PERSONA-004: As an implementation owner, I want a trigger matrix for when persona simulation is worth running, so that this panel does not become cargo-cult overhead.
   - PRD-TESTING-PERSONA-005: As a workflow owner, I want persona panel outputs to plug into role-based subagent review, so that internal review still closes through standard roles.
 - Critical User Flows:
-  1. `识别是否存在显著主观体验风险 -> 运行 `prepare-playability-l4-review.sh` 或按同一 contract 组装 persona review packet -> 选择默认或定制 persona 子集`
+  1. 识别是否存在显著主观体验风险 -> 运行 `prepare-playability-l4-review.sh` 或按同一 contract 组装 persona review packet -> 选择默认或定制 persona 子集
   2. `并行执行多个 persona 模拟 -> 回收 persona cards -> 标记共性断点 / 风格分歧`
   3. `qa_engineer` / `producer_system_designer` / 命中的工程角色读取 persona cards -> 回写正式 role review card`
-  4. `若需要更高信度 -> 从 `L4A` 升级到 `L4B embodied agent playtest`；若仍需真实人类 / 真实环境结论，再升级到 L5 受控外部信号；内部真人试玩只作为 `L4B` 可选校准`
+  4. 若需要更高信度 -> 从 `L4A` 升级到 `L4B embodied agent playtest`；若仍需真实人类 / 真实环境结论，再升级到 `L5` 受控外部信号；内部真人试玩只作为 `L4B` 可选校准
 
 ## 3. Persona Catalog
 | persona_id | 核心风格 | 高敏感项 | 低容忍项 | 最关注的问题 | 默认使用场景 |

--- a/doc/testing/governance/playability-simulated-player-persona-panel-2026-05-06.project.md
+++ b/doc/testing/governance/playability-simulated-player-persona-panel-2026-05-06.project.md
@@ -1,0 +1,25 @@
+# oasis7: 模拟玩家 persona 评审面板（2026-05-06）（项目管理）
+
+- 对应设计文档: `doc/testing/governance/playability-simulated-player-persona-panel-2026-05-06.design.md`
+- 对应需求文档: `doc/testing/governance/playability-simulated-player-persona-panel-2026-05-06.prd.md`
+
+审计轮次: 1
+
+## 任务拆解（含 PRD-ID 映射）
+- [x] simulated-player-persona-catalog (PRD-TESTING-PERSONA-001) [test_tier_required]: 定义固定 persona 清单、各自偏好、低容忍项与默认适用场景。 Trace: .pm/tasks/task_a9d3c884a3074ab2b0f3b10dab7bb86e.yaml
+- [x] simulated-player-persona-contracts (PRD-TESTING-PERSONA-002) [test_tier_required]: 冻结 persona review packet、persona card schema 与 persona divergence summary。 Trace: .pm/tasks/task_a9d3c884a3074ab2b0f3b10dab7bb86e.yaml
+- [x] simulated-player-persona-handoff (PRD-TESTING-PERSONA-003/004/005) [test_tier_required]: 定义 trigger matrix、与标准角色 subagent 的回流路径，以及不替代 L4/L5 的硬边界。 Trace: .pm/tasks/task_a9d3c884a3074ab2b0f3b10dab7bb86e.yaml
+
+## 依赖
+- `doc/testing/governance/playability-evidence-stack-2026-05-06.prd.md`
+- `doc/testing/governance/playability-subagent-review-system-2026-05-06.prd.md`
+- `.agents/roles/*.md`
+- `doc/testing/prd.md`
+- `doc/testing/project.md`
+
+## 状态
+- 更新日期: 2026-05-06
+- 当前阶段: 已完成
+- 阻塞项: 无
+- 下一步:
+  - 若后续需要真正执行 persona panel，再补 runbook / wrapper，把 persona review packet 和 persona card 变成可复制操作模板。

--- a/doc/testing/governance/playability-subagent-review-system-2026-05-06.design.md
+++ b/doc/testing/governance/playability-subagent-review-system-2026-05-06.design.md
@@ -1,0 +1,40 @@
+# oasis7: 好玩性 subagent 评审系统（2026-05-06）设计
+
+- 对应需求文档: `doc/testing/governance/playability-subagent-review-system-2026-05-06.prd.md`
+- 对应项目管理文档: `doc/testing/governance/playability-subagent-review-system-2026-05-06.project.md`
+
+审计轮次: 1
+
+## 1. 设计定位
+把“可以用多角色 subagent 补齐内部人工评审”从治理原则推进到可执行系统设计，提供标准角色 subagent 清单、统一输入包、统一输出卡和调度顺序。
+
+## 2. 系统结构
+- Orchestrator:
+  - `producer_system_designer` 负责总装与最终内部结论。
+- Gatekeeper:
+  - `qa_engineer` 负责阻断、证据质量和必跑验证。
+- Surface reviewers:
+  - `viewer_engineer`
+  - `agent_engineer`
+  - `runtime_engineer`
+  - `wasm_platform_engineer`
+- Claim reviewer:
+  - `liveops_community`
+
+## 3. 数据契约
+- Input:
+  - `review packet`
+- Output:
+  - `role review card`
+- Aggregation:
+  - `final internal playability review summary`
+
+## 4. 调度策略
+- 先做 packet 完整性检查。
+- 再按 trigger matrix 并行拉起 surface reviewers。
+- 最后由 `qa_engineer` 与 `producer_system_designer` 收口，并在需要时交 `liveops_community` 做对外边界复核。
+
+## 5. 约束
+- 不新增非标准正式角色。
+- 不让任一角色 subagent 越权替代其它角色的最终职责。
+- 不让内部 review 直接替代 L5 真实外部验证。

--- a/doc/testing/governance/playability-subagent-review-system-2026-05-06.design.md
+++ b/doc/testing/governance/playability-subagent-review-system-2026-05-06.design.md
@@ -28,6 +28,9 @@
   - `role review card`
 - Aggregation:
   - `final internal playability review summary`
+- Current scaffold:
+  - `scripts/prepare-playability-l4-review.sh` 负责在单个 worktree 内预置 `review packet`、`role review card` 模板、`summary` 与推荐命令。
+  - 该 scaffold 不自动替代任何角色给出 verdict。
 
 ## 4. 调度策略
 - 先做 packet 完整性检查。

--- a/doc/testing/governance/playability-subagent-review-system-2026-05-06.prd.md
+++ b/doc/testing/governance/playability-subagent-review-system-2026-05-06.prd.md
@@ -59,10 +59,10 @@
   - PRD-TESTING-SUBAGENT-003: As an implementation owner, I want a changed-surface trigger matrix, so that I only run the necessary role subagents.
   - PRD-TESTING-SUBAGENT-004: As a stage owner, I want explicit escalation and stop conditions, so that review conflicts or missing external evidence are not hidden.
 - Critical User Flows:
-  1. `识别当前变更的玩家 surface / 风险面 -> 运行 `prepare-playability-l4-review.sh` 或按同一 contract 组装 review packet -> 选择默认 + 按需 subagent`
+  1. 识别当前变更的玩家 surface / 风险面 -> 运行 `prepare-playability-l4-review.sh` 或按同一 contract 组装 review packet -> 选择默认 + 按需 subagent
   2. `若需要补多风格玩家假设 -> 先运行 simulated persona panel -> 回流 persona cards`
   3. `并行执行角色 subagent review -> 回收统一输出卡 -> 标记 blocker / watch / claim drift`
-  4. `producer_system_designer` 汇总各卡 -> 输出 `L4A synthetic` 内部阶段结论 -> 判断是否仍缺 `L4B/L5`，以及是否需要补可选内部真人校准`
+  4. `producer_system_designer` 汇总各卡 -> 输出 `L4A synthetic` 内部阶段结论 -> 判断是否仍缺 `L4B/L5`，以及是否需要补可选内部真人校准
 
 ## 3. Functional Specification Matrix
 | subagent | 默认/按需 | 主要输入 | 必答问题 | 输出 | 不得越权 |

--- a/doc/testing/governance/playability-subagent-review-system-2026-05-06.prd.md
+++ b/doc/testing/governance/playability-subagent-review-system-2026-05-06.prd.md
@@ -1,0 +1,172 @@
+# oasis7: 好玩性 subagent 评审系统（2026-05-06）
+
+- 对应设计文档: `doc/testing/governance/playability-subagent-review-system-2026-05-06.design.md`
+- 对应项目管理文档: `doc/testing/governance/playability-subagent-review-system-2026-05-06.project.md`
+
+审计轮次: 1
+
+## 目标
+- 把“多角色内部人工评审可以由标准角色 subagent 补齐”落成一份可执行的 testing/governance 专题。
+- 统一标准角色 subagent 的输入、输出、调度顺序、升级边界与 stop conditions。
+
+## 范围
+- 覆盖内部 playability review 所需的标准角色 subagent 设计、review packet contract、output card schema 与 orchestration 规则。
+- 不覆盖真实外部玩家研究方法，也不覆盖自动 orchestration 工具实现。
+
+## 接口 / 数据
+- 专题 PRD: `doc/testing/governance/playability-subagent-review-system-2026-05-06.prd.md`
+- 专题设计文档: `doc/testing/governance/playability-subagent-review-system-2026-05-06.design.md`
+- 专题项目管理文档: `doc/testing/governance/playability-subagent-review-system-2026-05-06.project.md`
+- 上游专题: `doc/testing/governance/playability-evidence-stack-2026-05-06.prd.md`
+- 角色真值入口: `.agents/roles/*.md`
+
+## 里程碑
+- M1 (2026-05-06): 冻结标准角色 subagent 清单、输入输出 contract 与 orchestration 规则。
+- M2: 若后续需要自动化执行，再补 runbook / wrapper 层设计。
+
+## 风险
+- 若角色输入输出不统一，多角色 review 仍会退回临时口头协作。
+- 若 internal review 与 external validation 边界写不清，subagent 结论容易被误当成真实玩家验证。
+
+## 1. Executive Summary
+- Problem Statement: 现有 `playability evidence stack` 已明确“内部人工评审可以用标准角色 subagent 补齐”，但还缺一份真正可执行的设计来回答：到底要设计哪些 subagent、每个 subagent 看什么输入、输出什么结论、谁负责汇总、哪些环节必须并行、哪些冲突需要升级。如果没有这一层设计，团队仍会回到“临时找几个视角看看”的松散模式。
+- Proposed Solution: 新增 `playability subagent review system` 专题，把多角色内部评审正式设计成一个可复用系统：固定 subagent 清单、输入包、输出卡、调用顺序、变更面触发矩阵、冲突升级规则与 stop conditions。
+- Success Criteria:
+  - SC-1: 至少定义 `producer_system_designer`、`qa_engineer`、`viewer_engineer`、`agent_engineer`、`runtime_engineer`、`wasm_platform_engineer`、`liveops_community` 七类标准角色 subagent。
+  - SC-2: 每个 subagent 都有明确的输入、关注问题、输出字段、不得越权边界和完成定义。
+  - SC-3: 系统定义一份统一 review packet，让各角色 review 可以并行，但汇总口径一致。
+  - SC-4: 系统定义“默认必开角色”和“按 changed surface 追加角色”的触发矩阵。
+  - SC-5: 系统明确 `subagent review = 内部证据编排`，仍不替代 L5 真实外部验证。
+
+## 2. User Experience & Functionality
+- User Personas:
+  - `producer_system_designer`: 需要把多角色内部评审收敛成一套固定流程，而不是每次靠口头协调。
+  - `qa_engineer`: 需要知道自己作为守门 review 的输入和输出格式，并在多角色意见冲突时保持阻断权。
+  - 工程 owner: 需要知道哪些 subagent 需要跑、跑完算不算 review 完成、还差什么外部证据。
+  - `liveops_community`: 需要清楚自己何时介入，以及何时只能做口径/风险评审，不能越权替代真实玩家反馈。
+- User Scenarios & Frequency:
+  - 新的 gameplay / onboarding / retention 变更准备提交或发 PR 时。
+  - 需要跨 `runtime` / `agent` / `viewer` / `qa` / `producer` 多角色一起给玩法结论时。
+  - 发生“自动化通过但体验争议很大”的争论时。
+- User Stories:
+  - PRD-TESTING-SUBAGENT-001: As a `producer_system_designer`, I want a fixed set of standard review subagents, so that internal playability review stops being ad hoc.
+  - PRD-TESTING-SUBAGENT-002: As a `qa_engineer`, I want a normalized review packet and output schema, so that parallel role reviews remain comparable.
+  - PRD-TESTING-SUBAGENT-003: As an implementation owner, I want a changed-surface trigger matrix, so that I only run the necessary role subagents.
+  - PRD-TESTING-SUBAGENT-004: As a stage owner, I want explicit escalation and stop conditions, so that review conflicts or missing external evidence are not hidden.
+- Critical User Flows:
+  1. `识别当前变更的玩家 surface / 风险面 -> 组装 review packet -> 选择默认 + 按需 subagent`
+  2. `并行执行角色 subagent review -> 回收统一输出卡 -> 标记 blocker / watch / claim drift`
+  3. `producer_system_designer` 汇总各卡 -> 输出内部阶段结论 -> 判断是否仍缺 L5`
+
+## 3. Functional Specification Matrix
+| subagent | 默认/按需 | 主要输入 | 必答问题 | 输出 | 不得越权 |
+| --- | --- | --- | --- | --- | --- |
+| `producer_system_designer` review subagent | 默认 | PRD、玩法目标、claim envelope、其余角色 review card | 这次改动到底想让玩家更想继续玩什么？现有证据能不能支撑这个说法？ | `claim_assessment`, `evidence_gap`, `go/watch/hold/block` 建议 | 不替代 QA 的失败签名判定 |
+| `qa_engineer` review subagent | 默认 | 自动化结果、playability card、failure signatures、smoke/runbook 结果 | 这次改动到底是“没坏”还是“足够稳定可以继续收更高层证据”？ | `qa_verdict`, `blockers`, `required_reruns`, `evidence_quality` | 不拍板规则方向 |
+| `viewer_engineer` review subagent | 触达 UI/首屏/反馈时必开 | 截图、录像、UI state、文案、交互路径 | 玩家能不能看懂当前目标、后果和下一步？UI 有没有把世界噪音误当成有用反馈？ | `ux_findings`, `readability_risk`, `player_feedback_gap` | 不改 runtime 语义 |
+| `agent_engineer` review subagent | 触达 LLM/agent 行为时必开 | agent trace、prompt/decision evidence、world changes | 是玩家在间接驱动 agent 产生后果，还是 agent 在自己运转？ | `agent_behavior_verdict`, `player_influence_gap`, `drift_risk` | 不改世界规则 |
+| `runtime_engineer` review subagent | 触达 runtime/progression/replay 时必开 | step/progression evidence、replay/recovery results、contracts | 体验问题是不是 runtime contract/推进语义失真导致的？ | `runtime_constraint_report`, `determinism_risk`, `contract_blocker` | 不替代玩法判断 |
+| `wasm_platform_engineer` review subagent | 触达 wasm/module/ABI 时按需 | module manifests、ABI diff、determinism evidence | 这次玩法问题是不是平台/模块边界造成的假阳性或假阴性？ | `platform_risk`, `abi_drift`, `module_limitations` | 不替代 runtime 或 producer 结论 |
+| `liveops_community` review subagent | 触达对外口径/preview 时必开 | release wording、preview plan、community signals | 这次内部结论能不能安全对外表达？需要什么 preview 边界？ | `claim_envelope_risk`, `preview_readiness`, `feedback_capture_plan` | 不把内部模拟当真实外部反馈 |
+
+## 4. Review Packet Contract
+- Required fields:
+  - `change_scope`
+  - `formal_surfaces`: `software_safe` / `pure_api` / others
+  - `target_claim`
+  - `automated_evidence`
+  - `playability_evidence`
+  - `known_blockers`
+  - `requested_roles`
+  - `outside_scope`
+- Optional fields:
+  - `telemetry_hypothesis`
+  - `limited_preview_context`
+  - `artifact_paths`
+  - `open_questions`
+- Output card schema:
+  - `role_name`
+  - `verdict`: `pass/watch/hold/block`
+  - `top_findings`
+  - `evidence_used`
+  - `what_this_does_not_prove`
+  - `required_followups`
+  - `claim_boundary_note`
+
+## 5. Trigger Matrix
+- Always-open:
+  - `producer_system_designer`
+  - `qa_engineer`
+- Open when changed surface includes:
+  - UI / onboarding / readability / player feedback wording:
+    - `viewer_engineer`
+  - LLM / NPC / indirect-control / agent progression:
+    - `agent_engineer`
+  - progression contract / replay / state transition / longrun stability:
+    - `runtime_engineer`
+  - wasm modules / ABI / provider module boundaries:
+    - `wasm_platform_engineer`
+  - public preview wording / liveops lane / community signal plan:
+    - `liveops_community`
+
+## 6. Sequencing Rules
+- Phase A: `qa_engineer` + `producer_system_designer` 先确认 review packet 是否完整。
+- Phase B: 其余按 changed surface 命中的角色 subagent 并行执行。
+- Phase C: `qa_engineer` 先做阻断归纳，`producer_system_designer` 再做最终内部结论汇总。
+- Phase D: 若需要对外说法或 preview，`liveops_community` 在最终汇总后做 claim-envelope 复核。
+
+## 7. Escalation And Stop Conditions
+- 必须立即 `stop` 的情况:
+  - `qa_engineer=block`
+  - 任一 formal surface 的基础 contract 不成立
+  - review packet 缺关键证据路径，导致其它角色只能猜
+- 必须升级但不直接阻断的情况:
+  - `viewer` 与 `agent` 对“玩家是否有杠杆”结论冲突
+  - `producer` 想升级 claim，但 `liveops` 认为对外口径不安全
+  - `runtime` / `wasm` 指出当前体验结论建立在不稳定 contract 上
+- 永远不能被内部 subagent 跳过的 stop line:
+  - 缺真实外部信号时，不得把结论写成“已被真实玩家验证”
+
+## 8. Acceptance Criteria
+- AC-1: 新专题定义七类标准角色 subagent。
+- AC-2: 每个 subagent 都有输入、必答问题、输出、越权边界。
+- AC-3: review packet contract 与 output card schema 明确可复用。
+- AC-4: trigger matrix、sequencing rules、stop conditions 都被写清。
+- AC-5: 明确“内部 subagent review 全补齐”与“L5 外部真实验证完成”是两回事。
+
+## 9. Non-Goals
+- 不在本轮实现自动 orchestration 脚本。
+- 不新增 `.agents/roles/` 之外的正式角色。
+- 不把这套系统误写成真实玩家研究平台。
+
+## 10. Technical Specifications
+- Integration Points:
+  - `doc/testing/governance/playability-evidence-stack-2026-05-06.prd.md`
+  - `.agents/roles/*.md`
+  - `doc/testing/prd.md`
+  - `doc/testing/project.md`
+  - `testing-manual.md`
+- Edge Cases:
+  - 若某角色输入为空，但 trigger matrix 命中：必须在输出卡显式写 `insufficient_input`，不能假装评审完成。
+  - 若某角色 review 只基于别的角色结论，没有一手证据：必须标记为 `secondary_review_only`。
+  - 若多个 subagent 全部正面，但没有任何 L4/L5 证据：只能给“内部准备完成”，不能给“玩法已被证明”。
+- Non-Functional Requirements:
+  - NFR-SUB-1: 新读者应在 5 分钟内知道本次改动要开哪些角色 subagent。
+  - NFR-SUB-2: 每张输出卡必须在 30 秒内看出该角色到底证明了什么、没证明什么。
+  - NFR-SUB-3: 系统设计必须只依赖标准角色名，兼容现有 execution log / handoff / PM 约束。
+
+## 11. Validation & Decision Record
+- Test Plan & Traceability:
+| PRD-ID | 对应任务 | 测试层级 | 验证方法 | 回归影响范围 |
+| --- | --- | --- | --- | --- |
+| PRD-TESTING-SUBAGENT-001 | `playability-subagent-review-system-2026-05-06` / `PSRS-1` | `test_tier_required` | `rg` 检查七类角色 subagent 定义与边界 | 多角色 review 设计完整性 |
+| PRD-TESTING-SUBAGENT-002 | `playability-subagent-review-system-2026-05-06` / `PSRS-1/2` | `test_tier_required` | 抽查 review packet/output card schema | review 输入输出一致性 |
+| PRD-TESTING-SUBAGENT-003 | `playability-subagent-review-system-2026-05-06` / `PSRS-2` | `test_tier_required` | 抽查 trigger matrix 与 sequencing rules | review 调度可执行性 |
+| PRD-TESTING-SUBAGENT-004 | `playability-subagent-review-system-2026-05-06` / `PSRS-2/3` | `test_tier_required` | 抽查 escalation/stop conditions 与 L5 边界说明 | 内外部验证边界 |
+- Decision Log:
+| 决策ID | 选定方案 | 备选方案（否决） | 依据 |
+| --- | --- | --- | --- |
+| `DEC-PSRS-001` | 只设计标准角色 subagent | 额外创造 `player` 正式 subagent | 与仓库角色治理冲突。 |
+| `DEC-PSRS-002` | 用统一 review packet + output card | 每个角色自由发挥输出格式 | 无法汇总、无法比较、无法自动化后续治理。 |
+| `DEC-PSRS-003` | 先 `qa + producer` 校验 packet，再并行其余角色 | 所有角色一上来全并行 | 输入包若不完整，会放大噪音和重复劳动。 |
+| `DEC-PSRS-004` | 保留 `liveops_community` 作为 claim-envelope 终段复核 | 让工程角色直接决定对外表达 | 工程结论和对外口径不是同一边界。 |

--- a/doc/testing/governance/playability-subagent-review-system-2026-05-06.prd.md
+++ b/doc/testing/governance/playability-subagent-review-system-2026-05-06.prd.md
@@ -62,7 +62,7 @@
   1. `识别当前变更的玩家 surface / 风险面 -> 运行 `prepare-playability-l4-review.sh` 或按同一 contract 组装 review packet -> 选择默认 + 按需 subagent`
   2. `若需要补多风格玩家假设 -> 先运行 simulated persona panel -> 回流 persona cards`
   3. `并行执行角色 subagent review -> 回收统一输出卡 -> 标记 blocker / watch / claim drift`
-  4. `producer_system_designer` 汇总各卡 -> 输出 `L4A synthetic` 内部阶段结论 -> 判断是否仍缺 `L4B/L5``
+  4. `producer_system_designer` 汇总各卡 -> 输出 `L4A synthetic` 内部阶段结论 -> 判断是否仍缺 `L4B/L5`，以及是否需要补可选内部真人校准`
 
 ## 3. Functional Specification Matrix
 | subagent | 默认/按需 | 主要输入 | 必答问题 | 输出 | 不得越权 |
@@ -108,7 +108,7 @@
     - `l4-summary.md`
     - `commands.sh`
     - `manifest.json`
-  - 该脚本只负责产物预置、路径冻结和 `L4A/L4B` 命令推荐；不会自动替代各角色做 verdict。
+  - 该脚本只负责产物预置、路径冻结和 `L4A/L4B` 命令推荐，并预留可选内部真人校准 notes；不会自动替代各角色做 verdict。
 
 ## 5. Trigger Matrix
 - Always-open:
@@ -148,7 +148,8 @@
   - `runtime` / `wasm` 指出当前体验结论建立在不稳定 contract 上
 - 永远不能被内部 subagent 跳过的 stop line:
   - 缺真实外部信号时，不得把结论写成“已被真实玩家验证”
-  - 缺 `L4B` 真人试玩时，不得把 `L4A` synthetic 结论写成“真人已经想继续玩”
+  - 缺 `L4B` agent 实玩时，不得把 `L4A` synthetic 结论写成“agent 已经真实玩过且想继续玩”
+  - 缺 `L5` 真实人类 / 线上样本时，不得把 `L4B` 结论写成“真实玩家已经想继续玩”
 
 ## 8. Acceptance Criteria
 - AC-1: 新专题定义七类标准角色 subagent。

--- a/doc/testing/governance/playability-subagent-review-system-2026-05-06.prd.md
+++ b/doc/testing/governance/playability-subagent-review-system-2026-05-06.prd.md
@@ -12,7 +12,8 @@
 
 ## 范围
 - 覆盖内部 playability review 所需的标准角色 subagent 设计、review packet contract、output card schema、与 simulated persona panel 的 handoff contract，以及 orchestration 规则。
-- 不覆盖真实外部玩家研究方法，也不覆盖自动 orchestration 工具实现。
+- 覆盖当前 repo-local scaffold 入口如何稳定生成 review packet、role review cards 和最终 summary。
+- 不覆盖真实外部玩家研究方法，也不覆盖“自动执行所有角色评审”的自治 orchestration 实现。
 
 ## 接口 / 数据
 - 专题 PRD: `doc/testing/governance/playability-subagent-review-system-2026-05-06.prd.md`
@@ -23,8 +24,8 @@
 - 角色真值入口: `.agents/roles/*.md`
 
 ## 里程碑
-- M1 (2026-05-06): 冻结标准角色 subagent 清单、输入输出 contract 与 orchestration 规则。
-- M2: 若后续需要自动化执行，再补 runbook / wrapper 层设计。
+- M1 (2026-05-06): 冻结标准角色 subagent 清单、输入输出 contract、orchestration 规则，以及 repo-local scaffold 入口。
+- M2: 若后续需要更强自动化，再补“自动执行角色评审 / 自动聚合 verdict”的扩展设计。
 
 ## 风险
 - 若角色输入输出不统一，多角色 review 仍会退回临时口头协作。
@@ -40,6 +41,7 @@
   - SC-4: 系统定义“默认必开角色”和“按 changed surface 追加角色”的触发矩阵。
   - SC-5: 系统明确 `subagent review = 内部证据编排`，仍不替代 L5 真实外部验证。
   - SC-6: 系统明确 simulated persona panel 不是正式角色，只能作为标准角色 review 的辅助输入层，并共同形成 `L4A`。
+  - SC-7: 当前仓库提供 `./scripts/prepare-playability-l4-review.sh`，能在单个 worktree 内稳定生成 review packet、七类 role review cards、summary 和推荐命令文件。
 
 ## 2. User Experience & Functionality
 - User Personas:
@@ -57,7 +59,7 @@
   - PRD-TESTING-SUBAGENT-003: As an implementation owner, I want a changed-surface trigger matrix, so that I only run the necessary role subagents.
   - PRD-TESTING-SUBAGENT-004: As a stage owner, I want explicit escalation and stop conditions, so that review conflicts or missing external evidence are not hidden.
 - Critical User Flows:
-  1. `识别当前变更的玩家 surface / 风险面 -> 组装 review packet -> 选择默认 + 按需 subagent`
+  1. `识别当前变更的玩家 surface / 风险面 -> 运行 `prepare-playability-l4-review.sh` 或按同一 contract 组装 review packet -> 选择默认 + 按需 subagent`
   2. `若需要补多风格玩家假设 -> 先运行 simulated persona panel -> 回流 persona cards`
   3. `并行执行角色 subagent review -> 回收统一输出卡 -> 标记 blocker / watch / claim drift`
   4. `producer_system_designer` 汇总各卡 -> 输出 `L4A synthetic` 内部阶段结论 -> 判断是否仍缺 `L4B/L5``
@@ -99,6 +101,14 @@
   - `what_this_does_not_prove`
   - `required_followups`
   - `claim_boundary_note`
+- Current repo-local scaffold:
+  - `./scripts/prepare-playability-l4-review.sh` 会一次性生成：
+    - `l4-review-packet.md`
+    - `role-review-cards/*.md`
+    - `l4-summary.md`
+    - `commands.sh`
+    - `manifest.json`
+  - 该脚本只负责产物预置、路径冻结和 `L4A/L4B` 命令推荐；不会自动替代各角色做 verdict。
 
 ## 5. Trigger Matrix
 - Always-open:
@@ -146,6 +156,7 @@
 - AC-3: review packet contract 与 output card schema 明确可复用。
 - AC-4: trigger matrix、sequencing rules、stop conditions 都被写清。
 - AC-5: 明确“内部 subagent review 全补齐”与“L5 外部真实验证完成”是两回事。
+- AC-6: 明确写出当前 repo-local scaffold 入口与其边界: 能稳定生成 packet/card/summary，但不会自动完成 role verdict。
 
 ## 9. Non-Goals
 - 不在本轮实现自动 orchestration 脚本。
@@ -160,11 +171,15 @@
   - `doc/testing/prd.md`
   - `doc/testing/project.md`
   - `testing-manual.md`
+  - `scripts/prepare-playability-l4-review.sh`
+  - `doc/testing/templates/playability-l4-review-packet-template.md`
+  - `doc/testing/templates/playability-l4-role-review-card-template.md`
 - Edge Cases:
   - 若某角色输入为空，但 trigger matrix 命中：必须在输出卡显式写 `insufficient_input`，不能假装评审完成。
   - 若某角色 review 只基于别的角色结论，没有一手证据：必须标记为 `secondary_review_only`。
   - 若 persona cards 已存在，但角色 review 完全忽略其共性断点：必须说明忽略理由，不能静默跳过。
   - 若多个 subagent 全部正面，但没有任何 `L4B/L5` 证据：只能给“`L4A synthetic` 准备完成”，不能给“玩法已被证明”。
+  - 若 scaffold 已生成，但命中的 role cards 未填写完：只能记为 packet/card 预置完成，不能记为 subagent review 已完成。
 - Non-Functional Requirements:
   - NFR-SUB-1: 新读者应在 5 分钟内知道本次改动要开哪些角色 subagent。
   - NFR-SUB-2: 每张输出卡必须在 30 秒内看出该角色到底证明了什么、没证明什么。
@@ -186,3 +201,4 @@
 | `DEC-PSRS-003` | 先 `qa + producer` 校验 packet，再并行其余角色 | 所有角色一上来全并行 | 输入包若不完整，会放大噪音和重复劳动。 |
 | `DEC-PSRS-004` | 保留 `liveops_community` 作为 claim-envelope 终段复核 | 让工程角色直接决定对外表达 | 工程结论和对外口径不是同一边界。 |
 | `DEC-PSRS-005` | 把 simulated personas 作为非正式玩家视角层接入标准角色 review | 把 `player` 升格成新的正式角色 | 会破坏现有角色治理边界，也会混淆内部模拟与外部验证。 |
+| `DEC-PSRS-006` | 当前先提供 repo-local scaffold 生成 packet/card/summary | 等自动 orchestration 全做完后再给 operator 入口 | 没有稳定 scaffold，当前 PR 仍无法在单个 worktree 内完整准备 `L4A`。 |

--- a/doc/testing/governance/playability-subagent-review-system-2026-05-06.prd.md
+++ b/doc/testing/governance/playability-subagent-review-system-2026-05-06.prd.md
@@ -3,12 +3,12 @@
 - 对应设计文档: `doc/testing/governance/playability-subagent-review-system-2026-05-06.design.md`
 - 对应项目管理文档: `doc/testing/governance/playability-subagent-review-system-2026-05-06.project.md`
 
-审计轮次: 2
+审计轮次: 3
 
 ## 目标
 - 把“多角色内部人工评审可以由标准角色 subagent 补齐”落成一份可执行的 testing/governance 专题。
 - 统一标准角色 subagent 的输入、输出、调度顺序、升级边界与 stop conditions。
-- 明确它们如何接收并收口 `simulated player persona panel` 产出的内部玩家视角假设。
+- 明确它们如何接收并收口 `simulated player persona panel` 产出的内部玩家视角假设，并共同形成 `L4A synthetic internal playability review`。
 
 ## 范围
 - 覆盖内部 playability review 所需的标准角色 subagent 设计、review packet contract、output card schema、与 simulated persona panel 的 handoff contract，以及 orchestration 规则。
@@ -39,7 +39,7 @@
   - SC-3: 系统定义一份统一 review packet，让各角色 review 可以并行，但汇总口径一致。
   - SC-4: 系统定义“默认必开角色”和“按 changed surface 追加角色”的触发矩阵。
   - SC-5: 系统明确 `subagent review = 内部证据编排`，仍不替代 L5 真实外部验证。
-  - SC-6: 系统明确 simulated persona panel 不是正式角色，只能作为标准角色 review 的辅助输入层。
+  - SC-6: 系统明确 simulated persona panel 不是正式角色，只能作为标准角色 review 的辅助输入层，并共同形成 `L4A`。
 
 ## 2. User Experience & Functionality
 - User Personas:
@@ -60,7 +60,7 @@
   1. `识别当前变更的玩家 surface / 风险面 -> 组装 review packet -> 选择默认 + 按需 subagent`
   2. `若需要补多风格玩家假设 -> 先运行 simulated persona panel -> 回流 persona cards`
   3. `并行执行角色 subagent review -> 回收统一输出卡 -> 标记 blocker / watch / claim drift`
-  4. `producer_system_designer` 汇总各卡 -> 输出内部阶段结论 -> 判断是否仍缺 L5`
+  4. `producer_system_designer` 汇总各卡 -> 输出 `L4A synthetic` 内部阶段结论 -> 判断是否仍缺 `L4B/L5``
 
 ## 3. Functional Specification Matrix
 | subagent | 默认/按需 | 主要输入 | 必答问题 | 输出 | 不得越权 |
@@ -90,6 +90,7 @@
   - `open_questions`
   - `persona_panel_request`
   - `persona_cards`
+  - `target_l4_lane`: `L4A_only` / `L4A_then_L4B`
 - Output card schema:
   - `role_name`
   - `verdict`: `pass/watch/hold/block`
@@ -122,7 +123,7 @@
 - Phase A: `qa_engineer` + `producer_system_designer` 先确认 review packet 是否完整。
 - Phase B: 若命中主观体验差异风险，先运行 simulated persona panel，回收 persona cards。
 - Phase C: 其余按 changed surface 命中的角色 subagent 并行执行，并吸收 persona cards。
-- Phase D: `qa_engineer` 先做阻断归纳，`producer_system_designer` 再做最终内部结论汇总。
+- Phase D: `qa_engineer` 先做阻断归纳，`producer_system_designer` 再做 `L4A synthetic` 结论汇总。
 - Phase E: 若需要对外说法或 preview，`liveops_community` 在最终汇总后做 claim-envelope 复核。
 
 ## 7. Escalation And Stop Conditions
@@ -137,6 +138,7 @@
   - `runtime` / `wasm` 指出当前体验结论建立在不稳定 contract 上
 - 永远不能被内部 subagent 跳过的 stop line:
   - 缺真实外部信号时，不得把结论写成“已被真实玩家验证”
+  - 缺 `L4B` 真人试玩时，不得把 `L4A` synthetic 结论写成“真人已经想继续玩”
 
 ## 8. Acceptance Criteria
 - AC-1: 新专题定义七类标准角色 subagent。
@@ -162,7 +164,7 @@
   - 若某角色输入为空，但 trigger matrix 命中：必须在输出卡显式写 `insufficient_input`，不能假装评审完成。
   - 若某角色 review 只基于别的角色结论，没有一手证据：必须标记为 `secondary_review_only`。
   - 若 persona cards 已存在，但角色 review 完全忽略其共性断点：必须说明忽略理由，不能静默跳过。
-  - 若多个 subagent 全部正面，但没有任何 L4/L5 证据：只能给“内部准备完成”，不能给“玩法已被证明”。
+  - 若多个 subagent 全部正面，但没有任何 `L4B/L5` 证据：只能给“`L4A synthetic` 准备完成”，不能给“玩法已被证明”。
 - Non-Functional Requirements:
   - NFR-SUB-1: 新读者应在 5 分钟内知道本次改动要开哪些角色 subagent。
   - NFR-SUB-2: 每张输出卡必须在 30 秒内看出该角色到底证明了什么、没证明什么。

--- a/doc/testing/governance/playability-subagent-review-system-2026-05-06.prd.md
+++ b/doc/testing/governance/playability-subagent-review-system-2026-05-06.prd.md
@@ -3,14 +3,15 @@
 - 对应设计文档: `doc/testing/governance/playability-subagent-review-system-2026-05-06.design.md`
 - 对应项目管理文档: `doc/testing/governance/playability-subagent-review-system-2026-05-06.project.md`
 
-审计轮次: 1
+审计轮次: 2
 
 ## 目标
 - 把“多角色内部人工评审可以由标准角色 subagent 补齐”落成一份可执行的 testing/governance 专题。
 - 统一标准角色 subagent 的输入、输出、调度顺序、升级边界与 stop conditions。
+- 明确它们如何接收并收口 `simulated player persona panel` 产出的内部玩家视角假设。
 
 ## 范围
-- 覆盖内部 playability review 所需的标准角色 subagent 设计、review packet contract、output card schema 与 orchestration 规则。
+- 覆盖内部 playability review 所需的标准角色 subagent 设计、review packet contract、output card schema、与 simulated persona panel 的 handoff contract，以及 orchestration 规则。
 - 不覆盖真实外部玩家研究方法，也不覆盖自动 orchestration 工具实现。
 
 ## 接口 / 数据
@@ -18,6 +19,7 @@
 - 专题设计文档: `doc/testing/governance/playability-subagent-review-system-2026-05-06.design.md`
 - 专题项目管理文档: `doc/testing/governance/playability-subagent-review-system-2026-05-06.project.md`
 - 上游专题: `doc/testing/governance/playability-evidence-stack-2026-05-06.prd.md`
+- 关联专题: `doc/testing/governance/playability-simulated-player-persona-panel-2026-05-06.prd.md`
 - 角色真值入口: `.agents/roles/*.md`
 
 ## 里程碑
@@ -30,13 +32,14 @@
 
 ## 1. Executive Summary
 - Problem Statement: 现有 `playability evidence stack` 已明确“内部人工评审可以用标准角色 subagent 补齐”，但还缺一份真正可执行的设计来回答：到底要设计哪些 subagent、每个 subagent 看什么输入、输出什么结论、谁负责汇总、哪些环节必须并行、哪些冲突需要升级。如果没有这一层设计，团队仍会回到“临时找几个视角看看”的松散模式。
-- Proposed Solution: 新增 `playability subagent review system` 专题，把多角色内部评审正式设计成一个可复用系统：固定 subagent 清单、输入包、输出卡、调用顺序、变更面触发矩阵、冲突升级规则与 stop conditions。
+- Proposed Solution: 新增 `playability subagent review system` 专题，把多角色内部评审正式设计成一个可复用系统：固定 subagent 清单、输入包、输出卡、调用顺序、变更面触发矩阵、冲突升级规则与 stop conditions；若需要模拟多种玩家风格，再把 `simulated player persona panel` 作为非正式角色层接入，并统一由标准角色 subagent 收口。
 - Success Criteria:
   - SC-1: 至少定义 `producer_system_designer`、`qa_engineer`、`viewer_engineer`、`agent_engineer`、`runtime_engineer`、`wasm_platform_engineer`、`liveops_community` 七类标准角色 subagent。
   - SC-2: 每个 subagent 都有明确的输入、关注问题、输出字段、不得越权边界和完成定义。
   - SC-3: 系统定义一份统一 review packet，让各角色 review 可以并行，但汇总口径一致。
   - SC-4: 系统定义“默认必开角色”和“按 changed surface 追加角色”的触发矩阵。
   - SC-5: 系统明确 `subagent review = 内部证据编排`，仍不替代 L5 真实外部验证。
+  - SC-6: 系统明确 simulated persona panel 不是正式角色，只能作为标准角色 review 的辅助输入层。
 
 ## 2. User Experience & Functionality
 - User Personas:
@@ -55,8 +58,9 @@
   - PRD-TESTING-SUBAGENT-004: As a stage owner, I want explicit escalation and stop conditions, so that review conflicts or missing external evidence are not hidden.
 - Critical User Flows:
   1. `识别当前变更的玩家 surface / 风险面 -> 组装 review packet -> 选择默认 + 按需 subagent`
-  2. `并行执行角色 subagent review -> 回收统一输出卡 -> 标记 blocker / watch / claim drift`
-  3. `producer_system_designer` 汇总各卡 -> 输出内部阶段结论 -> 判断是否仍缺 L5`
+  2. `若需要补多风格玩家假设 -> 先运行 simulated persona panel -> 回流 persona cards`
+  3. `并行执行角色 subagent review -> 回收统一输出卡 -> 标记 blocker / watch / claim drift`
+  4. `producer_system_designer` 汇总各卡 -> 输出内部阶段结论 -> 判断是否仍缺 L5`
 
 ## 3. Functional Specification Matrix
 | subagent | 默认/按需 | 主要输入 | 必答问题 | 输出 | 不得越权 |
@@ -84,6 +88,8 @@
   - `limited_preview_context`
   - `artifact_paths`
   - `open_questions`
+  - `persona_panel_request`
+  - `persona_cards`
 - Output card schema:
   - `role_name`
   - `verdict`: `pass/watch/hold/block`
@@ -108,12 +114,16 @@
     - `wasm_platform_engineer`
   - public preview wording / liveops lane / community signal plan:
     - `liveops_community`
+- Open simulated persona panel when:
+  - 本次体验 claim 主要风险是理解差异、节奏差异、系统偏好差异或叙事偏好差异
+  - 仅靠标准角色专业判断不足以覆盖多个玩家风格假设
 
 ## 6. Sequencing Rules
 - Phase A: `qa_engineer` + `producer_system_designer` 先确认 review packet 是否完整。
-- Phase B: 其余按 changed surface 命中的角色 subagent 并行执行。
-- Phase C: `qa_engineer` 先做阻断归纳，`producer_system_designer` 再做最终内部结论汇总。
-- Phase D: 若需要对外说法或 preview，`liveops_community` 在最终汇总后做 claim-envelope 复核。
+- Phase B: 若命中主观体验差异风险，先运行 simulated persona panel，回收 persona cards。
+- Phase C: 其余按 changed surface 命中的角色 subagent 并行执行，并吸收 persona cards。
+- Phase D: `qa_engineer` 先做阻断归纳，`producer_system_designer` 再做最终内部结论汇总。
+- Phase E: 若需要对外说法或 preview，`liveops_community` 在最终汇总后做 claim-envelope 复核。
 
 ## 7. Escalation And Stop Conditions
 - 必须立即 `stop` 的情况:
@@ -122,6 +132,7 @@
   - review packet 缺关键证据路径，导致其它角色只能猜
 - 必须升级但不直接阻断的情况:
   - `viewer` 与 `agent` 对“玩家是否有杠杆”结论冲突
+  - simulated persona panel 与标准角色 review 对“玩家为何掉线”给出相反解释
   - `producer` 想升级 claim，但 `liveops` 认为对外口径不安全
   - `runtime` / `wasm` 指出当前体验结论建立在不稳定 contract 上
 - 永远不能被内部 subagent 跳过的 stop line:
@@ -142,6 +153,7 @@
 ## 10. Technical Specifications
 - Integration Points:
   - `doc/testing/governance/playability-evidence-stack-2026-05-06.prd.md`
+  - `doc/testing/governance/playability-simulated-player-persona-panel-2026-05-06.prd.md`
   - `.agents/roles/*.md`
   - `doc/testing/prd.md`
   - `doc/testing/project.md`
@@ -149,6 +161,7 @@
 - Edge Cases:
   - 若某角色输入为空，但 trigger matrix 命中：必须在输出卡显式写 `insufficient_input`，不能假装评审完成。
   - 若某角色 review 只基于别的角色结论，没有一手证据：必须标记为 `secondary_review_only`。
+  - 若 persona cards 已存在，但角色 review 完全忽略其共性断点：必须说明忽略理由，不能静默跳过。
   - 若多个 subagent 全部正面，但没有任何 L4/L5 证据：只能给“内部准备完成”，不能给“玩法已被证明”。
 - Non-Functional Requirements:
   - NFR-SUB-1: 新读者应在 5 分钟内知道本次改动要开哪些角色 subagent。
@@ -170,3 +183,4 @@
 | `DEC-PSRS-002` | 用统一 review packet + output card | 每个角色自由发挥输出格式 | 无法汇总、无法比较、无法自动化后续治理。 |
 | `DEC-PSRS-003` | 先 `qa + producer` 校验 packet，再并行其余角色 | 所有角色一上来全并行 | 输入包若不完整，会放大噪音和重复劳动。 |
 | `DEC-PSRS-004` | 保留 `liveops_community` 作为 claim-envelope 终段复核 | 让工程角色直接决定对外表达 | 工程结论和对外口径不是同一边界。 |
+| `DEC-PSRS-005` | 把 simulated personas 作为非正式玩家视角层接入标准角色 review | 把 `player` 升格成新的正式角色 | 会破坏现有角色治理边界，也会混淆内部模拟与外部验证。 |

--- a/doc/testing/governance/playability-subagent-review-system-2026-05-06.project.md
+++ b/doc/testing/governance/playability-subagent-review-system-2026-05-06.project.md
@@ -1,0 +1,24 @@
+# oasis7: 好玩性 subagent 评审系统（2026-05-06）（项目管理）
+
+- 对应设计文档: `doc/testing/governance/playability-subagent-review-system-2026-05-06.design.md`
+- 对应需求文档: `doc/testing/governance/playability-subagent-review-system-2026-05-06.prd.md`
+
+审计轮次: 1
+
+## 任务拆解（含 PRD-ID 映射）
+- [x] playability-subagent-review-roles (PRD-TESTING-SUBAGENT-001) [test_tier_required]: 定义标准角色 subagent 清单、职责边界、输入输出和不得越权规则。 Trace: .pm/tasks/task_9a6bbbc3022f4d4e8a3f5f99fab4d1b2.yaml
+- [x] playability-subagent-review-contracts (PRD-TESTING-SUBAGENT-002) [test_tier_required]: 冻结 review packet、role review card 和汇总输出结构。 Trace: .pm/tasks/task_9a6bbbc3022f4d4e8a3f5f99fab4d1b2.yaml
+- [x] playability-subagent-review-orchestration (PRD-TESTING-SUBAGENT-003/004) [test_tier_required]: 定义 trigger matrix、调度顺序、冲突升级与 stop conditions，并写明 L5 边界。 Trace: .pm/tasks/task_9a6bbbc3022f4d4e8a3f5f99fab4d1b2.yaml
+
+## 依赖
+- `doc/testing/governance/playability-evidence-stack-2026-05-06.prd.md`
+- `.agents/roles/*.md`
+- `doc/testing/prd.md`
+- `doc/testing/project.md`
+
+## 状态
+- 更新日期: 2026-05-06
+- 当前阶段: 已完成
+- 阻塞项: 无
+- 下一步:
+  - 若后续要真正自动化调度，再新增 runbook 或 orchestration wrapper，把 review packet 和 output card 变成可执行模板。

--- a/doc/testing/prd.index.md
+++ b/doc/testing/prd.index.md
@@ -1,6 +1,6 @@
 # testing PRD 文件级索引
 
-审计轮次: 9
+审计轮次: 10
 
 更新时间：2026-05-06
 
@@ -13,6 +13,7 @@
 ## 首读分流
 - 想先回答 testing 模块覆盖哪些测试层级、证据与门禁边界：先读 `doc/testing/prd.md`
 - 想先回答“自动化能证明什么、不能证明什么，以及判断好玩还缺哪层证据”：先读 `doc/testing/governance/playability-evidence-stack-2026-05-06.prd.md`
+- 想先回答“为什么 `L4` 需要拆成 `L4A synthetic` 和 `L4B human`，以及 agent 角色扮演为什么还不能直接当真人试玩”：先读 `doc/testing/governance/playability-l4-synthetic-human-split-2026-05-06.prd.md`
 - 想先回答“对应标准角色 subagent 到底怎么设计、如何组合成 review 流程”：先读 `doc/testing/governance/playability-subagent-review-system-2026-05-06.prd.md`
 - 想先回答“如何用多个 simulated player personas 补内部玩家视角，但不新增正式 `player` 角色”：先读 `doc/testing/governance/playability-simulated-player-persona-panel-2026-05-06.prd.md`
 - 想先回答当前在推进什么、哪些测试治理任务或 QA 阻断仍在影响收口：先读 `doc/testing/project.md`
@@ -21,12 +22,12 @@
 - 想继续按子域或文件名下钻：使用下方热点子域导航，再跳到对应清单区域
 
 ## 密度快照（2026-05-06）
-- `doc/testing/`：187 份文件
+- `doc/testing/`：190 份文件
 - `doc/testing/evidence/`：49 份文件
 - `doc/testing/ci/`：33 份文件
 - `doc/testing/longrun/`：24 份文件
 - `doc/testing/launcher/`：18 份文件
-- `doc/testing/governance/`：25 份文件
+- `doc/testing/governance/`：28 份文件
 - `doc/testing/templates/`：12 份文件
 - `doc/testing/performance/`：12 份文件
 - `doc/testing/manual/`：7 份文件
@@ -39,7 +40,7 @@
 | `ci/` | 33 | CI、wasm determinism、tiering、required check 保护 |
 | `longrun/` | 24 | 长稳、chaos、soak 与在线稳定性 |
 | `launcher/` | 18 | 启动器链路测试、playtest 与配置自动接线 |
-| `governance/` | 25 | 质量趋势、release-gate 指标、审计检查、好玩性证据栈、subagent 评审系统与 simulated personas |
+| `governance/` | 28 | 质量趋势、release-gate 指标、审计检查、好玩性证据栈、L4 synthetic/human 分层、subagent 评审系统与 simulated personas |
 | `templates/` | 12 | 证据包、报告与检查清单模板；默认按需进入 |
 | `performance/` | 12 | runtime / viewer 性能观测与方法学 |
 | `manual/` | 7 | 系统测试手册分册与 Web UI 闭环 manual |
@@ -76,6 +77,7 @@
 | `doc/testing/ci/ci-wasm32-target-install.prd.md` | `doc/testing/ci/ci-wasm32-target-install.design.md` | `doc/testing/ci/ci-wasm32-target-install.project.md` |
 | `doc/testing/governance/llm-skip-tick-ratio-metric.prd.md` | `doc/testing/governance/llm-skip-tick-ratio-metric.design.md` | `doc/testing/governance/llm-skip-tick-ratio-metric.project.md` |
 | `doc/testing/governance/playability-evidence-stack-2026-05-06.prd.md` | `doc/testing/governance/playability-evidence-stack-2026-05-06.design.md` | `doc/testing/governance/playability-evidence-stack-2026-05-06.project.md` |
+| `doc/testing/governance/playability-l4-synthetic-human-split-2026-05-06.prd.md` | `doc/testing/governance/playability-l4-synthetic-human-split-2026-05-06.design.md` | `doc/testing/governance/playability-l4-synthetic-human-split-2026-05-06.project.md` |
 | `doc/testing/governance/playability-simulated-player-persona-panel-2026-05-06.prd.md` | `doc/testing/governance/playability-simulated-player-persona-panel-2026-05-06.design.md` | `doc/testing/governance/playability-simulated-player-persona-panel-2026-05-06.project.md` |
 | `doc/testing/governance/playability-subagent-review-system-2026-05-06.prd.md` | `doc/testing/governance/playability-subagent-review-system-2026-05-06.design.md` | `doc/testing/governance/playability-subagent-review-system-2026-05-06.project.md` |
 | `doc/testing/governance/release-gate-metric-policy-alignment-2026-02-28.prd.md` | `doc/testing/governance/release-gate-metric-policy-alignment-2026-02-28.design.md` | `doc/testing/governance/release-gate-metric-policy-alignment-2026-02-28.project.md` |

--- a/doc/testing/prd.index.md
+++ b/doc/testing/prd.index.md
@@ -1,6 +1,6 @@
 # testing PRD 文件级索引
 
-审计轮次: 8
+审计轮次: 9
 
 更新时间：2026-05-06
 
@@ -14,18 +14,19 @@
 - 想先回答 testing 模块覆盖哪些测试层级、证据与门禁边界：先读 `doc/testing/prd.md`
 - 想先回答“自动化能证明什么、不能证明什么，以及判断好玩还缺哪层证据”：先读 `doc/testing/governance/playability-evidence-stack-2026-05-06.prd.md`
 - 想先回答“对应标准角色 subagent 到底怎么设计、如何组合成 review 流程”：先读 `doc/testing/governance/playability-subagent-review-system-2026-05-06.prd.md`
+- 想先回答“如何用多个 simulated player personas 补内部玩家视角，但不新增正式 `player` 角色”：先读 `doc/testing/governance/playability-simulated-player-persona-panel-2026-05-06.prd.md`
 - 想先回答当前在推进什么、哪些测试治理任务或 QA 阻断仍在影响收口：先读 `doc/testing/project.md`
 - 想直接决定要跑哪套测试或按步骤执行：先读 `testing-manual.md` 与 `doc/testing/manual/web-ui-agent-browser-closure-manual.manual.md`
 - 想先进入 `evidence` 热点子域，并按 release gate / hosted-world / p2p-shared-network / governance drill / claim-audit 问题分流：先读 `doc/testing/evidence/README.md`
 - 想继续按子域或文件名下钻：使用下方热点子域导航，再跳到对应清单区域
 
 ## 密度快照（2026-05-06）
-- `doc/testing/`：184 份文件
+- `doc/testing/`：187 份文件
 - `doc/testing/evidence/`：49 份文件
 - `doc/testing/ci/`：33 份文件
 - `doc/testing/longrun/`：24 份文件
 - `doc/testing/launcher/`：18 份文件
-- `doc/testing/governance/`：22 份文件
+- `doc/testing/governance/`：25 份文件
 - `doc/testing/templates/`：12 份文件
 - `doc/testing/performance/`：12 份文件
 - `doc/testing/manual/`：7 份文件
@@ -38,7 +39,7 @@
 | `ci/` | 33 | CI、wasm determinism、tiering、required check 保护 |
 | `longrun/` | 24 | 长稳、chaos、soak 与在线稳定性 |
 | `launcher/` | 18 | 启动器链路测试、playtest 与配置自动接线 |
-| `governance/` | 22 | 质量趋势、release-gate 指标、审计检查、好玩性证据栈与 subagent 评审系统 |
+| `governance/` | 25 | 质量趋势、release-gate 指标、审计检查、好玩性证据栈、subagent 评审系统与 simulated personas |
 | `templates/` | 12 | 证据包、报告与检查清单模板；默认按需进入 |
 | `performance/` | 12 | runtime / viewer 性能观测与方法学 |
 | `manual/` | 7 | 系统测试手册分册与 Web UI 闭环 manual |
@@ -75,6 +76,7 @@
 | `doc/testing/ci/ci-wasm32-target-install.prd.md` | `doc/testing/ci/ci-wasm32-target-install.design.md` | `doc/testing/ci/ci-wasm32-target-install.project.md` |
 | `doc/testing/governance/llm-skip-tick-ratio-metric.prd.md` | `doc/testing/governance/llm-skip-tick-ratio-metric.design.md` | `doc/testing/governance/llm-skip-tick-ratio-metric.project.md` |
 | `doc/testing/governance/playability-evidence-stack-2026-05-06.prd.md` | `doc/testing/governance/playability-evidence-stack-2026-05-06.design.md` | `doc/testing/governance/playability-evidence-stack-2026-05-06.project.md` |
+| `doc/testing/governance/playability-simulated-player-persona-panel-2026-05-06.prd.md` | `doc/testing/governance/playability-simulated-player-persona-panel-2026-05-06.design.md` | `doc/testing/governance/playability-simulated-player-persona-panel-2026-05-06.project.md` |
 | `doc/testing/governance/playability-subagent-review-system-2026-05-06.prd.md` | `doc/testing/governance/playability-subagent-review-system-2026-05-06.design.md` | `doc/testing/governance/playability-subagent-review-system-2026-05-06.project.md` |
 | `doc/testing/governance/release-gate-metric-policy-alignment-2026-02-28.prd.md` | `doc/testing/governance/release-gate-metric-policy-alignment-2026-02-28.design.md` | `doc/testing/governance/release-gate-metric-policy-alignment-2026-02-28.project.md` |
 | `doc/testing/governance/token-genesis-allocation-audit-checklist-2026-03-22.prd.md` | `doc/testing/governance/token-genesis-allocation-audit-checklist-2026-03-22.design.md` | `doc/testing/governance/token-genesis-allocation-audit-checklist-2026-03-22.project.md` |

--- a/doc/testing/prd.index.md
+++ b/doc/testing/prd.index.md
@@ -2,7 +2,7 @@
 
 审计轮次: 8
 
-更新时间：2026-04-17
+更新时间：2026-05-06
 
 ## 入口
 - 模块 PRD：`doc/testing/prd.md`
@@ -12,18 +12,19 @@
 
 ## 首读分流
 - 想先回答 testing 模块覆盖哪些测试层级、证据与门禁边界：先读 `doc/testing/prd.md`
+- 想先回答“自动化能证明什么、不能证明什么，以及判断好玩还缺哪层证据”：先读 `doc/testing/governance/playability-evidence-stack-2026-05-06.prd.md`
 - 想先回答当前在推进什么、哪些测试治理任务或 QA 阻断仍在影响收口：先读 `doc/testing/project.md`
 - 想直接决定要跑哪套测试或按步骤执行：先读 `testing-manual.md` 与 `doc/testing/manual/web-ui-agent-browser-closure-manual.manual.md`
 - 想先进入 `evidence` 热点子域，并按 release gate / hosted-world / p2p-shared-network / governance drill / claim-audit 问题分流：先读 `doc/testing/evidence/README.md`
 - 想继续按子域或文件名下钻：使用下方热点子域导航，再跳到对应清单区域
 
-## 密度快照（2026-04-17）
-- `doc/testing/`：178 份文件
+## 密度快照（2026-05-06）
+- `doc/testing/`：181 份文件
 - `doc/testing/evidence/`：49 份文件
 - `doc/testing/ci/`：33 份文件
 - `doc/testing/longrun/`：24 份文件
 - `doc/testing/launcher/`：18 份文件
-- `doc/testing/governance/`：16 份文件
+- `doc/testing/governance/`：19 份文件
 - `doc/testing/templates/`：12 份文件
 - `doc/testing/performance/`：12 份文件
 - `doc/testing/manual/`：7 份文件
@@ -36,7 +37,7 @@
 | `ci/` | 33 | CI、wasm determinism、tiering、required check 保护 |
 | `longrun/` | 24 | 长稳、chaos、soak 与在线稳定性 |
 | `launcher/` | 18 | 启动器链路测试、playtest 与配置自动接线 |
-| `governance/` | 16 | 质量趋势、release-gate 指标与审计检查 |
+| `governance/` | 19 | 质量趋势、release-gate 指标、审计检查与好玩性证据栈 |
 | `templates/` | 12 | 证据包、报告与检查清单模板；默认按需进入 |
 | `performance/` | 12 | runtime / viewer 性能观测与方法学 |
 | `manual/` | 7 | 系统测试手册分册与 Web UI 闭环 manual |
@@ -72,6 +73,7 @@
 | `doc/testing/ci/ci-tiered-execution.prd.md` | `doc/testing/ci/ci-tiered-execution.design.md` | `doc/testing/ci/ci-tiered-execution.project.md` |
 | `doc/testing/ci/ci-wasm32-target-install.prd.md` | `doc/testing/ci/ci-wasm32-target-install.design.md` | `doc/testing/ci/ci-wasm32-target-install.project.md` |
 | `doc/testing/governance/llm-skip-tick-ratio-metric.prd.md` | `doc/testing/governance/llm-skip-tick-ratio-metric.design.md` | `doc/testing/governance/llm-skip-tick-ratio-metric.project.md` |
+| `doc/testing/governance/playability-evidence-stack-2026-05-06.prd.md` | `doc/testing/governance/playability-evidence-stack-2026-05-06.design.md` | `doc/testing/governance/playability-evidence-stack-2026-05-06.project.md` |
 | `doc/testing/governance/release-gate-metric-policy-alignment-2026-02-28.prd.md` | `doc/testing/governance/release-gate-metric-policy-alignment-2026-02-28.design.md` | `doc/testing/governance/release-gate-metric-policy-alignment-2026-02-28.project.md` |
 | `doc/testing/governance/token-genesis-allocation-audit-checklist-2026-03-22.prd.md` | `doc/testing/governance/token-genesis-allocation-audit-checklist-2026-03-22.design.md` | `doc/testing/governance/token-genesis-allocation-audit-checklist-2026-03-22.project.md` |
 | `doc/testing/governance/testing-quality-trend-tracking-2026-03-11.prd.md` | `doc/testing/governance/testing-quality-trend-tracking-2026-03-11.design.md` | `doc/testing/governance/testing-quality-trend-tracking-2026-03-11.project.md` |

--- a/doc/testing/prd.index.md
+++ b/doc/testing/prd.index.md
@@ -14,6 +14,7 @@
 - 想先回答 testing 模块覆盖哪些测试层级、证据与门禁边界：先读 `doc/testing/prd.md`
 - 想先回答“自动化能证明什么、不能证明什么，以及判断好玩还缺哪层证据”：先读 `doc/testing/governance/playability-evidence-stack-2026-05-06.prd.md`
 - 想先回答“为什么 `L4` 需要拆成 `L4A synthetic` 和 `L4B human`，以及 agent 角色扮演为什么还不能直接当真人试玩”：先读 `doc/testing/governance/playability-l4-synthetic-human-split-2026-05-06.prd.md`
+- 想直接在一个 worktree 里准备完整 `L4A + L4B` 执行包：先读 `testing-manual.md` 的 `L4A/L4B` 段落，再执行 `./scripts/prepare-playability-l4-review.sh`
 - 想先回答“对应标准角色 subagent 到底怎么设计、如何组合成 review 流程”：先读 `doc/testing/governance/playability-subagent-review-system-2026-05-06.prd.md`
 - 想先回答“如何用多个 simulated player personas 补内部玩家视角，但不新增正式 `player` 角色”：先读 `doc/testing/governance/playability-simulated-player-persona-panel-2026-05-06.prd.md`
 - 想先回答当前在推进什么、哪些测试治理任务或 QA 阻断仍在影响收口：先读 `doc/testing/project.md`
@@ -22,13 +23,13 @@
 - 想继续按子域或文件名下钻：使用下方热点子域导航，再跳到对应清单区域
 
 ## 密度快照（2026-05-06）
-- `doc/testing/`：190 份文件
+- `doc/testing/`：194 份文件
 - `doc/testing/evidence/`：49 份文件
 - `doc/testing/ci/`：33 份文件
 - `doc/testing/longrun/`：24 份文件
 - `doc/testing/launcher/`：18 份文件
 - `doc/testing/governance/`：28 份文件
-- `doc/testing/templates/`：12 份文件
+- `doc/testing/templates/`：16 份文件
 - `doc/testing/performance/`：12 份文件
 - `doc/testing/manual/`：7 份文件
 - `doc/testing/chaos-plans/`：1 份文件

--- a/doc/testing/prd.index.md
+++ b/doc/testing/prd.index.md
@@ -13,8 +13,8 @@
 ## 首读分流
 - 想先回答 testing 模块覆盖哪些测试层级、证据与门禁边界：先读 `doc/testing/prd.md`
 - 想先回答“自动化能证明什么、不能证明什么，以及判断好玩还缺哪层证据”：先读 `doc/testing/governance/playability-evidence-stack-2026-05-06.prd.md`
-- 想先回答“为什么 `L4` 需要拆成 `L4A synthetic` 和 `L4B human`，以及 agent 角色扮演为什么还不能直接当真人试玩”：先读 `doc/testing/governance/playability-l4-synthetic-human-split-2026-05-06.prd.md`
-- 想直接在一个 worktree 里准备完整 `L4A + L4B` 执行包：先读 `testing-manual.md` 的 `L4A/L4B` 段落，再执行 `./scripts/prepare-playability-l4-review.sh`
+- 想先回答“为什么 `L4` 现在只保留 `L4A synthetic`、`L4B embodied-agent` 两个正式内部层，并把内部真人试玩降为 `L4B` 可选佐证”：先读 `doc/testing/governance/playability-l4-synthetic-human-split-2026-05-06.prd.md`
+- 想直接在一个 worktree 里准备完整 `L4A + L4B` 执行包：先读 `testing-manual.md` 的 `L4A/L4B/L5` 段落，再执行 `./scripts/prepare-playability-l4-review.sh`；正式 `L4B` embodied-agent run 再由 `./scripts/run-playability-l4b-agent.sh --l4-manifest <artifact>/manifest.json` 收口。
 - 想先回答“对应标准角色 subagent 到底怎么设计、如何组合成 review 流程”：先读 `doc/testing/governance/playability-subagent-review-system-2026-05-06.prd.md`
 - 想先回答“如何用多个 simulated player personas 补内部玩家视角，但不新增正式 `player` 角色”：先读 `doc/testing/governance/playability-simulated-player-persona-panel-2026-05-06.prd.md`
 - 想先回答当前在推进什么、哪些测试治理任务或 QA 阻断仍在影响收口：先读 `doc/testing/project.md`

--- a/doc/testing/prd.index.md
+++ b/doc/testing/prd.index.md
@@ -13,18 +13,19 @@
 ## 首读分流
 - 想先回答 testing 模块覆盖哪些测试层级、证据与门禁边界：先读 `doc/testing/prd.md`
 - 想先回答“自动化能证明什么、不能证明什么，以及判断好玩还缺哪层证据”：先读 `doc/testing/governance/playability-evidence-stack-2026-05-06.prd.md`
+- 想先回答“对应标准角色 subagent 到底怎么设计、如何组合成 review 流程”：先读 `doc/testing/governance/playability-subagent-review-system-2026-05-06.prd.md`
 - 想先回答当前在推进什么、哪些测试治理任务或 QA 阻断仍在影响收口：先读 `doc/testing/project.md`
 - 想直接决定要跑哪套测试或按步骤执行：先读 `testing-manual.md` 与 `doc/testing/manual/web-ui-agent-browser-closure-manual.manual.md`
 - 想先进入 `evidence` 热点子域，并按 release gate / hosted-world / p2p-shared-network / governance drill / claim-audit 问题分流：先读 `doc/testing/evidence/README.md`
 - 想继续按子域或文件名下钻：使用下方热点子域导航，再跳到对应清单区域
 
 ## 密度快照（2026-05-06）
-- `doc/testing/`：181 份文件
+- `doc/testing/`：184 份文件
 - `doc/testing/evidence/`：49 份文件
 - `doc/testing/ci/`：33 份文件
 - `doc/testing/longrun/`：24 份文件
 - `doc/testing/launcher/`：18 份文件
-- `doc/testing/governance/`：19 份文件
+- `doc/testing/governance/`：22 份文件
 - `doc/testing/templates/`：12 份文件
 - `doc/testing/performance/`：12 份文件
 - `doc/testing/manual/`：7 份文件
@@ -37,7 +38,7 @@
 | `ci/` | 33 | CI、wasm determinism、tiering、required check 保护 |
 | `longrun/` | 24 | 长稳、chaos、soak 与在线稳定性 |
 | `launcher/` | 18 | 启动器链路测试、playtest 与配置自动接线 |
-| `governance/` | 19 | 质量趋势、release-gate 指标、审计检查与好玩性证据栈 |
+| `governance/` | 22 | 质量趋势、release-gate 指标、审计检查、好玩性证据栈与 subagent 评审系统 |
 | `templates/` | 12 | 证据包、报告与检查清单模板；默认按需进入 |
 | `performance/` | 12 | runtime / viewer 性能观测与方法学 |
 | `manual/` | 7 | 系统测试手册分册与 Web UI 闭环 manual |
@@ -74,6 +75,7 @@
 | `doc/testing/ci/ci-wasm32-target-install.prd.md` | `doc/testing/ci/ci-wasm32-target-install.design.md` | `doc/testing/ci/ci-wasm32-target-install.project.md` |
 | `doc/testing/governance/llm-skip-tick-ratio-metric.prd.md` | `doc/testing/governance/llm-skip-tick-ratio-metric.design.md` | `doc/testing/governance/llm-skip-tick-ratio-metric.project.md` |
 | `doc/testing/governance/playability-evidence-stack-2026-05-06.prd.md` | `doc/testing/governance/playability-evidence-stack-2026-05-06.design.md` | `doc/testing/governance/playability-evidence-stack-2026-05-06.project.md` |
+| `doc/testing/governance/playability-subagent-review-system-2026-05-06.prd.md` | `doc/testing/governance/playability-subagent-review-system-2026-05-06.design.md` | `doc/testing/governance/playability-subagent-review-system-2026-05-06.project.md` |
 | `doc/testing/governance/release-gate-metric-policy-alignment-2026-02-28.prd.md` | `doc/testing/governance/release-gate-metric-policy-alignment-2026-02-28.design.md` | `doc/testing/governance/release-gate-metric-policy-alignment-2026-02-28.project.md` |
 | `doc/testing/governance/token-genesis-allocation-audit-checklist-2026-03-22.prd.md` | `doc/testing/governance/token-genesis-allocation-audit-checklist-2026-03-22.design.md` | `doc/testing/governance/token-genesis-allocation-audit-checklist-2026-03-22.project.md` |
 | `doc/testing/governance/testing-quality-trend-tracking-2026-03-11.prd.md` | `doc/testing/governance/testing-quality-trend-tracking-2026-03-11.design.md` | `doc/testing/governance/testing-quality-trend-tracking-2026-03-11.project.md` |

--- a/doc/testing/prd.md
+++ b/doc/testing/prd.md
@@ -40,6 +40,7 @@
   - SC-5: 活跃 testing 专题文档按批次完成人工迁移到 strict schema，并统一 `*.prd.md` / `*.project.md` 命名。
   - SC-6: builtin wasm（m1/m4/m5）hash 发布链路具备 changed-path scope planner、跨 runner 对账、required check 保护与本地只读校验策略。
   - SC-7: 主链 Token 创世前具备一份 QA 审计清单，覆盖分配比例、custody/treasury 语义、个人上限、创世流通与首年释放上限，避免带着错误经济配置进入执行。
+  - SC-8: testing 模块具备一份正式的 `playability evidence stack` 专题，明确自动化、agent probe、遥测/实验、结构化真人试玩与受控外部信号的分层证明边界，禁止把“自动化已通过”误写为“游戏已被证明好玩”。
 
 ## 2. User Experience & Functionality
 - User Personas:
@@ -47,6 +48,7 @@
   - 功能开发者：需要明确改动后最小必跑集合。
   - 发布负责人：需要审计级测试证据判断放行。
   - 制作人与经济配置维护者：需要一份可审计的创世配置检查表，避免只靠聊天结论发币。
+  - 制作人与玩法 owner：需要一套分层证据栈，区分“没坏”“世界在动”“玩家真的想继续玩”。
 - User Scenarios & Frequency:
   - 开发分支回归：每次核心改动后触发一次 required 路径。
   - 发布候选验证：每个候选版本执行 required + full 组合。
@@ -55,6 +57,7 @@
   - 前期工业体验回归：影响 `首个制成品 / 停机恢复 / 首座工厂单元` 时，补跑 required-tier 手动卡组。
   - 创世配置冻结前审计：每次准备冻结 Token 分配表时执行一次 required-tier 配置审计。
   - 信任门 / 留存证据复核：每次宣称“玩家值得继续玩”前，必须先检查该样本是否只是世界在自己运转。
+  - 玩法质量争议复盘：每次出现“自动化通过但体验仍差”的争议时，必须先定位缺的是哪一层证据。
 - User Stories:
   - PRD-TESTING-001: As a 测试维护者, I want one canonical testing strategy, so that suite evolution stays coherent.
   - PRD-TESTING-002: As a 开发者, I want clear trigger matrices, so that I can run the right tests efficiently.
@@ -62,6 +65,7 @@
   - PRD-TESTING-004: As a 文档维护者, I want each legacy testing topic doc manually migrated with content-preserving rewrite, so that historical intent remains accurate after format upgrade.
   - PRD-TESTING-005: As a 发布工程维护者, I want builtin wasm hash chain hardened end-to-end, so that hash drift can be blocked and traced before release.
   - PRD-TESTING-006: As a `qa_engineer`, I want a token genesis allocation audit checklist, so that producer/runtime can freeze mint configuration without hidden control or circulation risk.
+  - PRD-TESTING-007: As a `producer_system_designer`, I want a canonical playability evidence stack, so that I can judge gameplay fun without conflating automation, world activity, and real player motivation.
 - Critical User Flows:
   1. Flow-TST-001: `识别改动类型 -> 匹配 S0~S10 -> 日常提交先执行 commit baseline，再按风险升级到 required/full -> 输出结果`
   2. Flow-TST-002: `发布前执行 full 套件 -> 按 Viewer/launcher 选择正确驱动链路 -> 汇总命令/日志/截图 -> 生成证据包`
@@ -71,6 +75,7 @@
   6. Flow-TST-006: `识别工业引导体验改动 -> 运行自动化前置 -> 执行 playability 卡组 -> 回写 QA 阻断结论`
   7. Flow-TST-007: `读取 token 创世参数表 -> 逐项核对比例/recipient/vesting/流通边界 -> 输出 QA verdict -> 回流 producer 决策`
   8. Flow-TST-008: `汇总 trust/playability 样本 -> 回答玩家动作与玩家导致的世界变化 -> 标记 world_activity_only -> 再给 pass/watch/block 结论`
+  9. Flow-TST-009: `按 evidence stack 标记当前只到 L1/L2/L3/L4/L5 哪一层 -> 明确缺口 -> 再决定是否能声称“值得继续玩”`
 - Functional Specification Matrix:
 | 功能点 | 字段定义 | 按钮/动作行为 | 状态转换 | 排序/计算规则 | 权限逻辑 |
 | --- | --- | --- | --- | --- | --- |
@@ -85,6 +90,7 @@
 | Windows 路径兼容校验 | tracked path、invalid segment、gate command、release runner | 在 required gate 早期扫描 git tracked paths，阻断 `windows-2022` 无法 checkout 的文件名进入 release/package-native | `scanned -> pass/block` | 默认按 git tracked path 全量扫描；发现 Windows 非法字符、保留名、尾随空格/点即直接 fail | QA / 发布维护者维护跨平台 release 可达性 |
 | Runtime gate 分片执行 | full-suite shard、sync check、runner capability、日志 artifact | 将 release runtime gate 拆成 core/support/sync 并行 job；聚合 gate 统一裁决是否放行 | `planned -> sharded -> aggregated` | 重型 `oasis7` full-tier 优先单独成 shard，其余 support / sync 独立并行；最终必须全部成功 | QA / 发布维护者维护 runtime 关键路径 |
 | Token 创世配置审计 | `bucket_id`、`ratio_bps`、`recipient`、`cliff_epochs`、`linear_unlock_epochs`、`genesis_liquid`、`founder_cap_bps`、`year1_external_release_cap_bps` | 逐项核对参数表与经济口径，输出 `pass/block` 审计结论 | `draft -> audited -> pass/block` | `sum=10000 bps`；项目战略控制 `5000 bps`；协议长期储备 `3500 bps`；`genesis_liquid=0`；个人上限 `<=1500 bps` | `qa_engineer` 独立出具结论，producer 决定是否冻结 |
+| 好玩性证据栈 | `evidence_layer`、`formal_surface`、`player_leverage_verdict`、`world_activity_only`、`human_playtest_verdict`、`external_signal_status` | 把玩法结论分层标记为 L1 自动化、L2 probe、L3 遥测/实验、L4 真人试玩、L5 外部信号，再输出 `go/watch/hold/block` | `collected -> layered -> decided` | 低层证据不能替代高层证据；自动化 pass 只能证明“没坏/可回归”，不能单独证明“好玩” | `producer_system_designer` 终判，`qa_engineer` 守门 |
 - Acceptance Criteria:
   - AC-1: testing PRD 覆盖分层模型、触发矩阵、证据规范。
   - AC-2: testing project 文档维护分层测试演进任务。
@@ -104,6 +110,7 @@
   - AC-14: `required-gate` 必须在命中 `crates/oasis7_client_launcher/**`、`crates/oasis7_launcher_ui/**`、`crates/oasis7_proto/**`、`crates/oasis7_wasm_abi/**` 或 `crates/oasis7/**` 的 launcher shared runtime 改动时按需执行 launcher Web `trunk build`，避免仅在 release `build-web-dist` 才暴露 wasm 编译错误。
   - AC-14A: 仓库必须提供轻量 Web/UI automation smoke，允许 `qa_engineer` 在不启动完整 runtime 栈的前提下，用 fixture 页面复用真 `agent-browser` 验证 `viewer-software-safe-step-regression.sh` 的最小浏览器链路与 summary/state 产物契约；该 smoke 只用于 tooling 预检，不替代正式 S6 证据。
   - AC-15: 正式 gameplay/trust evidence 至少要有 1 条代表性样本明确记录 `player_action`、`world_change_due_to_player`、`player_leverage_score` 与 `world_activity_only`，否则不得宣称“玩家已有 meaningful participation”。
+  - AC-16: `playability-evidence-stack-2026-05-06` 专题文档必须明确五层证据、组合规则、现有 oasis7 锚点映射，以及“自动化不能单独保证好玩”的正式结论。
 - Non-Goals:
   - 不在本 PRD 中替代业务模块的功能设计。
   - 不承诺所有测试都进入 CI 默认路径。
@@ -118,6 +125,7 @@
   - `testing-manual.md`
   - `doc/testing/manual/web-ui-agent-browser-closure-manual.manual.md`
   - `doc/testing/manual/web-ui-agent-browser-closure-manual.prd.md`
+  - `doc/testing/governance/playability-evidence-stack-2026-05-06.prd.md`
   - `doc/testing/governance/token-genesis-allocation-audit-checklist-2026-03-22.prd.md`
   - `doc/playability_test_result/topics/industrial-onboarding-required-tier-cards-2026-03-15.md`
   - `doc/p2p/token/mainchain-token-initial-allocation-and-early-contribution-reward-2026-03-22.prd.md`
@@ -142,6 +150,7 @@
   - 迁移断链：文档改名后若引用未同步，需在同批次修复并复测。
   - 创世语义误读：若把 `protocol:*` custody account 误当成已初始化 treasury bucket，QA 必须直接阻断。
   - 流通口径漂移：若创世参数表未显式声明 `genesis_liquid=0` 或首年外部释放上限，视为配置不完整。
+  - 自动化与真人试玩结论冲突：必须先记为“低层 pass / 高层 hold”，不能把高层体验问题降格成脚本未覆盖。
 - Non-Functional Requirements:
   - NFR-TST-1: required 套件变更前后执行时间波动 <= 20%。
   - NFR-TST-2: 发布证据包字段完整率 100%。
@@ -152,6 +161,7 @@
   - NFR-TST-7: builtin wasm hash 校验在多 runner 下可复现且差异可定位到模块与平台维度。
   - NFR-TST-8: Token 创世 QA 审计模板字段完整率必须为 `100%`，缺任何一项关键字段都不能给 `pass`。
   - NFR-TST-9: 正式 gameplay evidence 审查者必须能在 30 秒内看出“玩家是否真的改变了世界”，无需从长日志里二次拼装。
+  - NFR-TST-10: 正式玩法结论必须能在 60 秒内回答“当前只证明到哪一层，还缺哪一层”。
 - Security & Privacy: 测试日志与产物需避免泄露凭据；外部 API 测试使用最小化数据并执行脱敏。
 
 ## 5. Risks & Roadmap
@@ -177,6 +187,7 @@
 | PRD-TESTING-004 | TASK-TESTING-007/008/009/010/011/012/013/014/015/016/017/018/019/020/021/022/023/024/025/026/027/028/029/030/031/032/033/034/035/036/059/060/061 | `test_tier_required` | 原文约束点映射审查、命名与引用回归检查、历史专题标题零残留校验、活跃专题当前真值命名回归检查 | 专题文档可维护性与追溯一致性 |
 | PRD-TESTING-005 | TASK-TESTING-037/038/039/040/wasm-determinism-gate-ondemand-scope | `test_tier_required` | keyed manifest/strict policy/changed-path scope planner/多 runner required checks/identity 输入收敛回归 | builtin wasm 发布链路稳定性 |
 | PRD-TESTING-006 | TASK-TESTING-062 | `test_tier_required` | token 创世参数表审计清单、执行模板、p2p/testing 模块追踪回写 | 主链 Token 创世冻结与经济配置门禁 |
+| PRD-TESTING-007 | playability-evidence-stack-2026-05-06 | `test_tier_required` | 五层证据栈定义、现有锚点映射、模块入口互链与组合规则抽样检查 | 玩法质量 claim 与放行边界 |
 - Decision Log:
 | 决策ID | 选定方案 | 备选方案（否决） | 依据 |
 | --- | --- | --- | --- |
@@ -186,3 +197,4 @@
 | DEC-TST-004 | legacy 专题文档采用逐篇人工迁移并统一 `.prd` 命名 | 自动脚本批量改写 | 可确保内容语义与约束不丢失。 |
 | DEC-TST-005 | Token 创世前增加 QA 审计清单与阻断 verdict | 仅由 producer/runtime 自审 | 经济配置错误一旦进入创世，后续修复成本极高。 |
 | DEC-TST-006 | 在正式 gameplay evidence 中单列 `player leverage` 审查层 | 继续只看 world delta / activity / 总体有趣度 | `#166` 暴露的是“玩家是否参与有效”而不是“世界有没有动起来”，需要单独防误报。 |
+| DEC-TST-007 | 为“是否好玩”建立五层 evidence stack，并明确自动化不能单独保证好玩 | 继续把自动化 pass、世界活跃和真实玩家继续动机混写 | 这三类信号的证明强度不同，混写会持续污染 release/stage 结论。 |

--- a/doc/testing/prd.md
+++ b/doc/testing/prd.md
@@ -44,6 +44,7 @@
   - SC-9: testing 模块具备一份正式的 `playability subagent review system` 专题，明确标准角色 subagent 清单、输入输出 contract、触发矩阵和升级边界，让内部多角色评审可重复执行。
   - SC-10: testing 模块具备一份正式的 `simulated player persona panel` 专题，明确多个风格化玩家视角如何作为内部假设层接入标准角色 review，同时不新增正式 `player` 角色。
   - SC-11: testing 模块明确把 `L4` 拆成 `L4A synthetic internal playability review` 与 `L4B structured human playtest`，避免把 agent 角色扮演和真人继续游玩意愿混写成同一层结论。
+  - SC-12: 仓库必须提供一个 repo-local `L4` scaffold 入口，能够在单个 worktree 内稳定生成 `L4A` review packet、role/persona cards、`L4B` 卡片副本、最终 summary 与推荐命令，不再依赖临时手写 packet/card 文件名。
 
 ## 2. User Experience & Functionality
 - User Personas:
@@ -127,12 +128,13 @@
   - AC-17: `playability-subagent-review-system-2026-05-06` 专题文档必须明确标准角色 subagent 清单、review packet / output card、trigger matrix、sequencing rules 和 stop conditions。
   - AC-18: `playability-simulated-player-persona-panel-2026-05-06` 专题文档必须明确固定 persona 清单、persona packet / card、与标准角色 review 的回流方式，以及“不是正式角色、不能替代真人验证”的边界。
   - AC-19: `playability-l4-synthetic-human-split-2026-05-06` 专题文档必须明确 `L4A/L4B` 的定义、operator 入口、claim 边界与当前非替代承诺。
+  - AC-20: `scripts/prepare-playability-l4-review.sh` 与 `doc/testing/templates/playability-l4-*.md` 必须能在当前 worktree 下生成一套完整 `L4` scaffold，至少包含 review packet、role review cards、persona cards、summary、`L4B` 卡片副本和推荐命令文件。
 - Non-Goals:
   - 不在本 PRD 中替代业务模块的功能设计。
   - 不承诺所有测试都进入 CI 默认路径。
 
 ## 3. AI System Requirements (If Applicable)
-- Tool Requirements: `scripts/ci-tests.sh`、agent-browser 闭环工具、`oasis7_web_launcher` GUI Agent 接口、长跑脚本、结果汇总工具。
+- Tool Requirements: `scripts/ci-tests.sh`、agent-browser 闭环工具、`oasis7_web_launcher` GUI Agent 接口、长跑脚本、结果汇总工具、`scripts/prepare-playability-l4-review.sh`。
 - Evaluation Strategy: 通过门禁通过率、缺陷逃逸率、回归定位时长、证据完整度衡量测试体系质量。
 
 ## 4. Technical Specifications
@@ -145,12 +147,17 @@
   - `doc/testing/governance/playability-subagent-review-system-2026-05-06.prd.md`
   - `doc/testing/governance/playability-simulated-player-persona-panel-2026-05-06.prd.md`
   - `doc/testing/governance/playability-l4-synthetic-human-split-2026-05-06.prd.md`
+  - `doc/testing/templates/playability-l4-review-packet-template.md`
+  - `doc/testing/templates/playability-l4-role-review-card-template.md`
+  - `doc/testing/templates/playability-l4-persona-card-template.md`
+  - `doc/testing/templates/playability-l4-summary-template.md`
   - `doc/testing/governance/token-genesis-allocation-audit-checklist-2026-03-22.prd.md`
   - `doc/playability_test_result/topics/industrial-onboarding-required-tier-cards-2026-03-15.md`
   - `doc/p2p/token/mainchain-token-initial-allocation-and-early-contribution-reward-2026-03-22.prd.md`
   - `doc/testing/ci/ci-builtin-wasm-docker-canonical-gate.prd.md`
   - `scripts/check-windows-paths.sh`
   - `scripts/ci-tests.sh`
+  - `scripts/prepare-playability-l4-review.sh`
   - `scripts/viewer-software-safe-step-regression-smoke.sh`
   - `scripts/sync-m1-builtin-wasm-artifacts.sh`
   - `scripts/ci-m1-wasm-summary.sh`
@@ -211,10 +218,10 @@
 | PRD-TESTING-004 | TASK-TESTING-007/008/009/010/011/012/013/014/015/016/017/018/019/020/021/022/023/024/025/026/027/028/029/030/031/032/033/034/035/036/059/060/061 | `test_tier_required` | 原文约束点映射审查、命名与引用回归检查、历史专题标题零残留校验、活跃专题当前真值命名回归检查 | 专题文档可维护性与追溯一致性 |
 | PRD-TESTING-005 | TASK-TESTING-037/038/039/040/wasm-determinism-gate-ondemand-scope | `test_tier_required` | keyed manifest/strict policy/changed-path scope planner/多 runner required checks/identity 输入收敛回归 | builtin wasm 发布链路稳定性 |
 | PRD-TESTING-006 | TASK-TESTING-062 | `test_tier_required` | token 创世参数表审计清单、执行模板、p2p/testing 模块追踪回写 | 主链 Token 创世冻结与经济配置门禁 |
-| PRD-TESTING-007 | playability-evidence-stack-2026-05-06 | `test_tier_required` | 五层证据栈定义、现有锚点映射、模块入口互链与组合规则抽样检查 | 玩法质量 claim 与放行边界 |
-| PRD-TESTING-008 | playability-subagent-review-system-2026-05-06 | `test_tier_required` | 标准角色 subagent 定义、packet/card contract、trigger matrix 与 stop conditions 抽样检查 | 多角色内部评审系统设计 |
-| PRD-TESTING-009 | playability-simulated-player-persona-panel-2026-05-06 | `test_tier_required` | persona catalog、packet/card schema、回流规则与 L4/L5 边界抽样检查 | 多风格内部玩家视角治理 |
-| PRD-TESTING-010 | playability-l4-synthetic-human-split-2026-05-06 | `test_tier_required` | `L4A/L4B` 分层、manual 入口、claim 边界与根入口互链抽样检查 | synthetic/human 玩法证据治理 |
+| PRD-TESTING-007 | playability-evidence-stack-2026-05-06 | `test_tier_required` | 五层证据栈定义、现有锚点映射、模块入口互链、repo-local `L4` scaffold 入口与组合规则抽样检查 | 玩法质量 claim 与放行边界 |
+| PRD-TESTING-008 | playability-subagent-review-system-2026-05-06 | `test_tier_required` | 标准角色 subagent 定义、packet/card contract、scaffold 入口、trigger matrix 与 stop conditions 抽样检查 | 多角色内部评审系统设计 |
+| PRD-TESTING-009 | playability-simulated-player-persona-panel-2026-05-06 | `test_tier_required` | persona catalog、packet/card schema、persona scaffold、回流规则与 L4/L5 边界抽样检查 | 多风格内部玩家视角治理 |
+| PRD-TESTING-010 | playability-l4-synthetic-human-split-2026-05-06 | `test_tier_required` | `L4A/L4B` 分层、manual 入口、repo-local scaffold、claim 边界与根入口互链抽样检查 | synthetic/human 玩法证据治理 |
 - Decision Log:
 | 决策ID | 选定方案 | 备选方案（否决） | 依据 |
 | --- | --- | --- | --- |

--- a/doc/testing/prd.md
+++ b/doc/testing/prd.md
@@ -1,6 +1,6 @@
 # testing PRD
 
-审计轮次: 8
+审计轮次: 9
 
 ## 目标
 - 建立 testing 模块设计主文档，统一需求边界、技术方案与验收标准。
@@ -43,6 +43,7 @@
   - SC-8: testing 模块具备一份正式的 `playability evidence stack` 专题，明确自动化、agent probe、遥测/实验、结构化真人试玩与受控外部信号的分层证明边界，禁止把“自动化已通过”误写为“游戏已被证明好玩”。
   - SC-9: testing 模块具备一份正式的 `playability subagent review system` 专题，明确标准角色 subagent 清单、输入输出 contract、触发矩阵和升级边界，让内部多角色评审可重复执行。
   - SC-10: testing 模块具备一份正式的 `simulated player persona panel` 专题，明确多个风格化玩家视角如何作为内部假设层接入标准角色 review，同时不新增正式 `player` 角色。
+  - SC-11: testing 模块明确把 `L4` 拆成 `L4A synthetic internal playability review` 与 `L4B structured human playtest`，避免把 agent 角色扮演和真人继续游玩意愿混写成同一层结论。
 
 ## 2. User Experience & Functionality
 - User Personas:
@@ -71,6 +72,7 @@
   - PRD-TESTING-007: As a `producer_system_designer`, I want a canonical playability evidence stack, so that I can judge gameplay fun without conflating automation, world activity, and real player motivation.
   - PRD-TESTING-008: As a workflow owner, I want a designed system for role-based playability review subagents, so that internal multi-role review can run as a standard operating path instead of ad hoc coordination.
   - PRD-TESTING-009: As a playability reviewer, I want a designed panel of simulated player personas, so that internal review can compare multiple player mindsets without inventing a new formal role taxonomy.
+  - PRD-TESTING-010: As a stage owner, I want `L4A/L4B` split explicitly, so that synthetic and human playability claims stop collapsing into one undifferentiated `L4`.
 - Critical User Flows:
   1. Flow-TST-001: `识别改动类型 -> 匹配 S0~S10 -> 日常提交先执行 commit baseline，再按风险升级到 required/full -> 输出结果`
   2. Flow-TST-002: `发布前执行 full 套件 -> 按 Viewer/launcher 选择正确驱动链路 -> 汇总命令/日志/截图 -> 生成证据包`
@@ -83,6 +85,7 @@
   9. Flow-TST-009: `按 evidence stack 标记当前只到 L1/L2/L3/L4/L5 哪一层 -> 明确缺口 -> 再决定是否能声称“值得继续玩”`
   10. Flow-TST-010: `组装 review packet -> 按 changed surface 拉起标准角色 subagent -> 回收 review card -> producer/qa 汇总内部结论`
   11. Flow-TST-011: `若体验争议来自玩家风格差异 -> 选择 simulated personas -> 生成 persona cards -> 回流标准角色 review`
+  12. Flow-TST-012: `若先做高强度内部模拟 -> 形成 L4A；若需要真人继续游玩结论 -> 升级到 L4B；再判断是否仍缺 L5`
 - Functional Specification Matrix:
 | 功能点 | 字段定义 | 按钮/动作行为 | 状态转换 | 排序/计算规则 | 权限逻辑 |
 | --- | --- | --- | --- | --- | --- |
@@ -97,9 +100,10 @@
 | Windows 路径兼容校验 | tracked path、invalid segment、gate command、release runner | 在 required gate 早期扫描 git tracked paths，阻断 `windows-2022` 无法 checkout 的文件名进入 release/package-native | `scanned -> pass/block` | 默认按 git tracked path 全量扫描；发现 Windows 非法字符、保留名、尾随空格/点即直接 fail | QA / 发布维护者维护跨平台 release 可达性 |
 | Runtime gate 分片执行 | full-suite shard、sync check、runner capability、日志 artifact | 将 release runtime gate 拆成 core/support/sync 并行 job；聚合 gate 统一裁决是否放行 | `planned -> sharded -> aggregated` | 重型 `oasis7` full-tier 优先单独成 shard，其余 support / sync 独立并行；最终必须全部成功 | QA / 发布维护者维护 runtime 关键路径 |
 | Token 创世配置审计 | `bucket_id`、`ratio_bps`、`recipient`、`cliff_epochs`、`linear_unlock_epochs`、`genesis_liquid`、`founder_cap_bps`、`year1_external_release_cap_bps` | 逐项核对参数表与经济口径，输出 `pass/block` 审计结论 | `draft -> audited -> pass/block` | `sum=10000 bps`；项目战略控制 `5000 bps`；协议长期储备 `3500 bps`；`genesis_liquid=0`；个人上限 `<=1500 bps` | `qa_engineer` 独立出具结论，producer 决定是否冻结 |
-| 好玩性证据栈 | `evidence_layer`、`formal_surface`、`player_leverage_verdict`、`world_activity_only`、`human_playtest_verdict`、`external_signal_status` | 把玩法结论分层标记为 L1 自动化、L2 probe、L3 遥测/实验、L4 真人试玩、L5 外部信号，再输出 `go/watch/hold/block` | `collected -> layered -> decided` | 低层证据不能替代高层证据；自动化 pass 只能证明“没坏/可回归”，不能单独证明“好玩” | `producer_system_designer` 终判，`qa_engineer` 守门 |
+| 好玩性证据栈 | `evidence_layer`、`formal_surface`、`player_leverage_verdict`、`world_activity_only`、`synthetic_playability_verdict`、`human_playtest_verdict`、`external_signal_status` | 把玩法结论分层标记为 L1 自动化、L2 probe、L3 遥测/实验、L4A synthetic、L4B human、L5 外部信号，再输出 `go/watch/hold/block` | `collected -> layered -> decided` | 低层证据不能替代高层证据；`L4A` 不能自动等于 `L4B`；自动化 pass 只能证明“没坏/可回归”，不能单独证明“好玩” | `producer_system_designer` 终判，`qa_engineer` 守门 |
 | 好玩性 subagent 评审系统 | `review_packet`、`requested_roles`、`role_review_card`、`aggregated_review_summary` | 按 changed surface 拉起标准角色 subagent，收集 review card，并汇总成内部结论 | `packet_ready -> parallel_review -> aggregated -> escalated/closed` | 默认必开 `producer + qa`；其余按 surface 触发；缺 L5 时不得越权宣称真实外部验证完成 | `producer_system_designer` 编排，`qa_engineer` 守门 |
 | 模拟玩家 persona 面板 | `selected_personas`、`persona_card`、`persona_divergence_summary`、`handoff_recommended_to` | 按主观体验风险选择多个 simulated personas，生成风格化体验假设，再回流标准角色 review | `selected -> simulated -> handed_off -> absorbed` | 不新增正式 `player` 角色；persona 只能补内部假设，不能替代真人试玩或外部验证 | `producer_system_designer` 决定是否开启，命中的标准角色负责收口 |
+| L4 synthetic/human 分层 | `synthetic_playability_verdict`、`human_playtest_verdict`、`calibration_status` | 先区分当前结论属于 `L4A` 还是 `L4B`，再决定是否可以升级 claim | `synthetic_ready -> human_ready -> external_ready` | `L4A` 不得冒充 `L4B`；无 calibration 时不得宣称 synthetic 已替代 human | `producer_system_designer` 定义边界，`qa_engineer` 守门 |
 - Acceptance Criteria:
   - AC-1: testing PRD 覆盖分层模型、触发矩阵、证据规范。
   - AC-2: testing project 文档维护分层测试演进任务。
@@ -122,6 +126,7 @@
   - AC-16: `playability-evidence-stack-2026-05-06` 专题文档必须明确五层证据、组合规则、现有 oasis7 锚点映射，以及“自动化不能单独保证好玩”的正式结论。
   - AC-17: `playability-subagent-review-system-2026-05-06` 专题文档必须明确标准角色 subagent 清单、review packet / output card、trigger matrix、sequencing rules 和 stop conditions。
   - AC-18: `playability-simulated-player-persona-panel-2026-05-06` 专题文档必须明确固定 persona 清单、persona packet / card、与标准角色 review 的回流方式，以及“不是正式角色、不能替代真人验证”的边界。
+  - AC-19: `playability-l4-synthetic-human-split-2026-05-06` 专题文档必须明确 `L4A/L4B` 的定义、operator 入口、claim 边界与当前非替代承诺。
 - Non-Goals:
   - 不在本 PRD 中替代业务模块的功能设计。
   - 不承诺所有测试都进入 CI 默认路径。
@@ -139,6 +144,7 @@
   - `doc/testing/governance/playability-evidence-stack-2026-05-06.prd.md`
   - `doc/testing/governance/playability-subagent-review-system-2026-05-06.prd.md`
   - `doc/testing/governance/playability-simulated-player-persona-panel-2026-05-06.prd.md`
+  - `doc/testing/governance/playability-l4-synthetic-human-split-2026-05-06.prd.md`
   - `doc/testing/governance/token-genesis-allocation-audit-checklist-2026-03-22.prd.md`
   - `doc/playability_test_result/topics/industrial-onboarding-required-tier-cards-2026-03-15.md`
   - `doc/p2p/token/mainchain-token-initial-allocation-and-early-contribution-reward-2026-03-22.prd.md`
@@ -165,6 +171,7 @@
   - 流通口径漂移：若创世参数表未显式声明 `genesis_liquid=0` 或首年外部释放上限，视为配置不完整。
   - 自动化与真人试玩结论冲突：必须先记为“低层 pass / 高层 hold”，不能把高层体验问题降格成脚本未覆盖。
   - 模拟 persona 全部正面：只能说明内部假设面板没有发现高价值断点，不能替代真人试玩或外部 session。
+  - `L4A` 全正面、`L4B` 未执行：只能写 `synthetic_ready`，不能写 `human_ready`。
 - Non-Functional Requirements:
   - NFR-TST-1: required 套件变更前后执行时间波动 <= 20%。
   - NFR-TST-2: 发布证据包字段完整率 100%。
@@ -178,6 +185,7 @@
   - NFR-TST-10: 正式玩法结论必须能在 60 秒内回答“当前只证明到哪一层，还缺哪一层”。
   - NFR-TST-11: review orchestrator 必须能在 5 分钟内决定本次改动应开哪些标准角色 subagent。
   - NFR-TST-12: simulated persona panel 的使用者必须能在 5 分钟内决定该开哪几个 persona，以及它们的结论最终归谁收口。
+  - NFR-TST-13: 任何正式玩法结论都必须能在 30 秒内回答“这是 `L4A` 还是 `L4B`，以及为什么”。
 - Security & Privacy: 测试日志与产物需避免泄露凭据；外部 API 测试使用最小化数据并执行脱敏。
 
 ## 5. Risks & Roadmap
@@ -206,6 +214,7 @@
 | PRD-TESTING-007 | playability-evidence-stack-2026-05-06 | `test_tier_required` | 五层证据栈定义、现有锚点映射、模块入口互链与组合规则抽样检查 | 玩法质量 claim 与放行边界 |
 | PRD-TESTING-008 | playability-subagent-review-system-2026-05-06 | `test_tier_required` | 标准角色 subagent 定义、packet/card contract、trigger matrix 与 stop conditions 抽样检查 | 多角色内部评审系统设计 |
 | PRD-TESTING-009 | playability-simulated-player-persona-panel-2026-05-06 | `test_tier_required` | persona catalog、packet/card schema、回流规则与 L4/L5 边界抽样检查 | 多风格内部玩家视角治理 |
+| PRD-TESTING-010 | playability-l4-synthetic-human-split-2026-05-06 | `test_tier_required` | `L4A/L4B` 分层、manual 入口、claim 边界与根入口互链抽样检查 | synthetic/human 玩法证据治理 |
 - Decision Log:
 | 决策ID | 选定方案 | 备选方案（否决） | 依据 |
 | --- | --- | --- | --- |
@@ -218,3 +227,4 @@
 | DEC-TST-007 | 为“是否好玩”建立五层 evidence stack，并明确自动化不能单独保证好玩 | 继续把自动化 pass、世界活跃和真实玩家继续动机混写 | 这三类信号的证明强度不同，混写会持续污染 release/stage 结论。 |
 | DEC-TST-008 | 进一步把多角色内部评审设计成标准角色 subagent 系统 | 继续临时决定这次要不要找哪些角色来看 | 临时协调很难规模化，也无法稳定复用 review 输出。 |
 | DEC-TST-009 | 用 simulated player persona panel 补多风格玩家视角，但不新增正式 `player` 角色 | 直接把 `player` 升格成新的标准角色 | 会破坏仓库角色治理，并混淆内部模拟与外部真人验证。 |
+| DEC-TST-010 | 把 `L4` 拆成 `L4A synthetic` 与 `L4B human` | 继续把 agent 角色扮演与真人继续游玩意愿共用一个 `L4` 标签 | 两者证明强度不同，混写会持续污染 stage/release 结论。 |

--- a/doc/testing/prd.md
+++ b/doc/testing/prd.md
@@ -1,6 +1,6 @@
 # testing PRD
 
-审计轮次: 7
+审计轮次: 8
 
 ## 目标
 - 建立 testing 模块设计主文档，统一需求边界、技术方案与验收标准。
@@ -42,6 +42,7 @@
   - SC-7: 主链 Token 创世前具备一份 QA 审计清单，覆盖分配比例、custody/treasury 语义、个人上限、创世流通与首年释放上限，避免带着错误经济配置进入执行。
   - SC-8: testing 模块具备一份正式的 `playability evidence stack` 专题，明确自动化、agent probe、遥测/实验、结构化真人试玩与受控外部信号的分层证明边界，禁止把“自动化已通过”误写为“游戏已被证明好玩”。
   - SC-9: testing 模块具备一份正式的 `playability subagent review system` 专题，明确标准角色 subagent 清单、输入输出 contract、触发矩阵和升级边界，让内部多角色评审可重复执行。
+  - SC-10: testing 模块具备一份正式的 `simulated player persona panel` 专题，明确多个风格化玩家视角如何作为内部假设层接入标准角色 review，同时不新增正式 `player` 角色。
 
 ## 2. User Experience & Functionality
 - User Personas:
@@ -50,6 +51,7 @@
   - 发布负责人：需要审计级测试证据判断放行。
   - 制作人与经济配置维护者：需要一份可审计的创世配置检查表，避免只靠聊天结论发币。
   - 制作人与玩法 owner：需要一套分层证据栈，区分“没坏”“世界在动”“玩家真的想继续玩”。
+  - 内部玩法评审 owner：需要固定的 simulated personas，避免每次靠临时脑补多个“可能的玩家”。
 - User Scenarios & Frequency:
   - 开发分支回归：每次核心改动后触发一次 required 路径。
   - 发布候选验证：每个候选版本执行 required + full 组合。
@@ -68,6 +70,7 @@
   - PRD-TESTING-006: As a `qa_engineer`, I want a token genesis allocation audit checklist, so that producer/runtime can freeze mint configuration without hidden control or circulation risk.
   - PRD-TESTING-007: As a `producer_system_designer`, I want a canonical playability evidence stack, so that I can judge gameplay fun without conflating automation, world activity, and real player motivation.
   - PRD-TESTING-008: As a workflow owner, I want a designed system for role-based playability review subagents, so that internal multi-role review can run as a standard operating path instead of ad hoc coordination.
+  - PRD-TESTING-009: As a playability reviewer, I want a designed panel of simulated player personas, so that internal review can compare multiple player mindsets without inventing a new formal role taxonomy.
 - Critical User Flows:
   1. Flow-TST-001: `识别改动类型 -> 匹配 S0~S10 -> 日常提交先执行 commit baseline，再按风险升级到 required/full -> 输出结果`
   2. Flow-TST-002: `发布前执行 full 套件 -> 按 Viewer/launcher 选择正确驱动链路 -> 汇总命令/日志/截图 -> 生成证据包`
@@ -79,6 +82,7 @@
   8. Flow-TST-008: `汇总 trust/playability 样本 -> 回答玩家动作与玩家导致的世界变化 -> 标记 world_activity_only -> 再给 pass/watch/block 结论`
   9. Flow-TST-009: `按 evidence stack 标记当前只到 L1/L2/L3/L4/L5 哪一层 -> 明确缺口 -> 再决定是否能声称“值得继续玩”`
   10. Flow-TST-010: `组装 review packet -> 按 changed surface 拉起标准角色 subagent -> 回收 review card -> producer/qa 汇总内部结论`
+  11. Flow-TST-011: `若体验争议来自玩家风格差异 -> 选择 simulated personas -> 生成 persona cards -> 回流标准角色 review`
 - Functional Specification Matrix:
 | 功能点 | 字段定义 | 按钮/动作行为 | 状态转换 | 排序/计算规则 | 权限逻辑 |
 | --- | --- | --- | --- | --- | --- |
@@ -95,6 +99,7 @@
 | Token 创世配置审计 | `bucket_id`、`ratio_bps`、`recipient`、`cliff_epochs`、`linear_unlock_epochs`、`genesis_liquid`、`founder_cap_bps`、`year1_external_release_cap_bps` | 逐项核对参数表与经济口径，输出 `pass/block` 审计结论 | `draft -> audited -> pass/block` | `sum=10000 bps`；项目战略控制 `5000 bps`；协议长期储备 `3500 bps`；`genesis_liquid=0`；个人上限 `<=1500 bps` | `qa_engineer` 独立出具结论，producer 决定是否冻结 |
 | 好玩性证据栈 | `evidence_layer`、`formal_surface`、`player_leverage_verdict`、`world_activity_only`、`human_playtest_verdict`、`external_signal_status` | 把玩法结论分层标记为 L1 自动化、L2 probe、L3 遥测/实验、L4 真人试玩、L5 外部信号，再输出 `go/watch/hold/block` | `collected -> layered -> decided` | 低层证据不能替代高层证据；自动化 pass 只能证明“没坏/可回归”，不能单独证明“好玩” | `producer_system_designer` 终判，`qa_engineer` 守门 |
 | 好玩性 subagent 评审系统 | `review_packet`、`requested_roles`、`role_review_card`、`aggregated_review_summary` | 按 changed surface 拉起标准角色 subagent，收集 review card，并汇总成内部结论 | `packet_ready -> parallel_review -> aggregated -> escalated/closed` | 默认必开 `producer + qa`；其余按 surface 触发；缺 L5 时不得越权宣称真实外部验证完成 | `producer_system_designer` 编排，`qa_engineer` 守门 |
+| 模拟玩家 persona 面板 | `selected_personas`、`persona_card`、`persona_divergence_summary`、`handoff_recommended_to` | 按主观体验风险选择多个 simulated personas，生成风格化体验假设，再回流标准角色 review | `selected -> simulated -> handed_off -> absorbed` | 不新增正式 `player` 角色；persona 只能补内部假设，不能替代真人试玩或外部验证 | `producer_system_designer` 决定是否开启，命中的标准角色负责收口 |
 - Acceptance Criteria:
   - AC-1: testing PRD 覆盖分层模型、触发矩阵、证据规范。
   - AC-2: testing project 文档维护分层测试演进任务。
@@ -116,6 +121,7 @@
   - AC-15: 正式 gameplay/trust evidence 至少要有 1 条代表性样本明确记录 `player_action`、`world_change_due_to_player`、`player_leverage_score` 与 `world_activity_only`，否则不得宣称“玩家已有 meaningful participation”。
   - AC-16: `playability-evidence-stack-2026-05-06` 专题文档必须明确五层证据、组合规则、现有 oasis7 锚点映射，以及“自动化不能单独保证好玩”的正式结论。
   - AC-17: `playability-subagent-review-system-2026-05-06` 专题文档必须明确标准角色 subagent 清单、review packet / output card、trigger matrix、sequencing rules 和 stop conditions。
+  - AC-18: `playability-simulated-player-persona-panel-2026-05-06` 专题文档必须明确固定 persona 清单、persona packet / card、与标准角色 review 的回流方式，以及“不是正式角色、不能替代真人验证”的边界。
 - Non-Goals:
   - 不在本 PRD 中替代业务模块的功能设计。
   - 不承诺所有测试都进入 CI 默认路径。
@@ -132,6 +138,7 @@
   - `doc/testing/manual/web-ui-agent-browser-closure-manual.prd.md`
   - `doc/testing/governance/playability-evidence-stack-2026-05-06.prd.md`
   - `doc/testing/governance/playability-subagent-review-system-2026-05-06.prd.md`
+  - `doc/testing/governance/playability-simulated-player-persona-panel-2026-05-06.prd.md`
   - `doc/testing/governance/token-genesis-allocation-audit-checklist-2026-03-22.prd.md`
   - `doc/playability_test_result/topics/industrial-onboarding-required-tier-cards-2026-03-15.md`
   - `doc/p2p/token/mainchain-token-initial-allocation-and-early-contribution-reward-2026-03-22.prd.md`
@@ -157,6 +164,7 @@
   - 创世语义误读：若把 `protocol:*` custody account 误当成已初始化 treasury bucket，QA 必须直接阻断。
   - 流通口径漂移：若创世参数表未显式声明 `genesis_liquid=0` 或首年外部释放上限，视为配置不完整。
   - 自动化与真人试玩结论冲突：必须先记为“低层 pass / 高层 hold”，不能把高层体验问题降格成脚本未覆盖。
+  - 模拟 persona 全部正面：只能说明内部假设面板没有发现高价值断点，不能替代真人试玩或外部 session。
 - Non-Functional Requirements:
   - NFR-TST-1: required 套件变更前后执行时间波动 <= 20%。
   - NFR-TST-2: 发布证据包字段完整率 100%。
@@ -169,6 +177,7 @@
   - NFR-TST-9: 正式 gameplay evidence 审查者必须能在 30 秒内看出“玩家是否真的改变了世界”，无需从长日志里二次拼装。
   - NFR-TST-10: 正式玩法结论必须能在 60 秒内回答“当前只证明到哪一层，还缺哪一层”。
   - NFR-TST-11: review orchestrator 必须能在 5 分钟内决定本次改动应开哪些标准角色 subagent。
+  - NFR-TST-12: simulated persona panel 的使用者必须能在 5 分钟内决定该开哪几个 persona，以及它们的结论最终归谁收口。
 - Security & Privacy: 测试日志与产物需避免泄露凭据；外部 API 测试使用最小化数据并执行脱敏。
 
 ## 5. Risks & Roadmap
@@ -196,6 +205,7 @@
 | PRD-TESTING-006 | TASK-TESTING-062 | `test_tier_required` | token 创世参数表审计清单、执行模板、p2p/testing 模块追踪回写 | 主链 Token 创世冻结与经济配置门禁 |
 | PRD-TESTING-007 | playability-evidence-stack-2026-05-06 | `test_tier_required` | 五层证据栈定义、现有锚点映射、模块入口互链与组合规则抽样检查 | 玩法质量 claim 与放行边界 |
 | PRD-TESTING-008 | playability-subagent-review-system-2026-05-06 | `test_tier_required` | 标准角色 subagent 定义、packet/card contract、trigger matrix 与 stop conditions 抽样检查 | 多角色内部评审系统设计 |
+| PRD-TESTING-009 | playability-simulated-player-persona-panel-2026-05-06 | `test_tier_required` | persona catalog、packet/card schema、回流规则与 L4/L5 边界抽样检查 | 多风格内部玩家视角治理 |
 - Decision Log:
 | 决策ID | 选定方案 | 备选方案（否决） | 依据 |
 | --- | --- | --- | --- |
@@ -207,3 +217,4 @@
 | DEC-TST-006 | 在正式 gameplay evidence 中单列 `player leverage` 审查层 | 继续只看 world delta / activity / 总体有趣度 | `#166` 暴露的是“玩家是否参与有效”而不是“世界有没有动起来”，需要单独防误报。 |
 | DEC-TST-007 | 为“是否好玩”建立五层 evidence stack，并明确自动化不能单独保证好玩 | 继续把自动化 pass、世界活跃和真实玩家继续动机混写 | 这三类信号的证明强度不同，混写会持续污染 release/stage 结论。 |
 | DEC-TST-008 | 进一步把多角色内部评审设计成标准角色 subagent 系统 | 继续临时决定这次要不要找哪些角色来看 | 临时协调很难规模化，也无法稳定复用 review 输出。 |
+| DEC-TST-009 | 用 simulated player persona panel 补多风格玩家视角，但不新增正式 `player` 角色 | 直接把 `player` 升格成新的标准角色 | 会破坏仓库角色治理，并混淆内部模拟与外部真人验证。 |

--- a/doc/testing/prd.md
+++ b/doc/testing/prd.md
@@ -40,11 +40,12 @@
   - SC-5: 活跃 testing 专题文档按批次完成人工迁移到 strict schema，并统一 `*.prd.md` / `*.project.md` 命名。
   - SC-6: builtin wasm（m1/m4/m5）hash 发布链路具备 changed-path scope planner、跨 runner 对账、required check 保护与本地只读校验策略。
   - SC-7: 主链 Token 创世前具备一份 QA 审计清单，覆盖分配比例、custody/treasury 语义、个人上限、创世流通与首年释放上限，避免带着错误经济配置进入执行。
-  - SC-8: testing 模块具备一份正式的 `playability evidence stack` 专题，明确自动化、agent probe、遥测/实验、结构化真人试玩与受控外部信号的分层证明边界，禁止把“自动化已通过”误写为“游戏已被证明好玩”。
+  - SC-8: testing 模块具备一份正式的 `playability evidence stack` 专题，明确自动化、agent probe、遥测/实验、`L4A synthetic`、`L4B embodied-agent` 与 `L5` 真实人类 / 受控外部信号的分层证明边界，禁止把“自动化已通过”误写为“游戏已被证明好玩”。
   - SC-9: testing 模块具备一份正式的 `playability subagent review system` 专题，明确标准角色 subagent 清单、输入输出 contract、触发矩阵和升级边界，让内部多角色评审可重复执行。
   - SC-10: testing 模块具备一份正式的 `simulated player persona panel` 专题，明确多个风格化玩家视角如何作为内部假设层接入标准角色 review，同时不新增正式 `player` 角色。
-  - SC-11: testing 模块明确把 `L4` 拆成 `L4A synthetic internal playability review` 与 `L4B structured human playtest`，避免把 agent 角色扮演和真人继续游玩意愿混写成同一层结论。
-  - SC-12: 仓库必须提供一个 repo-local `L4` scaffold 入口，能够在单个 worktree 内稳定生成 `L4A` review packet、role/persona cards、`L4B` 卡片副本、最终 summary 与推荐命令，不再依赖临时手写 packet/card 文件名。
+  - SC-11: testing 模块明确把 `L4` 正式收口为 `L4A synthetic internal playability review` 与 `L4B embodied agent playtest`，并把内部真人试玩降为 `L4B` 的可选校准证据，避免把 agent 角色扮演、agent 实操试玩和真实人类 / 外部继续游玩意愿混写成同一层结论。
+  - SC-12: 仓库必须提供一个 repo-local `L4` scaffold 入口，能够在单个 worktree 内稳定生成 `L4A` review packet、role/persona cards、`L4B` agent 卡副本、可选内部真人佐证 notes、最终 summary 与推荐命令，不再依赖临时手写 packet/card 文件名。
+  - SC-13: 仓库必须提供一个 repo-local `L4B` embodied-agent runner，能够实际启动 producer playtest、执行最小真实操作链路、并把状态快照/截图/日志路径/summary 回填到同一 artifact 目录，而不是只留下手工提示。
 
 ## 2. User Experience & Functionality
 - User Personas:
@@ -73,7 +74,7 @@
   - PRD-TESTING-007: As a `producer_system_designer`, I want a canonical playability evidence stack, so that I can judge gameplay fun without conflating automation, world activity, and real player motivation.
   - PRD-TESTING-008: As a workflow owner, I want a designed system for role-based playability review subagents, so that internal multi-role review can run as a standard operating path instead of ad hoc coordination.
   - PRD-TESTING-009: As a playability reviewer, I want a designed panel of simulated player personas, so that internal review can compare multiple player mindsets without inventing a new formal role taxonomy.
-  - PRD-TESTING-010: As a stage owner, I want `L4A/L4B` split explicitly, so that synthetic and human playability claims stop collapsing into one undifferentiated `L4`.
+  - PRD-TESTING-010: As a stage owner, I want `L4A/L4B/L5` boundaries written explicitly, so that synthetic、agentic、real-human playability claims stop collapsing into one undifferentiated `L4`.
 - Critical User Flows:
   1. Flow-TST-001: `识别改动类型 -> 匹配 S0~S10 -> 日常提交先执行 commit baseline，再按风险升级到 required/full -> 输出结果`
   2. Flow-TST-002: `发布前执行 full 套件 -> 按 Viewer/launcher 选择正确驱动链路 -> 汇总命令/日志/截图 -> 生成证据包`
@@ -86,7 +87,7 @@
   9. Flow-TST-009: `按 evidence stack 标记当前只到 L1/L2/L3/L4/L5 哪一层 -> 明确缺口 -> 再决定是否能声称“值得继续玩”`
   10. Flow-TST-010: `组装 review packet -> 按 changed surface 拉起标准角色 subagent -> 回收 review card -> producer/qa 汇总内部结论`
   11. Flow-TST-011: `若体验争议来自玩家风格差异 -> 选择 simulated personas -> 生成 persona cards -> 回流标准角色 review`
-  12. Flow-TST-012: `若先做高强度内部模拟 -> 形成 L4A；若需要真人继续游玩结论 -> 升级到 L4B；再判断是否仍缺 L5`
+  12. Flow-TST-012: `若先做高强度内部模拟 -> 形成 L4A；若需要 agent 实际进游戏操作且尽量逼近真人评审效果的结论 -> 升级到 L4B；若仍需真实人类 / 真实环境结论 -> 再升级到 L5；内部真人试玩只作为 L4B 可选校准`
 - Functional Specification Matrix:
 | 功能点 | 字段定义 | 按钮/动作行为 | 状态转换 | 排序/计算规则 | 权限逻辑 |
 | --- | --- | --- | --- | --- | --- |
@@ -101,10 +102,10 @@
 | Windows 路径兼容校验 | tracked path、invalid segment、gate command、release runner | 在 required gate 早期扫描 git tracked paths，阻断 `windows-2022` 无法 checkout 的文件名进入 release/package-native | `scanned -> pass/block` | 默认按 git tracked path 全量扫描；发现 Windows 非法字符、保留名、尾随空格/点即直接 fail | QA / 发布维护者维护跨平台 release 可达性 |
 | Runtime gate 分片执行 | full-suite shard、sync check、runner capability、日志 artifact | 将 release runtime gate 拆成 core/support/sync 并行 job；聚合 gate 统一裁决是否放行 | `planned -> sharded -> aggregated` | 重型 `oasis7` full-tier 优先单独成 shard，其余 support / sync 独立并行；最终必须全部成功 | QA / 发布维护者维护 runtime 关键路径 |
 | Token 创世配置审计 | `bucket_id`、`ratio_bps`、`recipient`、`cliff_epochs`、`linear_unlock_epochs`、`genesis_liquid`、`founder_cap_bps`、`year1_external_release_cap_bps` | 逐项核对参数表与经济口径，输出 `pass/block` 审计结论 | `draft -> audited -> pass/block` | `sum=10000 bps`；项目战略控制 `5000 bps`；协议长期储备 `3500 bps`；`genesis_liquid=0`；个人上限 `<=1500 bps` | `qa_engineer` 独立出具结论，producer 决定是否冻结 |
-| 好玩性证据栈 | `evidence_layer`、`formal_surface`、`player_leverage_verdict`、`world_activity_only`、`synthetic_playability_verdict`、`human_playtest_verdict`、`external_signal_status` | 把玩法结论分层标记为 L1 自动化、L2 probe、L3 遥测/实验、L4A synthetic、L4B human、L5 外部信号，再输出 `go/watch/hold/block` | `collected -> layered -> decided` | 低层证据不能替代高层证据；`L4A` 不能自动等于 `L4B`；自动化 pass 只能证明“没坏/可回归”，不能单独证明“好玩” | `producer_system_designer` 终判，`qa_engineer` 守门 |
+| 好玩性证据栈 | `evidence_layer`、`formal_surface`、`player_leverage_verdict`、`world_activity_only`、`synthetic_playability_verdict`、`agentic_playtest_verdict`、`optional_internal_human_corroboration`、`external_signal_status` | 把玩法结论分层标记为 L1 自动化、L2 probe、L3 遥测/实验、L4A synthetic、L4B agent、L5 外部信号，再输出 `go/watch/hold/block` | `collected -> layered -> decided` | 低层证据不能替代高层证据；`L4A` 不能自动等于 `L4B`，`L4B` 也不能自动等于 `L5`；自动化 pass 只能证明“没坏/可回归”，不能单独证明“好玩” | `producer_system_designer` 终判，`qa_engineer` 守门 |
 | 好玩性 subagent 评审系统 | `review_packet`、`requested_roles`、`role_review_card`、`aggregated_review_summary` | 按 changed surface 拉起标准角色 subagent，收集 review card，并汇总成内部结论 | `packet_ready -> parallel_review -> aggregated -> escalated/closed` | 默认必开 `producer + qa`；其余按 surface 触发；缺 L5 时不得越权宣称真实外部验证完成 | `producer_system_designer` 编排，`qa_engineer` 守门 |
-| 模拟玩家 persona 面板 | `selected_personas`、`persona_card`、`persona_divergence_summary`、`handoff_recommended_to` | 按主观体验风险选择多个 simulated personas，生成风格化体验假设，再回流标准角色 review | `selected -> simulated -> handed_off -> absorbed` | 不新增正式 `player` 角色；persona 只能补内部假设，不能替代真人试玩或外部验证 | `producer_system_designer` 决定是否开启，命中的标准角色负责收口 |
-| L4 synthetic/human 分层 | `synthetic_playability_verdict`、`human_playtest_verdict`、`calibration_status` | 先区分当前结论属于 `L4A` 还是 `L4B`，再决定是否可以升级 claim | `synthetic_ready -> human_ready -> external_ready` | `L4A` 不得冒充 `L4B`；无 calibration 时不得宣称 synthetic 已替代 human | `producer_system_designer` 定义边界，`qa_engineer` 守门 |
+| 模拟玩家 persona 面板 | `selected_personas`、`persona_card`、`persona_divergence_summary`、`handoff_recommended_to` | 按主观体验风险选择多个 simulated personas，生成风格化体验假设，再回流标准角色 review | `selected -> simulated -> handed_off -> absorbed` | 不新增正式 `player` 角色；persona 只能补内部假设，不能替代 agent 实操试玩、真人试玩或外部验证 | `producer_system_designer` 决定是否开启，命中的标准角色负责收口 |
+| L4 synthetic/agent 分层 | `synthetic_playability_verdict`、`agentic_playtest_verdict`、`optional_internal_human_corroboration`、`calibration_status` | 先区分当前结论属于 `L4A` 还是 `L4B`，再决定是否可以升级 claim | `synthetic_ready -> agent_ready -> external_ready` | `L4A` 不得冒充 `L4B`；内部真人佐证只可作为 `L4B` 校准，不得伪装成 `L5`；无 calibration 时不得宣称低层已替代高层 | `producer_system_designer` 定义边界，`qa_engineer` 守门 |
 - Acceptance Criteria:
   - AC-1: testing PRD 覆盖分层模型、触发矩阵、证据规范。
   - AC-2: testing project 文档维护分层测试演进任务。
@@ -124,11 +125,12 @@
   - AC-14: `required-gate` 必须在命中 `crates/oasis7_client_launcher/**`、`crates/oasis7_launcher_ui/**`、`crates/oasis7_proto/**`、`crates/oasis7_wasm_abi/**` 或 `crates/oasis7/**` 的 launcher shared runtime 改动时按需执行 launcher Web `trunk build`，避免仅在 release `build-web-dist` 才暴露 wasm 编译错误。
   - AC-14A: 仓库必须提供轻量 Web/UI automation smoke，允许 `qa_engineer` 在不启动完整 runtime 栈的前提下，用 fixture 页面复用真 `agent-browser` 验证 `viewer-software-safe-step-regression.sh` 的最小浏览器链路与 summary/state 产物契约；该 smoke 只用于 tooling 预检，不替代正式 S6 证据。
   - AC-15: 正式 gameplay/trust evidence 至少要有 1 条代表性样本明确记录 `player_action`、`world_change_due_to_player`、`player_leverage_score` 与 `world_activity_only`，否则不得宣称“玩家已有 meaningful participation”。
-  - AC-16: `playability-evidence-stack-2026-05-06` 专题文档必须明确五层证据、组合规则、现有 oasis7 锚点映射，以及“自动化不能单独保证好玩”的正式结论。
+  - AC-16: `playability-evidence-stack-2026-05-06` 专题文档必须明确 `L1/L2/L3/L4A/L4B/L5` 证据边界、组合规则、现有 oasis7 锚点映射，以及“自动化不能单独保证好玩”的正式结论。
   - AC-17: `playability-subagent-review-system-2026-05-06` 专题文档必须明确标准角色 subagent 清单、review packet / output card、trigger matrix、sequencing rules 和 stop conditions。
   - AC-18: `playability-simulated-player-persona-panel-2026-05-06` 专题文档必须明确固定 persona 清单、persona packet / card、与标准角色 review 的回流方式，以及“不是正式角色、不能替代真人验证”的边界。
-  - AC-19: `playability-l4-synthetic-human-split-2026-05-06` 专题文档必须明确 `L4A/L4B` 的定义、operator 入口、claim 边界与当前非替代承诺。
-  - AC-20: `scripts/prepare-playability-l4-review.sh` 与 `doc/testing/templates/playability-l4-*.md` 必须能在当前 worktree 下生成一套完整 `L4` scaffold，至少包含 review packet、role review cards、persona cards、summary、`L4B` 卡片副本和推荐命令文件。
+  - AC-19: `playability-l4-synthetic-human-split-2026-05-06` 专题文档必须明确 `L4A/L4B/L5` 的定义、operator 入口、claim 边界与当前非替代承诺。
+  - AC-20: `scripts/prepare-playability-l4-review.sh` 与 `doc/testing/templates/playability-l4-*.md` 必须能在当前 worktree 下生成一套完整 `L4` scaffold，至少包含 review packet、role review cards、persona cards、summary、`L4B` agent 卡副本、可选内部真人佐证 notes 和推荐命令文件。
+  - AC-21: `scripts/run-playability-l4b-agent.sh` 必须能消费上述 `manifest.json` 或 artifact 目录，实际完成一次 `L4B` embodied-agent run，并落盘 `L4B` summary、关键 state snapshots、截图、启动日志路径以及对 copied `l4b-agent-playtest-card.md` / `l4-summary.md` 的自动预填。
 - Non-Goals:
   - 不在本 PRD 中替代业务模块的功能设计。
   - 不承诺所有测试都进入 CI 默认路径。
@@ -158,6 +160,7 @@
   - `scripts/check-windows-paths.sh`
   - `scripts/ci-tests.sh`
   - `scripts/prepare-playability-l4-review.sh`
+  - `scripts/run-playability-l4b-agent.sh`
   - `scripts/viewer-software-safe-step-regression-smoke.sh`
   - `scripts/sync-m1-builtin-wasm-artifacts.sh`
   - `scripts/ci-m1-wasm-summary.sh`
@@ -176,9 +179,10 @@
   - 迁移断链：文档改名后若引用未同步，需在同批次修复并复测。
   - 创世语义误读：若把 `protocol:*` custody account 误当成已初始化 treasury bucket，QA 必须直接阻断。
   - 流通口径漂移：若创世参数表未显式声明 `genesis_liquid=0` 或首年外部释放上限，视为配置不完整。
-  - 自动化与真人试玩结论冲突：必须先记为“低层 pass / 高层 hold”，不能把高层体验问题降格成脚本未覆盖。
-  - 模拟 persona 全部正面：只能说明内部假设面板没有发现高价值断点，不能替代真人试玩或外部 session。
-  - `L4A` 全正面、`L4B` 未执行：只能写 `synthetic_ready`，不能写 `human_ready`。
+  - 自动化、agent 试玩与真人试玩结论冲突：必须先记为“低层 pass / 高层 hold”，不能把高层体验问题降格成脚本未覆盖。
+  - 模拟 persona 全部正面：只能说明内部假设面板没有发现高价值断点，不能替代 `L4B` agent 实操或外部真实 session。
+  - `L4A` 全正面、`L4B` 未执行：只能写 `synthetic_ready`，不能写 `agent_ready`。
+  - `L4B` 全正面、`L5` 未执行：只能写 `agent_ready`，不能写 `external_ready`。
 - Non-Functional Requirements:
   - NFR-TST-1: required 套件变更前后执行时间波动 <= 20%。
   - NFR-TST-2: 发布证据包字段完整率 100%。
@@ -192,7 +196,7 @@
   - NFR-TST-10: 正式玩法结论必须能在 60 秒内回答“当前只证明到哪一层，还缺哪一层”。
   - NFR-TST-11: review orchestrator 必须能在 5 分钟内决定本次改动应开哪些标准角色 subagent。
   - NFR-TST-12: simulated persona panel 的使用者必须能在 5 分钟内决定该开哪几个 persona，以及它们的结论最终归谁收口。
-  - NFR-TST-13: 任何正式玩法结论都必须能在 30 秒内回答“这是 `L4A` 还是 `L4B`，以及为什么”。
+  - NFR-TST-13: 任何正式玩法结论都必须能在 30 秒内回答“这是 `L4A`、`L4B` 还是 `L5` 前的内部校准，以及为什么”。
 - Security & Privacy: 测试日志与产物需避免泄露凭据；外部 API 测试使用最小化数据并执行脱敏。
 
 ## 5. Risks & Roadmap
@@ -218,10 +222,10 @@
 | PRD-TESTING-004 | TASK-TESTING-007/008/009/010/011/012/013/014/015/016/017/018/019/020/021/022/023/024/025/026/027/028/029/030/031/032/033/034/035/036/059/060/061 | `test_tier_required` | 原文约束点映射审查、命名与引用回归检查、历史专题标题零残留校验、活跃专题当前真值命名回归检查 | 专题文档可维护性与追溯一致性 |
 | PRD-TESTING-005 | TASK-TESTING-037/038/039/040/wasm-determinism-gate-ondemand-scope | `test_tier_required` | keyed manifest/strict policy/changed-path scope planner/多 runner required checks/identity 输入收敛回归 | builtin wasm 发布链路稳定性 |
 | PRD-TESTING-006 | TASK-TESTING-062 | `test_tier_required` | token 创世参数表审计清单、执行模板、p2p/testing 模块追踪回写 | 主链 Token 创世冻结与经济配置门禁 |
-| PRD-TESTING-007 | playability-evidence-stack-2026-05-06 | `test_tier_required` | 五层证据栈定义、现有锚点映射、模块入口互链、repo-local `L4` scaffold 入口与组合规则抽样检查 | 玩法质量 claim 与放行边界 |
+| PRD-TESTING-007 | playability-evidence-stack-2026-05-06 | `test_tier_required` | `L1/L2/L3/L4A/L4B/L5` 证据边界、现有锚点映射、模块入口互链、repo-local `L4` scaffold 入口与组合规则抽样检查 | 玩法质量 claim 与放行边界 |
 | PRD-TESTING-008 | playability-subagent-review-system-2026-05-06 | `test_tier_required` | 标准角色 subagent 定义、packet/card contract、scaffold 入口、trigger matrix 与 stop conditions 抽样检查 | 多角色内部评审系统设计 |
 | PRD-TESTING-009 | playability-simulated-player-persona-panel-2026-05-06 | `test_tier_required` | persona catalog、packet/card schema、persona scaffold、回流规则与 L4/L5 边界抽样检查 | 多风格内部玩家视角治理 |
-| PRD-TESTING-010 | playability-l4-synthetic-human-split-2026-05-06 | `test_tier_required` | `L4A/L4B` 分层、manual 入口、repo-local scaffold、claim 边界与根入口互链抽样检查 | synthetic/human 玩法证据治理 |
+| PRD-TESTING-010 | playability-l4-synthetic-human-split-2026-05-06 | `test_tier_required` | `L4A/L4B/L5` 边界、manual 入口、repo-local scaffold、`L4B` runner、claim 边界与根入口互链抽样检查 | synthetic/agent/real-human 玩法证据治理 |
 - Decision Log:
 | 决策ID | 选定方案 | 备选方案（否决） | 依据 |
 | --- | --- | --- | --- |
@@ -231,7 +235,7 @@
 | DEC-TST-004 | legacy 专题文档采用逐篇人工迁移并统一 `.prd` 命名 | 自动脚本批量改写 | 可确保内容语义与约束不丢失。 |
 | DEC-TST-005 | Token 创世前增加 QA 审计清单与阻断 verdict | 仅由 producer/runtime 自审 | 经济配置错误一旦进入创世，后续修复成本极高。 |
 | DEC-TST-006 | 在正式 gameplay evidence 中单列 `player leverage` 审查层 | 继续只看 world delta / activity / 总体有趣度 | `#166` 暴露的是“玩家是否参与有效”而不是“世界有没有动起来”，需要单独防误报。 |
-| DEC-TST-007 | 为“是否好玩”建立五层 evidence stack，并明确自动化不能单独保证好玩 | 继续把自动化 pass、世界活跃和真实玩家继续动机混写 | 这三类信号的证明强度不同，混写会持续污染 release/stage 结论。 |
+| DEC-TST-007 | 为“是否好玩”建立分层 evidence stack，并明确自动化不能单独保证好玩 | 继续把自动化 pass、世界活跃和真实玩家继续动机混写 | 这些信号的证明强度不同，混写会持续污染 release/stage 结论。 |
 | DEC-TST-008 | 进一步把多角色内部评审设计成标准角色 subagent 系统 | 继续临时决定这次要不要找哪些角色来看 | 临时协调很难规模化，也无法稳定复用 review 输出。 |
 | DEC-TST-009 | 用 simulated player persona panel 补多风格玩家视角，但不新增正式 `player` 角色 | 直接把 `player` 升格成新的标准角色 | 会破坏仓库角色治理，并混淆内部模拟与外部真人验证。 |
-| DEC-TST-010 | 把 `L4` 拆成 `L4A synthetic` 与 `L4B human` | 继续把 agent 角色扮演与真人继续游玩意愿共用一个 `L4` 标签 | 两者证明强度不同，混写会持续污染 stage/release 结论。 |
+| DEC-TST-010 | 把 `L4` 正式收口为 `L4A synthetic` 与 `L4B agent`，并把内部真人试玩降为 `L4B` 可选校准、把真实人类验证留在 `L5` | 继续把 agent 角色扮演、agent 实操、内部真人试玩与真实人类继续游玩意愿共用一个 `L4` 标签 | 这些信号的证明强度不同，混写会持续污染 stage/release 结论。 |

--- a/doc/testing/prd.md
+++ b/doc/testing/prd.md
@@ -41,6 +41,7 @@
   - SC-6: builtin wasm（m1/m4/m5）hash 发布链路具备 changed-path scope planner、跨 runner 对账、required check 保护与本地只读校验策略。
   - SC-7: 主链 Token 创世前具备一份 QA 审计清单，覆盖分配比例、custody/treasury 语义、个人上限、创世流通与首年释放上限，避免带着错误经济配置进入执行。
   - SC-8: testing 模块具备一份正式的 `playability evidence stack` 专题，明确自动化、agent probe、遥测/实验、结构化真人试玩与受控外部信号的分层证明边界，禁止把“自动化已通过”误写为“游戏已被证明好玩”。
+  - SC-9: testing 模块具备一份正式的 `playability subagent review system` 专题，明确标准角色 subagent 清单、输入输出 contract、触发矩阵和升级边界，让内部多角色评审可重复执行。
 
 ## 2. User Experience & Functionality
 - User Personas:
@@ -66,6 +67,7 @@
   - PRD-TESTING-005: As a 发布工程维护者, I want builtin wasm hash chain hardened end-to-end, so that hash drift can be blocked and traced before release.
   - PRD-TESTING-006: As a `qa_engineer`, I want a token genesis allocation audit checklist, so that producer/runtime can freeze mint configuration without hidden control or circulation risk.
   - PRD-TESTING-007: As a `producer_system_designer`, I want a canonical playability evidence stack, so that I can judge gameplay fun without conflating automation, world activity, and real player motivation.
+  - PRD-TESTING-008: As a workflow owner, I want a designed system for role-based playability review subagents, so that internal multi-role review can run as a standard operating path instead of ad hoc coordination.
 - Critical User Flows:
   1. Flow-TST-001: `识别改动类型 -> 匹配 S0~S10 -> 日常提交先执行 commit baseline，再按风险升级到 required/full -> 输出结果`
   2. Flow-TST-002: `发布前执行 full 套件 -> 按 Viewer/launcher 选择正确驱动链路 -> 汇总命令/日志/截图 -> 生成证据包`
@@ -76,6 +78,7 @@
   7. Flow-TST-007: `读取 token 创世参数表 -> 逐项核对比例/recipient/vesting/流通边界 -> 输出 QA verdict -> 回流 producer 决策`
   8. Flow-TST-008: `汇总 trust/playability 样本 -> 回答玩家动作与玩家导致的世界变化 -> 标记 world_activity_only -> 再给 pass/watch/block 结论`
   9. Flow-TST-009: `按 evidence stack 标记当前只到 L1/L2/L3/L4/L5 哪一层 -> 明确缺口 -> 再决定是否能声称“值得继续玩”`
+  10. Flow-TST-010: `组装 review packet -> 按 changed surface 拉起标准角色 subagent -> 回收 review card -> producer/qa 汇总内部结论`
 - Functional Specification Matrix:
 | 功能点 | 字段定义 | 按钮/动作行为 | 状态转换 | 排序/计算规则 | 权限逻辑 |
 | --- | --- | --- | --- | --- | --- |
@@ -91,6 +94,7 @@
 | Runtime gate 分片执行 | full-suite shard、sync check、runner capability、日志 artifact | 将 release runtime gate 拆成 core/support/sync 并行 job；聚合 gate 统一裁决是否放行 | `planned -> sharded -> aggregated` | 重型 `oasis7` full-tier 优先单独成 shard，其余 support / sync 独立并行；最终必须全部成功 | QA / 发布维护者维护 runtime 关键路径 |
 | Token 创世配置审计 | `bucket_id`、`ratio_bps`、`recipient`、`cliff_epochs`、`linear_unlock_epochs`、`genesis_liquid`、`founder_cap_bps`、`year1_external_release_cap_bps` | 逐项核对参数表与经济口径，输出 `pass/block` 审计结论 | `draft -> audited -> pass/block` | `sum=10000 bps`；项目战略控制 `5000 bps`；协议长期储备 `3500 bps`；`genesis_liquid=0`；个人上限 `<=1500 bps` | `qa_engineer` 独立出具结论，producer 决定是否冻结 |
 | 好玩性证据栈 | `evidence_layer`、`formal_surface`、`player_leverage_verdict`、`world_activity_only`、`human_playtest_verdict`、`external_signal_status` | 把玩法结论分层标记为 L1 自动化、L2 probe、L3 遥测/实验、L4 真人试玩、L5 外部信号，再输出 `go/watch/hold/block` | `collected -> layered -> decided` | 低层证据不能替代高层证据；自动化 pass 只能证明“没坏/可回归”，不能单独证明“好玩” | `producer_system_designer` 终判，`qa_engineer` 守门 |
+| 好玩性 subagent 评审系统 | `review_packet`、`requested_roles`、`role_review_card`、`aggregated_review_summary` | 按 changed surface 拉起标准角色 subagent，收集 review card，并汇总成内部结论 | `packet_ready -> parallel_review -> aggregated -> escalated/closed` | 默认必开 `producer + qa`；其余按 surface 触发；缺 L5 时不得越权宣称真实外部验证完成 | `producer_system_designer` 编排，`qa_engineer` 守门 |
 - Acceptance Criteria:
   - AC-1: testing PRD 覆盖分层模型、触发矩阵、证据规范。
   - AC-2: testing project 文档维护分层测试演进任务。
@@ -111,6 +115,7 @@
   - AC-14A: 仓库必须提供轻量 Web/UI automation smoke，允许 `qa_engineer` 在不启动完整 runtime 栈的前提下，用 fixture 页面复用真 `agent-browser` 验证 `viewer-software-safe-step-regression.sh` 的最小浏览器链路与 summary/state 产物契约；该 smoke 只用于 tooling 预检，不替代正式 S6 证据。
   - AC-15: 正式 gameplay/trust evidence 至少要有 1 条代表性样本明确记录 `player_action`、`world_change_due_to_player`、`player_leverage_score` 与 `world_activity_only`，否则不得宣称“玩家已有 meaningful participation”。
   - AC-16: `playability-evidence-stack-2026-05-06` 专题文档必须明确五层证据、组合规则、现有 oasis7 锚点映射，以及“自动化不能单独保证好玩”的正式结论。
+  - AC-17: `playability-subagent-review-system-2026-05-06` 专题文档必须明确标准角色 subagent 清单、review packet / output card、trigger matrix、sequencing rules 和 stop conditions。
 - Non-Goals:
   - 不在本 PRD 中替代业务模块的功能设计。
   - 不承诺所有测试都进入 CI 默认路径。
@@ -126,6 +131,7 @@
   - `doc/testing/manual/web-ui-agent-browser-closure-manual.manual.md`
   - `doc/testing/manual/web-ui-agent-browser-closure-manual.prd.md`
   - `doc/testing/governance/playability-evidence-stack-2026-05-06.prd.md`
+  - `doc/testing/governance/playability-subagent-review-system-2026-05-06.prd.md`
   - `doc/testing/governance/token-genesis-allocation-audit-checklist-2026-03-22.prd.md`
   - `doc/playability_test_result/topics/industrial-onboarding-required-tier-cards-2026-03-15.md`
   - `doc/p2p/token/mainchain-token-initial-allocation-and-early-contribution-reward-2026-03-22.prd.md`
@@ -162,6 +168,7 @@
   - NFR-TST-8: Token 创世 QA 审计模板字段完整率必须为 `100%`，缺任何一项关键字段都不能给 `pass`。
   - NFR-TST-9: 正式 gameplay evidence 审查者必须能在 30 秒内看出“玩家是否真的改变了世界”，无需从长日志里二次拼装。
   - NFR-TST-10: 正式玩法结论必须能在 60 秒内回答“当前只证明到哪一层，还缺哪一层”。
+  - NFR-TST-11: review orchestrator 必须能在 5 分钟内决定本次改动应开哪些标准角色 subagent。
 - Security & Privacy: 测试日志与产物需避免泄露凭据；外部 API 测试使用最小化数据并执行脱敏。
 
 ## 5. Risks & Roadmap
@@ -188,6 +195,7 @@
 | PRD-TESTING-005 | TASK-TESTING-037/038/039/040/wasm-determinism-gate-ondemand-scope | `test_tier_required` | keyed manifest/strict policy/changed-path scope planner/多 runner required checks/identity 输入收敛回归 | builtin wasm 发布链路稳定性 |
 | PRD-TESTING-006 | TASK-TESTING-062 | `test_tier_required` | token 创世参数表审计清单、执行模板、p2p/testing 模块追踪回写 | 主链 Token 创世冻结与经济配置门禁 |
 | PRD-TESTING-007 | playability-evidence-stack-2026-05-06 | `test_tier_required` | 五层证据栈定义、现有锚点映射、模块入口互链与组合规则抽样检查 | 玩法质量 claim 与放行边界 |
+| PRD-TESTING-008 | playability-subagent-review-system-2026-05-06 | `test_tier_required` | 标准角色 subagent 定义、packet/card contract、trigger matrix 与 stop conditions 抽样检查 | 多角色内部评审系统设计 |
 - Decision Log:
 | 决策ID | 选定方案 | 备选方案（否决） | 依据 |
 | --- | --- | --- | --- |
@@ -198,3 +206,4 @@
 | DEC-TST-005 | Token 创世前增加 QA 审计清单与阻断 verdict | 仅由 producer/runtime 自审 | 经济配置错误一旦进入创世，后续修复成本极高。 |
 | DEC-TST-006 | 在正式 gameplay evidence 中单列 `player leverage` 审查层 | 继续只看 world delta / activity / 总体有趣度 | `#166` 暴露的是“玩家是否参与有效”而不是“世界有没有动起来”，需要单独防误报。 |
 | DEC-TST-007 | 为“是否好玩”建立五层 evidence stack，并明确自动化不能单独保证好玩 | 继续把自动化 pass、世界活跃和真实玩家继续动机混写 | 这三类信号的证明强度不同，混写会持续污染 release/stage 结论。 |
+| DEC-TST-008 | 进一步把多角色内部评审设计成标准角色 subagent 系统 | 继续临时决定这次要不要找哪些角色来看 | 临时协调很难规模化，也无法稳定复用 review 输出。 |

--- a/doc/testing/project.md
+++ b/doc/testing/project.md
@@ -3,6 +3,7 @@
 审计轮次: 7
 
 ## 任务拆解（含 PRD-ID 映射）
+- [x] playability-subagent-review-system-2026-05-06 (PRD-TESTING-008) [test_tier_required]: 新增“好玩性 subagent 评审系统（2026-05-06）”专题，设计标准角色 subagent 清单、review packet / output card、trigger matrix、调度顺序与 stop conditions。 Trace: .pm/tasks/task_9a6bbbc3022f4d4e8a3f5f99fab4d1b2.yaml
 - [x] playability-evidence-stack-2026-05-06 (PRD-TESTING-007) [test_tier_required]: 新增“好玩性证据栈（2026-05-06）”专题，正式定义自动化/agent probe/遥测实验/真人试玩/受控外部信号五层证据、`go/watch/hold/block` 组合规则，以及“自动化不能单独保证好玩”的模块级结论。 Trace: .pm/tasks/task_efe1a5f949e84160a1237302c9064168.yaml
 - [x] shared-player-gameplay-contract-parity (PRD-TESTING-003) [test_tier_required]: 收口 `software_safe` / `pure_api` 共享 `snapshot.player_gameplay` 的玩家可读语义 contract，补 active-LLM scope、旧 no-LLM 口径退役说明，以及 pure API parity smoke 对“同一组玩家问题”的显式摘要。 Trace: .pm/tasks/task_ebf98fe337b44bd8b10e7574316dee67.yaml
 - [x] TASK-TESTING-001 (PRD-TESTING-001) [test_tier_required]: 完成 testing PRD 改写，建立分层测试设计入口。
@@ -334,6 +335,7 @@
 ## 状态
 - 更新日期: 2026-05-06
 - 当前状态: active
+- 当前窗口摘要: `playability-subagent-review-system-2026-05-06` 已把多角色内部人工评审收口成标准角色 subagent 系统，定义默认必开角色、按 changed surface 追加角色、统一 review packet 与 output card，以及 stop conditions。
 - 当前窗口摘要: `playability-evidence-stack-2026-05-06` 已把“自动化不能单独保证好玩”收口为 testing/governance 正式专题，并给出 L1-L5 证据栈与 `go/watch/hold/block` 组合规则。
 - 当前窗口摘要: `playability-player-leverage-evidence-rubric` 已为 trust/playability 证据补单独的 `player leverage` 审查层，避免再用 world activity 代替玩家有效参与。
 - 下一任务: 等待 `producer_system_designer` / `runtime_engineer` 提供真实创世账户表后，用 `token-genesis-allocation-audit-template-2026-03-22` 执行首轮正式审计。

--- a/doc/testing/project.md
+++ b/doc/testing/project.md
@@ -3,7 +3,7 @@
 审计轮次: 9
 
 ## 任务拆解（含 PRD-ID 映射）
-- [x] playability-governance-stack-2026-05-06 (PRD-TESTING-007/008/009/010) [test_tier_required]: 本页将“好玩性证据栈 / subagent 评审系统 / 模拟玩家 persona 面板 / L4 synthetic-human 分层”四个 2026-05-06 专题收口为单个 bundle 入口，便于浏览；当前同批 follow-up 已补 repo-local `L4` scaffold/wrapper，使同一 worktree 内可以直接准备 packet、role/persona cards、summary 与 `L4B` 卡片副本。 Trace: .pm/tasks/task_efe1a5f949e84160a1237302c9064168.yaml
+- [x] playability-governance-stack-2026-05-06 (PRD-TESTING-007/008/009/010) [test_tier_required]: 本页将“好玩性证据栈 / subagent 评审系统 / 模拟玩家 persona 面板 / L4 synthetic-agent 分层”四个 2026-05-06 专题收口为单个 bundle 入口，便于浏览；当前同批 follow-up 已补 repo-local `L4` scaffold/wrapper + `L4B` runner，使同一 worktree 内可以直接准备 packet、role/persona cards、summary、`L4B` agent 卡，并执行一次会自动落 summary/state/screenshot 的 embodied-agent run，以及可选内部真人佐证 notes。 Trace: .pm/tasks/task_efe1a5f949e84160a1237302c9064168.yaml
   - Bundle includes: `playability-subagent-review-system-2026-05-06`、`playability-simulated-player-persona-panel-2026-05-06`、`playability-l4-synthetic-human-split-2026-05-06`
   - Related traces: `.pm/tasks/task_9a6bbbc3022f4d4e8a3f5f99fab4d1b2.yaml`、`.pm/tasks/task_a9d3c884a3074ab2b0f3b10dab7bb86e.yaml`、`.pm/tasks/task_a68decb0a2c8460aa7d989df7370c901.yaml`
 - [x] shared-player-gameplay-contract-parity (PRD-TESTING-003) [test_tier_required]: 收口 `software_safe` / `pure_api` 共享 `snapshot.player_gameplay` 的玩家可读语义 contract，补 active-LLM scope、旧 no-LLM 口径退役说明，以及 pure API parity smoke 对“同一组玩家问题”的显式摘要。 Trace: .pm/tasks/task_ebf98fe337b44bd8b10e7574316dee67.yaml
@@ -336,7 +336,7 @@
 ## 状态
 - 更新日期: 2026-05-06
 - 当前状态: active
-- 当前窗口摘要: `playability-governance-stack-2026-05-06` 已把“自动化不能单独保证好玩”的治理结论、标准角色 subagent 评审系统、模拟玩家 persona panel，以及 `L4A synthetic` / `L4B human` 分层收口为单个 bundle 视图；同批 follow-up 已补 `scripts/prepare-playability-l4-review.sh` 与 `playability-l4-*` 模板，让单个 worktree 内可以直接准备完整 `L4` 执行包。`--with-l4a-stack` 入口继承 formal gameplay 的 active LLM provider preflight；若当前环境缺少 `OASIS7_LLM_MODEL` / 等价 `config.toml`，会在 harness 启动前 `blocked`，这属于环境前置而不是 scaffold 缺项。
+- 当前窗口摘要: `playability-governance-stack-2026-05-06` 已把“自动化不能单独保证好玩”的治理结论、标准角色 subagent 评审系统、模拟玩家 persona panel，以及 `L4A synthetic` / `L4B embodied-agent` / `L5` 真实人类与线上验证边界收口为单个 bundle 视图；同批 follow-up 已补 `scripts/prepare-playability-l4-review.sh`、`scripts/run-playability-l4b-agent.sh` 与 `playability-l4-*` 模板，让单个 worktree 内可以直接准备完整 `L4A + L4B` 执行包，并把内部真人试玩降为 `L4B` 可选校准附录。`--with-l4a-stack` 入口继承 formal gameplay 的 active LLM provider preflight；若当前环境缺少 `OASIS7_LLM_MODEL` / 等价 `config.toml`，会在 harness 启动前 `blocked`，这属于环境前置而不是 scaffold 缺项。
 - 当前窗口摘要: `playability-player-leverage-evidence-rubric` 已为 trust/playability 证据补单独的 `player leverage` 审查层，避免再用 world activity 代替玩家有效参与。
 - 下一任务: 等待 `producer_system_designer` / `runtime_engineer` 提供真实创世账户表后，用 `token-genesis-allocation-audit-template-2026-03-22` 执行首轮正式审计。
 - 当前窗口摘要: `shared-network-ecs-triad-chain-status-metrics-rollout` 已冻结本机 observer + 两台阿里云 ECS 的 same-window triad snapshot、最近 `10` 分钟 traffic window，以及 `/v1/chain/status` 新增 `transactions` / `recent_finality_latency` / `pending_proposal` / `pending_consensus_actions` live contract 证据。

--- a/doc/testing/project.md
+++ b/doc/testing/project.md
@@ -3,10 +3,9 @@
 审计轮次: 9
 
 ## 任务拆解（含 PRD-ID 映射）
-- [x] playability-l4-synthetic-human-split-2026-05-06 (PRD-TESTING-010) [test_tier_required]: 新增“好玩性 L4 synthetic/human 分层（2026-05-06）”专题，正式把 `L4` 拆成 `L4A synthetic` 与 `L4B human`，并同步 evidence stack、manual 与模块根入口。 Trace: .pm/tasks/task_a68decb0a2c8460aa7d989df7370c901.yaml
-- [x] playability-simulated-player-persona-panel-2026-05-06 (PRD-TESTING-009) [test_tier_required]: 新增“模拟玩家 persona 评审面板（2026-05-06）”专题，设计固定 persona 清单、persona packet / card、触发矩阵，以及与标准角色 subagent 的回流边界。 Trace: .pm/tasks/task_a9d3c884a3074ab2b0f3b10dab7bb86e.yaml
-- [x] playability-subagent-review-system-2026-05-06 (PRD-TESTING-008) [test_tier_required]: 新增“好玩性 subagent 评审系统（2026-05-06）”专题，设计标准角色 subagent 清单、review packet / output card、trigger matrix、调度顺序与 stop conditions。 Trace: .pm/tasks/task_9a6bbbc3022f4d4e8a3f5f99fab4d1b2.yaml
-- [x] playability-evidence-stack-2026-05-06 (PRD-TESTING-007) [test_tier_required]: 新增“好玩性证据栈（2026-05-06）”专题，正式定义自动化/agent probe/遥测实验/真人试玩/受控外部信号五层证据、`go/watch/hold/block` 组合规则，以及“自动化不能单独保证好玩”的模块级结论。 Trace: .pm/tasks/task_efe1a5f949e84160a1237302c9064168.yaml
+- [x] playability-governance-stack-2026-05-06 (PRD-TESTING-007/008/009/010) [test_tier_required]: 本页将“好玩性证据栈 / subagent 评审系统 / 模拟玩家 persona 面板 / L4 synthetic-human 分层”四个 2026-05-06 专题收口为单个 bundle 入口，便于浏览；正式规格、专题 project 与运行态 trace 仍保持拆分。 Trace: .pm/tasks/task_efe1a5f949e84160a1237302c9064168.yaml
+  - Bundle includes: `playability-subagent-review-system-2026-05-06`、`playability-simulated-player-persona-panel-2026-05-06`、`playability-l4-synthetic-human-split-2026-05-06`
+  - Related traces: `.pm/tasks/task_9a6bbbc3022f4d4e8a3f5f99fab4d1b2.yaml`、`.pm/tasks/task_a9d3c884a3074ab2b0f3b10dab7bb86e.yaml`、`.pm/tasks/task_a68decb0a2c8460aa7d989df7370c901.yaml`
 - [x] shared-player-gameplay-contract-parity (PRD-TESTING-003) [test_tier_required]: 收口 `software_safe` / `pure_api` 共享 `snapshot.player_gameplay` 的玩家可读语义 contract，补 active-LLM scope、旧 no-LLM 口径退役说明，以及 pure API parity smoke 对“同一组玩家问题”的显式摘要。 Trace: .pm/tasks/task_ebf98fe337b44bd8b10e7574316dee67.yaml
 - [x] TASK-TESTING-001 (PRD-TESTING-001) [test_tier_required]: 完成 testing PRD 改写，建立分层测试设计入口。
 - [x] TASK-TESTING-002 (PRD-TESTING-001/002) [test_tier_required]: 对齐 S0~S10 与改动路径触发矩阵。
@@ -337,8 +336,7 @@
 ## 状态
 - 更新日期: 2026-05-06
 - 当前状态: active
-- 当前窗口摘要: `playability-subagent-review-system-2026-05-06` 已把多角色内部人工评审收口成标准角色 subagent 系统，定义默认必开角色、按 changed surface 追加角色、统一 review packet 与 output card，以及 stop conditions。
-- 当前窗口摘要: `playability-evidence-stack-2026-05-06` 已把“自动化不能单独保证好玩”收口为 testing/governance 正式专题，并给出 L1-L5 证据栈与 `go/watch/hold/block` 组合规则。
+- 当前窗口摘要: `playability-governance-stack-2026-05-06` 已把“自动化不能单独保证好玩”的治理结论、标准角色 subagent 评审系统、模拟玩家 persona panel，以及 `L4A synthetic` / `L4B human` 分层收口为单个 bundle 视图；本页只保留聚合入口，细节下钻到四个专题。
 - 当前窗口摘要: `playability-player-leverage-evidence-rubric` 已为 trust/playability 证据补单独的 `player leverage` 审查层，避免再用 world activity 代替玩家有效参与。
 - 下一任务: 等待 `producer_system_designer` / `runtime_engineer` 提供真实创世账户表后，用 `token-genesis-allocation-audit-template-2026-03-22` 执行首轮正式审计。
 - 当前窗口摘要: `shared-network-ecs-triad-chain-status-metrics-rollout` 已冻结本机 observer + 两台阿里云 ECS 的 same-window triad snapshot、最近 `10` 分钟 traffic window，以及 `/v1/chain/status` 新增 `transactions` / `recent_finality_latency` / `pending_proposal` / `pending_consensus_actions` live contract 证据。

--- a/doc/testing/project.md
+++ b/doc/testing/project.md
@@ -3,6 +3,7 @@
 审计轮次: 7
 
 ## 任务拆解（含 PRD-ID 映射）
+- [x] playability-evidence-stack-2026-05-06 (PRD-TESTING-007) [test_tier_required]: 新增“好玩性证据栈（2026-05-06）”专题，正式定义自动化/agent probe/遥测实验/真人试玩/受控外部信号五层证据、`go/watch/hold/block` 组合规则，以及“自动化不能单独保证好玩”的模块级结论。 Trace: .pm/tasks/task_efe1a5f949e84160a1237302c9064168.yaml
 - [x] shared-player-gameplay-contract-parity (PRD-TESTING-003) [test_tier_required]: 收口 `software_safe` / `pure_api` 共享 `snapshot.player_gameplay` 的玩家可读语义 contract，补 active-LLM scope、旧 no-LLM 口径退役说明，以及 pure API parity smoke 对“同一组玩家问题”的显式摘要。 Trace: .pm/tasks/task_ebf98fe337b44bd8b10e7574316dee67.yaml
 - [x] TASK-TESTING-001 (PRD-TESTING-001) [test_tier_required]: 完成 testing PRD 改写，建立分层测试设计入口。
 - [x] TASK-TESTING-002 (PRD-TESTING-001/002) [test_tier_required]: 对齐 S0~S10 与改动路径触发矩阵。
@@ -331,8 +332,9 @@
 - `.agents/skills/prd/check.md`
 
 ## 状态
-- 更新日期: 2026-04-28
+- 更新日期: 2026-05-06
 - 当前状态: active
+- 当前窗口摘要: `playability-evidence-stack-2026-05-06` 已把“自动化不能单独保证好玩”收口为 testing/governance 正式专题，并给出 L1-L5 证据栈与 `go/watch/hold/block` 组合规则。
 - 当前窗口摘要: `playability-player-leverage-evidence-rubric` 已为 trust/playability 证据补单独的 `player leverage` 审查层，避免再用 world activity 代替玩家有效参与。
 - 下一任务: 等待 `producer_system_designer` / `runtime_engineer` 提供真实创世账户表后，用 `token-genesis-allocation-audit-template-2026-03-22` 执行首轮正式审计。
 - 当前窗口摘要: `shared-network-ecs-triad-chain-status-metrics-rollout` 已冻结本机 observer + 两台阿里云 ECS 的 same-window triad snapshot、最近 `10` 分钟 traffic window，以及 `/v1/chain/status` 新增 `transactions` / `recent_finality_latency` / `pending_proposal` / `pending_consensus_actions` live contract 证据。

--- a/doc/testing/project.md
+++ b/doc/testing/project.md
@@ -3,7 +3,7 @@
 审计轮次: 9
 
 ## 任务拆解（含 PRD-ID 映射）
-- [x] playability-governance-stack-2026-05-06 (PRD-TESTING-007/008/009/010) [test_tier_required]: 本页将“好玩性证据栈 / subagent 评审系统 / 模拟玩家 persona 面板 / L4 synthetic-human 分层”四个 2026-05-06 专题收口为单个 bundle 入口，便于浏览；正式规格、专题 project 与运行态 trace 仍保持拆分。 Trace: .pm/tasks/task_efe1a5f949e84160a1237302c9064168.yaml
+- [x] playability-governance-stack-2026-05-06 (PRD-TESTING-007/008/009/010) [test_tier_required]: 本页将“好玩性证据栈 / subagent 评审系统 / 模拟玩家 persona 面板 / L4 synthetic-human 分层”四个 2026-05-06 专题收口为单个 bundle 入口，便于浏览；当前同批 follow-up 已补 repo-local `L4` scaffold/wrapper，使同一 worktree 内可以直接准备 packet、role/persona cards、summary 与 `L4B` 卡片副本。 Trace: .pm/tasks/task_efe1a5f949e84160a1237302c9064168.yaml
   - Bundle includes: `playability-subagent-review-system-2026-05-06`、`playability-simulated-player-persona-panel-2026-05-06`、`playability-l4-synthetic-human-split-2026-05-06`
   - Related traces: `.pm/tasks/task_9a6bbbc3022f4d4e8a3f5f99fab4d1b2.yaml`、`.pm/tasks/task_a9d3c884a3074ab2b0f3b10dab7bb86e.yaml`、`.pm/tasks/task_a68decb0a2c8460aa7d989df7370c901.yaml`
 - [x] shared-player-gameplay-contract-parity (PRD-TESTING-003) [test_tier_required]: 收口 `software_safe` / `pure_api` 共享 `snapshot.player_gameplay` 的玩家可读语义 contract，补 active-LLM scope、旧 no-LLM 口径退役说明，以及 pure API parity smoke 对“同一组玩家问题”的显式摘要。 Trace: .pm/tasks/task_ebf98fe337b44bd8b10e7574316dee67.yaml
@@ -336,7 +336,7 @@
 ## 状态
 - 更新日期: 2026-05-06
 - 当前状态: active
-- 当前窗口摘要: `playability-governance-stack-2026-05-06` 已把“自动化不能单独保证好玩”的治理结论、标准角色 subagent 评审系统、模拟玩家 persona panel，以及 `L4A synthetic` / `L4B human` 分层收口为单个 bundle 视图；本页只保留聚合入口，细节下钻到四个专题。
+- 当前窗口摘要: `playability-governance-stack-2026-05-06` 已把“自动化不能单独保证好玩”的治理结论、标准角色 subagent 评审系统、模拟玩家 persona panel，以及 `L4A synthetic` / `L4B human` 分层收口为单个 bundle 视图；同批 follow-up 已补 `scripts/prepare-playability-l4-review.sh` 与 `playability-l4-*` 模板，让单个 worktree 内可以直接准备完整 `L4` 执行包。`--with-l4a-stack` 入口继承 formal gameplay 的 active LLM provider preflight；若当前环境缺少 `OASIS7_LLM_MODEL` / 等价 `config.toml`，会在 harness 启动前 `blocked`，这属于环境前置而不是 scaffold 缺项。
 - 当前窗口摘要: `playability-player-leverage-evidence-rubric` 已为 trust/playability 证据补单独的 `player leverage` 审查层，避免再用 world activity 代替玩家有效参与。
 - 下一任务: 等待 `producer_system_designer` / `runtime_engineer` 提供真实创世账户表后，用 `token-genesis-allocation-audit-template-2026-03-22` 执行首轮正式审计。
 - 当前窗口摘要: `shared-network-ecs-triad-chain-status-metrics-rollout` 已冻结本机 observer + 两台阿里云 ECS 的 same-window triad snapshot、最近 `10` 分钟 traffic window，以及 `/v1/chain/status` 新增 `transactions` / `recent_finality_latency` / `pending_proposal` / `pending_consensus_actions` live contract 证据。

--- a/doc/testing/project.md
+++ b/doc/testing/project.md
@@ -1,8 +1,9 @@
 # testing PRD Project
 
-审计轮次: 8
+审计轮次: 9
 
 ## 任务拆解（含 PRD-ID 映射）
+- [x] playability-l4-synthetic-human-split-2026-05-06 (PRD-TESTING-010) [test_tier_required]: 新增“好玩性 L4 synthetic/human 分层（2026-05-06）”专题，正式把 `L4` 拆成 `L4A synthetic` 与 `L4B human`，并同步 evidence stack、manual 与模块根入口。 Trace: .pm/tasks/task_a68decb0a2c8460aa7d989df7370c901.yaml
 - [x] playability-simulated-player-persona-panel-2026-05-06 (PRD-TESTING-009) [test_tier_required]: 新增“模拟玩家 persona 评审面板（2026-05-06）”专题，设计固定 persona 清单、persona packet / card、触发矩阵，以及与标准角色 subagent 的回流边界。 Trace: .pm/tasks/task_a9d3c884a3074ab2b0f3b10dab7bb86e.yaml
 - [x] playability-subagent-review-system-2026-05-06 (PRD-TESTING-008) [test_tier_required]: 新增“好玩性 subagent 评审系统（2026-05-06）”专题，设计标准角色 subagent 清单、review packet / output card、trigger matrix、调度顺序与 stop conditions。 Trace: .pm/tasks/task_9a6bbbc3022f4d4e8a3f5f99fab4d1b2.yaml
 - [x] playability-evidence-stack-2026-05-06 (PRD-TESTING-007) [test_tier_required]: 新增“好玩性证据栈（2026-05-06）”专题，正式定义自动化/agent probe/遥测实验/真人试玩/受控外部信号五层证据、`go/watch/hold/block` 组合规则，以及“自动化不能单独保证好玩”的模块级结论。 Trace: .pm/tasks/task_efe1a5f949e84160a1237302c9064168.yaml

--- a/doc/testing/project.md
+++ b/doc/testing/project.md
@@ -1,8 +1,9 @@
 # testing PRD Project
 
-审计轮次: 7
+审计轮次: 8
 
 ## 任务拆解（含 PRD-ID 映射）
+- [x] playability-simulated-player-persona-panel-2026-05-06 (PRD-TESTING-009) [test_tier_required]: 新增“模拟玩家 persona 评审面板（2026-05-06）”专题，设计固定 persona 清单、persona packet / card、触发矩阵，以及与标准角色 subagent 的回流边界。 Trace: .pm/tasks/task_a9d3c884a3074ab2b0f3b10dab7bb86e.yaml
 - [x] playability-subagent-review-system-2026-05-06 (PRD-TESTING-008) [test_tier_required]: 新增“好玩性 subagent 评审系统（2026-05-06）”专题，设计标准角色 subagent 清单、review packet / output card、trigger matrix、调度顺序与 stop conditions。 Trace: .pm/tasks/task_9a6bbbc3022f4d4e8a3f5f99fab4d1b2.yaml
 - [x] playability-evidence-stack-2026-05-06 (PRD-TESTING-007) [test_tier_required]: 新增“好玩性证据栈（2026-05-06）”专题，正式定义自动化/agent probe/遥测实验/真人试玩/受控外部信号五层证据、`go/watch/hold/block` 组合规则，以及“自动化不能单独保证好玩”的模块级结论。 Trace: .pm/tasks/task_efe1a5f949e84160a1237302c9064168.yaml
 - [x] shared-player-gameplay-contract-parity (PRD-TESTING-003) [test_tier_required]: 收口 `software_safe` / `pure_api` 共享 `snapshot.player_gameplay` 的玩家可读语义 contract，补 active-LLM scope、旧 no-LLM 口径退役说明，以及 pure API parity smoke 对“同一组玩家问题”的显式摘要。 Trace: .pm/tasks/task_ebf98fe337b44bd8b10e7574316dee67.yaml

--- a/doc/testing/templates/playability-l4-persona-card-template.md
+++ b/doc/testing/templates/playability-l4-persona-card-template.md
@@ -1,0 +1,16 @@
+# Playability L4 Persona Card Template
+
+## Output Fields
+- `persona_id`:
+- `verdict`: `engaged` / `confused` / `bored` / `frustrated` / `exploitable`
+- `top_reactions`:
+- `moment_of_dropoff`:
+- `evidence_used`:
+- `what_this_persona_does_not_prove`:
+- `followup_questions`:
+- `handoff_recommended_to`:
+
+## Minimum Review Questions
+- At what exact moment would this persona lose confidence or interest?
+- Did the persona observe real player leverage, or only world activity?
+- Which follow-up role should consume this card next?

--- a/doc/testing/templates/playability-l4-review-packet-template.md
+++ b/doc/testing/templates/playability-l4-review-packet-template.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 - Use this packet as the canonical input bundle for one complete `L4` review run.
-- Keep `L4A synthetic` and `L4B human` evidence in the same packet, but do not collapse their verdicts.
+- Keep `L4A synthetic` and `L4B embodied-agent` evidence in the same packet, and record any internal human corroboration only as optional `L4B` calibration evidence.
 
 ## Required Fields
 - `change_scope`:
@@ -22,9 +22,11 @@
 - `limited_preview_context`:
 - `outside_scope`:
 - `persona_panel_request`:
+- `internal_human_corroboration_plan`:
 - `open_questions`:
 
 ## Packet Notes
 - Explicitly distinguish `player leverage` evidence from `world activity only` evidence.
 - If a formal surface is blocked, say so here before asking roles or personas to infer higher-level conclusions.
 - If the run only reached `L4A`, mark `L4B` as missing instead of leaving it implicit.
+- If you ran an internal human spot-check, record it as corroboration or contradiction for `L4B`, not as a third formal layer.

--- a/doc/testing/templates/playability-l4-review-packet-template.md
+++ b/doc/testing/templates/playability-l4-review-packet-template.md
@@ -1,0 +1,30 @@
+# Playability L4 Review Packet Template
+
+## Purpose
+- Use this packet as the canonical input bundle for one complete `L4` review run.
+- Keep `L4A synthetic` and `L4B human` evidence in the same packet, but do not collapse their verdicts.
+
+## Required Fields
+- `change_scope`:
+- `target_experience_claim`:
+- `formal_surfaces`:
+- `automated_evidence`:
+- `playability_evidence`:
+- `known_blockers`:
+- `requested_roles`:
+- `selected_personas`:
+- `questions_to_probe`:
+- `target_l4_lane`: `L4A_only` / `L4A_then_L4B`
+
+## Optional Fields
+- `artifact_paths`:
+- `telemetry_hypothesis`:
+- `limited_preview_context`:
+- `outside_scope`:
+- `persona_panel_request`:
+- `open_questions`:
+
+## Packet Notes
+- Explicitly distinguish `player leverage` evidence from `world activity only` evidence.
+- If a formal surface is blocked, say so here before asking roles or personas to infer higher-level conclusions.
+- If the run only reached `L4A`, mark `L4B` as missing instead of leaving it implicit.

--- a/doc/testing/templates/playability-l4-role-review-card-template.md
+++ b/doc/testing/templates/playability-l4-role-review-card-template.md
@@ -13,4 +13,4 @@
 - What does this role believe the player can currently do?
 - Where does this role think the player will likely drop off?
 - Which conclusion in this card is direct evidence, and which is only inference?
-- What still requires `L4B` or `L5` before the claim can be upgraded?
+- What still requires `L4B` or `L5` before the claim can be upgraded, and is optional internal human corroboration worth requesting?

--- a/doc/testing/templates/playability-l4-role-review-card-template.md
+++ b/doc/testing/templates/playability-l4-role-review-card-template.md
@@ -1,0 +1,16 @@
+# Playability L4 Role Review Card Template
+
+## Output Fields
+- `role_name`:
+- `verdict`: `pass` / `watch` / `hold` / `block`
+- `top_findings`:
+- `evidence_used`:
+- `what_this_does_not_prove`:
+- `required_followups`:
+- `claim_boundary_note`:
+
+## Minimum Review Questions
+- What does this role believe the player can currently do?
+- Where does this role think the player will likely drop off?
+- Which conclusion in this card is direct evidence, and which is only inference?
+- What still requires `L4B` or `L5` before the claim can be upgraded?

--- a/doc/testing/templates/playability-l4-summary-template.md
+++ b/doc/testing/templates/playability-l4-summary-template.md
@@ -2,18 +2,22 @@
 
 ## Verdict Summary
 - `l4a_synthetic_verdict`: `synthetic_continue_likely` / `synthetic_continue_unclear` / `synthetic_continue_unlikely`
-- `l4b_human_verdict`: `human_continue_observed` / `human_continue_mixed` / `human_continue_not_observed` / `missing`
+- `l4b_agentic_verdict`: `agent_continue_observed` / `agent_continue_mixed` / `agent_continue_not_observed` / `missing`
+- `optional_internal_human_corroboration`: `not_run` / `corroborates_l4b` / `mixed` / `contradicts_l4b`
 - `combined_stage_recommendation`: `go` / `watch` / `hold` / `block`
 
 ## Required Summary Questions
 - What does `L4A` currently prove?
 - What does `L4B` currently prove?
+- How close is the current `L4B` evidence to the human-level evaluation effect you want?
 - Where do `L4A` and `L4B` agree?
-- Where do `L4A` and `L4B` diverge?
-- Which claim is still out of scope because only synthetic evidence exists?
+- Did any optional internal human corroboration confirm or challenge `L4B`?
+- Which claim is still out of scope until `L5` real-human or live evidence exists?
 
 ## Follow-up
 - Required reruns:
 - Required role follow-ups:
-- Required human follow-ups:
+- Required agent-play follow-ups:
+- Optional internal human corroboration follow-ups:
+- Required `L5` follow-ups:
 - Claim boundary reminder:

--- a/doc/testing/templates/playability-l4-summary-template.md
+++ b/doc/testing/templates/playability-l4-summary-template.md
@@ -1,0 +1,19 @@
+# Playability L4 Summary Template
+
+## Verdict Summary
+- `l4a_synthetic_verdict`: `synthetic_continue_likely` / `synthetic_continue_unclear` / `synthetic_continue_unlikely`
+- `l4b_human_verdict`: `human_continue_observed` / `human_continue_mixed` / `human_continue_not_observed` / `missing`
+- `combined_stage_recommendation`: `go` / `watch` / `hold` / `block`
+
+## Required Summary Questions
+- What does `L4A` currently prove?
+- What does `L4B` currently prove?
+- Where do `L4A` and `L4B` agree?
+- Where do `L4A` and `L4B` diverge?
+- Which claim is still out of scope because only synthetic evidence exists?
+
+## Follow-up
+- Required reruns:
+- Required role follow-ups:
+- Required human follow-ups:
+- Claim boundary reminder:

--- a/scripts/prepare-playability-l4-review.sh
+++ b/scripts/prepare-playability-l4-review.sh
@@ -1,0 +1,497 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+source "$ROOT_DIR/scripts/worktree-harness-lib.sh"
+
+usage() {
+  cat <<'USAGE'
+Usage: ./scripts/prepare-playability-l4-review.sh [options]
+
+Create a worktree-local artifact scaffold for a complete L4 review run:
+- L4A synthetic packet
+- role review cards
+- persona cards
+- L4 summary
+- copied L4B playability card
+- exact commands for L4A harness and L4B producer playtest
+
+Options:
+  --output-dir <path>         Override output directory
+                              (default: output/harness/<worktree>/artifacts/playability-l4-<timestamp>)
+  --run-id <id>               Override run id suffix (default: YYYYMMDD-HHMMSS)
+  --change-scope <text>       Prefill packet `change_scope`
+  --target-claim <text>       Prefill packet `target_experience_claim`
+  --target-l4-lane <lane>     L4A_only | L4A_then_L4B (default: L4A_then_L4B)
+  --formal-surface <name>     Repeatable; defaults to `software_safe` + `pure_api`
+  --role <role_name>          Repeatable; defaults to all standard review roles
+  --persona <persona_id>      Repeatable; defaults to all fixed personas
+  --question <text>           Repeatable packet question
+  --known-blocker <text>      Repeatable packet blocker
+  --artifact-path <path>      Repeatable packet artifact path
+  --bundle-dir <path>         Bundle dir to embed into recommended L4B command
+  --with-l4a-stack            Boot `./scripts/worktree-harness.sh up` before writing artifacts
+                              (requires the same active LLM provider config as formal gameplay)
+  --json                      Print manifest JSON path summary
+  -h, --help                  Show this help
+
+Examples:
+  ./scripts/prepare-playability-l4-review.sh
+  ./scripts/prepare-playability-l4-review.sh --with-l4a-stack --change-scope "software_safe onboarding followup"
+  ./scripts/prepare-playability-l4-review.sh --role producer_system_designer --role qa_engineer --persona new_player_confused
+USAGE
+}
+
+STANDARD_ROLES=(
+  producer_system_designer
+  qa_engineer
+  viewer_engineer
+  agent_engineer
+  runtime_engineer
+  wasm_platform_engineer
+  liveops_community
+)
+DEFAULT_PERSONAS=(
+  new_player_confused
+  impatient_action_player
+  systems_optimizer
+  narrative_curiosity_player
+  chaos_tester
+)
+DEFAULT_FORMAL_SURFACES=(
+  software_safe
+  pure_api
+)
+
+RUN_ID="$(date +%Y%m%d-%H%M%S)"
+OUTPUT_DIR=""
+CHANGE_SCOPE=""
+TARGET_CLAIM=""
+TARGET_L4_LANE="L4A_then_L4B"
+BUNDLE_DIR=""
+WITH_L4A_STACK=0
+PRINT_JSON=0
+declare -a FORMAL_SURFACES=()
+declare -a REQUESTED_ROLES=()
+declare -a SELECTED_PERSONAS=()
+declare -a QUESTIONS_TO_PROBE=()
+declare -a KNOWN_BLOCKERS=()
+declare -a ARTIFACT_PATHS=()
+FORMAL_SURFACE_OVERRIDE=0
+ROLE_OVERRIDE=0
+PERSONA_OVERRIDE=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --output-dir)
+      OUTPUT_DIR="${2:-}"
+      shift 2
+      ;;
+    --run-id)
+      RUN_ID="${2:-}"
+      shift 2
+      ;;
+    --change-scope)
+      CHANGE_SCOPE="${2:-}"
+      shift 2
+      ;;
+    --target-claim)
+      TARGET_CLAIM="${2:-}"
+      shift 2
+      ;;
+    --target-l4-lane)
+      TARGET_L4_LANE="${2:-}"
+      shift 2
+      ;;
+    --formal-surface)
+      if [[ "$FORMAL_SURFACE_OVERRIDE" == "0" ]]; then
+        FORMAL_SURFACES=()
+        FORMAL_SURFACE_OVERRIDE=1
+      fi
+      FORMAL_SURFACES+=("${2:-}")
+      shift 2
+      ;;
+    --role)
+      if [[ "$ROLE_OVERRIDE" == "0" ]]; then
+        REQUESTED_ROLES=()
+        ROLE_OVERRIDE=1
+      fi
+      REQUESTED_ROLES+=("${2:-}")
+      shift 2
+      ;;
+    --persona)
+      if [[ "$PERSONA_OVERRIDE" == "0" ]]; then
+        SELECTED_PERSONAS=()
+        PERSONA_OVERRIDE=1
+      fi
+      SELECTED_PERSONAS+=("${2:-}")
+      shift 2
+      ;;
+    --question)
+      QUESTIONS_TO_PROBE+=("${2:-}")
+      shift 2
+      ;;
+    --known-blocker)
+      KNOWN_BLOCKERS+=("${2:-}")
+      shift 2
+      ;;
+    --artifact-path)
+      ARTIFACT_PATHS+=("${2:-}")
+      shift 2
+      ;;
+    --bundle-dir)
+      BUNDLE_DIR="${2:-}"
+      shift 2
+      ;;
+    --with-l4a-stack)
+      WITH_L4A_STACK=1
+      shift
+      ;;
+    --json)
+      PRINT_JSON=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "error: unknown option: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+wh_require_git_worktree
+WORKTREE_ID="$(wh_worktree_id)"
+HARNESS_ROOT="$(wh_harness_root "$ROOT_DIR" "$WORKTREE_ID")"
+ARTIFACT_ROOT="$(wh_artifacts_dir "$HARNESS_ROOT")"
+STATE_FILE="$(wh_state_file "$HARNESS_ROOT")"
+wh_prepare_dirs "$HARNESS_ROOT"
+
+if [[ -z "$OUTPUT_DIR" ]]; then
+  OUTPUT_DIR="$ARTIFACT_ROOT/playability-l4-$RUN_ID"
+fi
+if [[ "$OUTPUT_DIR" != /* ]]; then
+  OUTPUT_DIR="$ROOT_DIR/$OUTPUT_DIR"
+fi
+[[ "$TARGET_L4_LANE" == "L4A_only" || "$TARGET_L4_LANE" == "L4A_then_L4B" ]] || {
+  echo "error: --target-l4-lane must be L4A_only or L4A_then_L4B" >&2
+  exit 2
+}
+[[ -n "$RUN_ID" ]] || { echo "error: --run-id cannot be empty" >&2; exit 2; }
+if [[ -e "$OUTPUT_DIR" ]]; then
+  echo "error: output directory already exists: $OUTPUT_DIR" >&2
+  exit 2
+fi
+
+if [[ "${#FORMAL_SURFACES[@]}" -eq 0 ]]; then
+  FORMAL_SURFACES=("${DEFAULT_FORMAL_SURFACES[@]}")
+fi
+if [[ "${#REQUESTED_ROLES[@]}" -eq 0 ]]; then
+  REQUESTED_ROLES=("${STANDARD_ROLES[@]}")
+fi
+if [[ "${#SELECTED_PERSONAS[@]}" -eq 0 ]]; then
+  SELECTED_PERSONAS=("${DEFAULT_PERSONAS[@]}")
+fi
+
+contains_item() {
+  local needle=$1
+  shift
+  local item
+  for item in "$@"; do
+    if [[ "$item" == "$needle" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+validate_membership() {
+  local label=$1
+  local -n values_ref=$2
+  local -n allow_ref=$3
+  local value
+  for value in "${values_ref[@]}"; do
+    contains_item "$value" "${allow_ref[@]}" || {
+      echo "error: unsupported $label: $value" >&2
+      exit 2
+    }
+  done
+}
+
+validate_membership "role" REQUESTED_ROLES STANDARD_ROLES
+validate_membership "persona" SELECTED_PERSONAS DEFAULT_PERSONAS
+
+mkdir -p \
+  "$OUTPUT_DIR" \
+  "$OUTPUT_DIR/role-review-cards" \
+  "$OUTPUT_DIR/persona-cards" \
+  "$OUTPUT_DIR/evidence"
+
+json_array() {
+  python3 - "$@" <<'PY'
+from __future__ import annotations
+
+import json
+import sys
+
+print(json.dumps(sys.argv[1:], ensure_ascii=False))
+PY
+}
+
+emit_backticked_bullets() {
+  local item
+  for item in "$@"; do
+    printf -- '- `%s`\n' "$item"
+  done
+}
+
+append_template_body() {
+  local template=$1
+  sed '1d' "$template"
+}
+
+PACKET_PATH="$OUTPUT_DIR/l4-review-packet.md"
+SUMMARY_PATH="$OUTPUT_DIR/l4-summary.md"
+COMMANDS_PATH="$OUTPUT_DIR/commands.sh"
+MANIFEST_PATH="$OUTPUT_DIR/manifest.json"
+L4B_CARD_PATH="$OUTPUT_DIR/l4b-playability-test-card.md"
+EVIDENCE_README_PATH="$OUTPUT_DIR/evidence/README.md"
+
+if [[ "$WITH_L4A_STACK" == "1" ]]; then
+  ./scripts/worktree-harness.sh up
+  ./scripts/worktree-harness.sh status --json >"$OUTPUT_DIR/evidence/l4a-harness-state.json"
+  ./scripts/worktree-harness.sh url >"$OUTPUT_DIR/evidence/l4a-viewer-url.txt"
+fi
+
+L4A_VIEWER_URL=""
+if [[ -f "$OUTPUT_DIR/evidence/l4a-viewer-url.txt" ]]; then
+  L4A_VIEWER_URL="$(cat "$OUTPUT_DIR/evidence/l4a-viewer-url.txt")"
+fi
+if [[ -z "$L4A_VIEWER_URL" && -f "$STATE_FILE" ]]; then
+  L4A_VIEWER_URL="$(python3 - "$STATE_FILE" <<'PY'
+from __future__ import annotations
+
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+if not path.exists():
+    raise SystemExit(1)
+data = json.loads(path.read_text(encoding="utf-8"))
+print(data.get("viewer_url") or "")
+PY
+)"
+fi
+
+{
+  printf '# L4 Review Packet\n\n'
+  printf -- '- Run ID: `%s`\n' "$RUN_ID"
+  printf -- '- Generated at: `%s`\n' "$(date '+%Y-%m-%d %H:%M:%S %Z')"
+  printf -- '- Worktree: `%s`\n' "$(pwd -P)"
+  printf -- '- Harness root: `%s`\n' "$HARNESS_ROOT"
+  printf -- '- Target L4 lane: `%s`\n' "$TARGET_L4_LANE"
+  if [[ -n "$CHANGE_SCOPE" ]]; then
+    printf -- '- Prefilled change scope: `%s`\n' "$CHANGE_SCOPE"
+  fi
+  if [[ -n "$TARGET_CLAIM" ]]; then
+    printf -- '- Prefilled target claim: `%s`\n' "$TARGET_CLAIM"
+  fi
+  if [[ -n "$L4A_VIEWER_URL" ]]; then
+    printf -- '- Current L4A viewer URL: `%s`\n' "$L4A_VIEWER_URL"
+  fi
+  if [[ "${#QUESTIONS_TO_PROBE[@]}" -gt 0 ]]; then
+    printf -- '- Prefilled questions to probe:\n'
+    emit_backticked_bullets "${QUESTIONS_TO_PROBE[@]}"
+  fi
+  if [[ "${#KNOWN_BLOCKERS[@]}" -gt 0 ]]; then
+    printf -- '- Prefilled known blockers:\n'
+    emit_backticked_bullets "${KNOWN_BLOCKERS[@]}"
+  fi
+  if [[ "${#ARTIFACT_PATHS[@]}" -gt 0 ]]; then
+    printf -- '- Prefilled artifact paths:\n'
+    emit_backticked_bullets "${ARTIFACT_PATHS[@]}"
+  fi
+  printf -- '- Requested roles:\n'
+  emit_backticked_bullets "${REQUESTED_ROLES[@]}"
+  printf -- '- Selected personas:\n'
+  emit_backticked_bullets "${SELECTED_PERSONAS[@]}"
+  printf -- '- Formal surfaces:\n'
+  emit_backticked_bullets "${FORMAL_SURFACES[@]}"
+  printf '\n'
+  append_template_body "$ROOT_DIR/doc/testing/templates/playability-l4-review-packet-template.md"
+} >"$PACKET_PATH"
+
+{
+  printf '# L4 Validation Summary\n\n'
+  printf -- '- Run ID: `%s`\n' "$RUN_ID"
+  printf -- '- Packet: `%s`\n' "$PACKET_PATH"
+  printf -- '- L4B card copy: `%s`\n' "$L4B_CARD_PATH"
+  printf -- '- Commands: `%s`\n' "$COMMANDS_PATH"
+  printf '\n'
+  append_template_body "$ROOT_DIR/doc/testing/templates/playability-l4-summary-template.md"
+} >"$SUMMARY_PATH"
+
+role_name=
+for role_name in "${REQUESTED_ROLES[@]}"; do
+  {
+    printf '# Role Review Card: %s\n\n' "$role_name"
+    printf -- '- Run ID: `%s`\n' "$RUN_ID"
+    printf -- '- Role: `%s`\n' "$role_name"
+    printf -- '- Packet: `%s`\n' "$PACKET_PATH"
+    printf -- '- Summary target: `%s`\n' "$SUMMARY_PATH"
+    printf '\n'
+    append_template_body "$ROOT_DIR/doc/testing/templates/playability-l4-role-review-card-template.md"
+  } >"$OUTPUT_DIR/role-review-cards/${role_name}.md"
+done
+
+persona_id=
+for persona_id in "${SELECTED_PERSONAS[@]}"; do
+  {
+    printf '# Persona Card: %s\n\n' "$persona_id"
+    printf -- '- Run ID: `%s`\n' "$RUN_ID"
+    printf -- '- Persona ID: `%s`\n' "$persona_id"
+    printf -- '- Packet: `%s`\n' "$PACKET_PATH"
+    printf '\n'
+    append_template_body "$ROOT_DIR/doc/testing/templates/playability-l4-persona-card-template.md"
+  } >"$OUTPUT_DIR/persona-cards/${persona_id}.md"
+done
+
+cp "$ROOT_DIR/doc/playability_test_result/playability_test_card.md" "$L4B_CARD_PATH"
+
+L4B_COMMAND=(./scripts/run-producer-playtest.sh --open-headed)
+if [[ -n "$BUNDLE_DIR" ]]; then
+  L4B_COMMAND+=(--bundle-dir "$BUNDLE_DIR")
+fi
+
+{
+  printf '#!/usr/bin/env bash\n'
+  printf 'set -euo pipefail\n\n'
+  printf 'cd %q\n\n' "$ROOT_DIR"
+  printf '# Boot or refresh the L4A synthetic stack and capture fresh evidence.\n'
+  printf './scripts/worktree-harness.sh up\n'
+  printf './scripts/worktree-harness.sh status --json > %q\n' "$OUTPUT_DIR/evidence/l4a-harness-state.json"
+  printf './scripts/worktree-harness.sh url > %q\n' "$OUTPUT_DIR/evidence/l4a-viewer-url.txt"
+  printf '\n'
+  printf '# Launch the L4B human playtest path.\n'
+  printf '%q' "${L4B_COMMAND[0]}"
+  command_arg=
+  for command_arg in "${L4B_COMMAND[@]:1}"; do
+    printf ' %q' "$command_arg"
+  done
+  printf '\n'
+  printf '# After the human playtest, complete %q and reflect the L4B verdict in %q.\n' "$L4B_CARD_PATH" "$SUMMARY_PATH"
+} >"$COMMANDS_PATH"
+chmod +x "$COMMANDS_PATH"
+
+{
+  printf '# L4 Evidence Directory\n\n'
+  printf 'Drop concrete run artifacts here so the packet and summary can point to stable files.\n\n'
+  printf 'Recommended contents:\n'
+  printf -- '- `l4a-harness-state.json`: current harness snapshot after `worktree-harness.sh status --json`\n'
+  printf -- '- `l4a-viewer-url.txt`: current L4A viewer URL\n'
+  printf -- '- screenshots / recordings from L4A Web closure\n'
+  printf -- '- launcher startup logs and bundle notes from L4B\n'
+  printf -- '- any copied `session.meta`, console snippets, or external issue references\n'
+} >"$EVIDENCE_README_PATH"
+
+python3 - "$MANIFEST_PATH" "$RUN_ID" "$OUTPUT_DIR" "$PACKET_PATH" "$SUMMARY_PATH" "$L4B_CARD_PATH" "$COMMANDS_PATH" "$HARNESS_ROOT" "$WORKTREE_ID" "$STATE_FILE" "$(git rev-parse --abbrev-ref HEAD)" "$(git rev-parse HEAD)" "$(json_array "${FORMAL_SURFACES[@]}")" "$(json_array "${REQUESTED_ROLES[@]}")" "$(json_array "${SELECTED_PERSONAS[@]}")" "$(json_array "${QUESTIONS_TO_PROBE[@]}")" "$(json_array "${KNOWN_BLOCKERS[@]}")" "$(json_array "${ARTIFACT_PATHS[@]}")" "$TARGET_L4_LANE" "$L4A_VIEWER_URL" <<'PY'
+from __future__ import annotations
+
+import json
+import pathlib
+import sys
+
+(
+    manifest_path,
+    run_id,
+    output_dir,
+    packet_path,
+    summary_path,
+    l4b_card_path,
+    commands_path,
+    harness_root,
+    worktree_id,
+    state_file,
+    branch,
+    git_head,
+    formal_surfaces,
+    requested_roles,
+    selected_personas,
+    questions_to_probe,
+    known_blockers,
+    artifact_paths,
+    target_l4_lane,
+    l4a_viewer_url,
+) = sys.argv[1:]
+
+payload = {
+    "run_id": run_id,
+    "output_dir": output_dir,
+    "packet_path": packet_path,
+    "summary_path": summary_path,
+    "l4b_card_path": l4b_card_path,
+    "commands_path": commands_path,
+    "harness_root": harness_root,
+    "worktree_id": worktree_id,
+    "state_file": state_file,
+    "branch": branch,
+    "git_head": git_head,
+    "formal_surfaces": json.loads(formal_surfaces),
+    "requested_roles": json.loads(requested_roles),
+    "selected_personas": json.loads(selected_personas),
+    "questions_to_probe": json.loads(questions_to_probe),
+    "known_blockers": json.loads(known_blockers),
+    "artifact_paths": json.loads(artifact_paths),
+    "target_l4_lane": target_l4_lane,
+    "l4a_viewer_url": l4a_viewer_url or None,
+}
+pathlib.Path(manifest_path).write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+PY
+
+{
+  printf '# Complete L4 Review Scaffold\n\n'
+  printf -- '- Run ID: `%s`\n' "$RUN_ID"
+  printf -- '- Packet: `%s`\n' "$PACKET_PATH"
+  printf -- '- Summary: `%s`\n' "$SUMMARY_PATH"
+  printf -- '- L4B card copy: `%s`\n' "$L4B_CARD_PATH"
+  printf -- '- Commands: `%s`\n' "$COMMANDS_PATH"
+  printf -- '- Manifest: `%s`\n' "$MANIFEST_PATH"
+  printf '\n## Next Steps\n'
+  printf '1. Fill `l4-review-packet.md` with this change scope, target claim, known blockers, and artifact paths.\n'
+  printf '2. Run `commands.sh` or the individual commands to refresh `L4A` evidence and launch `L4B` producer playtest.\n'
+  printf '3. Complete every role card and persona card that applies to this run.\n'
+  printf '4. After the human playtest, complete `l4b-playability-test-card.md` and record the `L4B` verdict.\n'
+  printf '5. Copy concrete screenshots / logs into `evidence/` and reference them from the packet, `l4b-playability-test-card.md`, and summary.\n'
+  printf '6. Summarize `L4A`, `L4B`, and combined `go/watch/hold/block` in `l4-summary.md`.\n'
+} >"$OUTPUT_DIR/README.md"
+
+if [[ "$PRINT_JSON" == "1" ]]; then
+  python3 - <<PY
+import json
+
+print(json.dumps({
+    "run_id": ${RUN_ID@Q},
+    "output_dir": ${OUTPUT_DIR@Q},
+    "packet_path": ${PACKET_PATH@Q},
+    "summary_path": ${SUMMARY_PATH@Q},
+    "manifest_path": ${MANIFEST_PATH@Q},
+}, ensure_ascii=False, indent=2))
+PY
+else
+  cat <<EOF
+Prepared complete L4 scaffold.
+- run_id: $RUN_ID
+- output_dir: $OUTPUT_DIR
+- packet: $PACKET_PATH
+- summary: $SUMMARY_PATH
+- l4b_card: $L4B_CARD_PATH
+- commands: $COMMANDS_PATH
+- manifest: $MANIFEST_PATH
+EOF
+fi

--- a/scripts/prepare-playability-l4-review.sh
+++ b/scripts/prepare-playability-l4-review.sh
@@ -15,8 +15,9 @@ Create a worktree-local artifact scaffold for a complete L4 review run:
 - role review cards
 - persona cards
 - L4 summary
-- copied L4B playability card
-- exact commands for L4A harness and L4B producer playtest
+- copied L4B embodied-agent playability card
+- optional internal human corroboration notes
+- exact commands for L4A harness, repo-local L4B agent evidence capture, and optional internal human corroboration
 
 Options:
   --output-dir <path>         Override output directory
@@ -24,14 +25,15 @@ Options:
   --run-id <id>               Override run id suffix (default: YYYYMMDD-HHMMSS)
   --change-scope <text>       Prefill packet `change_scope`
   --target-claim <text>       Prefill packet `target_experience_claim`
-  --target-l4-lane <lane>     L4A_only | L4A_then_L4B (default: L4A_then_L4B)
+  --target-l4-lane <lane>     L4A_only | L4A_then_L4B
+                              (default: L4A_then_L4B)
   --formal-surface <name>     Repeatable; defaults to `software_safe` + `pure_api`
   --role <role_name>          Repeatable; defaults to all standard review roles
   --persona <persona_id>      Repeatable; defaults to all fixed personas
   --question <text>           Repeatable packet question
   --known-blocker <text>      Repeatable packet blocker
   --artifact-path <path>      Repeatable packet artifact path
-  --bundle-dir <path>         Bundle dir to embed into recommended L4B command
+  --bundle-dir <path>         Bundle dir to embed into recommended L4B commands
   --with-l4a-stack            Boot `./scripts/worktree-harness.sh up` before writing artifacts
                               (requires the same active LLM provider config as formal gameplay)
   --json                      Print manifest JSON path summary
@@ -259,7 +261,8 @@ PACKET_PATH="$OUTPUT_DIR/l4-review-packet.md"
 SUMMARY_PATH="$OUTPUT_DIR/l4-summary.md"
 COMMANDS_PATH="$OUTPUT_DIR/commands.sh"
 MANIFEST_PATH="$OUTPUT_DIR/manifest.json"
-L4B_CARD_PATH="$OUTPUT_DIR/l4b-playability-test-card.md"
+L4B_AGENT_CARD_PATH="$OUTPUT_DIR/l4b-agent-playtest-card.md"
+OPTIONAL_HUMAN_NOTES_PATH="$OUTPUT_DIR/optional-internal-human-corroboration.md"
 EVIDENCE_README_PATH="$OUTPUT_DIR/evidence/README.md"
 
 if [[ "$WITH_L4A_STACK" == "1" ]]; then
@@ -331,7 +334,8 @@ fi
   printf '# L4 Validation Summary\n\n'
   printf -- '- Run ID: `%s`\n' "$RUN_ID"
   printf -- '- Packet: `%s`\n' "$PACKET_PATH"
-  printf -- '- L4B card copy: `%s`\n' "$L4B_CARD_PATH"
+  printf -- '- L4B agent card copy: `%s`\n' "$L4B_AGENT_CARD_PATH"
+  printf -- '- Optional internal human corroboration notes: `%s`\n' "$OPTIONAL_HUMAN_NOTES_PATH"
   printf -- '- Commands: `%s`\n' "$COMMANDS_PATH"
   printf '\n'
   append_template_body "$ROOT_DIR/doc/testing/templates/playability-l4-summary-template.md"
@@ -362,11 +366,23 @@ for persona_id in "${SELECTED_PERSONAS[@]}"; do
   } >"$OUTPUT_DIR/persona-cards/${persona_id}.md"
 done
 
-cp "$ROOT_DIR/doc/playability_test_result/playability_test_card.md" "$L4B_CARD_PATH"
+cp "$ROOT_DIR/doc/playability_test_result/playability_test_card.md" "$L4B_AGENT_CARD_PATH"
+{
+  printf '# Optional Internal Human Corroboration\n\n'
+  printf 'Use this only as optional calibration evidence for `L4B`.\n\n'
+  printf -- '- Reviewer:\n'
+  printf -- '- Session / surface:\n'
+  printf -- '- Relation to `L4B`: `corroborates_l4b` / `mixed` / `contradicts_l4b`\n'
+  printf -- '- What the human actually did:\n'
+  printf -- '- Whether the human wanted to continue, and why:\n'
+  printf -- '- Key divergence from `L4B` (if any):\n'
+  printf -- '- Evidence paths:\n'
+  printf -- '- Claim boundary note: this is still internal corroboration, not formal `L5`.\n'
+} >"$OPTIONAL_HUMAN_NOTES_PATH"
 
-L4B_COMMAND=(./scripts/run-producer-playtest.sh --open-headed)
+PLAYTEST_COMMAND=(./scripts/run-producer-playtest.sh --open-headed)
 if [[ -n "$BUNDLE_DIR" ]]; then
-  L4B_COMMAND+=(--bundle-dir "$BUNDLE_DIR")
+  PLAYTEST_COMMAND+=(--bundle-dir "$BUNDLE_DIR")
 fi
 
 {
@@ -378,14 +394,21 @@ fi
   printf './scripts/worktree-harness.sh status --json > %q\n' "$OUTPUT_DIR/evidence/l4a-harness-state.json"
   printf './scripts/worktree-harness.sh url > %q\n' "$OUTPUT_DIR/evidence/l4a-viewer-url.txt"
   printf '\n'
-  printf '# Launch the L4B human playtest path.\n'
-  printf '%q' "${L4B_COMMAND[0]}"
-  command_arg=
-  for command_arg in "${L4B_COMMAND[@]:1}"; do
+  printf '# Launch the L4B embodied-agent playtest path and capture stable evidence.\n'
+  printf './scripts/run-playability-l4b-agent.sh --l4-manifest %q' "$MANIFEST_PATH"
+  if [[ -n "$BUNDLE_DIR" ]]; then
+    printf ' --bundle-dir %q' "$BUNDLE_DIR"
+  fi
+  printf '\n'
+  printf '# After the agent playtest, review %q, then tighten %q and %q if needed.\n' "$OUTPUT_DIR/evidence" "$L4B_AGENT_CARD_PATH" "$SUMMARY_PATH"
+  printf '\n'
+  printf '# Optional: rerun the same entry with an internal human for L4B calibration.\n'
+  printf '%q' "${PLAYTEST_COMMAND[0]}"
+  for command_arg in "${PLAYTEST_COMMAND[@]:1}"; do
     printf ' %q' "$command_arg"
   done
   printf '\n'
-  printf '# After the human playtest, complete %q and reflect the L4B verdict in %q.\n' "$L4B_CARD_PATH" "$SUMMARY_PATH"
+  printf '# After the human pass, complete %q and reflect the corroboration status in %q.\n' "$OPTIONAL_HUMAN_NOTES_PATH" "$SUMMARY_PATH"
 } >"$COMMANDS_PATH"
 chmod +x "$COMMANDS_PATH"
 
@@ -396,11 +419,12 @@ chmod +x "$COMMANDS_PATH"
   printf -- '- `l4a-harness-state.json`: current harness snapshot after `worktree-harness.sh status --json`\n'
   printf -- '- `l4a-viewer-url.txt`: current L4A viewer URL\n'
   printf -- '- screenshots / recordings from L4A Web closure\n'
-  printf -- '- launcher startup logs and bundle notes from L4B\n'
+  printf -- '- launcher startup logs, state snapshots, screenshots, and run summaries from L4B playtests\n'
+  printf -- '- optional internal human corroboration notes or canonical playability card references\n'
   printf -- '- any copied `session.meta`, console snippets, or external issue references\n'
 } >"$EVIDENCE_README_PATH"
 
-python3 - "$MANIFEST_PATH" "$RUN_ID" "$OUTPUT_DIR" "$PACKET_PATH" "$SUMMARY_PATH" "$L4B_CARD_PATH" "$COMMANDS_PATH" "$HARNESS_ROOT" "$WORKTREE_ID" "$STATE_FILE" "$(git rev-parse --abbrev-ref HEAD)" "$(git rev-parse HEAD)" "$(json_array "${FORMAL_SURFACES[@]}")" "$(json_array "${REQUESTED_ROLES[@]}")" "$(json_array "${SELECTED_PERSONAS[@]}")" "$(json_array "${QUESTIONS_TO_PROBE[@]}")" "$(json_array "${KNOWN_BLOCKERS[@]}")" "$(json_array "${ARTIFACT_PATHS[@]}")" "$TARGET_L4_LANE" "$L4A_VIEWER_URL" <<'PY'
+python3 - "$MANIFEST_PATH" "$RUN_ID" "$OUTPUT_DIR" "$PACKET_PATH" "$SUMMARY_PATH" "$L4B_AGENT_CARD_PATH" "$OPTIONAL_HUMAN_NOTES_PATH" "$COMMANDS_PATH" "$HARNESS_ROOT" "$WORKTREE_ID" "$STATE_FILE" "$(git rev-parse --abbrev-ref HEAD)" "$(git rev-parse HEAD)" "$(json_array "${FORMAL_SURFACES[@]}")" "$(json_array "${REQUESTED_ROLES[@]}")" "$(json_array "${SELECTED_PERSONAS[@]}")" "$(json_array "${QUESTIONS_TO_PROBE[@]}")" "$(json_array "${KNOWN_BLOCKERS[@]}")" "$(json_array "${ARTIFACT_PATHS[@]}")" "$TARGET_L4_LANE" "$L4A_VIEWER_URL" <<'PY'
 from __future__ import annotations
 
 import json
@@ -413,7 +437,8 @@ import sys
     output_dir,
     packet_path,
     summary_path,
-    l4b_card_path,
+    l4b_agent_card_path,
+    optional_human_notes_path,
     commands_path,
     harness_root,
     worktree_id,
@@ -435,7 +460,8 @@ payload = {
     "output_dir": output_dir,
     "packet_path": packet_path,
     "summary_path": summary_path,
-    "l4b_card_path": l4b_card_path,
+    "l4b_agent_card_path": l4b_agent_card_path,
+    "optional_internal_human_corroboration_path": optional_human_notes_path,
     "commands_path": commands_path,
     "harness_root": harness_root,
     "worktree_id": worktree_id,
@@ -459,16 +485,18 @@ PY
   printf -- '- Run ID: `%s`\n' "$RUN_ID"
   printf -- '- Packet: `%s`\n' "$PACKET_PATH"
   printf -- '- Summary: `%s`\n' "$SUMMARY_PATH"
-  printf -- '- L4B card copy: `%s`\n' "$L4B_CARD_PATH"
+  printf -- '- L4B agent card copy: `%s`\n' "$L4B_AGENT_CARD_PATH"
+  printf -- '- Optional internal human corroboration notes: `%s`\n' "$OPTIONAL_HUMAN_NOTES_PATH"
   printf -- '- Commands: `%s`\n' "$COMMANDS_PATH"
   printf -- '- Manifest: `%s`\n' "$MANIFEST_PATH"
   printf '\n## Next Steps\n'
   printf '1. Fill `l4-review-packet.md` with this change scope, target claim, known blockers, and artifact paths.\n'
-  printf '2. Run `commands.sh` or the individual commands to refresh `L4A` evidence and launch `L4B` producer playtest.\n'
+  printf '2. Run `commands.sh` or the individual commands to refresh `L4A` evidence and execute the repo-local `L4B` embodied agent runner.\n'
   printf '3. Complete every role card and persona card that applies to this run.\n'
-  printf '4. After the human playtest, complete `l4b-playability-test-card.md` and record the `L4B` verdict.\n'
-  printf '5. Copy concrete screenshots / logs into `evidence/` and reference them from the packet, `l4b-playability-test-card.md`, and summary.\n'
-  printf '6. Summarize `L4A`, `L4B`, and combined `go/watch/hold/block` in `l4-summary.md`.\n'
+  printf '4. Review the auto-filled `L4B` evidence/card output, then tighten `l4b-agent-playtest-card.md` and record the final `L4B` verdict.\n'
+  printf '5. If needed, add optional internal human corroboration in `optional-internal-human-corroboration.md` as calibration for `L4B`.\n'
+  printf '6. Copy concrete screenshots / logs into `evidence/` and reference them from the packet, `L4B` card, corroboration notes, and summary.\n'
+  printf '7. Summarize `L4A`, `L4B`, optional corroboration, and combined `go/watch/hold/block` in `l4-summary.md`.\n'
 } >"$OUTPUT_DIR/README.md"
 
 if [[ "$PRINT_JSON" == "1" ]]; then
@@ -490,7 +518,8 @@ Prepared complete L4 scaffold.
 - output_dir: $OUTPUT_DIR
 - packet: $PACKET_PATH
 - summary: $SUMMARY_PATH
-- l4b_card: $L4B_CARD_PATH
+- l4b_agent_card: $L4B_AGENT_CARD_PATH
+- optional_internal_human_corroboration: $OPTIONAL_HUMAN_NOTES_PATH
 - commands: $COMMANDS_PATH
 - manifest: $MANIFEST_PATH
 EOF

--- a/scripts/run-playability-l4b-agent.sh
+++ b/scripts/run-playability-l4b-agent.sh
@@ -1,0 +1,751 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+source "$ROOT_DIR/scripts/agent-browser-lib.sh"
+source "$ROOT_DIR/scripts/worktree-harness-lib.sh"
+
+usage() {
+  cat <<'USAGE'
+Usage: ./scripts/run-playability-l4b-agent.sh [options]
+
+Run one embodied-agent `L4B` playability pass against the producer playtest entry,
+capture stable evidence under the current worktree, and prefill the copied L4B card
+when an `L4` manifest/artifact directory is provided.
+
+Options:
+  --l4-manifest <path>          Existing `prepare-playability-l4-review.sh` manifest.json
+  --artifact-dir <path>         Existing or new artifact root to write evidence under
+  --bundle-dir <path>           Forwarded to `run-producer-playtest.sh`
+  --session <name>              `agent-browser` session name (default: producer-playtest)
+  --startup-timeout <secs>      Wait timeout for stack/browser readiness (default: 180)
+  --step-wait-ms <ms>           Max wait window for `推进一步` to reach a completed world delta (default: 10000)
+  --submit-wait-ms <ms>         Max wait window for gameplay submit to reach final `ack` (default: 60000)
+  --submit-action <action_id>   Gameplay action id to submit (default: build_factory_smelter_mk1)
+  --persona-id <id>             Optional simulated persona label to stamp into evidence
+  --change-scope <text>         Optional change scope note for the run summary
+  --target-claim <text>         Optional target claim note for the run summary
+  --json                        Print final summary JSON payload
+  -h, --help                    Show this help
+
+Examples:
+  ./scripts/run-playability-l4b-agent.sh --l4-manifest output/harness/<wt>/artifacts/playability-l4-*/manifest.json
+  ./scripts/run-playability-l4b-agent.sh --artifact-dir output/harness/<wt>/artifacts/l4b-rerun --persona-id impatient_action_player
+USAGE
+}
+
+RUN_ID="$(date +%Y%m%d-%H%M%S)"
+L4_MANIFEST=""
+ARTIFACT_DIR=""
+BUNDLE_DIR=""
+SESSION_NAME="producer-playtest"
+AUTOMATION_SESSION=""
+PRIMARY_SESSION=""
+STARTUP_TIMEOUT_SECS=180
+STEP_WAIT_MS=10000
+SUBMIT_WAIT_MS=60000
+SUBMIT_ACTION_ID="build_factory_smelter_mk1"
+PERSONA_ID=""
+CHANGE_SCOPE=""
+TARGET_CLAIM=""
+PRINT_JSON=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --l4-manifest)
+      L4_MANIFEST="${2:-}"
+      shift 2
+      ;;
+    --artifact-dir)
+      ARTIFACT_DIR="${2:-}"
+      shift 2
+      ;;
+    --bundle-dir)
+      BUNDLE_DIR="${2:-}"
+      shift 2
+      ;;
+    --session)
+      SESSION_NAME="${2:-}"
+      shift 2
+      ;;
+    --startup-timeout)
+      STARTUP_TIMEOUT_SECS="${2:-}"
+      shift 2
+      ;;
+    --step-wait-ms)
+      STEP_WAIT_MS="${2:-}"
+      shift 2
+      ;;
+    --submit-wait-ms)
+      SUBMIT_WAIT_MS="${2:-}"
+      shift 2
+      ;;
+    --submit-action)
+      SUBMIT_ACTION_ID="${2:-}"
+      shift 2
+      ;;
+    --persona-id)
+      PERSONA_ID="${2:-}"
+      shift 2
+      ;;
+    --change-scope)
+      CHANGE_SCOPE="${2:-}"
+      shift 2
+      ;;
+    --target-claim)
+      TARGET_CLAIM="${2:-}"
+      shift 2
+      ;;
+    --json)
+      PRINT_JSON=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "error: unknown option: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+ab_require
+wh_require_git_worktree
+[[ -n "$SESSION_NAME" ]] || { echo "error: --session cannot be empty" >&2; exit 2; }
+PRIMARY_SESSION="$SESSION_NAME"
+AUTOMATION_SESSION="${SESSION_NAME}-l4b-driver"
+[[ -n "$SUBMIT_ACTION_ID" ]] || { echo "error: --submit-action cannot be empty" >&2; exit 2; }
+[[ "$STARTUP_TIMEOUT_SECS" =~ ^[0-9]+$ && "$STARTUP_TIMEOUT_SECS" -gt 0 ]] || { echo "error: --startup-timeout must be a positive integer" >&2; exit 2; }
+[[ "$STEP_WAIT_MS" =~ ^[0-9]+$ && "$STEP_WAIT_MS" -ge 0 ]] || { echo "error: --step-wait-ms must be a non-negative integer" >&2; exit 2; }
+[[ "$SUBMIT_WAIT_MS" =~ ^[0-9]+$ && "$SUBMIT_WAIT_MS" -ge 0 ]] || { echo "error: --submit-wait-ms must be a non-negative integer" >&2; exit 2; }
+
+if [[ -n "$L4_MANIFEST" && "$L4_MANIFEST" != /* ]]; then
+  L4_MANIFEST="$ROOT_DIR/$L4_MANIFEST"
+fi
+if [[ -n "$ARTIFACT_DIR" && "$ARTIFACT_DIR" != /* ]]; then
+  ARTIFACT_DIR="$ROOT_DIR/$ARTIFACT_DIR"
+fi
+
+MANIFEST_OUTPUT_DIR=""
+L4B_CARD_PATH=""
+L4_SUMMARY_PATH=""
+if [[ -n "$L4_MANIFEST" ]]; then
+  [[ -f "$L4_MANIFEST" ]] || { echo "error: manifest not found: $L4_MANIFEST" >&2; exit 2; }
+  readarray -t manifest_values < <(python3 - "$L4_MANIFEST" <<'PY'
+from __future__ import annotations
+
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+data = json.loads(path.read_text(encoding="utf-8"))
+print(data.get("output_dir") or "")
+print(data.get("l4b_agent_card_path") or "")
+print(data.get("summary_path") or "")
+PY
+)
+  MANIFEST_OUTPUT_DIR="${manifest_values[0]:-}"
+  L4B_CARD_PATH="${manifest_values[1]:-}"
+  L4_SUMMARY_PATH="${manifest_values[2]:-}"
+fi
+
+if [[ -z "$ARTIFACT_DIR" ]]; then
+  if [[ -n "$MANIFEST_OUTPUT_DIR" ]]; then
+    ARTIFACT_DIR="$MANIFEST_OUTPUT_DIR"
+  else
+    WORKTREE_ID="$(wh_worktree_id)"
+    HARNESS_ROOT="$(wh_harness_root "$ROOT_DIR" "$WORKTREE_ID")"
+    ARTIFACT_DIR="$(wh_artifacts_dir "$HARNESS_ROOT")/playability-l4b-$RUN_ID"
+  fi
+fi
+
+mkdir -p "$ARTIFACT_DIR"
+EVIDENCE_DIR="$ARTIFACT_DIR/evidence/l4b-agent-$RUN_ID"
+mkdir -p "$EVIDENCE_DIR"
+
+WRAPPER_LOG="$EVIDENCE_DIR/run-producer-playtest.log"
+STARTUP_LOG="$EVIDENCE_DIR/producer-launch.log"
+SNAPSHOT_PATH="$EVIDENCE_DIR/interactive-snapshot.txt"
+INITIAL_STATE_PATH="$EVIDENCE_DIR/state-initial.json"
+STEP_STATE_PATH="$EVIDENCE_DIR/state-after-step.json"
+STEP_FALLBACK_PATH="$EVIDENCE_DIR/step-fallback-feedback.json"
+SUBMIT_IMMEDIATE_PATH="$EVIDENCE_DIR/gameplay-submit-immediate.json"
+FINAL_STATE_PATH="$EVIDENCE_DIR/state-after-submit.json"
+FINAL_SUMMARY_PATH="$EVIDENCE_DIR/l4b-agent-summary.json"
+FINAL_SUMMARY_MD_PATH="$EVIDENCE_DIR/l4b-agent-summary.md"
+SCREENSHOT_PATH="$EVIDENCE_DIR/final.png"
+
+PLAYTEST_PID=""
+AUTOMATION_OPENED=0
+cleanup() {
+  local exit_code=$?
+  trap - EXIT INT TERM
+  if [[ -n "$PLAYTEST_PID" ]] && kill -0 "$PLAYTEST_PID" >/dev/null 2>&1; then
+    kill "$PLAYTEST_PID" >/dev/null 2>&1 || true
+    wait "$PLAYTEST_PID" >/dev/null 2>&1 || true
+  fi
+  if [[ -n "$AUTOMATION_SESSION" ]]; then
+    ab_cmd "$AUTOMATION_SESSION" close >/dev/null 2>&1 || true
+  fi
+  exit "$exit_code"
+}
+trap cleanup EXIT INT TERM
+
+normalize_ab_payload() {
+  python3 - "$1" <<'PY'
+from __future__ import annotations
+
+import json
+import sys
+
+raw = sys.argv[1]
+try:
+    data = json.loads(raw)
+except Exception:
+    print(raw)
+    raise SystemExit(0)
+if isinstance(data, str):
+    try:
+        data = json.loads(data)
+    except Exception:
+        pass
+print(json.dumps(data, ensure_ascii=False))
+PY
+}
+
+write_pretty_json() {
+  local raw_payload=$1
+  local out_path=$2
+  python3 - "$raw_payload" "$out_path" <<'PY'
+from __future__ import annotations
+
+import json
+import pathlib
+import sys
+
+raw = sys.argv[1]
+out = pathlib.Path(sys.argv[2])
+data = json.loads(raw)
+out.write_text(json.dumps(data, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+PY
+}
+
+capture_state() {
+  local out_path=$1
+  local script=${2:-'JSON.stringify(window.__AW_TEST__ ? window.__AW_TEST__.getState() : null)'}
+  local raw normalized
+  raw=$(ab_eval "$SESSION_NAME" "$script")
+  normalized=$(normalize_ab_payload "$raw")
+  write_pretty_json "$normalized" "$out_path"
+  printf '%s\n' "$normalized"
+}
+
+wait_for_state_progress() {
+  local mode=$1
+  local out_path=$2
+  local timeout_ms=$3
+  local elapsed=0
+  while (( elapsed <= timeout_ms )); do
+    capture_state "$out_path" >/dev/null
+    if python3 - "$mode" "$INITIAL_STATE_PATH" "$out_path" <<'PY'
+from __future__ import annotations
+
+import json
+import pathlib
+import sys
+
+mode, initial_path, current_path = sys.argv[1:]
+initial = json.loads(pathlib.Path(initial_path).read_text(encoding="utf-8"))
+current = json.loads(pathlib.Path(current_path).read_text(encoding="utf-8"))
+
+initial_gameplay = initial.get("gameplaySummary") or {}
+current_gameplay = current.get("gameplaySummary") or {}
+control = current.get("lastControlFeedback") or {}
+action = current.get("lastGameplayActionFeedback") or {}
+
+if mode == "step":
+    initial_time = initial.get("logicalTime")
+    current_time = current.get("logicalTime")
+    initial_progress = initial_gameplay.get("progressPercent")
+    current_progress = current_gameplay.get("progressPercent")
+    completed = control.get("stage") in {"completed", "completed_advanced"}
+    time_advanced = isinstance(initial_time, int) and isinstance(current_time, int) and current_time > initial_time
+    progress_advanced = isinstance(initial_progress, (int, float)) and isinstance(current_progress, (int, float)) and current_progress > initial_progress
+    raise SystemExit(0 if completed and (time_advanced or progress_advanced) else 1)
+
+if mode == "submit":
+    accepted = action.get("accepted") is True
+    ok = action.get("ok") is True
+    stage = action.get("stage")
+    raise SystemExit(0 if accepted and ok and stage == "ack" else 1)
+
+raise SystemExit(1)
+PY
+    then
+      return 0
+    fi
+    sleep 1
+    elapsed=$((elapsed + 1000))
+  done
+  return 1
+}
+
+extract_button_ref() {
+  local snapshot_file=$1
+  local button_text=$2
+  python3 - "$snapshot_file" "$button_text" <<'PY'
+from __future__ import annotations
+
+import pathlib
+import re
+import sys
+
+path = pathlib.Path(sys.argv[1])
+label = sys.argv[2]
+pattern = re.compile(rf'^\-\s+button\s+"{re.escape(label)}"\s+\[ref=(e\d+)\]', re.MULTILINE)
+match = pattern.search(path.read_text(encoding="utf-8"))
+if match:
+    print(f"@{match.group(1)}")
+PY
+}
+
+extract_log_value() {
+  local marker=$1
+  python3 - "$WRAPPER_LOG" "$marker" <<'PY'
+from __future__ import annotations
+
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+marker = sys.argv[2]
+if not path.exists():
+    raise SystemExit(0)
+for raw in path.read_text(encoding="utf-8").splitlines():
+    if raw.startswith(marker):
+        print(raw[len(marker):].strip())
+PY
+}
+
+extract_ready_url() {
+  python3 - "$WRAPPER_LOG" <<'PY'
+from __future__ import annotations
+
+import pathlib
+import re
+import sys
+
+path = pathlib.Path(sys.argv[1])
+if not path.exists():
+    raise SystemExit(0)
+text = path.read_text(encoding="utf-8")
+matches = re.findall(r"(http://[^\s]+software_safe\.html[^\s]*)", text)
+if matches:
+    print(matches[-1])
+    raise SystemExit(0)
+matches = re.findall(r"opening headed browser session '.*?' -> (http://[^\s]+)", text)
+if matches:
+    print(matches[-1])
+PY
+}
+
+PLAYTEST_COMMAND=(./scripts/run-producer-playtest.sh --open-headed --session "$SESSION_NAME" --startup-timeout "$STARTUP_TIMEOUT_SECS" --startup-log "$STARTUP_LOG")
+if [[ -n "$BUNDLE_DIR" ]]; then
+  PLAYTEST_COMMAND+=(--bundle-dir "$BUNDLE_DIR")
+fi
+
+STARTED_AT_UNIX_MS="$(python3 - <<'PY'
+import time
+print(int(time.time() * 1000))
+PY
+)"
+
+if command -v stdbuf >/dev/null 2>&1; then
+  stdbuf -oL -eL "${PLAYTEST_COMMAND[@]}" > >(tee "$WRAPPER_LOG") 2>&1 &
+else
+  "${PLAYTEST_COMMAND[@]}" > >(tee "$WRAPPER_LOG") 2>&1 &
+fi
+PLAYTEST_PID=$!
+
+READY=0
+CURRENT_URL=""
+STATE_RAW=""
+for ((i = 0; i < STARTUP_TIMEOUT_SECS; i++)); do
+  if ! kill -0 "$PLAYTEST_PID" >/dev/null 2>&1; then
+    echo "error: producer playtest exited unexpectedly" >&2
+    tail -n 120 "$WRAPPER_LOG" >&2 || true
+    exit 1
+  fi
+  CURRENT_URL="$(extract_ready_url)"
+  if [[ -n "$CURRENT_URL" ]]; then
+    if [[ "$AUTOMATION_OPENED" != "1" ]]; then
+      ab_open "$AUTOMATION_SESSION" 0 "$CURRENT_URL" >>"$WRAPPER_LOG" 2>&1 || true
+      ab_cmd "$AUTOMATION_SESSION" wait --load networkidle >/dev/null 2>&1 || true
+      AUTOMATION_OPENED=1
+    fi
+    SESSION_NAME="$AUTOMATION_SESSION"
+    STATE_RAW="$(capture_state "$INITIAL_STATE_PATH" 2>/dev/null || true)"
+    if [[ -n "$STATE_RAW" ]]; then
+      CONNECTION_STATUS="$(json_get "$STATE_RAW" connectionStatus)"
+      AUTH_READY="$(json_get "$STATE_RAW" authReady)"
+      if [[ "$CONNECTION_STATUS" == "connected" && "$AUTH_READY" == "true" ]]; then
+        READY=1
+        break
+      fi
+    fi
+    SESSION_NAME="$PRIMARY_SESSION"
+  fi
+  sleep 1
+done
+
+if [[ "$READY" != "1" ]]; then
+  echo "error: timed out waiting for L4B browser session readiness" >&2
+  tail -n 120 "$WRAPPER_LOG" >&2 || true
+  exit 1
+fi
+
+SESSION_NAME="$AUTOMATION_SESSION"
+
+SNAPSHOT_OUTPUT="$(ab_cmd "$SESSION_NAME" snapshot -i)"
+printf '%s\n' "$SNAPSHOT_OUTPUT" >"$SNAPSHOT_PATH"
+STEP_REF="$(extract_button_ref "$SNAPSHOT_PATH" "推进一步")"
+if [[ -z "$STEP_REF" ]]; then
+  echo "error: failed to locate '推进一步' button in interactive snapshot" >&2
+  cat "$SNAPSHOT_PATH" >&2
+  exit 1
+fi
+
+ab_cmd "$SESSION_NAME" click "$STEP_REF" >/dev/null
+if ! wait_for_state_progress "step" "$STEP_STATE_PATH" "$STEP_WAIT_MS"; then
+  STEP_FALLBACK_RAW="$(ab_eval "$SESSION_NAME" "JSON.stringify(window.__AW_TEST__.sendControl('step', {count: 1}), null, 2)")"
+  STEP_FALLBACK_NORMALIZED="$(normalize_ab_payload "$STEP_FALLBACK_RAW")"
+  write_pretty_json "$STEP_FALLBACK_NORMALIZED" "$STEP_FALLBACK_PATH"
+  if ! wait_for_state_progress "step" "$STEP_STATE_PATH" "$STEP_WAIT_MS"; then
+    STEP_STATE_RAW="$(capture_state "$STEP_STATE_PATH")"
+  else
+    STEP_STATE_RAW="$(cat "$STEP_STATE_PATH")"
+  fi
+else
+  STEP_STATE_RAW="$(cat "$STEP_STATE_PATH")"
+fi
+
+SUBMIT_RAW="$(ab_eval "$SESSION_NAME" "JSON.stringify(window.__AW_TEST__.sendGameplayAction($(json_quote "$SUBMIT_ACTION_ID")), null, 2)")"
+SUBMIT_RAW_NORMALIZED="$(normalize_ab_payload "$SUBMIT_RAW")"
+write_pretty_json "$SUBMIT_RAW_NORMALIZED" "$SUBMIT_IMMEDIATE_PATH"
+
+if ! wait_for_state_progress "submit" "$FINAL_STATE_PATH" "$SUBMIT_WAIT_MS"; then
+  FINAL_STATE_RAW="$(capture_state "$FINAL_STATE_PATH")"
+else
+  FINAL_STATE_RAW="$(cat "$FINAL_STATE_PATH")"
+fi
+ab_screenshot "$SESSION_NAME" "$SCREENSHOT_PATH" >>"$WRAPPER_LOG" 2>&1 || true
+
+STACK_LOG_DIR="$(extract_log_value "info: stack logs: ")"
+STARTUP_LOG_REPORTED="$(extract_log_value "info: startup log: ")"
+PLAYER_BROWSER_URL="$(ab_cmd "$SESSION_NAME" get url 2>/dev/null || true)"
+TITLE="$(ab_cmd "$SESSION_NAME" get title 2>/dev/null || true)"
+
+SUMMARY_PAYLOAD="$(python3 - "$INITIAL_STATE_PATH" "$STEP_STATE_PATH" "$SUBMIT_IMMEDIATE_PATH" "$FINAL_STATE_PATH" "$PLAYER_BROWSER_URL" "$TITLE" "$STACK_LOG_DIR" "$STARTUP_LOG_REPORTED" "$SCREENSHOT_PATH" "$SESSION_NAME" "$SUBMIT_ACTION_ID" "$PERSONA_ID" "$CHANGE_SCOPE" "$TARGET_CLAIM" "$STARTED_AT_UNIX_MS" <<'PY'
+from __future__ import annotations
+
+import json
+import pathlib
+import sys
+import time
+
+(
+    initial_path,
+    step_path,
+    submit_path,
+    final_path,
+    player_browser_url,
+    title,
+    stack_log_dir,
+    startup_log_reported,
+    screenshot_path,
+    session_name,
+    submit_action_id,
+    persona_id,
+    change_scope,
+    target_claim,
+    started_at_unix_ms,
+) = sys.argv[1:]
+
+def read_json(path: str) -> dict:
+    return json.loads(pathlib.Path(path).read_text(encoding="utf-8"))
+
+initial = read_json(initial_path)
+after_step = read_json(step_path)
+submit_immediate = read_json(submit_path)
+after_submit = read_json(final_path)
+
+initial_gameplay = initial.get("gameplaySummary") or {}
+step_gameplay = after_step.get("gameplaySummary") or {}
+final_feedback = after_submit.get("lastGameplayActionFeedback") or {}
+final_response = final_feedback.get("response") or {}
+
+initial_logical_time = initial.get("logicalTime")
+after_step_logical_time = after_step.get("logicalTime")
+initial_progress = initial_gameplay.get("progressPercent")
+after_step_progress = step_gameplay.get("progressPercent")
+step_advanced = (
+    isinstance(initial_logical_time, int)
+    and isinstance(after_step_logical_time, int)
+    and after_step_logical_time > initial_logical_time
+)
+progress_advanced = (
+    isinstance(initial_progress, (int, float))
+    and isinstance(after_step_progress, (int, float))
+    and after_step_progress > initial_progress
+)
+
+submit_ack = (
+    final_feedback.get("accepted") is True
+    and final_feedback.get("ok") is True
+    and final_feedback.get("stage") == "ack"
+)
+player_id_matches = (
+    final_response.get("player_id")
+    and final_response.get("player_id") == after_submit.get("authPlayerId")
+)
+
+verdict = "agent_continue_observed" if step_advanced and progress_advanced and submit_ack and player_id_matches else "agent_continue_not_observed"
+combined_recommendation = "watch" if verdict == "agent_continue_observed" else "hold"
+human_equivalence = (
+    "This run proves the embodied agent can progress and submit one real gameplay action on the default chain-enabled path, "
+    "but it still does not by itself prove durable human-level desire to continue without broader L4A/L5 corroboration."
+)
+problem_summary = (
+    "Default chain-enabled L4B path reached one real world-advance and one acknowledged gameplay submit."
+    if verdict == "agent_continue_observed"
+    else "Embodied agent did not reach a stable 'step advances + gameplay submit ack' outcome on the default path."
+)
+leverage_summary = (
+    f"The agent first advanced the world from logicalTime {initial_logical_time} to {after_step_logical_time}, "
+    f"moving progress from {initial_progress}% to {after_step_progress}%, then submitted `{submit_action_id}` and received "
+    f"`stage={final_feedback.get('stage')}` with runtime action id `{final_response.get('runtime_action_id')}`."
+)
+duration_ms = max(0, int(time.time() * 1000) - int(started_at_unix_ms))
+
+payload = {
+    "generated_at_unix_ms": int(time.time() * 1000),
+    "started_at_unix_ms": int(started_at_unix_ms),
+    "duration_ms": duration_ms,
+    "session_name": session_name,
+    "persona_id": persona_id or None,
+    "change_scope": change_scope or None,
+    "target_claim": target_claim or None,
+    "browser_url": player_browser_url or None,
+    "browser_title": title or None,
+    "startup_log": startup_log_reported or None,
+    "stack_log_dir": stack_log_dir or None,
+    "screenshot_path": screenshot_path,
+    "submit_action_id": submit_action_id,
+    "initial_state_path": initial_path,
+    "step_state_path": step_path,
+    "submit_immediate_path": submit_path,
+    "final_state_path": final_path,
+    "initial_goal_id": initial_gameplay.get("goalId"),
+    "after_step_goal_id": step_gameplay.get("goalId"),
+    "initial_progress_percent": initial_progress,
+    "after_step_progress_percent": after_step_progress,
+    "initial_logical_time": initial_logical_time,
+    "after_step_logical_time": after_step_logical_time,
+    "step_advanced": step_advanced,
+    "progress_advanced": progress_advanced,
+    "submit_ack": submit_ack,
+    "player_id_matches": player_id_matches,
+    "final_auth_player_id": after_submit.get("authPlayerId"),
+    "final_feedback": final_feedback,
+    "submit_immediate": submit_immediate,
+    "l4b_agentic_verdict": verdict,
+    "combined_stage_recommendation_hint": combined_recommendation,
+    "problem_summary": problem_summary,
+    "player_leverage_summary": leverage_summary,
+    "human_equivalence_note": human_equivalence,
+    "suggested_card_fields": {
+        "test_scenario": "L4B embodied agent playtest",
+        "tester": "agent embodied playtest",
+        "conclusion_tag": "需观察" if verdict == "agent_continue_observed" else "高优先级阻断",
+        "player_leverage_score": 5 if verdict == "agent_continue_observed" else 1,
+        "leverage_verdict": "pass" if verdict == "agent_continue_observed" else "block",
+        "world_activity_only": "no" if submit_ack else "yes",
+        "problem_summary": problem_summary,
+        "player_leverage_summary": leverage_summary,
+    },
+}
+print(json.dumps(payload, ensure_ascii=False))
+PY
+)"
+write_pretty_json "$SUMMARY_PAYLOAD" "$FINAL_SUMMARY_PATH"
+
+python3 - "$FINAL_SUMMARY_PATH" "$FINAL_SUMMARY_MD_PATH" <<'PY'
+from __future__ import annotations
+
+import json
+import pathlib
+import sys
+
+summary = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+out = pathlib.Path(sys.argv[2])
+lines = [
+    "# L4B Agent Summary",
+    "",
+    f"- `l4b_agentic_verdict`: `{summary['l4b_agentic_verdict']}`",
+    f"- `combined_stage_recommendation_hint`: `{summary['combined_stage_recommendation_hint']}`",
+    f"- `session_name`: `{summary['session_name']}`",
+    f"- `persona_id`: `{summary['persona_id'] or 'not_set'}`",
+    f"- `change_scope`: `{summary['change_scope'] or 'not_set'}`",
+    f"- `target_claim`: `{summary['target_claim'] or 'not_set'}`",
+    f"- `browser_url`: `{summary['browser_url'] or 'unknown'}`",
+    f"- `startup_log`: `{summary['startup_log'] or 'unknown'}`",
+    f"- `stack_log_dir`: `{summary['stack_log_dir'] or 'unknown'}`",
+    f"- `screenshot_path`: `{summary['screenshot_path']}`",
+    "",
+    "## Direct Evidence",
+    f"- `logicalTime`: `{summary['initial_logical_time']}` -> `{summary['after_step_logical_time']}`",
+    f"- `progressPercent`: `{summary['initial_progress_percent']}` -> `{summary['after_step_progress_percent']}`",
+    f"- `goalId`: `{summary['initial_goal_id']}` -> `{summary['after_step_goal_id']}`",
+    f"- `submit_ack`: `{summary['submit_ack']}`",
+    f"- `player_id_matches`: `{summary['player_id_matches']}`",
+    f"- `submit_action_id`: `{summary['submit_action_id']}`",
+    "",
+    "## Interpretation",
+    f"- {summary['problem_summary']}",
+    f"- {summary['player_leverage_summary']}",
+    f"- {summary['human_equivalence_note']}",
+]
+out.write_text("\n".join(lines) + "\n", encoding="utf-8")
+PY
+
+if [[ -n "$L4B_CARD_PATH" && -f "$L4B_CARD_PATH" ]]; then
+  python3 - "$L4B_CARD_PATH" "$FINAL_SUMMARY_PATH" "$FINAL_SUMMARY_MD_PATH" <<'PY'
+from __future__ import annotations
+
+import json
+import pathlib
+import re
+import sys
+
+card_path = pathlib.Path(sys.argv[1])
+summary = json.loads(pathlib.Path(sys.argv[2]).read_text(encoding="utf-8"))
+summary_md_path = pathlib.Path(sys.argv[3])
+text = card_path.read_text(encoding="utf-8")
+
+replacements = {
+    r"^- 测试场景：.*$": f"- 测试场景：`{summary['suggested_card_fields']['test_scenario']}`",
+    r"^- 测试者：.*$": f"- 测试者：`{summary['suggested_card_fields']['tester']}`",
+    r"^- 会话时长：.*$": f"- 会话时长：`{summary['duration_ms']} ms`",
+    r"^- 关键操作链路：.*$": f"- 关键操作链路：`open software_safe -> click step -> submit {summary['submit_action_id']}`",
+    r"^- 结论标签：.*$": f"- 结论标签：`{summary['suggested_card_fields']['conclusion_tag']}`",
+    r"^- 问题摘要：.*$": f"- 问题摘要：{summary['suggested_card_fields']['problem_summary']}",
+    r"^- 玩家杠杆摘要：.*$": f"- 玩家杠杆摘要：{summary['suggested_card_fields']['player_leverage_summary']}",
+    r"^- 访问地址：.*$": f"- 访问地址：`{summary['browser_url'] or 'unknown'}`",
+    r"^- 过程证据：.*$": f"- 过程证据：`{summary_md_path}` / `{summary['initial_state_path']}` / `{summary['step_state_path']}` / `{summary['final_state_path']}`",
+    r"^- 录屏文件：.*$": "- 录屏文件：`not_captured`",
+    r"^- 启动日志：.*$": f"- 启动日志：`{summary['startup_log'] or 'unknown'}` / `{summary['stack_log_dir'] or 'unknown'}`",
+    r"^- 控制台关键信息：.*$": f"- 控制台关键信息：`submit_ack={summary['submit_ack']}` / `player_id_matches={summary['player_id_matches']}` / `final_auth_player_id={summary['final_auth_player_id']}`",
+    r"^- TTFC（首次可控时间，ms）：.*$": f"- TTFC（首次可控时间，ms）：`{summary['duration_ms']}`",
+    r"^- 有效控制命中率（有效推进控制次数 / 预期推进控制次数）：.*$": f"- 有效控制命中率（有效推进控制次数 / 预期推进控制次数）：`{1 if summary['step_advanced'] else 0}/1`",
+    r"^- 无进展窗口时长（ms，connected 下 tick 不变最长窗口）：.*$": "- 无进展窗口时长（ms，connected 下 tick 不变最长窗口）：`not_measured_in_this_runner`",
+    r"^\s+- A（play/pause）：.*$": "  - A（play/pause）：`not_run_in_this_l4b_runner`",
+    r"^\s+- B（step/seek）：.*$": f"  - B（step/seek）：`logicalTime {summary['initial_logical_time']} -> {summary['after_step_logical_time']}; submit_ack={summary['submit_ack']}`",
+    r"^- `player_leverage_score`（0~5）：.*$": f"- `player_leverage_score`（0~5）：`{summary['suggested_card_fields']['player_leverage_score']}`",
+    r"^- `leverage_verdict`：.*$": f"- `leverage_verdict`：`{summary['suggested_card_fields']['leverage_verdict']}`",
+    r"^- `world_activity_only`：.*$": f"- `world_activity_only`：`{summary['suggested_card_fields']['world_activity_only']}`",
+}
+
+for pattern, replacement in replacements.items():
+    text = re.sub(pattern, replacement, text, flags=re.MULTILINE)
+
+autofill = "\n".join(
+    [
+        "## Auto-filled L4B Agent Evidence",
+        f"- `l4b_agentic_verdict`: `{summary['l4b_agentic_verdict']}`",
+        f"- `combined_stage_recommendation_hint`: `{summary['combined_stage_recommendation_hint']}`",
+        f"- `persona_id`: `{summary['persona_id'] or 'not_set'}`",
+        f"- `summary_md`: `{summary_md_path}`",
+        f"- `human_equivalence_note`: {summary['human_equivalence_note']}",
+        "",
+    ]
+)
+marker = "## Auto-filled L4B Agent Evidence"
+if marker in text:
+    text = re.sub(
+        r"## Auto-filled L4B Agent Evidence\n.*?(?=\n# |\Z)",
+        autofill.rstrip(),
+        text,
+        flags=re.S,
+    )
+else:
+    text = text.rstrip() + "\n\n" + autofill
+
+card_path.write_text(text.rstrip() + "\n", encoding="utf-8")
+PY
+fi
+
+if [[ -n "$L4_SUMMARY_PATH" && -f "$L4_SUMMARY_PATH" ]]; then
+  python3 - "$L4_SUMMARY_PATH" "$FINAL_SUMMARY_PATH" "$FINAL_SUMMARY_MD_PATH" <<'PY'
+from __future__ import annotations
+
+import json
+import pathlib
+import re
+import sys
+
+summary_path = pathlib.Path(sys.argv[1])
+run = json.loads(pathlib.Path(sys.argv[2]).read_text(encoding="utf-8"))
+run_md_path = pathlib.Path(sys.argv[3])
+text = summary_path.read_text(encoding="utf-8")
+
+text = re.sub(
+    r"^- `l4b_agentic_verdict`:.*$",
+    f"- `l4b_agentic_verdict`: `{run['l4b_agentic_verdict']}`",
+    text,
+    flags=re.MULTILINE,
+)
+text = re.sub(
+    r"^- `combined_stage_recommendation`:.*$",
+    f"- `combined_stage_recommendation`: `{run['combined_stage_recommendation_hint']}`",
+    text,
+    flags=re.MULTILINE,
+)
+
+block = "\n".join(
+    [
+        "## Auto-filled L4B Agent Evidence",
+        f"- `summary_md`: `{run_md_path}`",
+        f"- `problem_summary`: {run['problem_summary']}",
+        f"- `player_leverage_summary`: {run['player_leverage_summary']}",
+        f"- `human_equivalence_note`: {run['human_equivalence_note']}",
+    ]
+)
+marker = "## Auto-filled L4B Agent Evidence"
+if marker in text:
+    text = re.sub(r"## Auto-filled L4B Agent Evidence\n.*?(?=\n## |\Z)", block, text, flags=re.S)
+else:
+    text = text.rstrip() + "\n\n" + block + "\n"
+
+summary_path.write_text(text, encoding="utf-8")
+PY
+fi
+
+if [[ "$PRINT_JSON" == "1" ]]; then
+  cat "$FINAL_SUMMARY_PATH"
+else
+  cat <<EOF
+Captured L4B embodied-agent evidence.
+- artifact_dir: $ARTIFACT_DIR
+- evidence_dir: $EVIDENCE_DIR
+- l4b_summary_json: $FINAL_SUMMARY_PATH
+- l4b_summary_md: $FINAL_SUMMARY_MD_PATH
+- l4b_card: ${L4B_CARD_PATH:-not_updated}
+- l4_summary: ${L4_SUMMARY_PATH:-not_updated}
+EOF
+fi

--- a/testing-manual.md
+++ b/testing-manual.md
@@ -144,12 +144,16 @@
 ### L4A synthetic 内部闭环层（Web 为默认）
 - 目标：验证 formal player surface 的真实可用性（加载、交互、状态可见、无 console error），并在此基础上完成 synthetic internal playability review。
 - 默认：agent / QA 在当前 git worktree 内做开发回归时，优先使用 `./scripts/worktree-harness.sh up` 起一套 worktree 隔离 Web 栈；它会为当前 worktree 派生独立端口组、bundle / runtime / artifact 根目录与浏览器 session，并把状态写到 `output/harness/<worktree_id>/state.json`。这一层属于 `L4A synthetic`，可以产出 UI 闭环、subagent review、persona panel 等内部模拟证据。`scripts/run-game-test.sh` 保留为底层 bootstrap，并支持 `--bundle-dir <bundle>` 复用产物入口；当 bundle 缺少 freshness manifest 或已落后于当前工作区源码时，脚本会默认阻断。launcher stack 已不再接受 no-LLM 启动；`--no-llm` 只保留给直接 `oasis7_viewer_live` 观战/调试排障。
+- 完整 `L4` scaffold：先运行 `./scripts/prepare-playability-l4-review.sh --with-l4a-stack`。它会在当前 worktree 自己的 `output/harness/<worktree_id>/artifacts/playability-l4-<timestamp>/` 下生成 `l4-review-packet.md`、`role-review-cards/*.md`、`persona-cards/*.md`、`l4-summary.md`、`commands.sh`、`manifest.json`，并在 `evidence/` 下冻结当前 `L4A` harness state / URL。这个入口继承 formal gameplay 的 active LLM provider preflight；若当前环境缺少 `OASIS7_LLM_MODEL` / 等价 `config.toml`，会在 harness 启动前 fail-fast。
+- 最低完成定义：至少回填 review packet、`producer_system_designer` / `qa_engineer` 角色卡，以及命中的其余角色卡与 persona cards；只跑 harness / S6，不回填这些卡片，不算 `L4A` 完成。
 - 结论边界：这一层可以回答“synthetic 看起来会不会继续玩”，不能直接回答“真人是否真的想继续玩”。
 - native 抓图：仅 fallback（Web 无法复现或 native 图形链路问题）。
 
 ### L4B 结构化真人试玩层
 - 目标：验证真实人类在有时间、耐心和机会成本约束下，是否看得懂、是否感到有杠杆、是否想继续玩。
 - 默认：制作人试玩 / 发布前人工验收优先使用 `./scripts/run-producer-playtest.sh`（需要自动打开浏览器时加 `--open-headed`）；其默认 bundle 根目录也会落到当前 worktree 自己的 `output/harness/<worktree_id>/bundle/` 下。脚本退出后，必须继续填写 `doc/playability_test_result/playability_test_card.md` 或等价正式卡片；只有脚本执行而没有人类主观反馈，不算 `L4B` 完成。
+- 与 `L4A` 的衔接：`./scripts/prepare-playability-l4-review.sh` 会在同一 artifact 目录里复制 `l4b-playability-test-card.md`，并生成可直接执行的 `commands.sh`。若目标是完整 `L4`，应在同一 scaffold 目录同时收口 `L4A` packet / cards、`L4B` 人测卡和最终 `l4-summary.md`。
+- 最低完成定义：脚本实际跑过、真人实际游玩过、`l4b-playability-test-card.md`（或等价正式卡片）已回填，并在 `l4-summary.md` 明确写出 `L4B` verdict；只有启动脚本，没有人类主观反馈或 summary，不算完整 `L4B`。
 - 结论边界：这一层可以回答“真人是否真的想继续玩”，但仍不自动等价于外部市场验证。
 - source-tree `oasis7-run.sh play` 与 `run-game-test.sh` 的 Viewer Web 开发态入口都必须走 freshness gate；当 `crates/oasis7_viewer/index.html`、`software_safe.html`、`software_safe.js`、`package.json`、`package-lock.json`、`vite.software-safe.config.mjs`、`scripts/`、`software_safe_src/` 或相关静态资源比 `dist/` 更新时，默认应优先重建 fresh dist，而不是继续拿 stale `dist` 给 Web 闭环下结论。
 

--- a/testing-manual.md
+++ b/testing-manual.md
@@ -141,11 +141,17 @@
 - 目标：验证共识、网络、复制、存储一致性与恢复链路。
 - 性质：不应缺席；否则“整应用测试”会有明显盲区。
 
-### L4 UI 闭环层（Web 为默认）
-- 目标：验证真实用户路径可用性（加载、交互、状态可见、无 console error）。
-- 默认：agent / QA 在当前 git worktree 内做开发回归时，优先使用 `./scripts/worktree-harness.sh up` 起一套 worktree 隔离 Web 栈；它会为当前 worktree 派生独立端口组、bundle / runtime / artifact 根目录与浏览器 session，并把状态写到 `output/harness/<worktree_id>/state.json`。制作人试玩 / 发布前人工验收仍优先使用 `./scripts/run-producer-playtest.sh`（需要自动打开浏览器时加 `--open-headed`）；其默认 bundle 根目录也会落到当前 worktree 自己的 `output/harness/<worktree_id>/bundle/` 下。`scripts/run-game-test.sh` 保留为底层 bootstrap，并支持 `--bundle-dir <bundle>` 复用产物入口；当 bundle 缺少 freshness manifest 或已落后于当前工作区源码时，脚本会默认阻断，制作人入口则会自动重建。launcher stack 已不再接受 no-LLM 启动；`--no-llm` 只保留给直接 `oasis7_viewer_live` 观战/调试排障。
-- source-tree `oasis7-run.sh play` 与 `run-game-test.sh` 的 Viewer Web 开发态入口都必须走 freshness gate；当 `crates/oasis7_viewer/index.html`、`software_safe.html`、`software_safe.js`、`package.json`、`package-lock.json`、`vite.software-safe.config.mjs`、`scripts/`、`software_safe_src/` 或相关静态资源比 `dist/` 更新时，默认应优先重建 fresh dist，而不是继续拿 stale `dist` 给 Web 闭环下结论。
+### L4A synthetic 内部闭环层（Web 为默认）
+- 目标：验证 formal player surface 的真实可用性（加载、交互、状态可见、无 console error），并在此基础上完成 synthetic internal playability review。
+- 默认：agent / QA 在当前 git worktree 内做开发回归时，优先使用 `./scripts/worktree-harness.sh up` 起一套 worktree 隔离 Web 栈；它会为当前 worktree 派生独立端口组、bundle / runtime / artifact 根目录与浏览器 session，并把状态写到 `output/harness/<worktree_id>/state.json`。这一层属于 `L4A synthetic`，可以产出 UI 闭环、subagent review、persona panel 等内部模拟证据。`scripts/run-game-test.sh` 保留为底层 bootstrap，并支持 `--bundle-dir <bundle>` 复用产物入口；当 bundle 缺少 freshness manifest 或已落后于当前工作区源码时，脚本会默认阻断。launcher stack 已不再接受 no-LLM 启动；`--no-llm` 只保留给直接 `oasis7_viewer_live` 观战/调试排障。
+- 结论边界：这一层可以回答“synthetic 看起来会不会继续玩”，不能直接回答“真人是否真的想继续玩”。
 - native 抓图：仅 fallback（Web 无法复现或 native 图形链路问题）。
+
+### L4B 结构化真人试玩层
+- 目标：验证真实人类在有时间、耐心和机会成本约束下，是否看得懂、是否感到有杠杆、是否想继续玩。
+- 默认：制作人试玩 / 发布前人工验收优先使用 `./scripts/run-producer-playtest.sh`（需要自动打开浏览器时加 `--open-headed`）；其默认 bundle 根目录也会落到当前 worktree 自己的 `output/harness/<worktree_id>/bundle/` 下。脚本退出后，必须继续填写 `doc/playability_test_result/playability_test_card.md` 或等价正式卡片；只有脚本执行而没有人类主观反馈，不算 `L4B` 完成。
+- 结论边界：这一层可以回答“真人是否真的想继续玩”，但仍不自动等价于外部市场验证。
+- source-tree `oasis7-run.sh play` 与 `run-game-test.sh` 的 Viewer Web 开发态入口都必须走 freshness gate；当 `crates/oasis7_viewer/index.html`、`software_safe.html`、`software_safe.js`、`package.json`、`package-lock.json`、`vite.software-safe.config.mjs`、`scripts/`、`software_safe_src/` 或相关静态资源比 `dist/` 更新时，默认应优先重建 fresh dist，而不是继续拿 stale `dist` 给 Web 闭环下结论。
 
 ### L5 长稳与压力层
 - 目标：验证在长时运行/高事件量下系统退化策略和稳定性。
@@ -338,7 +344,7 @@ env -u RUSTC_WRAPPER cargo test -p oasis7_net --features runtime_bridge --lib
   - `--block-remove-signer-id` 可重复使用；当 block manifest 让 `finality signer_count < threshold` 时，默认预期是 `import_policy_reject`
   - 若对 finality slot 复用原 `signer_id`，真实导入会命中 `GovernancePolicyInvalid`，因为 finality signer 绑定到现有 node identity
 
-### S5：Viewer crate 单测与 wasm 编译套件（L4 前置）
+### S5：Viewer crate 单测与 wasm 编译套件（L4A 前置）
 ```bash
 env -u RUSTC_WRAPPER cargo test -p oasis7_viewer
 env -u RUSTC_WRAPPER cargo check -p oasis7_viewer --target wasm32-unknown-unknown
@@ -348,7 +354,7 @@ env -u RUSTC_WRAPPER cargo check -p oasis7_viewer --target wasm32-unknown-unknow
   - 这是 UI 闭环前的稳定性筛网；
   - 该套件已并入 `S1/S2` 的默认 gate。
 
-### S6：Web UI 闭环 smoke 套件（L4）
+### S6：Web UI 闭环 smoke 套件（L4A）
 - S6 详细执行步骤、agent-browser 命令、发布门禁与补充约定已拆分到：
   - `doc/testing/manual/web-ui-agent-browser-closure-manual.manual.md`
   - `doc/testing/manual/web-ui-agent-browser-closure-manual.prd.md`（需求边界/成功标准）
@@ -370,14 +376,14 @@ env -u RUSTC_WRAPPER cargo check -p oasis7_viewer --target wasm32-unknown-unknow
 - `headed` 不是充分条件：若 `browser_env.json` / WebGL renderer 显示 `SwiftShader` 或其他 software renderer，先查看 `window.__AW_TEST__.getState().renderMode`。
   - `renderMode=software_safe`：允许继续做最小闭环验证（连接、选择目标、自然实时推进；若运行态被 blocker 卡住，则要求 blocker 文案显式可见）。
   - `renderMode!=software_safe`：仍按图形环境阻断处理；默认先使用 `--use-angle=gl,--ignore-gpu-blocklist` 固定硬件路径。
-- `oasis7_web_launcher` / launcher Web 控制面：默认优先使用 GUI Agent 驱动产品动作，再用 Web 页面做状态与字段校验；Canvas 直点仅作补充。制作人试玩与发布前人工验收若要进入真实产品路径，优先直接执行 `./scripts/run-producer-playtest.sh`（需要自动打开浏览器时加 `--open-headed`，脚本退出时会自动关闭该浏览器会话）；如需手动控制 bundle，再使用 `<bundle>/run-game.sh` 或 `./scripts/run-game-test.sh --bundle-dir <bundle>` 启动。
+- `oasis7_web_launcher` / launcher Web 控制面：默认优先使用 GUI Agent 驱动产品动作，再用 Web 页面做状态与字段校验；Canvas 直点仅作补充。若目标是 `L4A synthetic`，优先走 harness / Web UI 闭环；若目标是 `L4B human`，优先直接执行 `./scripts/run-producer-playtest.sh`（需要自动打开浏览器时加 `--open-headed`，脚本退出时会自动关闭该浏览器会话），并补齐正式 playability 卡。仅执行脚本不填卡，不算 `L4B` 完成；如需手动控制 bundle，再使用 `<bundle>/run-game.sh` 或 `./scripts/run-game-test.sh --bundle-dir <bundle>` 启动。
 - agent / QA 若只是想在当前 worktree 内起一套隔离回归栈，优先执行 `./scripts/worktree-harness.sh up`，然后通过 `./scripts/worktree-harness.sh url` / `status --json` / `logs` 获取 URL 与状态；`run-game-test.sh` 继续作为该 harness 的底层启动器，不应再被当作并行 worktree 回归的顶层主入口。
 - 不要把 Viewer 页面专用的 `agent-browser` 操作步骤直接套用到 launcher 控制面动作执行上。
 - 涉及 `Explorer / Transfer` 的闭环时，先准备可观测数据，再执行查询与字段断言；不得只以“页面打开了/接口返回 200”判定通过。
 - 防误用约束：
   - `scripts/run-game-test-ab.sh` 仅用于自动化回归哨兵（TTFC/命中率/无进展窗口）；推荐与 `--bundle-dir <bundle>` 搭配做产物态 smoke，但仍不等价于“真实玩家长玩评测”。
 - `run-game-test-ab.sh --headless` 若命中 `SwiftShader` / software renderer，应先确认页面是否已自动切到 `software_safe`；只有未切入 safe-mode 时才按环境阻断处理，不得把 `connectionStatus=connecting` 误判为 fresh Web 构建或玩法回归；Viewer Web 默认继续使用 headed 模式。
-  - 发布前结论仍需补充手动长玩与卡片填写（按 `doc/playability_test_result/game-test.prd.md` 执行）。
+  - 发布前结论仍需补充 `L4B` 手动长玩与卡片填写（按 `doc/playability_test_result/game-test.prd.md` 执行）。
 - 若改动影响前期工业引导（`首个制成品 / 停机恢复 / 首座工厂单元`），必须补跑 `doc/playability_test_result/topics/industrial-onboarding-required-tier-cards-2026-03-15.md` 中对应卡片，并把结论回写正式 playability 卡。
   - 对外样张链路需使用 strict 语义门禁，不得以 `off` / `soft` 结果作为发布判定证据。
 - 若需要为 `#46 PostOnboarding` 补无 UI / 非浏览器验证，执行 `./scripts/viewer-post-onboarding-headless-smoke.sh`。

--- a/testing-manual.md
+++ b/testing-manual.md
@@ -149,17 +149,20 @@
 - 结论边界：这一层可以回答“synthetic 看起来会不会继续玩”，不能直接回答“真人是否真的想继续玩”。
 - native 抓图：仅 fallback（Web 无法复现或 native 图形链路问题）。
 
-### L4B 结构化真人试玩层
-- 目标：验证真实人类在有时间、耐心和机会成本约束下，是否看得懂、是否感到有杠杆、是否想继续玩。
-- 默认：制作人试玩 / 发布前人工验收优先使用 `./scripts/run-producer-playtest.sh`（需要自动打开浏览器时加 `--open-headed`）；其默认 bundle 根目录也会落到当前 worktree 自己的 `output/harness/<worktree_id>/bundle/` 下。脚本退出后，必须继续填写 `doc/playability_test_result/playability_test_card.md` 或等价正式卡片；只有脚本执行而没有人类主观反馈，不算 `L4B` 完成。
-- 与 `L4A` 的衔接：`./scripts/prepare-playability-l4-review.sh` 会在同一 artifact 目录里复制 `l4b-playability-test-card.md`，并生成可直接执行的 `commands.sh`。若目标是完整 `L4`，应在同一 scaffold 目录同时收口 `L4A` packet / cards、`L4B` 人测卡和最终 `l4-summary.md`。
-- 最低完成定义：脚本实际跑过、真人实际游玩过、`l4b-playability-test-card.md`（或等价正式卡片）已回填，并在 `l4-summary.md` 明确写出 `L4B` verdict；只有启动脚本，没有人类主观反馈或 summary，不算完整 `L4B`。
-- 结论边界：这一层可以回答“真人是否真的想继续玩”，但仍不自动等价于外部市场验证。
+### L4B 具身 agent 试玩层
+- 目标：验证 agent 实际进入 formal player surface、执行真实操作链路后，是否表现出可持续继续游玩的行为与可解释的玩家杠杆判断；这一层的设计目标是尽可能逼近真人评审“还想不想继续玩”的判断效果。
+- 默认：agent 试玩优先使用 `./scripts/run-playability-l4b-agent.sh --l4-manifest <artifact>/manifest.json`。它会通过 `./scripts/run-producer-playtest.sh --open-headed` 拉起真实游玩入口、在同一浏览器 session 内执行最小真实操作链路（至少包含一步推进与一次玩法动作提交）、并把状态快照、截图、启动日志路径与 `L4B` summary 落到当前 artifact；只有启动脚本、没有实际 agent play session 与 summary/card 产物，不算 `L4B` 完成。
+- 与 `L4A` 的衔接：`./scripts/prepare-playability-l4-review.sh` 会在同一 artifact 目录里复制 `l4b-agent-playtest-card.md`、生成 `optional-internal-human-corroboration.md`、`manifest.json` 和可直接执行的 `commands.sh`；`commands.sh` 默认调用 `run-playability-l4b-agent.sh` 收口 `L4B` evidence。默认完整 `L4` 至少收口 `L4A` packet / cards、`L4B` agent 卡和最终 `l4-summary.md`；若还需要内部人类校准，只能作为 `L4B` 的可选佐证附录，不新增正式层。
+- 最低完成定义：脚本实际跑过、agent 实际游玩过、`evidence/l4b-agent-*/l4b-agent-summary.json` 与 `l4b-agent-playtest-card.md`（或等价正式卡片）已落盘，并在 `l4-summary.md` 明确写出 `L4B` verdict；只有启动脚本，没有 agent 主动操作或 summary，不算完整 `L4B`。
+- 结论边界：这一层可以回答“agent 在真实操作链路里是否表现出继续玩的倾向”，并应尽量逼近真人评审效果，但仍不能自动等价于 `L5` 真实人类或外部市场验证。
+- 可选内部真人佐证：制作人试玩 / QA headed rerun 仍可沿用 `./scripts/run-producer-playtest.sh`；如执行，必须把结果写入 `optional-internal-human-corroboration.md` 或等价正式卡片，并在 `l4-summary.md` 里明确它是 `L4B` corroboration / contradiction，而不是新层级。只有人类试玩而没有对 `L4B` 的对照说明，不算合格佐证。
 - source-tree `oasis7-run.sh play` 与 `run-game-test.sh` 的 Viewer Web 开发态入口都必须走 freshness gate；当 `crates/oasis7_viewer/index.html`、`software_safe.html`、`software_safe.js`、`package.json`、`package-lock.json`、`vite.software-safe.config.mjs`、`scripts/`、`software_safe_src/` 或相关静态资源比 `dist/` 更新时，默认应优先重建 fresh dist，而不是继续拿 stale `dist` 给 Web 闭环下结论。
 
-### L5 长稳与压力层
-- 目标：验证在长时运行/高事件量下系统退化策略和稳定性。
-- 入口：`viewer-owr4-stress.sh`、`llm-longrun-stress.sh`。
+### L5 真实人类 / 受控线上验证层
+- 目标：验证真实人类或受控外部玩家在真实时间、注意力和机会成本约束下，是否仍愿意继续玩；这是 `L4B` 之上的正式验证层。
+- 入口：limited preview、liveops 反馈回流、真实玩家 session、受控人工试玩样本。
+- 结论边界：只有到这一层，才能正式回答“真实人类/真实环境里是否仍想继续玩”；内部真人 spot-check 仍只算 `L4B` 的可选校准，不单列新层。
+- 说明：长稳、压力和 soak 仍属于测试套件层（如 S8/S10），不是这里的 playability `L5`。
 
 ## 测试套件目录（S0~S10）
 
@@ -380,14 +383,14 @@ env -u RUSTC_WRAPPER cargo check -p oasis7_viewer --target wasm32-unknown-unknow
 - `headed` 不是充分条件：若 `browser_env.json` / WebGL renderer 显示 `SwiftShader` 或其他 software renderer，先查看 `window.__AW_TEST__.getState().renderMode`。
   - `renderMode=software_safe`：允许继续做最小闭环验证（连接、选择目标、自然实时推进；若运行态被 blocker 卡住，则要求 blocker 文案显式可见）。
   - `renderMode!=software_safe`：仍按图形环境阻断处理；默认先使用 `--use-angle=gl,--ignore-gpu-blocklist` 固定硬件路径。
-- `oasis7_web_launcher` / launcher Web 控制面：默认优先使用 GUI Agent 驱动产品动作，再用 Web 页面做状态与字段校验；Canvas 直点仅作补充。若目标是 `L4A synthetic`，优先走 harness / Web UI 闭环；若目标是 `L4B human`，优先直接执行 `./scripts/run-producer-playtest.sh`（需要自动打开浏览器时加 `--open-headed`，脚本退出时会自动关闭该浏览器会话），并补齐正式 playability 卡。仅执行脚本不填卡，不算 `L4B` 完成；如需手动控制 bundle，再使用 `<bundle>/run-game.sh` 或 `./scripts/run-game-test.sh --bundle-dir <bundle>` 启动。
+- `oasis7_web_launcher` / launcher Web 控制面：默认优先使用 GUI Agent 驱动产品动作，再用 Web 页面做状态与字段校验；Canvas 直点仅作补充。若目标是 `L4A synthetic`，优先走 harness / Web UI 闭环；若目标是 `L4B embodied-agent`，优先执行 `./scripts/run-playability-l4b-agent.sh --l4-manifest <artifact>/manifest.json`，由它内部调用 `./scripts/run-producer-playtest.sh --open-headed` 并自动采集证据，再审阅/补齐 `l4b-agent-playtest-card.md`。若需要内部人类 spot-check，只能沿用同一入口并把结果写进 `optional-internal-human-corroboration.md` 或等价正式卡片，作为 `L4B` 校准附录。仅执行启动脚本、不产出 `L4B` summary/card，不算 `L4B` 完成；如需手动控制 bundle，再使用 `<bundle>/run-game.sh` 或 `./scripts/run-game-test.sh --bundle-dir <bundle>` 启动。
 - agent / QA 若只是想在当前 worktree 内起一套隔离回归栈，优先执行 `./scripts/worktree-harness.sh up`，然后通过 `./scripts/worktree-harness.sh url` / `status --json` / `logs` 获取 URL 与状态；`run-game-test.sh` 继续作为该 harness 的底层启动器，不应再被当作并行 worktree 回归的顶层主入口。
 - 不要把 Viewer 页面专用的 `agent-browser` 操作步骤直接套用到 launcher 控制面动作执行上。
 - 涉及 `Explorer / Transfer` 的闭环时，先准备可观测数据，再执行查询与字段断言；不得只以“页面打开了/接口返回 200”判定通过。
 - 防误用约束：
   - `scripts/run-game-test-ab.sh` 仅用于自动化回归哨兵（TTFC/命中率/无进展窗口）；推荐与 `--bundle-dir <bundle>` 搭配做产物态 smoke，但仍不等价于“真实玩家长玩评测”。
 - `run-game-test-ab.sh --headless` 若命中 `SwiftShader` / software renderer，应先确认页面是否已自动切到 `software_safe`；只有未切入 safe-mode 时才按环境阻断处理，不得把 `connectionStatus=connecting` 误判为 fresh Web 构建或玩法回归；Viewer Web 默认继续使用 headed 模式。
-  - 发布前结论仍需补充 `L4B` 手动长玩与卡片填写（按 `doc/playability_test_result/game-test.prd.md` 执行）。
+  - 发布前若只要求 agent 可执行闭环，至少补齐 `L4B` agent 试玩与卡片填写；若要对“真实人类是否想继续玩”下结论，必须进入 `L5` 的真人 / 受控线上样本，内部真人试玩只能作为 `L4B` 的可选校准。
 - 若改动影响前期工业引导（`首个制成品 / 停机恢复 / 首座工厂单元`），必须补跑 `doc/playability_test_result/topics/industrial-onboarding-required-tier-cards-2026-03-15.md` 中对应卡片，并把结论回写正式 playability 卡。
   - 对外样张链路需使用 strict 语义门禁，不得以 `off` / `soft` 结果作为发布判定证据。
 - 若需要为 `#46 PostOnboarding` 补无 UI / 非浏览器验证，执行 `./scripts/viewer-post-onboarding-headless-smoke.sh`。


### PR DESCRIPTION
Collapses the prior stacked playability follow-ups into one retained branch, and carries the runtime/code work needed to make the L4B path runnable on the same PR head.

Scope included in this PR:
- playability evidence stack
- role-based subagent review system
- simulated player persona panel
- L4 synthetic vs embodied-agent split
- runnable L4B embodied-agent execution path and launcher/viewer bootstrap fixes needed to produce real evidence
- integer-centimeter GeoPos/runtime follow-through, including legacy snapshot compatibility guards and related runtime/test updates already stacked on this branch

This replaces the stacked follow-up PRs #187, #188, and #192.