### PR TITLE
fix: recover oasis7_node issue 182 replication lib regressions

### DIFF
--- a/.pm/tasks/task_b4c03075497348cfbcf30fcb4c970226.execution.md
+++ b/.pm/tasks/task_b4c03075497348cfbcf30fcb4c970226.execution.md
@@ -1,0 +1,18 @@
+# task_b4c03075497348cfbcf30fcb4c970226 Execution Log
+
+- task_uid: task_b4c03075497348cfbcf30fcb4c970226
+- title: repair oasis7_node replication lib regressions from issue 182
+- owner_role: runtime_engineer
+- worktree_hint: /home/scc/worktrees/oasis7-p2p-issue-182-replication-lib-regressions
+
+<!-- Append entries using:
+Example:
+  ## YYYY-MM-DD HH:MM:SS CST / role_name
+  - 完成内容: ...
+  - 遗留事项: ...
+-->
+## 2026-05-13 22:02:02 CST / runtime_engineer
+- 完成内容: 修复 `NodeRuntime::stop()` 未释放 `gossip_endpoint` 导致同一 runtime 对象二次启动时 UDP 端口仍被占用的问题；stop 完成后现在会主动丢弃 endpoint，`runtime_gossip_replication_persists_guard_across_restart` 已恢复通过。
+- 完成内容: 对齐 `#182` 中两条已与当前 contract 偏离的测试假设：`runtime_network_replication_respects_topic_isolation` 现在显式关闭 replication-network consensus，只验证 replication topic 隔离本身；`runtime_fetch_handlers_reject_unsigned_fetch_request_in_signed_mode` 改为使用允许 `Serve` sync lane 的 `Storage` 角色，继续验证 signed fetch handler 会拒绝 unsigned 请求。
+- 完成内容: 已完成 `env -u RUSTC_WRAPPER cargo test -p oasis7_node runtime_network_replication_respects_topic_isolation -- --nocapture`、`env -u RUSTC_WRAPPER cargo test -p oasis7_node runtime_fetch_handlers_reject_unsigned_fetch_request_in_signed_mode -- --nocapture`、`env -u RUSTC_WRAPPER cargo test -p oasis7_node runtime_gossip_replication_persists_guard_across_restart -- --nocapture` 与 `env -u RUSTC_WRAPPER cargo test -p oasis7_node --lib`，当前 `oasis7_node --lib` 为 `209 passed; 0 failed`。
+- 遗留事项: 需继续执行文档门禁 / diff 校验、完成 commit 与 PR 收口。

--- a/.pm/tasks/task_b4c03075497348cfbcf30fcb4c970226.execution.md
+++ b/.pm/tasks/task_b4c03075497348cfbcf30fcb4c970226.execution.md
@@ -16,3 +16,9 @@ Example:
 - 完成内容: 对齐 `#182` 中两条已与当前 contract 偏离的测试假设：`runtime_network_replication_respects_topic_isolation` 现在显式关闭 replication-network consensus，只验证 replication topic 隔离本身；`runtime_fetch_handlers_reject_unsigned_fetch_request_in_signed_mode` 改为使用允许 `Serve` sync lane 的 `Storage` 角色，继续验证 signed fetch handler 会拒绝 unsigned 请求。
 - 完成内容: 已完成 `env -u RUSTC_WRAPPER cargo test -p oasis7_node runtime_network_replication_respects_topic_isolation -- --nocapture`、`env -u RUSTC_WRAPPER cargo test -p oasis7_node runtime_fetch_handlers_reject_unsigned_fetch_request_in_signed_mode -- --nocapture`、`env -u RUSTC_WRAPPER cargo test -p oasis7_node runtime_gossip_replication_persists_guard_across_restart -- --nocapture` 与 `env -u RUSTC_WRAPPER cargo test -p oasis7_node --lib`，当前 `oasis7_node --lib` 为 `209 passed; 0 failed`。
 - 遗留事项: 需继续执行文档门禁 / diff 校验、完成 commit 与 PR 收口。
+
+## 2026-05-13 22:32:02 CST / runtime_engineer
+- 完成内容: 处理 PR `#216` review comments：移除 `doc/p2p/project.md` 中重复的 `git diff --check` 验证命令，并修复 `NodeRuntime::stop()` 在 `worker.join()` 失败时提前返回、遗漏 `gossip_endpoint` 与 `running` 清理的问题。
+- 完成内容: 新增 `runtime_stop_cleans_up_after_worker_join_failure` 回归测试，验证 worker panic 后 `stop()` 仍会释放 UDP 端口并允许后续 runtime 重新绑定；同时把 `runtime_gossip_replication_with_signature_applies_files` 从固定 `220ms` 睡眠改为带截止时间的落盘轮询，消除全量 `--lib` 下的偶发失败。
+- 完成内容: 已完成 `./scripts/doc-governance-check.sh`、`git diff --check` 与 `env -u RUSTC_WRAPPER cargo test -p oasis7_node --lib`，当前 `oasis7_node --lib` 为 `210 passed; 0 failed`。
+- 遗留事项: 需提交 comment fix commit、push 分支并 resolve PR review threads。

--- a/.pm/tasks/task_b4c03075497348cfbcf30fcb4c970226.yaml
+++ b/.pm/tasks/task_b4c03075497348cfbcf30fcb4c970226.yaml
@@ -1,0 +1,27 @@
+task_uid: task_b4c03075497348cfbcf30fcb4c970226
+title: "repair oasis7_node replication lib regressions from issue 182"
+owner_role: runtime_engineer
+worktree_hint: /home/scc/worktrees/oasis7-p2p-issue-182-replication-lib-regressions
+execution_log_path: .pm/tasks/task_b4c03075497348cfbcf30fcb4c970226.execution.md
+status: done
+priority: P2
+source_signal: null
+source_refs:
+  - doc/p2p/prd.md
+  - doc/p2p/project.md
+  - crates/oasis7_node/src/tests_storage_replication.rs
+  - crates/oasis7_node/src/tests_hardening.rs
+  - crates/oasis7_node/src/tests/non_sequencer_followers.rs
+doc_refs: []
+related_prd:
+  - PRD-P2P-001
+  - PRD-P2P-003
+acceptance:
+  - "env -u RUSTC_WRAPPER cargo test -p oasis7_node runtime_network_replication_respects_topic_isolation -- --nocapture passes"
+  - "env -u RUSTC_WRAPPER cargo test -p oasis7_node runtime_fetch_handlers_reject_unsigned_fetch_request_in_signed_mode -- --nocapture passes"
+  - "env -u RUSTC_WRAPPER cargo test -p oasis7_node runtime_gossip_replication_persists_guard_across_restart -- --nocapture passes"
+  - "env -u RUSTC_WRAPPER cargo test -p oasis7_node --lib passes"
+handoff_to: []
+updated_at: 2026-05-13T22:04:57+08:00
+last_started_at: 2026-05-13T21:57:14+08:00
+last_closed_at: 2026-05-13T22:04:57+08:00

--- a/crates/oasis7_node/src/lib.rs
+++ b/crates/oasis7_node/src/lib.rs
@@ -632,6 +632,7 @@ impl NodeRuntime {
                 node_id: self.config.node_id.clone(),
             })?;
         }
+        self.gossip_endpoint = None;
         self.running.store(false, Ordering::SeqCst);
         Ok(())
     }

--- a/crates/oasis7_node/src/lib.rs
+++ b/crates/oasis7_node/src/lib.rs
@@ -627,14 +627,18 @@ impl NodeRuntime {
         if let Some(stop_tx) = self.stop_tx.take() {
             let _ = stop_tx.send(());
         }
-        if let Some(worker) = self.worker.take() {
+        let join_result = if let Some(worker) = self.worker.take() {
             worker.join().map_err(|_| NodeError::ThreadJoinFailed {
                 node_id: self.config.node_id.clone(),
-            })?;
-        }
+            })
+        } else {
+            Ok(())
+        };
+        // Always drop the bound gossip socket and clear the runtime flag, even if the
+        // worker thread already panicked and `join` surfaces an error.
         self.gossip_endpoint = None;
         self.running.store(false, Ordering::SeqCst);
-        Ok(())
+        join_result
     }
 
     pub fn snapshot(&self) -> NodeSnapshot {

--- a/crates/oasis7_node/src/tests/non_sequencer_followers.rs
+++ b/crates/oasis7_node/src/tests/non_sequencer_followers.rs
@@ -52,12 +52,15 @@ fn runtime_network_replication_respects_topic_isolation() {
             NodeReplicationNetworkHandle::new(Arc::clone(&network))
                 .with_topic("aw.world-topic-repl.replication.a")
                 .expect("topic a"),
-        );
-    let mut runtime_b = NodeRuntime::new(config_b).with_replication_network(
-        NodeReplicationNetworkHandle::new(Arc::clone(&network))
-            .with_topic("aw.world-topic-repl.replication.b")
-            .expect("topic b"),
-    );
+        )
+        .with_replication_network_consensus_enabled(false);
+    let mut runtime_b = NodeRuntime::new(config_b)
+        .with_replication_network(
+            NodeReplicationNetworkHandle::new(Arc::clone(&network))
+                .with_topic("aw.world-topic-repl.replication.b")
+                .expect("topic b"),
+        )
+        .with_replication_network_consensus_enabled(false);
     runtime_a.start().expect("start a");
     runtime_b.start().expect("start b");
     thread::sleep(Duration::from_millis(220));

--- a/crates/oasis7_node/src/tests_hardening.rs
+++ b/crates/oasis7_node/src/tests_hardening.rs
@@ -648,7 +648,7 @@ fn runtime_fetch_handlers_reject_unsigned_fetch_request_in_signed_mode() {
         dyn oasis7_proto::distributed_net::DistributedNetwork<WorldError> + Send + Sync,
     > = Arc::new(TestInMemoryNetwork::default());
 
-    let config = NodeConfig::new("node-a", world_id, NodeRole::Observer)
+    let config = NodeConfig::new("node-a", world_id, NodeRole::Storage)
         .expect("config")
         .with_tick_interval(Duration::from_millis(10))
         .expect("tick")

--- a/crates/oasis7_node/src/tests_pos_engine_guardrails.rs
+++ b/crates/oasis7_node/src/tests_pos_engine_guardrails.rs
@@ -1,5 +1,19 @@
 use super::*;
 
+struct PanicExecutionHook {
+    called: Arc<std::sync::atomic::AtomicBool>,
+}
+
+impl NodeExecutionHook for PanicExecutionHook {
+    fn on_commit(
+        &mut self,
+        _context: NodeExecutionCommitContext,
+    ) -> Result<NodeExecutionCommitResult, String> {
+        self.called.store(true, std::sync::atomic::Ordering::SeqCst);
+        panic!("panic execution hook");
+    }
+}
+
 #[test]
 fn pos_engine_commits_single_validator_head() {
     let config = NodeConfig::new("node-a", "world-a", NodeRole::Observer).expect("config");
@@ -447,4 +461,44 @@ fn runtime_start_and_stop_updates_snapshot() {
     let stopped = runtime.snapshot();
     assert!(!stopped.running);
     assert!(stopped.tick_count >= running.tick_count);
+}
+
+#[test]
+fn runtime_stop_cleans_up_after_worker_join_failure() {
+    let socket = UdpSocket::bind("127.0.0.1:0").expect("bind socket");
+    let addr = socket.local_addr().expect("addr");
+    drop(socket);
+
+    let called = Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let config = NodeConfig::new("node-a", "world-join-failure", NodeRole::Observer)
+        .expect("config")
+        .with_tick_interval(Duration::from_millis(10))
+        .expect("tick interval")
+        .with_gossip_optional(addr, Vec::new());
+    let mut runtime = NodeRuntime::new(config).with_execution_hook(PanicExecutionHook {
+        called: Arc::clone(&called),
+    });
+    runtime.start().expect("start");
+
+    let hook_panicked = wait_until(Instant::now() + Duration::from_secs(1), || {
+        called.load(std::sync::atomic::Ordering::SeqCst)
+    });
+    assert!(hook_panicked, "execution hook did not run before stop");
+
+    let err = runtime
+        .stop()
+        .expect_err("stop should surface thread join failure");
+    assert!(matches!(err, NodeError::ThreadJoinFailed { .. }));
+    assert!(!runtime.snapshot().running);
+
+    let config_retry = NodeConfig::new("node-b", "world-join-failure", NodeRole::Observer)
+        .expect("retry config")
+        .with_tick_interval(Duration::from_millis(10))
+        .expect("retry tick interval")
+        .with_gossip_optional(addr, Vec::new());
+    let mut retry_runtime = NodeRuntime::new(config_retry);
+    retry_runtime
+        .start()
+        .expect("start retry runtime on released socket");
+    retry_runtime.stop().expect("stop retry runtime");
 }

--- a/crates/oasis7_node/src/tests_storage_replication.rs
+++ b/crates/oasis7_node/src/tests_storage_replication.rs
@@ -521,16 +521,26 @@ fn runtime_gossip_replication_with_signature_applies_files() {
     let mut runtime_b = NodeRuntime::new(config_b);
     runtime_a.start().expect("start a");
     runtime_b.start().expect("start b");
-    thread::sleep(Duration::from_millis(220));
+
+    let store_b = LocalCasStore::new(dir_b.join("store"));
+    let replicated = wait_until(Instant::now() + Duration::from_secs(3), || {
+        store_b
+            .list_files()
+            .map(|files| {
+                files
+                    .iter()
+                    .any(|item| item.path.starts_with("consensus/commits/"))
+            })
+            .unwrap_or(false)
+    });
+    let files = store_b.list_files().expect("list files");
+    assert!(
+        replicated,
+        "expected signed gossip replication to apply commit files, got {files:?}"
+    );
 
     runtime_a.stop().expect("stop a");
     runtime_b.stop().expect("stop b");
-
-    let store_b = LocalCasStore::new(dir_b.join("store"));
-    let files = store_b.list_files().expect("list files");
-    assert!(files
-        .iter()
-        .any(|item| item.path.starts_with("consensus/commits/")));
 
     let _ = fs::remove_dir_all(&dir_a);
     let _ = fs::remove_dir_all(&dir_b);

--- a/doc/p2p/project.md
+++ b/doc/p2p/project.md
@@ -688,6 +688,20 @@
     - `env -u RUSTC_WRAPPER cargo test -p oasis7_node libp2p_replication_network -- --nocapture`
     - `./scripts/doc-governance-check.sh`
     - `./scripts/check-rust-file-size.sh`
+- [x] issue-182-replication-lib-regressions (PRD-P2P-001/003) [test_tier_required]: 修复 GitHub issue `#182` 中剩余的 `oasis7_node --lib` regression，收口 gossip restart socket 释放、replication topic isolation 测试边界与 signed fetch handler 测试角色假设，恢复 `oasis7_node --lib` 全绿。 Trace: .pm/tasks/task_b4c03075497348cfbcf30fcb4c970226.yaml
+  - 产物文件:
+    - `crates/oasis7_node/src/lib.rs`
+    - `crates/oasis7_node/src/tests/non_sequencer_followers.rs`
+    - `crates/oasis7_node/src/tests_hardening.rs`
+    - `doc/p2p/project.md`
+    - `.pm/tasks/task_b4c03075497348cfbcf30fcb4c970226.execution.md`
+  - 验收命令 (`test_tier_required`):
+    - `env -u RUSTC_WRAPPER cargo test -p oasis7_node runtime_network_replication_respects_topic_isolation -- --nocapture`
+    - `env -u RUSTC_WRAPPER cargo test -p oasis7_node runtime_fetch_handlers_reject_unsigned_fetch_request_in_signed_mode -- --nocapture`
+    - `env -u RUSTC_WRAPPER cargo test -p oasis7_node runtime_gossip_replication_persists_guard_across_restart -- --nocapture`
+    - `env -u RUSTC_WRAPPER cargo test -p oasis7_node --lib`
+    - `./scripts/doc-governance-check.sh`
+    - `git diff --check`
     - `git diff --check`
 
 ## 依赖

--- a/doc/p2p/project.md
+++ b/doc/p2p/project.md
@@ -702,7 +702,6 @@
     - `env -u RUSTC_WRAPPER cargo test -p oasis7_node --lib`
     - `./scripts/doc-governance-check.sh`
     - `git diff --check`
-    - `git diff --check`
 
 ## 依赖
 - 模块设计总览：`doc/p2p/design.md`


### PR DESCRIPTION
## Summary
Closes #182.

- release the retained gossip endpoint on `NodeRuntime::stop()` so restart-in-place no longer keeps the UDP socket bound
- align the topic-isolation regression test with the current replication-only boundary by disabling replication-network consensus in that test
- align the signed fetch-handler regression test with the current lane policy by using a role that is allowed to serve sync requests

## Testing
- `env -u RUSTC_WRAPPER cargo test -p oasis7_node runtime_network_replication_respects_topic_isolation -- --nocapture`
- `env -u RUSTC_WRAPPER cargo test -p oasis7_node runtime_fetch_handlers_reject_unsigned_fetch_request_in_signed_mode -- --nocapture`
- `env -u RUSTC_WRAPPER cargo test -p oasis7_node runtime_gossip_replication_persists_guard_across_restart -- --nocapture`
- `env -u RUSTC_WRAPPER cargo test -p oasis7_node --lib`
- `./scripts/doc-governance-check.sh`
- `git diff --check`
