### PR TITLE
Fix player goal execution causality surface

### DIFF
--- a/.pm/tasks/task_b3a14c16dbf04258865c10c80a9fa460.execution.md
+++ b/.pm/tasks/task_b3a14c16dbf04258865c10c80a9fa460.execution.md
@@ -1,0 +1,20 @@
+# task_b3a14c16dbf04258865c10c80a9fa460 Execution Log
+
+- task_uid: task_b3a14c16dbf04258865c10c80a9fa460
+- title: issue 161 action causality blocker taxonomy
+- owner_role: viewer_engineer
+- worktree_hint: /home/scc/worktrees/oasis7-game-issue-161-action-causality-blocker-taxonomy
+
+<!-- Append entries using:
+Example:
+  ## YYYY-MM-DD HH:MM:SS CST / role_name
+  - 完成内容: ...
+  - 遗留事项: ...
+-->
+
+## 2026-05-14 09:08:21 CST / viewer_engineer
+- 完成内容: 将玩家目标反馈的统一执行状态机与因果分类下沉到 canonical `player_gameplay` snapshot，新增 `execution_state` / `causality_kind` / `causality_detail` 合同字段；在 `software_safe` 正式 Web 主入口新增 `Goal Execution` 卡片，显式区分 `world_constraint` 与 `agent_override`。
+- 完成内容: 用 runtime event 驱动补齐 `agent_override` 回归链路，新增 Rust snapshot test 断言 `RuleDecisionRecorded`/`ActionOverridden` 会进入 canonical snapshot，并同步更新前端 contract test 与 UI fixture。
+- 验证: `rtk node crates/oasis7_viewer/scripts/software-safe-feedback-contract.test.mjs`
+- 验证: `rtk env -u RUSTC_WRAPPER cargo test -p oasis7 viewer::runtime_live::tests::snapshot_progress -- --nocapture`
+- 遗留事项: `crates/oasis7_viewer` 本地 `vitest` 依赖尚未就绪，`rtk npm run test:ui -- --runInBand software_safe_src/main.test.jsx` 之前报 `vitest: not found`；本次先以 Rust snapshot + viewer contract tests 作为 required-tier 证据。

--- a/.pm/tasks/task_b3a14c16dbf04258865c10c80a9fa460.execution.md
+++ b/.pm/tasks/task_b3a14c16dbf04258865c10c80a9fa460.execution.md
@@ -17,4 +17,14 @@ Example:
 - 完成内容: 用 runtime event 驱动补齐 `agent_override` 回归链路，新增 Rust snapshot test 断言 `RuleDecisionRecorded`/`ActionOverridden` 会进入 canonical snapshot，并同步更新前端 contract test 与 UI fixture。
 - 验证: `rtk node crates/oasis7_viewer/scripts/software-safe-feedback-contract.test.mjs`
 - 验证: `rtk env -u RUSTC_WRAPPER cargo test -p oasis7 viewer::runtime_live::tests::snapshot_progress -- --nocapture`
-- 遗留事项: `crates/oasis7_viewer` 本地 `vitest` 依赖尚未就绪，`rtk npm run test:ui -- --runInBand software_safe_src/main.test.jsx` 之前报 `vitest: not found`；本次先以 Rust snapshot + viewer contract tests 作为 required-tier 证据。
+- 遗留事项: 初次本地收口时 `crates/oasis7_viewer` 的 `vitest` 依赖未就绪，UI 单测当时尚未跑通；后续已在同一 task 中补执行 `rtk npm ci`、UI 单测与 `required` 定向门禁，见下一个条目。
+
+## 2026-05-14 10:01:16 CST / viewer_engineer
+- 完成内容: 根据 PR review comments 修正四个一致性缺口：按整次 control request 累积 runtime events、在写回最新 gameplay feedback 后补发最终 snapshot、为 legacy `player_gameplay.execution_state` 增加反序列化回填、并让 `software_safe` 的 empty-entity guard 同时强制 `execution_state=blocked`。
+- 完成内容: 回写 formal bundle 与测试，避免 source / bundle 与 task log / PR 验证口径不一致。
+- 验证: `rtk env -u RUSTC_WRAPPER cargo test -p oasis7 viewer::runtime_live::tests::snapshot_progress -- --nocapture`
+- 验证: `rtk env -u RUSTC_WRAPPER cargo test -p oasis7 simulator::tests::persist -- --nocapture`
+- 验证: `rtk node crates/oasis7_viewer/scripts/software-safe-feedback-contract.test.mjs`
+- 验证: `rtk npm run test:ui -- software_safe_src/main.test.jsx`
+- 验证: `rtk env OASIS7_CI_RUN_OASIS7_REQUIRED_TESTS=true OASIS7_CI_RUN_CONSENSUS_TESTS=false OASIS7_CI_RUN_DISTFS_TESTS=false OASIS7_CI_RUN_VIEWER_CONTRACT_TESTS=true OASIS7_CI_RUN_VIEWER_WASM_CHECK=true OASIS7_CI_RUN_LAUNCHER_WEB_BUILD=true ./scripts/ci-tests.sh required`
+- 遗留事项: 无新的本地验证阻塞；后续只剩 GitHub review thread 关闭与 PR 审批/required checks 正常收口。

--- a/.pm/tasks/task_b3a14c16dbf04258865c10c80a9fa460.yaml
+++ b/.pm/tasks/task_b3a14c16dbf04258865c10c80a9fa460.yaml
@@ -1,0 +1,23 @@
+task_uid: task_b3a14c16dbf04258865c10c80a9fa460
+title: "issue 161 action causality blocker taxonomy"
+owner_role: viewer_engineer
+worktree_hint: /home/scc/worktrees/oasis7-game-issue-161-action-causality-blocker-taxonomy
+execution_log_path: .pm/tasks/task_b3a14c16dbf04258865c10c80a9fa460.execution.md
+status: done
+priority: P2
+source_signal: null
+source_refs:
+  - doc/game/project.md
+  - doc/game/gameplay/gameplay-top-level-design.prd.md
+  - doc/game/gameplay/gameplay-micro-loop-feedback-visibility-2026-03-05.prd.md
+doc_refs: []
+related_prd:
+  - PRD-GAME-012
+acceptance:
+  - "Canonical player surface exposes a unified goal execution state machine for player-issued goals."
+  - "Failure reasons stay inside a small blocker taxonomy with actionable next steps."
+  - "Player can distinguish agent choice override from world constraint blockage."
+handoff_to: []
+updated_at: 2026-05-14T09:11:06+08:00
+last_started_at: 2026-05-13T22:28:21+08:00
+last_closed_at: 2026-05-14T09:11:06+08:00

--- a/crates/oasis7/src/simulator/mod.rs
+++ b/crates/oasis7/src/simulator/mod.rs
@@ -106,9 +106,10 @@ pub use native_resolution::{
 };
 pub use persist::{
     PersistError, PlayerAgentClaimOwnedSnapshot, PlayerAgentClaimQuoteSnapshot,
-    PlayerAgentClaimSnapshot, PlayerGameplayAction, PlayerGameplayGoalKind,
-    PlayerGameplayRecentFeedback, PlayerGameplaySnapshot, PlayerGameplayStageId,
-    PlayerGameplayStageStatus, WorldJournal, WorldSnapshot,
+    PlayerAgentClaimSnapshot, PlayerGameplayAction, PlayerGameplayCausalityKind,
+    PlayerGameplayExecutionState, PlayerGameplayGoalKind, PlayerGameplayRecentFeedback,
+    PlayerGameplaySnapshot, PlayerGameplayStageId, PlayerGameplayStageStatus, WorldJournal,
+    WorldSnapshot,
 };
 #[cfg(not(target_arch = "wasm32"))]
 pub use provider_loopback_adapter::ProviderLoopbackAdapter;

--- a/crates/oasis7/src/simulator/persist.rs
+++ b/crates/oasis7/src/simulator/persist.rs
@@ -70,6 +70,26 @@ pub enum PlayerGameplayGoalKind {
     ChooseMidLoopPath,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PlayerGameplayExecutionState {
+    Accepted,
+    Executing,
+    Blocked,
+    Completed,
+    Rejected,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PlayerGameplayCausalityKind {
+    QueuedForExecution,
+    WorldConstraint,
+    AgentOverride,
+    GoalProgressed,
+    RequestRejected,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PlayerGameplayAction {
     pub action_id: String,
@@ -174,6 +194,7 @@ pub struct PlayerAgentClaimSnapshot {
 pub struct PlayerGameplaySnapshot {
     pub stage_id: PlayerGameplayStageId,
     pub stage_status: PlayerGameplayStageStatus,
+    pub execution_state: PlayerGameplayExecutionState,
     pub goal_id: String,
     pub goal_kind: PlayerGameplayGoalKind,
     pub goal_title: String,
@@ -186,6 +207,10 @@ pub struct PlayerGameplaySnapshot {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub blocker_detail: Option<String>,
     pub next_step_hint: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub causality_kind: Option<PlayerGameplayCausalityKind>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub causality_detail: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub branch_hint: Option<String>,
     #[serde(default)]

--- a/crates/oasis7/src/simulator/persist.rs
+++ b/crates/oasis7/src/simulator/persist.rs
@@ -1,7 +1,7 @@
 //! Persistence utilities: WorldSnapshot, WorldJournal, and error types.
 
 use serde::de::DeserializeOwned;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use std::fs;
 use std::io;
 use std::path::Path;
@@ -190,7 +190,7 @@ pub struct PlayerAgentClaimSnapshot {
     pub owned_claims: Vec<PlayerAgentClaimOwnedSnapshot>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct PlayerGameplaySnapshot {
     pub stage_id: PlayerGameplayStageId,
     pub stage_status: PlayerGameplayStageStatus,
@@ -219,6 +219,93 @@ pub struct PlayerGameplaySnapshot {
     pub recent_feedback: Option<PlayerGameplayRecentFeedback>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub agent_claim: Option<PlayerAgentClaimSnapshot>,
+}
+
+#[derive(Deserialize)]
+struct PlayerGameplaySnapshotSerde {
+    stage_id: PlayerGameplayStageId,
+    stage_status: PlayerGameplayStageStatus,
+    #[serde(default)]
+    execution_state: Option<PlayerGameplayExecutionState>,
+    goal_id: String,
+    goal_kind: PlayerGameplayGoalKind,
+    goal_title: String,
+    objective: String,
+    progress_detail: String,
+    #[serde(default)]
+    progress_percent: u8,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    blocker_kind: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    blocker_detail: Option<String>,
+    next_step_hint: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    causality_kind: Option<PlayerGameplayCausalityKind>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    causality_detail: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    branch_hint: Option<String>,
+    #[serde(default)]
+    available_actions: Vec<PlayerGameplayAction>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    recent_feedback: Option<PlayerGameplayRecentFeedback>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    agent_claim: Option<PlayerAgentClaimSnapshot>,
+}
+
+fn derive_legacy_execution_state(
+    stage_status: PlayerGameplayStageStatus,
+    recent_feedback: Option<&PlayerGameplayRecentFeedback>,
+) -> PlayerGameplayExecutionState {
+    if let Some(feedback) = recent_feedback {
+        match feedback.stage.as_str() {
+            "accepted" | "submitted" | "queued" | "ack" => {
+                return PlayerGameplayExecutionState::Accepted;
+            }
+            "rejected" => return PlayerGameplayExecutionState::Rejected,
+            "blocked" | "completed_no_progress" => return PlayerGameplayExecutionState::Blocked,
+            "completed_advanced" => return PlayerGameplayExecutionState::Completed,
+            _ => {}
+        }
+    }
+
+    match stage_status {
+        PlayerGameplayStageStatus::Blocked => PlayerGameplayExecutionState::Blocked,
+        PlayerGameplayStageStatus::BranchReady => PlayerGameplayExecutionState::Completed,
+        PlayerGameplayStageStatus::Active => PlayerGameplayExecutionState::Executing,
+    }
+}
+
+impl<'de> Deserialize<'de> for PlayerGameplaySnapshot {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let legacy = PlayerGameplaySnapshotSerde::deserialize(deserializer)?;
+        let execution_state = legacy.execution_state.unwrap_or_else(|| {
+            derive_legacy_execution_state(legacy.stage_status, legacy.recent_feedback.as_ref())
+        });
+        Ok(Self {
+            stage_id: legacy.stage_id,
+            stage_status: legacy.stage_status,
+            execution_state,
+            goal_id: legacy.goal_id,
+            goal_kind: legacy.goal_kind,
+            goal_title: legacy.goal_title,
+            objective: legacy.objective,
+            progress_detail: legacy.progress_detail,
+            progress_percent: legacy.progress_percent,
+            blocker_kind: legacy.blocker_kind,
+            blocker_detail: legacy.blocker_detail,
+            next_step_hint: legacy.next_step_hint,
+            causality_kind: legacy.causality_kind,
+            causality_detail: legacy.causality_detail,
+            branch_hint: legacy.branch_hint,
+            available_actions: legacy.available_actions,
+            recent_feedback: legacy.recent_feedback,
+            agent_claim: legacy.agent_claim,
+        })
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/crates/oasis7/src/simulator/tests/persist.rs
+++ b/crates/oasis7/src/simulator/tests/persist.rs
@@ -431,6 +431,67 @@ fn snapshot_runtime_snapshot_accepts_stringified_numeric_map_keys() {
 }
 
 #[test]
+fn snapshot_player_gameplay_execution_state_backfills_from_legacy_fields() {
+    let mut snapshot = WorldKernel::new().snapshot();
+    snapshot.player_gameplay = Some(PlayerGameplaySnapshot {
+        stage_id: PlayerGameplayStageId::PostOnboarding,
+        stage_status: PlayerGameplayStageStatus::Blocked,
+        execution_state: PlayerGameplayExecutionState::Blocked,
+        goal_id: "post_onboarding.recover_capability".to_string(),
+        goal_kind: PlayerGameplayGoalKind::RecoverCapability,
+        goal_title: "Recover sustainable capability".to_string(),
+        objective: "Restore the first blocked capability chain.".to_string(),
+        progress_detail: "The primary line is blocked.".to_string(),
+        progress_percent: 68,
+        blocker_kind: Some("material_shortage".to_string()),
+        blocker_detail: Some("iron input exhausted at factory-0".to_string()),
+        next_step_hint: "Replenish upstream materials and advance again.".to_string(),
+        causality_kind: Some(PlayerGameplayCausalityKind::WorldConstraint),
+        causality_detail: Some("iron input exhausted at factory-0".to_string()),
+        branch_hint: None,
+        available_actions: Vec::new(),
+        recent_feedback: Some(PlayerGameplayRecentFeedback {
+            action: "step".to_string(),
+            stage: "completed_no_progress".to_string(),
+            effect: "no visible world delta".to_string(),
+            reason: Some("latest command did not create forward progress".to_string()),
+            hint: Some("repair the line, then advance again".to_string()),
+            delta_logical_time: 0,
+            delta_event_seq: 0,
+        }),
+        agent_claim: None,
+    });
+
+    let mut value: serde_json::Value =
+        serde_json::from_str(&snapshot.to_json().expect("snapshot to json"))
+            .expect("parse snapshot json");
+    value
+        .get_mut("player_gameplay")
+        .and_then(|gameplay| gameplay.as_object_mut())
+        .expect("player gameplay object")
+        .remove("execution_state");
+
+    let migrated = WorldSnapshot::from_json(
+        &serde_json::to_string(&value).expect("serialize migrated snapshot"),
+    )
+    .expect("load legacy player gameplay snapshot");
+
+    let gameplay = migrated
+        .player_gameplay
+        .as_ref()
+        .expect("restored player gameplay");
+    assert_eq!(gameplay.stage_status, PlayerGameplayStageStatus::Blocked);
+    assert_eq!(
+        gameplay.execution_state,
+        PlayerGameplayExecutionState::Blocked
+    );
+    assert_eq!(
+        gameplay.causality_kind,
+        Some(PlayerGameplayCausalityKind::WorldConstraint)
+    );
+}
+
+#[test]
 fn journal_version_validation_accepts_legacy() {
     let mut journal = WorldJournal::default();
     journal.version = JOURNAL_VERSION.saturating_sub(1);

--- a/crates/oasis7/src/viewer/runtime_live.rs
+++ b/crates/oasis7/src/viewer/runtime_live.rs
@@ -62,7 +62,8 @@ use control_plane::RuntimeLlmSidecar;
 use control_utils::{control_mode_for_action, control_mode_label, runtime_control_error_details};
 use gameplay_snapshot::{
     apply_runtime_snapshot_empty_entities_blocker, build_player_gameplay_snapshot,
-    player_gameplay_feedback_from_control_ack,
+    player_gameplay_causality_from_runtime_events, player_gameplay_feedback_from_control_ack,
+    PlayerGameplayCausalitySignal,
 };
 use mapping::{map_runtime_event, runtime_state_to_simulator_model};
 use session_policy::{
@@ -197,6 +198,7 @@ pub struct ViewerRuntimeLiveServer {
     session_revoke_metadata: BTreeMap<(String, String), RuntimeSessionRevokeMetadata>,
     settlement_ranking_gate: RuntimeSettlementRankingGate,
     latest_player_gameplay_feedback: Option<PlayerGameplayRecentFeedback>,
+    latest_player_gameplay_causality: Option<PlayerGameplayCausalitySignal>,
 }
 
 const BACKGROUND_PLAY_TRANSIENT_FAILURE_BUDGET: u8 = 3;
@@ -231,6 +233,7 @@ impl ViewerRuntimeLiveServer {
             session_revoke_metadata: BTreeMap::new(),
             settlement_ranking_gate: RuntimeSettlementRankingGate::default(),
             latest_player_gameplay_feedback: None,
+            latest_player_gameplay_causality: None,
         })
     }
 
@@ -254,9 +257,18 @@ impl ViewerRuntimeLiveServer {
     }
 
     fn set_latest_player_gameplay_feedback(&mut self, feedback: PlayerGameplayRecentFeedback) {
+        self.set_latest_player_gameplay_feedback_with_causality(feedback, None);
+    }
+
+    fn set_latest_player_gameplay_feedback_with_causality(
+        &mut self,
+        feedback: PlayerGameplayRecentFeedback,
+        causality: Option<PlayerGameplayCausalitySignal>,
+    ) {
         if feedback.delta_logical_time > 0 || feedback.delta_event_seq > 0 {
             self.confirm_player_gameplay_progress();
         }
+        self.latest_player_gameplay_causality = causality;
         self.latest_player_gameplay_feedback = Some(feedback);
     }
 
@@ -644,6 +656,7 @@ impl ViewerRuntimeLiveServer {
     ) -> Result<(), ViewerRuntimeLiveServerError> {
         let baseline_logical_time = self.world.state().time;
         let baseline_event_seq = latest_runtime_event_seq(&self.world);
+        let mut latest_runtime_events_for_feedback = Vec::new();
 
         for _ in 0..step_count.max(1) {
             if let Err(reason) = self
@@ -752,6 +765,7 @@ impl ViewerRuntimeLiveServer {
             }
 
             let new_events: Vec<_> = self.world.journal().events[journal_start..].to_vec();
+            latest_runtime_events_for_feedback = new_events.clone();
             let mut mapped_events = Vec::new();
             for runtime_event in &new_events {
                 let event = map_runtime_event(runtime_event, &self.snapshot_config);
@@ -868,10 +882,13 @@ impl ViewerRuntimeLiveServer {
                 error_code: None,
                 error_message: None,
             };
-            self.set_latest_player_gameplay_feedback(player_gameplay_feedback_from_control_ack(
+            let feedback = player_gameplay_feedback_from_control_ack(
                 &control_mode_for_action(action, step_count),
                 &ack,
-            ));
+            );
+            let causality =
+                player_gameplay_causality_from_runtime_events(&latest_runtime_events_for_feedback);
+            self.set_latest_player_gameplay_feedback_with_causality(feedback, causality);
             send_response(writer, &ViewerResponse::ControlCompletionAck { ack })?;
         }
 
@@ -995,6 +1012,7 @@ impl ViewerRuntimeLiveServer {
             self.world.state(),
             self.confirmed_player_gameplay_progress_time.is_some(),
             self.latest_player_gameplay_feedback.as_ref(),
+            self.latest_player_gameplay_causality.as_ref(),
             gameplay_gate.is_none(),
             gameplay_gate.as_deref(),
             self.llm_sidecar.is_llm_mode() && self.llm_sidecar.supports_agent_chat(),

--- a/crates/oasis7/src/viewer/runtime_live.rs
+++ b/crates/oasis7/src/viewer/runtime_live.rs
@@ -6,6 +6,20 @@ use std::sync::{Arc, Mutex, MutexGuard};
 use std::thread;
 use std::time::{Duration, Instant};
 
+use super::auth::verify_session_register_auth_proof;
+use super::live::ViewerLiveDecisionMode;
+use super::protocol::{
+    viewer_event_kind_matches, AuthoritativeBatchFinality, AuthoritativeChallengeAck,
+    AuthoritativeChallengeCommand, AuthoritativeChallengeError,
+    AuthoritativeChallengeResolveRequest, AuthoritativeChallengeStatus,
+    AuthoritativeChallengeSubmitRequest, AuthoritativeFinalityState,
+    AuthoritativeReconnectSyncRequest, AuthoritativeRecoveryAck, AuthoritativeRecoveryCommand,
+    AuthoritativeRecoveryError, AuthoritativeRecoveryStatus, AuthoritativeRollbackRequest,
+    AuthoritativeSessionRegisterRequest, AuthoritativeSessionRevokeRequest,
+    AuthoritativeSessionRotateRequest, ControlCompletionAck, ControlCompletionStatus,
+    ViewerControl, ViewerControlProfile, ViewerEventKind, ViewerRequest, ViewerResponse,
+    ViewerStream, VIEWER_PROTOCOL_VERSION,
+};
 use crate::geometry::GeoPos;
 use crate::observability::emit_stderr_or_event;
 use crate::runtime::{
@@ -21,21 +35,6 @@ use crate::simulator::{
     SNAPSHOT_VERSION,
 };
 use tracing::Level;
-
-use super::auth::verify_session_register_auth_proof;
-use super::live::ViewerLiveDecisionMode;
-use super::protocol::{
-    viewer_event_kind_matches, AuthoritativeBatchFinality, AuthoritativeChallengeAck,
-    AuthoritativeChallengeCommand, AuthoritativeChallengeError,
-    AuthoritativeChallengeResolveRequest, AuthoritativeChallengeStatus,
-    AuthoritativeChallengeSubmitRequest, AuthoritativeFinalityState,
-    AuthoritativeReconnectSyncRequest, AuthoritativeRecoveryAck, AuthoritativeRecoveryCommand,
-    AuthoritativeRecoveryError, AuthoritativeRecoveryStatus, AuthoritativeRollbackRequest,
-    AuthoritativeSessionRegisterRequest, AuthoritativeSessionRevokeRequest,
-    AuthoritativeSessionRotateRequest, ControlCompletionAck, ControlCompletionStatus,
-    ViewerControl, ViewerControlProfile, ViewerEventKind, ViewerRequest, ViewerResponse,
-    ViewerStream, VIEWER_PROTOCOL_VERSION,
-};
 mod authoritative;
 #[path = "runtime_live/chain_link.rs"]
 mod chain_link;
@@ -52,7 +51,6 @@ mod session_policy;
 mod support;
 #[cfg(test)]
 mod tests;
-
 use authoritative::{
     RuntimeAuthoritativeBatchRecord, RuntimeAuthoritativeChallengeRecord,
     RuntimeSettlementRankingGate, RuntimeStableCheckpoint,
@@ -656,7 +654,7 @@ impl ViewerRuntimeLiveServer {
     ) -> Result<(), ViewerRuntimeLiveServerError> {
         let baseline_logical_time = self.world.state().time;
         let baseline_event_seq = latest_runtime_event_seq(&self.world);
-        let mut latest_runtime_events_for_feedback = Vec::new();
+        let mut runtime_events_for_feedback = Vec::new();
 
         for _ in 0..step_count.max(1) {
             if let Err(reason) = self
@@ -765,7 +763,7 @@ impl ViewerRuntimeLiveServer {
             }
 
             let new_events: Vec<_> = self.world.journal().events[journal_start..].to_vec();
-            latest_runtime_events_for_feedback = new_events.clone();
+            runtime_events_for_feedback.extend(new_events.iter().cloned());
             let mut mapped_events = Vec::new();
             for runtime_event in &new_events {
                 let event = map_runtime_event(runtime_event, &self.snapshot_config);
@@ -887,8 +885,12 @@ impl ViewerRuntimeLiveServer {
                 &ack,
             );
             let causality =
-                player_gameplay_causality_from_runtime_events(&latest_runtime_events_for_feedback);
+                player_gameplay_causality_from_runtime_events(&runtime_events_for_feedback);
             self.set_latest_player_gameplay_feedback_with_causality(feedback, causality);
+            if session.subscribed.contains(&ViewerStream::Snapshot) {
+                let snapshot = self.compat_snapshot();
+                send_response(writer, &ViewerResponse::Snapshot { snapshot })?;
+            }
             send_response(writer, &ViewerResponse::ControlCompletionAck { ack })?;
         }
 

--- a/crates/oasis7/src/viewer/runtime_live/gameplay_snapshot.rs
+++ b/crates/oasis7/src/viewer/runtime_live/gameplay_snapshot.rs
@@ -1,13 +1,22 @@
-use crate::runtime::{FactoryProductionStatus, FactoryState, IndustryStage, WorldState};
+use crate::runtime::{
+    FactoryProductionStatus, FactoryState, IndustryStage, WorldEvent as RuntimeWorldEvent,
+    WorldEventBody as RuntimeWorldEventBody, WorldState,
+};
 use crate::simulator::persist::{
-    PlayerAgentClaimSnapshot, PlayerGameplayAction, PlayerGameplayGoalKind,
-    PlayerGameplayRecentFeedback, PlayerGameplaySnapshot, PlayerGameplayStageId,
-    PlayerGameplayStageStatus,
+    PlayerAgentClaimSnapshot, PlayerGameplayAction, PlayerGameplayCausalityKind,
+    PlayerGameplayExecutionState, PlayerGameplayGoalKind, PlayerGameplayRecentFeedback,
+    PlayerGameplaySnapshot, PlayerGameplayStageId, PlayerGameplayStageStatus,
 };
 use crate::viewer::{ControlCompletionAck, ControlCompletionStatus, ViewerControl};
 
 use super::player_gameplay::extend_available_actions;
 use crate::viewer::FACTORY_SMELTER_MK1;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct PlayerGameplayCausalitySignal {
+    pub kind: PlayerGameplayCausalityKind,
+    pub detail: String,
+}
 
 fn blocked_control_hint(error_code: Option<&str>) -> String {
     match error_code {
@@ -45,6 +54,41 @@ fn first_session_runtime_sync_blocker(
             .to_string()
     });
     Some((kind, detail, hint))
+}
+
+pub(super) fn player_gameplay_causality_from_runtime_events(
+    new_events: &[RuntimeWorldEvent],
+) -> Option<PlayerGameplayCausalitySignal> {
+    let mut override_detail = None;
+    let mut override_fallback = None;
+    for runtime_event in new_events {
+        match &runtime_event.body {
+            RuntimeWorldEventBody::RuleDecisionRecorded(record)
+                if record.override_action.is_some() =>
+            {
+                let notes = if record.notes.is_empty() {
+                    "no rule note supplied".to_string()
+                } else {
+                    record.notes.join("; ")
+                };
+                override_detail = Some(format!(
+                    "rule module {} redirected the accepted action before execution: {}",
+                    record.module_id, notes
+                ));
+            }
+            RuntimeWorldEventBody::ActionOverridden(record) => {
+                override_fallback = Some(format!(
+                    "the acting agent followed an overridden plan instead of the original action: {:?} -> {:?}",
+                    record.original_action, record.override_action
+                ));
+            }
+            _ => {}
+        }
+    }
+    override_fallback.map(|fallback| PlayerGameplayCausalitySignal {
+        kind: PlayerGameplayCausalityKind::AgentOverride,
+        detail: override_detail.unwrap_or(fallback),
+    })
 }
 
 pub(super) fn player_gameplay_feedback_from_control_ack(
@@ -101,10 +145,106 @@ pub(super) fn player_gameplay_feedback_from_control_ack(
     }
 }
 
+fn derive_player_gameplay_execution_state(
+    stage_status: PlayerGameplayStageStatus,
+    recent_feedback: Option<&PlayerGameplayRecentFeedback>,
+) -> PlayerGameplayExecutionState {
+    if let Some(feedback) = recent_feedback {
+        match feedback.stage.as_str() {
+            "accepted" | "submitted" | "queued" | "ack" => {
+                return PlayerGameplayExecutionState::Accepted;
+            }
+            "rejected" => return PlayerGameplayExecutionState::Rejected,
+            "blocked" | "completed_no_progress" => return PlayerGameplayExecutionState::Blocked,
+            "completed_advanced" => return PlayerGameplayExecutionState::Completed,
+            _ => {}
+        }
+    }
+
+    match stage_status {
+        PlayerGameplayStageStatus::Blocked => PlayerGameplayExecutionState::Blocked,
+        PlayerGameplayStageStatus::BranchReady => PlayerGameplayExecutionState::Completed,
+        PlayerGameplayStageStatus::Active => PlayerGameplayExecutionState::Executing,
+    }
+}
+
+fn derive_player_gameplay_causality(
+    gameplay: &PlayerGameplaySnapshot,
+    recent_feedback: Option<&PlayerGameplayRecentFeedback>,
+    causality_signal: Option<&PlayerGameplayCausalitySignal>,
+) -> (Option<PlayerGameplayCausalityKind>, Option<String>) {
+    if let Some(signal) = causality_signal {
+        return (Some(signal.kind), Some(signal.detail.clone()));
+    }
+
+    match gameplay.execution_state {
+        PlayerGameplayExecutionState::Accepted => (
+            Some(PlayerGameplayCausalityKind::QueuedForExecution),
+            Some(
+                recent_feedback
+                    .and_then(|feedback| feedback.hint.clone())
+                    .unwrap_or_else(|| {
+                        "the latest goal-affecting command is accepted and waiting for committed world progress"
+                            .to_string()
+                    }),
+            ),
+        ),
+        PlayerGameplayExecutionState::Rejected => (
+            Some(PlayerGameplayCausalityKind::RequestRejected),
+            Some(
+                recent_feedback
+                    .and_then(|feedback| feedback.reason.clone())
+                    .unwrap_or_else(|| {
+                        "the latest goal-affecting request was rejected before execution"
+                            .to_string()
+                    }),
+            ),
+        ),
+        PlayerGameplayExecutionState::Blocked => (
+            Some(PlayerGameplayCausalityKind::WorldConstraint),
+            gameplay
+                .blocker_detail
+                .clone()
+                .or_else(|| recent_feedback.and_then(|feedback| feedback.reason.clone()))
+                .or_else(|| {
+                    gameplay
+                        .blocker_kind
+                        .as_ref()
+                        .map(|kind| format!("current goal is blocked by {kind}"))
+                }),
+        ),
+        PlayerGameplayExecutionState::Completed => (
+            Some(PlayerGameplayCausalityKind::GoalProgressed),
+            Some(
+                recent_feedback
+                    .map(|feedback| feedback.effect.clone())
+                    .filter(|effect| !effect.trim().is_empty())
+                    .unwrap_or_else(|| gameplay.progress_detail.clone()),
+            ),
+        ),
+        PlayerGameplayExecutionState::Executing => (None, None),
+    }
+}
+
+fn finalize_player_gameplay_snapshot(
+    mut gameplay: PlayerGameplaySnapshot,
+    recent_feedback: Option<&PlayerGameplayRecentFeedback>,
+    causality_signal: Option<&PlayerGameplayCausalitySignal>,
+) -> PlayerGameplaySnapshot {
+    gameplay.execution_state =
+        derive_player_gameplay_execution_state(gameplay.stage_status, recent_feedback);
+    let (causality_kind, causality_detail) =
+        derive_player_gameplay_causality(&gameplay, recent_feedback, causality_signal);
+    gameplay.causality_kind = causality_kind;
+    gameplay.causality_detail = causality_detail;
+    gameplay
+}
+
 pub(super) fn build_player_gameplay_snapshot(
     state: &WorldState,
     confirmed_gameplay_progress: bool,
     recent_feedback: Option<&PlayerGameplayRecentFeedback>,
+    causality_signal: Option<&PlayerGameplayCausalitySignal>,
     gameplay_enabled: bool,
     gameplay_disabled_reason: Option<&str>,
     supports_agent_chat: bool,
@@ -120,12 +260,15 @@ pub(super) fn build_player_gameplay_snapshot(
     if gameplay_enabled {
         extend_available_actions(state, first_agent_id.as_deref(), &mut available_actions);
     }
+    let finalize =
+        |gameplay| finalize_player_gameplay_snapshot(gameplay, recent_feedback, causality_signal);
     if !gameplay_enabled {
         let disabled_reason = gameplay_disabled_reason
             .unwrap_or("gameplay requires runtime live server running with --llm");
-        return PlayerGameplaySnapshot {
+        return finalize(PlayerGameplaySnapshot {
             stage_id: PlayerGameplayStageId::FirstSessionLoop,
             stage_status: PlayerGameplayStageStatus::Blocked,
+            execution_state: PlayerGameplayExecutionState::Executing,
             goal_id: "first_session_loop.configure_llm_access".to_string(),
             goal_kind: PlayerGameplayGoalKind::CreateFirstWorldFeedback,
             goal_title: "Configure LLM access before entering the world".to_string(),
@@ -141,11 +284,13 @@ pub(super) fn build_player_gameplay_snapshot(
             next_step_hint:
                 "Enable --llm and configure a reachable provider before retrying play, step, or gameplay actions."
                     .to_string(),
+            causality_kind: None,
+            causality_detail: None,
             branch_hint: None,
             available_actions,
             recent_feedback: recent_feedback.cloned(),
             agent_claim,
-        };
+        });
     }
     let primary_factory = primary_factory_for_player_gameplay(state);
     let latest_blocker = primary_factory.and_then(|factory| {
@@ -203,9 +348,10 @@ pub(super) fn build_player_gameplay_snapshot(
                 }
                 action.disabled_reason = Some(disabled_reason.clone());
             }
-            return PlayerGameplaySnapshot {
+            return finalize(PlayerGameplaySnapshot {
                 stage_id: PlayerGameplayStageId::FirstSessionLoop,
                 stage_status: PlayerGameplayStageStatus::Blocked,
+                execution_state: PlayerGameplayExecutionState::Executing,
                 goal_id: "first_session_loop.recover_runtime_sync".to_string(),
                 goal_kind: PlayerGameplayGoalKind::CreateFirstWorldFeedback,
                 goal_title: "Recover committed runtime sync".to_string(),
@@ -217,11 +363,13 @@ pub(super) fn build_player_gameplay_snapshot(
                 blocker_kind: Some(blocker_kind),
                 blocker_detail: Some(blocker_detail),
                 next_step_hint,
+                causality_kind: None,
+                causality_detail: None,
                 branch_hint: None,
                 available_actions,
                 recent_feedback: recent_feedback.cloned(),
                 agent_claim,
-            };
+            });
         }
     }
 
@@ -234,9 +382,10 @@ pub(super) fn build_player_gameplay_snapshot(
     {
         available_actions[0].label =
             "Advance 1 step to create the first world feedback".to_string();
-        return PlayerGameplaySnapshot {
+        return finalize(PlayerGameplaySnapshot {
             stage_id: PlayerGameplayStageId::FirstSessionLoop,
             stage_status: PlayerGameplayStageStatus::Active,
+            execution_state: PlayerGameplayExecutionState::Executing,
             goal_id: "first_session_loop.create_first_world_feedback".to_string(),
             goal_kind: PlayerGameplayGoalKind::CreateFirstWorldFeedback,
             goal_title: "Create the first visible world feedback".to_string(),
@@ -246,11 +395,13 @@ pub(super) fn build_player_gameplay_snapshot(
             blocker_kind: None,
             blocker_detail: None,
             next_step_hint: "Request a snapshot, advance 1 step, then inspect the new delta and events.".to_string(),
+            causality_kind: None,
+            causality_detail: None,
             branch_hint: None,
             available_actions,
             recent_feedback: recent_feedback.cloned(),
             agent_claim,
-        };
+        });
     }
 
     let fallback_feedback_blocker = if latest_blocker.is_none()
@@ -276,9 +427,10 @@ pub(super) fn build_player_gameplay_snapshot(
                 68,
             )
         };
-        return PlayerGameplaySnapshot {
+        return finalize(PlayerGameplaySnapshot {
             stage_id: PlayerGameplayStageId::PostOnboarding,
             stage_status: PlayerGameplayStageStatus::Blocked,
+            execution_state: PlayerGameplayExecutionState::Executing,
             goal_id: "post_onboarding.recover_capability".to_string(),
             goal_kind: PlayerGameplayGoalKind::RecoverCapability,
             goal_title: "Recover sustainable capability".to_string(),
@@ -290,11 +442,13 @@ pub(super) fn build_player_gameplay_snapshot(
             blocker_kind: Some(blocker_kind.clone()),
             blocker_detail: Some(blocker_detail.clone()),
             next_step_hint: blocker_next_step(blocker_kind.as_str(), blocker_detail.as_str()),
+            causality_kind: None,
+            causality_detail: None,
             branch_hint: None,
             available_actions,
             recent_feedback: recent_feedback.cloned(),
             agent_claim,
-        };
+        });
     }
 
     if has_first_output {
@@ -325,9 +479,10 @@ pub(super) fn build_player_gameplay_snapshot(
                         80,
                     )
                 };
-                return PlayerGameplaySnapshot {
+                return finalize(PlayerGameplaySnapshot {
                     stage_id: PlayerGameplayStageId::PostOnboarding,
                     stage_status: PlayerGameplayStageStatus::Active,
+                    execution_state: PlayerGameplayExecutionState::Executing,
                     goal_id: "post_onboarding.stabilize_first_line_after_output".to_string(),
                     goal_kind: PlayerGameplayGoalKind::StabilizeFirstLine,
                     goal_title: "Harden your first output into resilient production".to_string(),
@@ -337,16 +492,19 @@ pub(super) fn build_player_gameplay_snapshot(
                     blocker_kind: None,
                     blocker_detail: None,
                     next_step_hint,
+                    causality_kind: None,
+                    causality_detail: None,
                     branch_hint: None,
                     available_actions,
                     recent_feedback: recent_feedback.cloned(),
                     agent_claim,
-                };
+                });
             }
             IndustryStage::ScaleOut => {
-                return PlayerGameplaySnapshot {
+                return finalize(PlayerGameplaySnapshot {
                     stage_id: PlayerGameplayStageId::PostOnboarding,
                     stage_status: PlayerGameplayStageStatus::BranchReady,
+                    execution_state: PlayerGameplayExecutionState::Executing,
                     goal_id: "post_onboarding.choose_first_expansion_tradeoff".to_string(),
                     goal_kind: PlayerGameplayGoalKind::ChooseFirstExpansionTradeoff,
                     goal_title: "Choose the first expansion tradeoff".to_string(),
@@ -356,6 +514,8 @@ pub(super) fn build_player_gameplay_snapshot(
                     blocker_kind: None,
                     blocker_detail: None,
                     next_step_hint: "Advance again and commit to one tradeoff: add capacity, protect upstream inputs, or widen distribution coverage.".to_string(),
+                    causality_kind: None,
+                    causality_detail: None,
                     branch_hint: Some(
                         "Tradeoffs unlocked: throughput expansion / input resilience / logistics reach"
                             .to_string(),
@@ -363,12 +523,13 @@ pub(super) fn build_player_gameplay_snapshot(
                     available_actions,
                     recent_feedback: recent_feedback.cloned(),
                     agent_claim,
-                };
+                });
             }
             IndustryStage::Governance => {
-                return PlayerGameplaySnapshot {
+                return finalize(PlayerGameplaySnapshot {
                     stage_id: PlayerGameplayStageId::PostOnboarding,
                     stage_status: PlayerGameplayStageStatus::BranchReady,
+                    execution_state: PlayerGameplayExecutionState::Executing,
                     goal_id: "post_onboarding.choose_midloop_path".to_string(),
                     goal_kind: PlayerGameplayGoalKind::ChooseMidLoopPath,
                     goal_title: "Choose your mid-loop path".to_string(),
@@ -378,6 +539,8 @@ pub(super) fn build_player_gameplay_snapshot(
                     blocker_kind: None,
                     blocker_detail: None,
                     next_step_hint: "Keep advancing and either expand production, push governance, or secure a critical node.".to_string(),
+                    causality_kind: None,
+                    causality_detail: None,
                     branch_hint: Some(
                         "Branches unlocked: production expansion / governance influence / conflict security"
                             .to_string(),
@@ -385,15 +548,16 @@ pub(super) fn build_player_gameplay_snapshot(
                     available_actions,
                     recent_feedback: recent_feedback.cloned(),
                     agent_claim,
-                };
+                });
             }
         }
     }
 
     if has_recipe_running {
-        return PlayerGameplaySnapshot {
+        return finalize(PlayerGameplaySnapshot {
             stage_id: PlayerGameplayStageId::PostOnboarding,
             stage_status: PlayerGameplayStageStatus::Active,
+            execution_state: PlayerGameplayExecutionState::Executing,
             goal_id: "post_onboarding.stabilize_first_line".to_string(),
             goal_kind: PlayerGameplayGoalKind::StabilizeFirstLine,
             goal_title: "Stabilize your first line".to_string(),
@@ -403,17 +567,20 @@ pub(super) fn build_player_gameplay_snapshot(
             blocker_kind: None,
             blocker_detail: None,
             next_step_hint: "Advance 1-2 more times and watch for output, recovery, or blocker feedback.".to_string(),
+            causality_kind: None,
+            causality_detail: None,
             branch_hint: None,
             available_actions,
             recent_feedback: recent_feedback.cloned(),
             agent_claim,
-        };
+        });
     }
 
     if has_factory_ready {
-        return PlayerGameplaySnapshot {
+        return finalize(PlayerGameplaySnapshot {
             stage_id: PlayerGameplayStageId::PostOnboarding,
             stage_status: PlayerGameplayStageStatus::Active,
+            execution_state: PlayerGameplayExecutionState::Executing,
             goal_id: "post_onboarding.start_factory_run".to_string(),
             goal_kind: PlayerGameplayGoalKind::StartFactoryRun,
             goal_title: "Start your first factory run".to_string(),
@@ -423,17 +590,20 @@ pub(super) fn build_player_gameplay_snapshot(
             blocker_kind: None,
             blocker_detail: None,
             next_step_hint: "Keep advancing until the factory starts a recipe, yields output, or returns a blocker.".to_string(),
+            causality_kind: None,
+            causality_detail: None,
             branch_hint: None,
             available_actions,
             recent_feedback: recent_feedback.cloned(),
             agent_claim,
-        };
+        });
     }
 
     if has_material_flow {
-        return PlayerGameplaySnapshot {
+        return finalize(PlayerGameplaySnapshot {
             stage_id: PlayerGameplayStageId::PostOnboarding,
             stage_status: PlayerGameplayStageStatus::Active,
+            execution_state: PlayerGameplayExecutionState::Executing,
             goal_id: "post_onboarding.turn_material_flow_into_output".to_string(),
             goal_kind: PlayerGameplayGoalKind::TurnMaterialFlowIntoOutput,
             goal_title: "Turn material flow into output".to_string(),
@@ -443,16 +613,19 @@ pub(super) fn build_player_gameplay_snapshot(
             blocker_kind: None,
             blocker_detail: None,
             next_step_hint: "Keep harvesting, refining, building, or starting the first recipe until stable output appears.".to_string(),
+            causality_kind: None,
+            causality_detail: None,
             branch_hint: None,
             available_actions,
             recent_feedback: recent_feedback.cloned(),
             agent_claim,
-        };
+        });
     }
 
-    PlayerGameplaySnapshot {
+    finalize(PlayerGameplaySnapshot {
         stage_id: PlayerGameplayStageId::PostOnboarding,
         stage_status: PlayerGameplayStageStatus::Active,
+        execution_state: PlayerGameplayExecutionState::Executing,
         goal_id: "post_onboarding.establish_first_capability".to_string(),
         goal_kind: PlayerGameplayGoalKind::EstablishFirstCapability,
         goal_title: "Establish your first sustainable capability".to_string(),
@@ -462,11 +635,13 @@ pub(super) fn build_player_gameplay_snapshot(
         blocker_kind: None,
         blocker_detail: None,
         next_step_hint: "Advance 2-3 more times and prioritize the first output, the first stable line, or one clear recovery signal.".to_string(),
+        causality_kind: None,
+        causality_detail: None,
         branch_hint: None,
         available_actions,
         recent_feedback: recent_feedback.cloned(),
         agent_claim,
-    }
+    })
 }
 
 pub(super) fn apply_runtime_snapshot_empty_entities_blocker(
@@ -488,6 +663,7 @@ pub(super) fn apply_runtime_snapshot_empty_entities_blocker(
     let disabled_reason =
         format!("runtime snapshot is missing {missing_summary}; refresh snapshot or repair runtime bootstrap first");
     gameplay.stage_status = PlayerGameplayStageStatus::Blocked;
+    gameplay.execution_state = PlayerGameplayExecutionState::Blocked;
     gameplay.blocker_kind = Some("runtime_snapshot_empty_entities".to_string());
     gameplay.blocker_detail = Some(format!(
         "runtime exposed gameplay progress but no {missing_summary} in the viewer snapshot; primary web entry cannot continue yet"
@@ -495,6 +671,8 @@ pub(super) fn apply_runtime_snapshot_empty_entities_blocker(
     gameplay.next_step_hint =
         "Request a fresh snapshot. If entities stay empty, restart or repair the runtime world bootstrap before retrying gameplay."
             .to_string();
+    gameplay.causality_kind = Some(PlayerGameplayCausalityKind::WorldConstraint);
+    gameplay.causality_detail = gameplay.blocker_detail.clone();
     for action in &mut gameplay.available_actions {
         if action.protocol_action == "request_snapshot" {
             continue;

--- a/crates/oasis7/src/viewer/runtime_live/tests/snapshot_progress.rs
+++ b/crates/oasis7/src/viewer/runtime_live/tests/snapshot_progress.rs
@@ -194,10 +194,112 @@ fn compat_snapshot_exposes_player_gameplay_snapshot() {
 }
 
 #[test]
+fn compat_snapshot_surfaces_agent_override_causality_from_runtime_events() {
+    let _guard = runtime_provider_env_lock().lock().expect("env lock");
+    clear_runtime_provider_env();
+    let (base_url, serve) = spawn_runtime_provider_probe_server();
+    std::env::set_var(VIEWER_AGENT_PROVIDER_MODE_ENV, "provider_loopback_http");
+    std::env::set_var(VIEWER_AGENT_PROVIDER_URL_ENV, base_url);
+    std::env::set_var(VIEWER_AGENT_PROVIDER_PROFILE_ENV, "oasis7_p0_low_freq_npc");
+    std::env::set_var(VIEWER_AGENT_EXECUTION_LANE_ENV, "player_parity");
+    let mut server = ViewerRuntimeLiveServer::new(
+        ViewerRuntimeLiveServerConfig::new(WorldScenario::Minimal)
+            .with_decision_mode(ViewerLiveDecisionMode::Llm),
+    )
+    .expect("runtime server");
+
+    let original_action = crate::runtime::Action::MoveAgent {
+        agent_id: "agent-primary".to_string(),
+        to: crate::geometry::GeoPos::new(100, 0, 0),
+    };
+    let override_action = crate::runtime::Action::MoveAgent {
+        agent_id: "agent-primary".to_string(),
+        to: crate::geometry::GeoPos::new(250, 0, 0),
+    };
+    let causality =
+        super::super::gameplay_snapshot::player_gameplay_causality_from_runtime_events(&[
+            crate::runtime::WorldEvent {
+                id: 1,
+                time: 1,
+                caused_by: None,
+                body: crate::runtime::WorldEventBody::RuleDecisionRecorded(
+                    crate::runtime::RuleDecisionRecord {
+                        action_id: 7,
+                        module_id: "test.rule".to_string(),
+                        stage: crate::runtime::ModuleSubscriptionStage::PreAction,
+                        verdict: crate::runtime::RuleVerdict::Modify,
+                        override_action: Some(override_action.clone()),
+                        cost: crate::runtime::ResourceDelta::default(),
+                        notes: vec!["reroute to safer waypoint".to_string()],
+                    },
+                ),
+            },
+            crate::runtime::WorldEvent {
+                id: 2,
+                time: 1,
+                caused_by: None,
+                body: crate::runtime::WorldEventBody::ActionOverridden(
+                    crate::runtime::ActionOverrideRecord {
+                        action_id: 7,
+                        original_action,
+                        override_action,
+                    },
+                ),
+            },
+        ])
+        .expect("agent override causality");
+    assert_eq!(
+        causality.kind,
+        crate::simulator::PlayerGameplayCausalityKind::AgentOverride
+    );
+    assert!(causality.detail.contains("test.rule"));
+    assert!(causality.detail.contains("reroute to safer waypoint"));
+
+    server.set_latest_player_gameplay_feedback_with_causality(
+        crate::simulator::PlayerGameplayRecentFeedback {
+            action: "move_agent".to_string(),
+            stage: "completed_advanced".to_string(),
+            effect: "world advanced: logicalTime +1, eventSeq +2".to_string(),
+            reason: None,
+            hint: None,
+            delta_logical_time: 1,
+            delta_event_seq: 2,
+        },
+        Some(causality),
+    );
+
+    let snapshot = server.compat_snapshot();
+    let gameplay = snapshot
+        .player_gameplay
+        .as_ref()
+        .expect("player gameplay snapshot");
+    assert_eq!(
+        gameplay.execution_state,
+        crate::simulator::PlayerGameplayExecutionState::Completed
+    );
+    assert_eq!(
+        gameplay.causality_kind,
+        Some(crate::simulator::PlayerGameplayCausalityKind::AgentOverride)
+    );
+    assert!(gameplay
+        .causality_detail
+        .as_deref()
+        .is_some_and(|detail| detail.contains("redirected the accepted action")));
+    assert!(gameplay
+        .causality_detail
+        .as_deref()
+        .is_some_and(|detail| detail.contains("reroute to safer waypoint")));
+
+    clear_runtime_provider_env();
+    serve.join().expect("server thread should finish");
+}
+
+#[test]
 fn empty_entity_guard_marks_gameplay_snapshot_blocked() {
     let mut gameplay = super::super::gameplay_snapshot::build_player_gameplay_snapshot(
         &crate::runtime::WorldState::default(),
         true,
+        None,
         None,
         true,
         None,

--- a/crates/oasis7_viewer/scripts/software-safe-feedback-contract.test.mjs
+++ b/crates/oasis7_viewer/scripts/software-safe-feedback-contract.test.mjs
@@ -89,6 +89,7 @@ const core = await import("../software_safe_src/legacy_core.js");
     player_gameplay: {
       stage_id: "post_onboarding",
       stage_status: "blocked",
+      execution_state: "blocked",
       goal_id: "post_onboarding.recover_capability",
       goal_kind: "RecoverCapability",
       goal_title: "Recover sustainable capability",
@@ -97,6 +98,8 @@ const core = await import("../software_safe_src/legacy_core.js");
       progress_percent: 68,
       blocker_kind: "material_shortage",
       blocker_detail: "iron input exhausted at factory-0",
+      causality_kind: "world_constraint",
+      causality_detail: "iron input exhausted at factory-0",
       next_step_hint: "Replenish upstream materials, then advance again to confirm the line resumes.",
       branch_hint: null,
       available_actions: [
@@ -130,6 +133,9 @@ const core = await import("../software_safe_src/legacy_core.js");
   const gameplaySummary = core.buildGameplaySummary();
   assert.equal(gameplaySummary.stageId, "post_onboarding");
   assert.equal(gameplaySummary.stageStatus, "blocked");
+  assert.equal(gameplaySummary.executionState, "blocked");
+  assert.equal(gameplaySummary.executionCauseKind, "world_constraint");
+  assert.match(gameplaySummary.executionCauseLabel, /World Constraint/i);
   assert.equal(gameplaySummary.progressPercent, 68);
   assert.deepEqual(
     gameplaySummary.availableActions.map((action) => action.actionId),
@@ -142,6 +148,27 @@ const core = await import("../software_safe_src/legacy_core.js");
 {
   const gameplaySummary = core.buildGameplaySummary("zh");
   assert.match(gameplaySummary.assetGovernanceHandoff, /资产 \/ 治理动作/);
+  assert.equal(gameplaySummary.executionStateLabel, "已阻塞");
+}
+
+{
+  core.state.snapshot.player_gameplay.execution_state = "completed";
+  core.state.snapshot.player_gameplay.causality_kind = "agent_override";
+  core.state.snapshot.player_gameplay.causality_detail = "rule module policy.guard redirected the accepted action before execution";
+  core.state.snapshot.player_gameplay.recent_feedback = {
+    action: "step",
+    stage: "completed_advanced",
+    effect: "world advanced: logicalTime +1, eventSeq +2",
+    reason: null,
+    hint: null,
+    delta_logical_time: 1,
+    delta_event_seq: 2,
+  };
+  const gameplaySummary = core.buildGameplaySummary();
+  assert.equal(gameplaySummary.executionState, "completed");
+  assert.equal(gameplaySummary.executionCauseKind, "agent_override");
+  assert.match(gameplaySummary.executionCauseLabel, /Agent Chose Differently/i);
+  assert.match(gameplaySummary.executionCauseDetail, /policy\.guard/i);
 }
 
 {

--- a/crates/oasis7_viewer/scripts/software-safe-feedback-contract.test.mjs
+++ b/crates/oasis7_viewer/scripts/software-safe-feedback-contract.test.mjs
@@ -172,6 +172,20 @@ const core = await import("../software_safe_src/legacy_core.js");
 }
 
 {
+  core.state.snapshot.model.agents = {};
+  core.state.snapshot.model.locations = {};
+  core.state.snapshot.player_gameplay.execution_state = "completed";
+  core.state.snapshot.player_gameplay.stage_status = "active";
+  core.state.snapshot.player_gameplay.blocker_kind = null;
+  core.state.snapshot.player_gameplay.blocker_detail = null;
+  const gameplaySummary = core.buildGameplaySummary();
+  assert.equal(gameplaySummary.stageStatus, "blocked");
+  assert.equal(gameplaySummary.executionState, "blocked");
+  assert.equal(gameplaySummary.executionCauseKind, "world_constraint");
+  assert.equal(gameplaySummary.blockerKind, "runtime_snapshot_empty_entities");
+}
+
+{
   const injectedState = core.injectSnapshot({
     time: 12,
     config: {

--- a/crates/oasis7_viewer/software_safe.js
+++ b/crates/oasis7_viewer/software_safe.js
@@ -1931,7 +1931,7 @@ function buildGameplaySummary(locale = state.uiLocale) {
   const resolvedStageStatus = emptyEntityBlocker ? "blocked" : gameplay.stage_status || null;
   const resolvedBlockerKind = runtimeAlreadyPublishedEmptyEntityBlocker ? runtimeBlockerKind : emptyEntityBlocker ? emptyEntityBlocker.blockerKind : runtimeBlockerKind;
   const resolvedBlockerDetail = runtimeAlreadyPublishedEmptyEntityBlocker ? runtimeBlockerDetail || emptyEntityBlocker?.blockerDetail || null : emptyEntityBlocker ? emptyEntityBlocker.blockerDetail : runtimeBlockerDetail;
-  const executionState = gameplay.execution_state || (() => {
+  const executionState = emptyEntityBlocker ? "blocked" : gameplay.execution_state || (() => {
     const recentStage = String(recentFeedback?.stage || "").trim().toLowerCase();
     if (["accepted", "submitted", "queued", "ack"].includes(recentStage)) {
       return "accepted";
@@ -1974,7 +1974,7 @@ function buildGameplaySummary(locale = state.uiLocale) {
     { id: "completed", label: localeText(locale, "已完成", "Completed") },
     { id: "rejected", label: localeText(locale, "已拒绝", "Rejected") }
   ];
-  const executionCauseKind = gameplay.causality_kind || (() => {
+  const executionCauseKind = emptyEntityBlocker ? "world_constraint" : gameplay.causality_kind || (() => {
     if (executionState === "accepted") return "queued_for_execution";
     if (executionState === "rejected") return "request_rejected";
     if (executionState === "blocked") return "world_constraint";
@@ -1997,7 +1997,7 @@ function buildGameplaySummary(locale = state.uiLocale) {
         return null;
     }
   })();
-  const executionCauseDetail = gameplay.causality_detail || (() => {
+  const executionCauseDetail = emptyEntityBlocker ? resolvedBlockerDetail || emptyEntityBlocker.blockerDetail || null : gameplay.causality_detail || (() => {
     if (executionState === "blocked") {
       return resolvedBlockerDetail || recentFeedback?.reason || null;
     }

--- a/crates/oasis7_viewer/software_safe.js
+++ b/crates/oasis7_viewer/software_safe.js
@@ -897,6 +897,9 @@ function resolveInitialUiLocale() {
   const params = getSearchParams();
   return normalizeUiLocale(params.get("locale") || params.get("language")) || resolveStoredUiLocale() || "en";
 }
+function localeText(locale, zh, en) {
+  return isLocaleZh(locale) ? zh : en;
+}
 function promptOverridesVisibilityStorageKey() {
   return `${PROMPT_OVERRIDES_VISIBILITY_STORAGE_PREFIX}:${window.location.pathname || "viewer.html"}`;
 }
@@ -1925,17 +1928,172 @@ function buildGameplaySummary(locale = state.uiLocale) {
   const runtimeBlockerKind = gameplay.blocker_kind || null;
   const runtimeBlockerDetail = gameplay.blocker_detail || null;
   const runtimeAlreadyPublishedEmptyEntityBlocker = runtimeBlockerKind === "runtime_snapshot_empty_entities";
+  const resolvedStageStatus = emptyEntityBlocker ? "blocked" : gameplay.stage_status || null;
+  const resolvedBlockerKind = runtimeAlreadyPublishedEmptyEntityBlocker ? runtimeBlockerKind : emptyEntityBlocker ? emptyEntityBlocker.blockerKind : runtimeBlockerKind;
+  const resolvedBlockerDetail = runtimeAlreadyPublishedEmptyEntityBlocker ? runtimeBlockerDetail || emptyEntityBlocker?.blockerDetail || null : emptyEntityBlocker ? emptyEntityBlocker.blockerDetail : runtimeBlockerDetail;
+  const executionState = gameplay.execution_state || (() => {
+    const recentStage = String(recentFeedback?.stage || "").trim().toLowerCase();
+    if (["accepted", "submitted", "queued", "ack"].includes(recentStage)) {
+      return "accepted";
+    }
+    if (recentStage === "rejected") {
+      return "rejected";
+    }
+    if (["blocked", "completed_no_progress"].includes(recentStage)) {
+      return "blocked";
+    }
+    if (recentStage === "completed_advanced") {
+      return "completed";
+    }
+    if (resolvedStageStatus === "blocked") {
+      return "blocked";
+    }
+    if (resolvedStageStatus === "branch_ready") {
+      return "completed";
+    }
+    return "executing";
+  })();
+  const executionStateLabel = (() => {
+    switch (executionState) {
+      case "accepted":
+        return localeText(locale, "已接受", "Accepted");
+      case "blocked":
+        return localeText(locale, "已阻塞", "Blocked");
+      case "completed":
+        return localeText(locale, "已完成", "Completed");
+      case "rejected":
+        return localeText(locale, "已拒绝", "Rejected");
+      default:
+        return localeText(locale, "执行中", "Executing");
+    }
+  })();
+  const executionStateMachine = [
+    { id: "accepted", label: localeText(locale, "已接受", "Accepted") },
+    { id: "executing", label: localeText(locale, "执行中", "Executing") },
+    { id: "blocked", label: localeText(locale, "已阻塞", "Blocked") },
+    { id: "completed", label: localeText(locale, "已完成", "Completed") },
+    { id: "rejected", label: localeText(locale, "已拒绝", "Rejected") }
+  ];
+  const executionCauseKind = gameplay.causality_kind || (() => {
+    if (executionState === "accepted") return "queued_for_execution";
+    if (executionState === "rejected") return "request_rejected";
+    if (executionState === "blocked") return "world_constraint";
+    if (executionState === "completed") return "goal_progressed";
+    return null;
+  })();
+  const executionCauseLabel = (() => {
+    switch (executionCauseKind) {
+      case "queued_for_execution":
+        return localeText(locale, "等待执行", "Queued for Execution");
+      case "world_constraint":
+        return localeText(locale, "世界约束", "World Constraint");
+      case "agent_override":
+        return localeText(locale, "Agent 改走了别的允许路径", "Agent Chose Differently");
+      case "goal_progressed":
+        return localeText(locale, "世界已推进", "World Progressed");
+      case "request_rejected":
+        return localeText(locale, "请求被拒绝", "Request Rejected");
+      default:
+        return null;
+    }
+  })();
+  const executionCauseDetail = gameplay.causality_detail || (() => {
+    if (executionState === "blocked") {
+      return resolvedBlockerDetail || recentFeedback?.reason || null;
+    }
+    if (executionState === "accepted") {
+      return recentFeedback?.hint || recentFeedback?.effect || null;
+    }
+    if (executionState === "completed") {
+      return recentFeedback?.effect || gameplay.progress_detail || null;
+    }
+    if (executionState === "rejected") {
+      return recentFeedback?.reason || null;
+    }
+    return null;
+  })();
+  const executionSummary = (() => {
+    if (executionCauseKind === "agent_override") {
+      return localeText(
+        locale,
+        "本次目标已推动世界继续前进，但执行它的 Agent 最终采用了另一条被允许的计划。",
+        "This goal still advanced the world, but the acting agent finished it through a different allowed plan."
+      );
+    }
+    switch (executionState) {
+      case "accepted":
+        return localeText(
+          locale,
+          "最新一条目标相关指令已经入队，正在等待 committed world delta 或后续回执。",
+          "The latest goal-affecting command is queued and waiting for committed world delta or follow-up feedback."
+        );
+      case "blocked":
+        return localeText(
+          locale,
+          "当前目标没有继续推进，主要原因已经被归入可修复的 blocker taxonomy。",
+          "The current goal is not moving forward; the primary reason is now grouped into a repairable blocker taxonomy."
+        );
+      case "completed":
+        return localeText(
+          locale,
+          "当前目标最近一次执行已经产生世界级结果，可以决定是继续放大、恢复，还是切到下一条主线。",
+          "The current goal's latest execution already produced a world-level result; you can now amplify it, recover it, or pivot to the next line."
+        );
+      case "rejected":
+        return localeText(
+          locale,
+          "最新请求在执行前被拒绝，需要先修正请求本身或权限/模式前提。",
+          "The latest request was rejected before execution; fix the request itself or its permission/mode prerequisites first."
+        );
+      default:
+        return localeText(
+          locale,
+          "当前目标正在执行中，先盯住状态机、主因果和下一步，再决定是否继续推进。",
+          "The current goal is executing; read the state machine, primary causality, and next step before pushing again."
+        );
+    }
+  })();
+  const blockerLabel = (() => {
+    switch (resolvedBlockerKind) {
+      case "material_shortage":
+        return localeText(locale, "缺料", "Missing Material");
+      case "power_shortage":
+        return localeText(locale, "缺电", "Missing Power");
+      case "governance_gate":
+        return localeText(locale, "治理限制", "Governance Restriction");
+      case "no_progress":
+        return localeText(locale, "没有前进", "No Forward Progress");
+      case "llm_required":
+        return localeText(locale, "缺少玩法能力", "Missing Gameplay Capability");
+      case "runtime_sync_unavailable":
+        return localeText(locale, "运行时同步不可用", "Runtime Sync Unavailable");
+      case "execution_world_not_ready":
+        return localeText(locale, "执行世界未就绪", "Execution World Not Ready");
+      case "runtime_snapshot_empty_entities":
+        return localeText(locale, "空快照", "Empty Snapshot");
+      default:
+        return resolvedBlockerKind || null;
+    }
+  })();
   return {
     stageId: gameplay.stage_id || null,
-    stageStatus: emptyEntityBlocker ? "blocked" : gameplay.stage_status || null,
+    stageStatus: resolvedStageStatus,
+    executionState,
+    executionStateLabel,
+    executionStateMachine,
+    executionSummary,
+    executionCauseKind,
+    executionCauseLabel,
+    executionCauseDetail,
     goalId: gameplay.goal_id || null,
     goalKind: gameplay.goal_kind || null,
     goalTitle: gameplay.goal_title || null,
     objective: gameplay.objective || null,
     progressDetail: gameplay.progress_detail || null,
     progressPercent,
-    blockerKind: runtimeAlreadyPublishedEmptyEntityBlocker ? runtimeBlockerKind : emptyEntityBlocker ? emptyEntityBlocker.blockerKind : runtimeBlockerKind,
-    blockerDetail: runtimeAlreadyPublishedEmptyEntityBlocker ? runtimeBlockerDetail || emptyEntityBlocker?.blockerDetail || null : emptyEntityBlocker ? emptyEntityBlocker.blockerDetail : runtimeBlockerDetail,
+    blockerKind: resolvedBlockerKind,
+    blockerLabel,
+    blockerDetail: resolvedBlockerDetail,
     blockerSupplementalDetail: emptyEntityBlocker && runtimeBlockerDetail && !runtimeAlreadyPublishedEmptyEntityBlocker ? runtimeBlockerDetail : null,
     nextStepHint: runtimeAlreadyPublishedEmptyEntityBlocker ? gameplay.next_step_hint || emptyEntityBlocker?.nextStepHint || null : emptyEntityBlocker ? emptyEntityBlocker.nextStepHint : gameplay.next_step_hint || null,
     branchHint: gameplay.branch_hint || null,
@@ -5008,6 +5166,9 @@ function gameplayStageLabel(status, locale) {
   }
   return status || tr(locale, "等待同步", "Waiting for Sync");
 }
+function goalExecutionBadgeClass(state2) {
+  return state2 === "blocked" || state2 === "rejected" ? "badge badge--warn" : state2 === "completed" ? "badge badge--good" : "badge badge--accent";
+}
 function gameplayProgressLabel(progressPercent, locale) {
   return progressPercent == null ? tr(locale, "进度待发布", "Progress Pending") : tr(locale, `进度 ${progressPercent}%`, `Progress ${progressPercent}%`);
 }
@@ -5261,7 +5422,65 @@ function WorldSummaryPanel() {
               }
             }), null);
             return _el$114;
-          })(), createComponent(Show, {
+          })(), createComponent(EventCard, {
+            get title() {
+              return tr(locale(), "目标执行状态", "Goal Execution");
+            },
+            get badge() {
+              return gameplay().executionStateLabel || gameplay().executionState || "-";
+            },
+            get badgeClass() {
+              return goalExecutionBadgeClass(gameplay().executionState);
+            },
+            get meta() {
+              return tr(locale(), "统一状态机：Accepted -> Executing -> Blocked / Completed / Rejected", "Unified state machine: Accepted -> Executing -> Blocked / Completed / Rejected");
+            },
+            get children() {
+              return [(() => {
+                var _el$115 = _tmpl$14();
+                insert(_el$115, createComponent(For, {
+                  get each() {
+                    return gameplay().executionStateMachine || [];
+                  },
+                  children: (item) => createComponent(Badge, {
+                    get ["class"]() {
+                      return memo(() => gameplay().executionState === item.id)() ? goalExecutionBadgeClass(item.id) : "badge";
+                    },
+                    get children() {
+                      return item.label;
+                    }
+                  })
+                }));
+                return _el$115;
+              })(), (() => {
+                var _el$116 = _tmpl$13();
+                insert(_el$116, () => gameplay().executionSummary || tr(locale(), "等待目标执行状态更新。", "Waiting for goal execution state updates."));
+                return _el$116;
+              })(), createComponent(Show, {
+                get when() {
+                  return gameplay().executionCauseLabel;
+                },
+                get children() {
+                  var _el$117 = _tmpl$14();
+                  insert(_el$117, createComponent(Badge, {
+                    get children() {
+                      return gameplay().executionCauseLabel;
+                    }
+                  }));
+                  return _el$117;
+                }
+              }), createComponent(Show, {
+                get when() {
+                  return gameplay().executionCauseDetail;
+                },
+                get children() {
+                  var _el$118 = _tmpl$4();
+                  insert(_el$118, () => gameplay().executionCauseDetail);
+                  return _el$118;
+                }
+              })];
+            }
+          }), createComponent(Show, {
             get when() {
               return gameplay().blockerKind || gameplay().blockerDetail;
             },
@@ -5271,50 +5490,50 @@ function WorldSummaryPanel() {
                   return memo(() => gameplay().blockerKind === "runtime_snapshot_empty_entities")() ? tr(locale(), "当前阻塞：空快照", "Current Blocker: Empty Snapshot") : tr(locale(), "当前阻塞", "Current Blocker");
                 },
                 get badge() {
-                  return gameplay().blockerKind || "blocked";
+                  return gameplay().blockerLabel || gameplay().blockerKind || "blocked";
                 },
                 badgeClass: "badge badge--warn",
                 variant: "warn",
                 get children() {
                   return [(() => {
-                    var _el$115 = _tmpl$13();
-                    insert(_el$115, () => gameplay().blockerDetail || tr(locale(), "当前玩法被阻塞，需要显式恢复。", "Gameplay is blocked and needs explicit recovery."));
-                    return _el$115;
+                    var _el$119 = _tmpl$13();
+                    insert(_el$119, () => gameplay().blockerDetail || tr(locale(), "当前玩法被阻塞，需要显式恢复。", "Gameplay is blocked and needs explicit recovery."));
+                    return _el$119;
                   })(), createComponent(Show, {
                     get when() {
                       return gameplay().blockerSupplementalDetail;
                     },
                     get children() {
-                      var _el$116 = _tmpl$4();
-                      insert(_el$116, () => gameplay().blockerSupplementalDetail);
-                      return _el$116;
+                      var _el$120 = _tmpl$4();
+                      insert(_el$120, () => gameplay().blockerSupplementalDetail);
+                      return _el$120;
                     }
                   }), createComponent(Show, {
                     get when() {
                       return gameplay().nextStepHint;
                     },
                     get children() {
-                      var _el$117 = _tmpl$4();
-                      insert(_el$117, () => gameplay().nextStepHint);
-                      return _el$117;
+                      var _el$121 = _tmpl$4();
+                      insert(_el$121, () => gameplay().nextStepHint);
+                      return _el$121;
                     }
                   }), createComponent(Show, {
                     get when() {
                       return gameplay().entityCounts;
                     },
                     get children() {
-                      var _el$118 = _tmpl$14();
-                      insert(_el$118, createComponent(Badge, {
+                      var _el$122 = _tmpl$14();
+                      insert(_el$122, createComponent(Badge, {
                         get children() {
                           return `agents=${gameplay().entityCounts.agents}`;
                         }
                       }), null);
-                      insert(_el$118, createComponent(Badge, {
+                      insert(_el$122, createComponent(Badge, {
                         get children() {
                           return `locations=${gameplay().entityCounts.locations}`;
                         }
                       }), null);
-                      return _el$118;
+                      return _el$122;
                     }
                   })];
                 }
@@ -5337,9 +5556,9 @@ function WorldSummaryPanel() {
                   return gameplay().progressDetail;
                 },
                 get children() {
-                  var _el$119 = _tmpl$4();
-                  insert(_el$119, () => gameplay().progressDetail);
-                  return _el$119;
+                  var _el$123 = _tmpl$4();
+                  insert(_el$123, () => gameplay().progressDetail);
+                  return _el$123;
                 }
               });
             }
@@ -5362,26 +5581,26 @@ function WorldSummaryPanel() {
               },
               get children() {
                 return [(() => {
-                  var _el$127 = _tmpl$13();
-                  insert(_el$127, () => feedback().effect || feedback().reason || "Gameplay feedback updated.");
-                  return _el$127;
+                  var _el$131 = _tmpl$13();
+                  insert(_el$131, () => feedback().effect || feedback().reason || "Gameplay feedback updated.");
+                  return _el$131;
                 })(), createComponent(Show, {
                   get when() {
                     return feedback().reason;
                   },
                   get children() {
-                    var _el$128 = _tmpl$4();
-                    insert(_el$128, () => feedback().reason);
-                    return _el$128;
+                    var _el$132 = _tmpl$4();
+                    insert(_el$132, () => feedback().reason);
+                    return _el$132;
                   }
                 }), createComponent(Show, {
                   get when() {
                     return feedback().hint;
                   },
                   get children() {
-                    var _el$129 = _tmpl$4();
-                    insert(_el$129, () => feedback().hint);
-                    return _el$129;
+                    var _el$133 = _tmpl$4();
+                    insert(_el$133, () => feedback().hint);
+                    return _el$133;
                   }
                 })];
               }
@@ -5395,17 +5614,17 @@ function WorldSummaryPanel() {
             },
             get children() {
               return [(() => {
-                var _el$120 = _tmpl$13();
-                insert(_el$120, () => gameplay().nextStepHint || tr(locale(), "等待下一次 runtime 指引更新。", "Wait for the next runtime guidance update."));
-                return _el$120;
+                var _el$124 = _tmpl$13();
+                insert(_el$124, () => gameplay().nextStepHint || tr(locale(), "等待下一次 runtime 指引更新。", "Wait for the next runtime guidance update."));
+                return _el$124;
               })(), createComponent(Show, {
                 get when() {
                   return gameplay().branchHint;
                 },
                 get children() {
-                  var _el$121 = _tmpl$4();
-                  insert(_el$121, () => gameplay().branchHint);
-                  return _el$121;
+                  var _el$125 = _tmpl$4();
+                  insert(_el$125, () => gameplay().branchHint);
+                  return _el$125;
                 }
               })];
             }
@@ -5422,9 +5641,9 @@ function WorldSummaryPanel() {
               }
             })
           }), (() => {
-            var _el$122 = _tmpl$27(), _el$123 = _el$122.firstChild, _el$124 = _el$123.nextSibling;
-            insert(_el$123, () => tr(locale(), "可用玩法动作", "Available Gameplay Actions"));
-            insert(_el$124, createComponent(Show, {
+            var _el$126 = _tmpl$27(), _el$127 = _el$126.firstChild, _el$128 = _el$127.nextSibling;
+            insert(_el$127, () => tr(locale(), "可用玩法动作", "Available Gameplay Actions"));
+            insert(_el$128, createComponent(Show, {
               get when() {
                 return gameplay().availableActions.length > 0;
               },
@@ -5456,36 +5675,36 @@ function WorldSummaryPanel() {
                     },
                     get children() {
                       return [(() => {
-                        var _el$130 = _tmpl$4();
-                        insert(_el$130, () => action.disabledReason || tr(locale(), "无需打开 visual QA viewer，也可以直接从正式 Web 入口执行。", "Playable from the formal Web entry without opening the visual QA viewer."));
-                        return _el$130;
+                        var _el$134 = _tmpl$4();
+                        insert(_el$134, () => action.disabledReason || tr(locale(), "无需打开 visual QA viewer，也可以直接从正式 Web 入口执行。", "Playable from the formal Web entry without opening the visual QA viewer."));
+                        return _el$134;
                       })(), createComponent(Show, {
                         get when() {
                           return action.executeKind === "request_snapshot" || action.executeKind === "step" || action.executeKind === "play" || action.executeKind === "gameplay_action";
                         },
                         get children() {
-                          var _el$131 = _tmpl$28(), _el$132 = _el$131.firstChild;
-                          _el$132.$$click = () => sendGameplayAction(action);
-                          insert(_el$132, (() => {
+                          var _el$135 = _tmpl$28(), _el$136 = _el$135.firstChild;
+                          _el$136.$$click = () => sendGameplayAction(action);
+                          insert(_el$136, (() => {
                             var _c$ = memo(() => action.executeKind === "request_snapshot");
                             return () => _c$() ? tr(locale(), "刷新快照", "Refresh Snapshot") : memo(() => action.executeKind === "step")() ? tr(locale(), "推进一步", "Advance One Step") : memo(() => action.executeKind === "play")() ? tr(locale(), "恢复实时推进", "Resume Live Play") : tr(locale(), "提交玩法动作", "Submit Gameplay Action");
                           })());
-                          createRenderEffect(() => _el$132.disabled = Boolean(action.disabledReason));
-                          return _el$131;
+                          createRenderEffect(() => _el$136.disabled = Boolean(action.disabledReason));
+                          return _el$135;
                         }
                       }), createComponent(Show, {
                         get when() {
                           return action.executeKind === "agent_chat";
                         },
                         get children() {
-                          var _el$133 = _tmpl$28(), _el$134 = _el$133.firstChild;
-                          _el$134.$$click = () => applySelection({
+                          var _el$137 = _tmpl$28(), _el$138 = _el$137.firstChild;
+                          _el$138.$$click = () => applySelection({
                             kind: "agent",
                             id: action.targetAgentId
                           });
-                          insert(_el$134, () => tr(locale(), "切到聊天面板", "Use Chat Panel"));
-                          createRenderEffect(() => _el$134.disabled = Boolean(action.disabledReason));
-                          return _el$133;
+                          insert(_el$138, () => tr(locale(), "切到聊天面板", "Use Chat Panel"));
+                          createRenderEffect(() => _el$138.disabled = Boolean(action.disabledReason));
+                          return _el$137;
                         }
                       })];
                     }
@@ -5493,7 +5712,7 @@ function WorldSummaryPanel() {
                 });
               }
             }));
-            return _el$122;
+            return _el$126;
           })(), createComponent(CalloutCard, {
             get title() {
               return tr(locale(), "未在此页暴露的动作", "Actions Not Exposed On This Page");
@@ -5502,13 +5721,13 @@ function WorldSummaryPanel() {
             badgeClass: "badge badge--warn",
             get children() {
               return [(() => {
-                var _el$125 = _tmpl$13();
-                insert(_el$125, () => gameplay().assetGovernanceHandoff);
-                return _el$125;
+                var _el$129 = _tmpl$13();
+                insert(_el$129, () => gameplay().assetGovernanceHandoff);
+                return _el$129;
               })(), (() => {
-                var _el$126 = _tmpl$4();
-                insert(_el$126, () => tr(locale(), "资产 / 治理相关能力请走单独 lane；这张主入口页面只保留正式玩法所需的最小动作面。", "Asset and governance actions stay on their dedicated lane; this primary entry only keeps the minimum surface needed for formal gameplay."));
-                return _el$126;
+                var _el$130 = _tmpl$4();
+                insert(_el$130, () => tr(locale(), "资产 / 治理相关能力请走单独 lane；这张主入口页面只保留正式玩法所需的最小动作面。", "Asset and governance actions stay on their dedicated lane; this primary entry only keeps the minimum surface needed for formal gameplay."));
+                return _el$130;
               })()];
             }
           })]
@@ -5567,13 +5786,13 @@ function WorldSummaryPanel() {
                 return hostedRecoveryHint();
               },
               children: (hint) => (() => {
-                var _el$135 = _tmpl$21(), _el$136 = _el$135.firstChild;
-                _el$136.$$click = () => {
+                var _el$139 = _tmpl$21(), _el$140 = _el$139.firstChild;
+                _el$140.$$click = () => {
                   void retryHostedPlayerIdentityIssue();
                 };
-                insert(_el$136, () => hint().cta);
-                createRenderEffect(() => _el$136.disabled = state$1.auth.issueInFlight);
-                return _el$135;
+                insert(_el$140, () => hint().cta);
+                createRenderEffect(() => _el$140.disabled = state$1.auth.issueInFlight);
+                return _el$139;
               })()
             }), createComponent(Show, {
               get when() {
@@ -5677,99 +5896,99 @@ function WorldSummaryPanel() {
             });
           },
           children: (debug) => [(() => {
-            var _el$137 = _tmpl$14();
-            insert(_el$137, createComponent(Badge, {
+            var _el$141 = _tmpl$14();
+            insert(_el$141, createComponent(Badge, {
               "class": "badge badge--accent",
               children: "selected agent lane"
             }), null);
-            insert(_el$137, createComponent(Badge, {
+            insert(_el$141, createComponent(Badge, {
               get children() {
                 return `provider=${debug().provider_mode || "-"}`;
               }
             }), null);
-            insert(_el$137, createComponent(Badge, {
+            insert(_el$141, createComponent(Badge, {
               get children() {
                 return `mode=${debug().execution_mode || "-"}`;
               }
             }), null);
-            insert(_el$137, createComponent(Badge, {
+            insert(_el$141, createComponent(Badge, {
               get children() {
                 return `env=${debug().environment_class || "-"}`;
               }
             }), null);
-            return _el$137;
+            return _el$141;
           })(), (() => {
-            var _el$138 = _tmpl$14();
-            insert(_el$138, createComponent(Badge, {
+            var _el$142 = _tmpl$14();
+            insert(_el$142, createComponent(Badge, {
               get children() {
                 return `obs=${debug().observation_schema_version || "-"}`;
               }
             }), null);
-            insert(_el$138, createComponent(Badge, {
+            insert(_el$142, createComponent(Badge, {
               get children() {
                 return `act=${debug().action_schema_version || "-"}`;
               }
             }), null);
-            insert(_el$138, createComponent(Badge, {
+            insert(_el$142, createComponent(Badge, {
               get children() {
                 return `agentProfile=${debug().agent_profile || "-"}`;
               }
             }), null);
-            insert(_el$138, createComponent(Badge, {
+            insert(_el$142, createComponent(Badge, {
               get children() {
                 return `providerFallback=${debug().fallback_reason || "-"}`;
               }
             }), null);
-            return _el$138;
+            return _el$142;
           })(), createComponent(EmptyState, {
             style: "margin-top:-2px;",
             get children() {
               return tr(locale(), "上面的 lane badge 表示 phase-1 期望执行 contract；下面的 provider check badge 表示 runtime_live 基于 /v1/provider/info 和 /v1/provider/health 的真实探测结果。", "Lane badges show the expected phase-1 execution contract. Provider check badges below show the actual runtime_live probe against /v1/provider/info and /v1/provider/health.");
             }
           }), (() => {
-            var _el$139 = _tmpl$14();
-            insert(_el$139, createComponent(Badge, {
+            var _el$143 = _tmpl$14();
+            insert(_el$143, createComponent(Badge, {
               "class": "badge badge--accent",
               children: "provider check"
             }), null);
-            insert(_el$139, createComponent(Badge, {
+            insert(_el$143, createComponent(Badge, {
               get children() {
                 return `status=${debug().provider_check_status || "-"}`;
               }
             }), null);
-            insert(_el$139, createComponent(Badge, {
+            insert(_el$143, createComponent(Badge, {
               get children() {
                 return `source=${debug().provider_check_source || "-"}`;
               }
             }), null);
-            insert(_el$139, createComponent(Badge, {
+            insert(_el$143, createComponent(Badge, {
               get children() {
                 return `fallback=${debug().provider_check_fallback_reason || "-"}`;
               }
             }), null);
-            return _el$139;
+            return _el$143;
           })(), createComponent(Show, {
             get when() {
               return debug().provider_check_error || debug().provider_reported_capabilities?.length || debug().provider_reported_supported_action_sets?.length;
             },
             get children() {
-              var _el$140 = _tmpl$14();
-              insert(_el$140, createComponent(Badge, {
+              var _el$144 = _tmpl$14();
+              insert(_el$144, createComponent(Badge, {
                 get children() {
                   return `actualCaps=${(debug().provider_reported_capabilities || []).join(",") || "-"}`;
                 }
               }), null);
-              insert(_el$140, createComponent(Badge, {
+              insert(_el$144, createComponent(Badge, {
                 get children() {
                   return `actualActions=${(debug().provider_reported_supported_action_sets || []).join(",") || "-"}`;
                 }
               }), null);
-              insert(_el$140, createComponent(Badge, {
+              insert(_el$144, createComponent(Badge, {
                 get children() {
                   return `checkError=${debug().provider_check_error || "-"}`;
                 }
               }), null);
-              return _el$140;
+              return _el$144;
             }
           }), createComponent(JsonBlock, {
             get value() {
@@ -5843,13 +6062,13 @@ function WorldSummaryPanel() {
         return hostedRecoveryHint();
       },
       children: (hint) => (() => {
-        var _el$141 = _tmpl$23();
-        _el$141.$$click = () => {
+        var _el$145 = _tmpl$23();
+        _el$145.$$click = () => {
           void retryHostedPlayerIdentityIssue();
         };
-        insert(_el$141, () => hint().cta);
-        createRenderEffect(() => _el$141.disabled = state$1.auth.issueInFlight);
-        return _el$141;
+        insert(_el$145, () => hint().cta);
+        createRenderEffect(() => _el$145.disabled = state$1.auth.issueInFlight);
+        return _el$145;
       })()
     }), null);
     insert(_el$101, createComponent(Show, {
@@ -5931,53 +6150,53 @@ function WorldSummaryPanel() {
         return state$1.hostedAdmission;
       },
       children: (admission) => (() => {
-        var _el$142 = _tmpl$14();
-        insert(_el$142, createComponent(Badge, {
+        var _el$146 = _tmpl$14();
+        insert(_el$146, createComponent(Badge, {
           get children() {
             return `activeSlots=${admission().active_player_sessions}/${admission().max_player_sessions}`;
           }
         }), null);
-        insert(_el$142, createComponent(Badge, {
+        insert(_el$146, createComponent(Badge, {
           get children() {
             return `effectiveSlots=${admission().effective_player_sessions == null ? "-" : `${admission().effective_player_sessions}/${admission().max_player_sessions}`}`;
           }
         }), null);
-        insert(_el$142, createComponent(Badge, {
+        insert(_el$146, createComponent(Badge, {
           get children() {
             return `runtimeBound=${admission().runtime_bound_player_sessions ?? "-"}`;
           }
         }), null);
-        insert(_el$142, createComponent(Badge, {
+        insert(_el$146, createComponent(Badge, {
           get children() {
             return `runtimeOnly=${admission().runtime_only_player_sessions ?? "-"}`;
           }
         }), null);
-        insert(_el$142, createComponent(Badge, {
+        insert(_el$146, createComponent(Badge, {
           get children() {
             return `runtimeProbe=${admission().runtime_probe_status || "-"}`;
           }
         }), null);
-        insert(_el$142, createComponent(Badge, {
+        insert(_el$146, createComponent(Badge, {
           get children() {
             return `issueBudget=${admission().remaining_issue_budget}`;
           }
         }), null);
-        insert(_el$142, createComponent(Badge, {
+        insert(_el$146, createComponent(Badge, {
           get children() {
             return `leaseTTL=${admission().slot_lease_ttl_ms}`;
           }
         }), null);
-        insert(_el$142, createComponent(Badge, {
+        insert(_el$146, createComponent(Badge, {
           get children() {
             return `issued=${admission().issued_players_total}`;
           }
         }), null);
-        insert(_el$142, createComponent(Badge, {
+        insert(_el$146, createComponent(Badge, {
           get children() {
             return `released=${admission().released_players_total}`;
           }
         }), null);
-        return _el$142;
+        return _el$146;
       })()
     }), _el$110);
     insert(_el$97, createComponent(Show, {
@@ -6245,19 +6464,19 @@ function InteractionPanel() {
     });
   }
   return (() => {
-    var _el$143 = _tmpl$40(), _el$144 = _el$143.firstChild, _el$146 = _el$144.nextSibling;
-    insert(_el$144, createComponent(Badge, {
+    var _el$147 = _tmpl$40(), _el$148 = _el$147.firstChild, _el$150 = _el$148.nextSibling;
+    insert(_el$148, createComponent(Badge, {
       "class": "badge badge--accent",
       get children() {
         return tr(locale(), "当前交互目标", "Current Target");
       }
     }), null);
-    insert(_el$144, createComponent(Badge, {
+    insert(_el$148, createComponent(Badge, {
       get children() {
         return `agent=${agentId()}`;
       }
     }), null);
-    insert(_el$144, createComponent(Badge, {
+    insert(_el$148, createComponent(Badge, {
       get ["class"]() {
         return chatCapability().enabled ? "badge badge--good" : "badge badge--warn";
       },
@@ -6265,7 +6484,7 @@ function InteractionPanel() {
         return memo(() => !!chatCapability().enabled)() ? tr(locale(), "聊天可用", "Chat Ready") : tr(locale(), "聊天受限", "Chat Limited");
       }
     }), null);
-    insert(_el$143, createComponent(Show, {
+    insert(_el$147, createComponent(Show, {
       get when() {
         return debugContext()?.provider_mode === "provider_loopback_http";
       },
@@ -6276,8 +6495,8 @@ function InteractionPanel() {
           }
         });
       }
-    }), _el$146);
-    insert(_el$143, createComponent(Show, {
+    }), _el$150);
+    insert(_el$147, createComponent(Show, {
       get when() {
         return debugContext()?.provider_mode !== "provider_loopback_http";
       },
@@ -6295,24 +6514,24 @@ function InteractionPanel() {
           },
           get children() {
             return [(() => {
-              var _el$145 = _tmpl$14();
-              insert(_el$145, createComponent(Badge, {
+              var _el$149 = _tmpl$14();
+              insert(_el$149, createComponent(Badge, {
                 "class": "badge badge--good",
                 get children() {
                   return authSurface().currentTier;
                 }
               }), null);
-              insert(_el$145, createComponent(Badge, {
+              insert(_el$149, createComponent(Badge, {
                 get children() {
                   return `player=${state.auth.playerId}`;
                 }
               }), null);
-              insert(_el$145, createComponent(Badge, {
+              insert(_el$149, createComponent(Badge, {
                 get children() {
                   return `source=${authSurface().source}`;
                 }
               }), null);
-              return _el$145;
+              return _el$149;
             })(), createComponent(EmptyState, {
               get children() {
                 return promptCapability().reason;
@@ -6321,18 +6540,18 @@ function InteractionPanel() {
           }
         });
       }
-    }), _el$146);
-    insert(_el$146, createComponent(Badge, {
+    }), _el$150);
+    insert(_el$150, createComponent(Badge, {
       get children() {
         return `boundPlayer=${binding()?.playerId || "-"}`;
       }
     }), null);
-    insert(_el$146, createComponent(Badge, {
+    insert(_el$150, createComponent(Badge, {
       get children() {
         return `boundKey=${binding()?.publicKey ? `${binding().publicKey.slice(0, 10)}…` : "-"}`;
       }
     }), null);
-    insert(_el$146, createComponent(Badge, {
+    insert(_el$150, createComponent(Badge, {
       get ["class"]() {
         return promptCapability().enabled ? "badge badge--good" : "badge badge--warn";
       },
@@ -6340,7 +6559,7 @@ function InteractionPanel() {
         return `prompt=${promptCapability().enabled ? "enabled" : promptCapability().code}`;
       }
     }), null);
-    insert(_el$146, createComponent(Badge, {
+    insert(_el$150, createComponent(Badge, {
       get ["class"]() {
         return chatCapability().enabled ? "badge badge--good" : "badge badge--warn";
       },
@@ -6348,7 +6567,7 @@ function InteractionPanel() {
         return `chat=${chatCapability().enabled ? "enabled" : chatCapability().code}`;
       }
     }), null);
-    insert(_el$146, createComponent(Badge, {
+    insert(_el$150, createComponent(Badge, {
       get ["class"]() {
         return mainTokenTransferCapability().enabled ? "badge badge--good" : "badge badge--warn";
       },
@@ -6356,12 +6575,12 @@ function InteractionPanel() {
         return `mainToken=${assetLaneStatusText()}`;
       }
     }), null);
-    insert(_el$143, createComponent(EmptyState, {
+    insert(_el$147, createComponent(EmptyState, {
       get children() {
         return assetLaneDetail();
       }
     }), null);
-    insert(_el$143, createComponent(PanelSection, {
+    insert(_el$147, createComponent(PanelSection, {
       get title() {
         return tr(locale(), "Agent 聊天", "Agent Chat");
       },
@@ -6373,29 +6592,29 @@ function InteractionPanel() {
       },
       get children() {
         return [(() => {
-          var _el$147 = _tmpl$29(), _el$148 = _el$147.firstChild, _el$149 = _el$148.nextSibling;
-          insert(_el$148, () => tr(locale(), "消息", "Message"));
-          _el$149.$$input = (event) => {
+          var _el$151 = _tmpl$29(), _el$152 = _el$151.firstChild, _el$153 = _el$152.nextSibling;
+          insert(_el$152, () => tr(locale(), "消息", "Message"));
+          _el$153.$$input = (event) => {
             state.chatDraft.message = String(event.currentTarget.value || "");
             state.chatDraft.dirty = true;
           };
           createRenderEffect((_p$) => {
             var _v$7 = tr(locale(), "给当前选中的 Agent 发一条消息", "Send a message to the selected agent"), _v$8 = !chatCapability().enabled;
-            _v$7 !== _p$.e && setAttribute(_el$149, "placeholder", _p$.e = _v$7);
-            _v$8 !== _p$.t && (_el$149.disabled = _p$.t = _v$8);
+            _v$7 !== _p$.e && setAttribute(_el$153, "placeholder", _p$.e = _v$7);
+            _v$8 !== _p$.t && (_el$153.disabled = _p$.t = _v$8);
             return _p$;
           }, {
             e: void 0,
             t: void 0
           });
-          createRenderEffect(() => _el$149.value = state.chatDraft.message);
-          return _el$147;
+          createRenderEffect(() => _el$153.value = state.chatDraft.message);
+          return _el$151;
         })(), (() => {
-          var _el$150 = _tmpl$30(), _el$151 = _el$150.firstChild;
-          _el$151.$$click = () => sendAgentChat(agentId(), state.chatDraft.message);
-          insert(_el$151, () => tr(locale(), "发送聊天", "Send Chat"));
-          createRenderEffect(() => _el$151.disabled = !chatCapability().enabled);
-          return _el$150;
+          var _el$154 = _tmpl$30(), _el$155 = _el$154.firstChild;
+          _el$155.$$click = () => sendAgentChat(agentId(), state.chatDraft.message);
+          insert(_el$155, () => tr(locale(), "发送聊天", "Send Chat"));
+          createRenderEffect(() => _el$155.disabled = !chatCapability().enabled);
+          return _el$154;
         })(), createComponent(Show, {
           get when() {
             return chatFeedback();
@@ -6416,9 +6635,9 @@ function InteractionPanel() {
             }
           })
         }), (() => {
-          var _el$152 = _tmpl$31(), _el$153 = _el$152.firstChild, _el$154 = _el$153.nextSibling;
-          insert(_el$153, () => tr(locale(), "消息流", "Message Flow"));
-          insert(_el$154, createComponent(Show, {
+          var _el$156 = _tmpl$31(), _el$157 = _el$156.firstChild, _el$158 = _el$157.nextSibling;
+          insert(_el$157, () => tr(locale(), "消息流", "Message Flow"));
+          insert(_el$158, createComponent(Show, {
             get when() {
               return chatHistory().length > 0;
             },
@@ -6453,11 +6672,11 @@ function InteractionPanel() {
               });
             }
           }));
-          return _el$152;
+          return _el$156;
         })()];
       }
     }), null);
-    insert(_el$143, createComponent(PanelSection, {
+    insert(_el$147, createComponent(PanelSection, {
       get title() {
         return tr(locale(), "高级 Prompt 设置", "Advanced Prompt Settings");
       },
@@ -6469,18 +6688,18 @@ function InteractionPanel() {
       },
       get children() {
         return [(() => {
-          var _el$155 = _tmpl$14();
-          insert(_el$155, createComponent(Badge, {
+          var _el$159 = _tmpl$14();
+          insert(_el$159, createComponent(Badge, {
             get children() {
               return `activePrompt=v${promptVersionState().currentVersion}`;
             }
           }), null);
-          insert(_el$155, createComponent(Badge, {
+          insert(_el$159, createComponent(Badge, {
             get children() {
               return `nextRollback=v${promptVersionState().nextRollbackTargetVersion}`;
             }
           }), null);
-          insert(_el$155, createComponent(Show, {
+          insert(_el$159, createComponent(Show, {
             get when() {
               return promptVersionState().restoredFromVersion != null;
             },
@@ -6492,7 +6711,7 @@ function InteractionPanel() {
               });
             }
           }), null);
-          insert(_el$155, createComponent(Badge, {
+          insert(_el$159, createComponent(Badge, {
             get ["class"]() {
               return promptOverridesVisible() ? "badge badge--good" : "badge";
             },
@@ -6500,25 +6719,25 @@ function InteractionPanel() {
               return memo(() => !!promptOverridesVisible())() ? tr(locale(), "状态=已展开", "state=expanded") : tr(locale(), "状态=默认收起", "state=hidden_by_default");
             }
           }), null);
-          insert(_el$155, createComponent(Badge, {
+          insert(_el$159, createComponent(Badge, {
             get children() {
               return tr(locale(), "本地设置持久化", "locally persisted");
             }
           }), null);
-          return _el$155;
+          return _el$159;
         })(), createComponent(EmptyState, {
           get children() {
             return promptSettingsSummary();
           }
         }), (() => {
-          var _el$156 = _tmpl$32(), _el$157 = _el$156.firstChild;
-          _el$157.$$click = () => togglePromptOverridesVisible();
-          insert(_el$157, promptSettingsButtonLabel);
-          return _el$156;
+          var _el$160 = _tmpl$32(), _el$161 = _el$160.firstChild;
+          _el$161.$$click = () => togglePromptOverridesVisible();
+          insert(_el$161, promptSettingsButtonLabel);
+          return _el$160;
         })()];
       }
     }), null);
-    insert(_el$143, createComponent(Show, {
+    insert(_el$147, createComponent(Show, {
       get when() {
         return promptOverridesVisible();
       },
@@ -6527,97 +6746,97 @@ function InteractionPanel() {
           title: "Prompt Overrides",
           get children() {
             return [(() => {
-              var _el$158 = _tmpl$4();
-              insert(_el$158, () => promptVersionState().summary);
-              return _el$158;
+              var _el$162 = _tmpl$4();
+              insert(_el$162, () => promptVersionState().summary);
+              return _el$162;
             })(), (() => {
-              var _el$159 = _tmpl$4();
-              insert(_el$159, () => promptVersionState().detail);
-              return _el$159;
+              var _el$163 = _tmpl$4();
+              insert(_el$163, () => promptVersionState().detail);
+              return _el$163;
             })(), createComponent(Show, {
               get when() {
                 return memo(() => !!authSurface().capabilities.prompt_control.enabled)() && String(state.hostedAccess?.deployment_mode || "").trim() === "hosted_public_join";
               },
               get children() {
-                var _el$160 = _tmpl$33(), _el$161 = _el$160.firstChild, _el$162 = _el$161.nextSibling;
-                insert(_el$161, () => tr(locale(), "后端审批码", "Backend Approval Code"));
-                _el$162.$$input = (event) => {
+                var _el$164 = _tmpl$33(), _el$165 = _el$164.firstChild, _el$166 = _el$165.nextSibling;
+                insert(_el$165, () => tr(locale(), "后端审批码", "Backend Approval Code"));
+                _el$166.$$input = (event) => {
                   state.strongAuth.approvalCode = String(event.currentTarget.value || "");
                 };
-                createRenderEffect(() => _el$162.value = state.strongAuth.approvalCode || "");
-                return _el$160;
+                createRenderEffect(() => _el$166.value = state.strongAuth.approvalCode || "");
+                return _el$164;
               }
             }), (() => {
-              var _el$163 = _tmpl$34(), _el$164 = _el$163.firstChild, _el$165 = _el$164.nextSibling;
-              insert(_el$164, () => tr(locale(), "System Prompt 覆盖", "System Prompt Override"));
-              _el$165.$$input = (event) => {
+              var _el$167 = _tmpl$34(), _el$168 = _el$167.firstChild, _el$169 = _el$168.nextSibling;
+              insert(_el$168, () => tr(locale(), "System Prompt 覆盖", "System Prompt Override"));
+              _el$169.$$input = (event) => {
                 state.promptDraft.systemPrompt = String(event.currentTarget.value || "");
                 state.promptDraft.dirty = true;
               };
-              createRenderEffect(() => _el$165.disabled = !promptCapability().enabled);
-              createRenderEffect(() => _el$165.value = state.promptDraft.systemPrompt);
-              return _el$163;
+              createRenderEffect(() => _el$169.disabled = !promptCapability().enabled);
+              createRenderEffect(() => _el$169.value = state.promptDraft.systemPrompt);
+              return _el$167;
             })(), (() => {
-              var _el$166 = _tmpl$35(), _el$167 = _el$166.firstChild, _el$168 = _el$167.nextSibling;
-              insert(_el$167, () => tr(locale(), "短期目标覆盖", "Short-Term Goal Override"));
-              _el$168.$$input = (event) => {
+              var _el$170 = _tmpl$35(), _el$171 = _el$170.firstChild, _el$172 = _el$171.nextSibling;
+              insert(_el$171, () => tr(locale(), "短期目标覆盖", "Short-Term Goal Override"));
+              _el$172.$$input = (event) => {
                 state.promptDraft.shortTermGoal = String(event.currentTarget.value || "");
                 state.promptDraft.dirty = true;
               };
-              createRenderEffect(() => _el$168.disabled = !promptCapability().enabled);
-              createRenderEffect(() => _el$168.value = state.promptDraft.shortTermGoal);
-              return _el$166;
+              createRenderEffect(() => _el$172.disabled = !promptCapability().enabled);
+              createRenderEffect(() => _el$172.value = state.promptDraft.shortTermGoal);
+              return _el$170;
             })(), (() => {
-              var _el$169 = _tmpl$36(), _el$170 = _el$169.firstChild, _el$171 = _el$170.nextSibling;
-              insert(_el$170, () => tr(locale(), "长期目标覆盖", "Long-Term Goal Override"));
-              _el$171.$$input = (event) => {
+              var _el$173 = _tmpl$36(), _el$174 = _el$173.firstChild, _el$175 = _el$174.nextSibling;
+              insert(_el$174, () => tr(locale(), "长期目标覆盖", "Long-Term Goal Override"));
+              _el$175.$$input = (event) => {
                 state.promptDraft.longTermGoal = String(event.currentTarget.value || "");
                 state.promptDraft.dirty = true;
               };
-              createRenderEffect(() => _el$171.disabled = !promptCapability().enabled);
-              createRenderEffect(() => _el$171.value = state.promptDraft.longTermGoal);
-              return _el$169;
+              createRenderEffect(() => _el$175.disabled = !promptCapability().enabled);
+              createRenderEffect(() => _el$175.value = state.promptDraft.longTermGoal);
+              return _el$173;
             })(), (() => {
-              var _el$172 = _tmpl$37(), _el$173 = _el$172.firstChild, _el$174 = _el$173.nextSibling;
-              _el$173.$$click = () => sendPromptControl("preview", null);
-              insert(_el$173, () => tr(locale(), "预览 Prompt", "Preview Prompt"));
-              _el$174.$$click = () => sendPromptControl("apply", null);
-              insert(_el$174, () => tr(locale(), "应用 Prompt", "Apply Prompt"));
+              var _el$176 = _tmpl$37(), _el$177 = _el$176.firstChild, _el$178 = _el$177.nextSibling;
+              _el$177.$$click = () => sendPromptControl("preview", null);
+              insert(_el$177, () => tr(locale(), "预览 Prompt", "Preview Prompt"));
+              _el$178.$$click = () => sendPromptControl("apply", null);
+              insert(_el$178, () => tr(locale(), "应用 Prompt", "Apply Prompt"));
               createRenderEffect((_p$) => {
                 var _v$9 = !promptCapability().enabled, _v$0 = !promptCapability().enabled;
-                _v$9 !== _p$.e && (_el$173.disabled = _p$.e = _v$9);
-                _v$0 !== _p$.t && (_el$174.disabled = _p$.t = _v$0);
+                _v$9 !== _p$.e && (_el$177.disabled = _p$.e = _v$9);
+                _v$0 !== _p$.t && (_el$178.disabled = _p$.t = _v$0);
                 return _p$;
               }, {
                 e: void 0,
                 t: void 0
               });
-              return _el$172;
+              return _el$176;
             })(), (() => {
-              var _el$175 = _tmpl$38(), _el$176 = _el$175.firstChild, _el$177 = _el$176.firstChild, _el$178 = _el$177.nextSibling, _el$179 = _el$176.nextSibling;
-              insert(_el$177, () => tr(locale(), "下一次回滚目标版本", "Next Rollback Target Version"));
-              _el$178.$$input = (event) => {
+              var _el$179 = _tmpl$38(), _el$180 = _el$179.firstChild, _el$181 = _el$180.firstChild, _el$182 = _el$181.nextSibling, _el$183 = _el$180.nextSibling;
+              insert(_el$181, () => tr(locale(), "下一次回滚目标版本", "Next Rollback Target Version"));
+              _el$182.$$input = (event) => {
                 const nextValue = Number(event.currentTarget.value || 0);
                 state.promptDraft.rollbackTargetVersion = Math.max(0, Math.floor(nextValue || 0));
                 requestRender();
               };
-              _el$179.$$click = () => {
+              _el$183.$$click = () => {
                 sendPromptControl("rollback", {
                   toVersion: Number(state.promptDraft.rollbackTargetVersion || 0)
                 });
               };
-              insert(_el$179, () => tr(locale(), "回滚 Prompt", "Rollback Prompt"));
+              insert(_el$183, () => tr(locale(), "回滚 Prompt", "Rollback Prompt"));
               createRenderEffect((_p$) => {
                 var _v$1 = !promptCapability().enabled, _v$10 = !promptCapability().enabled;
-                _v$1 !== _p$.e && (_el$178.disabled = _p$.e = _v$1);
-                _v$10 !== _p$.t && (_el$179.disabled = _p$.t = _v$10);
+                _v$1 !== _p$.e && (_el$182.disabled = _p$.e = _v$1);
+                _v$10 !== _p$.t && (_el$183.disabled = _p$.t = _v$10);
                 return _p$;
               }, {
                 e: void 0,
                 t: void 0
               });
-              createRenderEffect(() => _el$178.value = Number(state.promptDraft.rollbackTargetVersion || 0));
-              return _el$175;
+              createRenderEffect(() => _el$182.value = Number(state.promptDraft.rollbackTargetVersion || 0));
+              return _el$179;
             })(), createComponent(Show, {
               get when() {
                 return promptFeedback();
@@ -6665,7 +6884,7 @@ function InteractionPanel() {
         });
       }
     }), null);
-    insert(_el$143, createComponent(PanelSection, {
+    insert(_el$147, createComponent(PanelSection, {
       get title() {
         return tr(locale(), "资产 / 治理 Lane", "Asset / Governance Lane");
       },
@@ -6677,8 +6896,8 @@ function InteractionPanel() {
       },
       get children() {
         return [(() => {
-          var _el$180 = _tmpl$14();
-          insert(_el$180, createComponent(Badge, {
+          var _el$184 = _tmpl$14();
+          insert(_el$184, createComponent(Badge, {
             get ["class"]() {
               return mainTokenTransferCapability().enabled ? "badge badge--good" : "badge badge--warn";
             },
@@ -6686,17 +6905,17 @@ function InteractionPanel() {
               return `main_token_transfer=${assetLaneStatusText()}`;
             }
           }), null);
-          insert(_el$180, createComponent(Badge, {
+          insert(_el$184, createComponent(Badge, {
             get children() {
               return `required_auth=${mainTokenTransferPolicy()?.required_auth || "-"}`;
             }
           }), null);
-          insert(_el$180, createComponent(Badge, {
+          insert(_el$184, createComponent(Badge, {
             get children() {
               return `availability=${mainTokenTransferPolicy()?.availability || "-"}`;
             }
           }), null);
-          return _el$180;
+          return _el$184;
         })(), createComponent(EmptyState, {
           get children() {
             return assetLaneDetail();
@@ -6706,13 +6925,13 @@ function InteractionPanel() {
             return mainTokenTransferPolicy()?.reason || tr(locale(), "当前 lane 没有 main_token_transfer 的 hosted action policy。", "No hosted action policy is available for main_token_transfer on this lane.");
           }
         }), (() => {
-          var _el$181 = _tmpl$39(), _el$182 = _el$181.firstChild;
-          insert(_el$182, () => tr(locale(), "主代币转账（这里暂未开放）", "Main Token Transfer (Not Exposed Here Yet)"));
-          return _el$181;
+          var _el$185 = _tmpl$39(), _el$186 = _el$185.firstChild;
+          insert(_el$186, () => tr(locale(), "主代币转账（这里暂未开放）", "Main Token Transfer (Not Exposed Here Yet)"));
+          return _el$185;
         })()];
       }
     }), null);
-    return _el$143;
+    return _el$147;
   })();
 }
 function DetailsPanel() {
@@ -6739,20 +6958,20 @@ function DetailsPanel() {
   });
   const hasSnapshotDiagnostics = () => !!state.snapshot || !!state.metrics || !!state.hostedAccess;
   return (() => {
-    var _el$183 = _tmpl$42(), _el$184 = _el$183.firstChild, _el$185 = _el$184.nextSibling, _el$186 = _el$185.firstChild, _el$187 = _el$186.nextSibling, _el$188 = _el$187.nextSibling, _el$189 = _el$188.firstChild, _el$190 = _el$189.nextSibling, _el$191 = _el$190.nextSibling, _el$192 = _el$191.firstChild, _el$193 = _el$192.nextSibling;
-    insert(_el$184, createComponent(Badge, {
+    var _el$187 = _tmpl$42(), _el$188 = _el$187.firstChild, _el$189 = _el$188.nextSibling, _el$190 = _el$189.firstChild, _el$191 = _el$190.nextSibling, _el$192 = _el$191.nextSibling, _el$193 = _el$192.firstChild, _el$194 = _el$193.nextSibling, _el$195 = _el$194.nextSibling, _el$196 = _el$195.firstChild, _el$197 = _el$196.nextSibling;
+    insert(_el$188, createComponent(Badge, {
       "class": "badge badge--accent",
       get children() {
         return tr(locale(), "当前命令目标", "Current Command Target");
       }
     }), null);
-    insert(_el$184, createComponent(Badge, {
+    insert(_el$188, createComponent(Badge, {
       get children() {
         return selectedLabel();
       }
     }), null);
-    insert(_el$183, createComponent(InteractionPanel, {}), _el$185);
-    insert(_el$183, createComponent(Show, {
+    insert(_el$187, createComponent(InteractionPanel, {}), _el$189);
+    insert(_el$187, createComponent(Show, {
       get when() {
         return state.selectedObject;
       },
@@ -6783,29 +7002,29 @@ function DetailsPanel() {
         },
         value: () => clone(selected())
       })
-    }), _el$185);
-    insert(_el$186, () => tr(locale(), "世界规模", "World Scale"));
-    insert(_el$187, createComponent(Badge, {
+    }), _el$189);
+    insert(_el$190, () => tr(locale(), "世界规模", "World Scale"));
+    insert(_el$191, createComponent(Badge, {
       get children() {
         return `agents=${snapshotCounts().agents}`;
       }
     }), null);
-    insert(_el$187, createComponent(Badge, {
+    insert(_el$191, createComponent(Badge, {
       get children() {
         return `locations=${snapshotCounts().locations}`;
       }
     }), null);
-    insert(_el$187, createComponent(Badge, {
+    insert(_el$191, createComponent(Badge, {
       get children() {
         return `promptProfiles=${snapshotCounts().promptProfiles}`;
       }
     }), null);
-    insert(_el$187, createComponent(Badge, {
+    insert(_el$191, createComponent(Badge, {
       get children() {
         return `debugContexts=${snapshotCounts().executionDebugContexts}`;
       }
     }), null);
-    insert(_el$188, createComponent(MetricCard, {
+    insert(_el$192, createComponent(MetricCard, {
       get label() {
         return tr(locale(), "物理真值单位", "Canonical Physical Unit");
       },
@@ -6819,9 +7038,9 @@ function DetailsPanel() {
           }
         });
       }
-    }), _el$189);
-    insert(_el$189, () => worldScaleSurface().physicalTruth.canonicalUnitDetail);
-    insert(_el$188, createComponent(MetricCard, {
+    }), _el$193);
+    insert(_el$193, () => worldScaleSurface().physicalTruth.canonicalUnitDetail);
+    insert(_el$192, createComponent(MetricCard, {
       get label() {
         return tr(locale(), "世界边界", "World Bounds");
       },
@@ -6835,9 +7054,9 @@ function DetailsPanel() {
           }
         });
       }
-    }), _el$190);
-    insert(_el$190, () => worldScaleSurface().physicalTruth.worldBoundsDetail);
-    insert(_el$188, createComponent(Show, {
+    }), _el$194);
+    insert(_el$194, () => worldScaleSurface().physicalTruth.worldBoundsDetail);
+    insert(_el$192, createComponent(Show, {
       get when() {
         return worldScaleSurface().physicalTruth.anchor;
       },
@@ -6854,25 +7073,25 @@ function DetailsPanel() {
         },
         get children() {
           return [(() => {
-            var _el$200 = _tmpl$13();
-            insert(_el$200, () => anchor().positionLabel || tr(locale(), "缺少可读坐标。", "Missing readable coordinates."));
-            return _el$200;
+            var _el$204 = _tmpl$13();
+            insert(_el$204, () => anchor().positionLabel || tr(locale(), "缺少可读坐标。", "Missing readable coordinates."));
+            return _el$204;
           })(), createComponent(Show, {
             get when() {
               return anchor().radiusLabel;
             },
             get children() {
-              var _el$201 = _tmpl$43(), _el$202 = _el$201.firstChild;
-              insert(_el$201, () => tr(locale(), "地点半径真值", "Location radius truth"), _el$202);
-              insert(_el$201, () => anchor().radiusLabel, null);
-              return _el$201;
+              var _el$205 = _tmpl$43(), _el$206 = _el$205.firstChild;
+              insert(_el$205, () => tr(locale(), "地点半径真值", "Location radius truth"), _el$206);
+              insert(_el$205, () => anchor().radiusLabel, null);
+              return _el$205;
             }
           })];
         }
       })
-    }), _el$191);
-    insert(_el$192, () => tr(locale(), "最近距离样本", "Nearest Distance Samples"));
-    insert(_el$193, createComponent(Show, {
+    }), _el$195);
+    insert(_el$196, () => tr(locale(), "最近距离样本", "Nearest Distance Samples"));
+    insert(_el$197, createComponent(Show, {
       get when() {
         return worldScaleSurface().physicalTruth.nearestLocations.length > 0;
       },
@@ -6901,19 +7120,19 @@ function DetailsPanel() {
             },
             get children() {
               return [(() => {
-                var _el$203 = _tmpl$43(), _el$204 = _el$203.firstChild;
-                insert(_el$203, () => tr(locale(), "真实距离", "Physical distance"), _el$204);
-                insert(_el$203, () => location.distanceLabel || "-", null);
-                return _el$203;
+                var _el$207 = _tmpl$43(), _el$208 = _el$207.firstChild;
+                insert(_el$207, () => tr(locale(), "真实距离", "Physical distance"), _el$208);
+                insert(_el$207, () => location.distanceLabel || "-", null);
+                return _el$207;
               })(), createComponent(Show, {
                 get when() {
                   return location.radiusLabel;
                 },
                 get children() {
-                  var _el$205 = _tmpl$43(), _el$206 = _el$205.firstChild;
-                  insert(_el$205, () => tr(locale(), "地点半径", "Location radius"), _el$206);
-                  insert(_el$205, () => location.radiusLabel, null);
-                  return _el$205;
+                  var _el$209 = _tmpl$43(), _el$210 = _el$209.firstChild;
+                  insert(_el$209, () => tr(locale(), "地点半径", "Location radius"), _el$210);
+                  insert(_el$209, () => location.radiusLabel, null);
+                  return _el$209;
                 }
               })];
             }
@@ -6921,7 +7140,7 @@ function DetailsPanel() {
         });
       }
     }));
-    insert(_el$188, createComponent(EventCard, {
+    insert(_el$192, createComponent(EventCard, {
       get title() {
         return tr(locale(), "表现层说明", "Presentation Notes");
       },
@@ -6931,26 +7150,26 @@ function DetailsPanel() {
       badgeClass: "badge badge--warn",
       get children() {
         return [(() => {
-          var _el$194 = _tmpl$13();
-          insert(_el$194, () => worldScaleSurface().presentationScale.markerTruthNote);
-          return _el$194;
+          var _el$198 = _tmpl$13();
+          insert(_el$198, () => worldScaleSurface().presentationScale.markerTruthNote);
+          return _el$198;
         })(), (() => {
-          var _el$195 = _tmpl$4();
-          insert(_el$195, () => worldScaleSurface().presentationScale.zoomTruthNote);
-          return _el$195;
+          var _el$199 = _tmpl$4();
+          insert(_el$199, () => worldScaleSurface().presentationScale.zoomTruthNote);
+          return _el$199;
         })(), (() => {
-          var _el$196 = _tmpl$4();
-          insert(_el$196, () => worldScaleSurface().presentationScale.softwareSafeNote);
-          return _el$196;
+          var _el$200 = _tmpl$4();
+          insert(_el$200, () => worldScaleSurface().presentationScale.softwareSafeNote);
+          return _el$200;
         })()];
       }
     }), null);
-    insert(_el$188, createComponent(EmptyState, {
+    insert(_el$192, createComponent(EmptyState, {
       get children() {
         return tr(locale(), "主状态已经在中间的“世界摘要”里展示；这里现在专门保留“厘米真值 vs 表现层夸张”的读图锚点，原始快照仍按需展开。", "The main runtime state already lives in World Summary; this section now reserves the reading anchors for centimeter truth vs presentation exaggeration, while raw snapshots stay collapsible.");
       }
     }), null);
-    insert(_el$185, createComponent(Show, {
+    insert(_el$189, createComponent(Show, {
       get when() {
         return hasSnapshotDiagnostics();
       },
@@ -6969,46 +7188,46 @@ function DetailsPanel() {
         });
       }
     }), null);
-    insert(_el$183, createComponent(Show, {
+    insert(_el$187, createComponent(Show, {
       get when() {
         return state.lastError;
       },
       get children() {
-        var _el$197 = _tmpl$41(), _el$198 = _el$197.firstChild, _el$199 = _el$198.nextSibling;
-        insert(_el$198, () => tr(locale(), "最近错误", "Last Error"));
-        insert(_el$199, () => state.lastError);
-        return _el$197;
+        var _el$201 = _tmpl$41(), _el$202 = _el$201.firstChild, _el$203 = _el$202.nextSibling;
+        insert(_el$202, () => tr(locale(), "最近错误", "Last Error"));
+        insert(_el$203, () => state.lastError);
+        return _el$201;
       }
     }), null);
-    return _el$183;
+    return _el$187;
   })();
 }
 function AppShell() {
   const locale = () => uiLocale();
   return [createComponent(MobileJumpRail, {}), (() => {
-    var _el$207 = _tmpl$44(), _el$208 = _el$207.firstChild, _el$209 = _el$208.firstChild, _el$210 = _el$209.nextSibling, _el$211 = _el$210.nextSibling, _el$212 = _el$208.nextSibling;
-    insert(_el$209, () => tr(locale(), "导航", "Navigate"));
-    insert(_el$210, () => tr(locale(), "目标", "Targets"));
-    insert(_el$211, () => tr(locale(), "先锁定对象，再进入世界舞台或右侧命令面。", "Lock onto a target first, then move into the stage or command surface."));
-    insert(_el$212, createComponent(TargetsPanel, {}));
-    return _el$207;
+    var _el$211 = _tmpl$44(), _el$212 = _el$211.firstChild, _el$213 = _el$212.firstChild, _el$214 = _el$213.nextSibling, _el$215 = _el$214.nextSibling, _el$216 = _el$212.nextSibling;
+    insert(_el$213, () => tr(locale(), "导航", "Navigate"));
+    insert(_el$214, () => tr(locale(), "目标", "Targets"));
+    insert(_el$215, () => tr(locale(), "先锁定对象，再进入世界舞台或右侧命令面。", "Lock onto a target first, then move into the stage or command surface."));
+    insert(_el$216, createComponent(TargetsPanel, {}));
+    return _el$211;
   })(), (() => {
-    var _el$213 = _tmpl$45(), _el$214 = _el$213.firstChild, _el$215 = _el$214.firstChild;
-    insert(_el$215, createComponent(WorldStageHero, {}), null);
-    insert(_el$215, createComponent(PixelWorldHost, {
+    var _el$217 = _tmpl$45(), _el$218 = _el$217.firstChild, _el$219 = _el$218.firstChild;
+    insert(_el$219, createComponent(WorldStageHero, {}), null);
+    insert(_el$219, createComponent(PixelWorldHost, {
       get locale() {
         return locale();
       }
     }), null);
-    insert(_el$215, createComponent(WorldSummaryPanel, {}), null);
-    return _el$213;
+    insert(_el$219, createComponent(WorldSummaryPanel, {}), null);
+    return _el$217;
   })(), (() => {
-    var _el$216 = _tmpl$46(), _el$217 = _el$216.firstChild, _el$218 = _el$217.firstChild, _el$219 = _el$218.nextSibling, _el$220 = _el$219.nextSibling, _el$221 = _el$217.nextSibling;
-    insert(_el$218, () => tr(locale(), "指挥与核查", "Command and Inspect"));
-    insert(_el$219, () => tr(locale(), "交互与明细", "Interact and Inspect"));
-    insert(_el$220, () => tr(locale(), "只有锁定目标后才进入这里。聊天优先，Prompt 与对象核查继续后置。", "Enter this column only after locking a target. Chat comes first; prompt controls and raw inspection stay behind it."));
-    insert(_el$221, createComponent(DetailsPanel, {}));
-    return _el$216;
+    var _el$220 = _tmpl$46(), _el$221 = _el$220.firstChild, _el$222 = _el$221.firstChild, _el$223 = _el$222.nextSibling, _el$224 = _el$223.nextSibling, _el$225 = _el$221.nextSibling;
+    insert(_el$222, () => tr(locale(), "指挥与核查", "Command and Inspect"));
+    insert(_el$223, () => tr(locale(), "交互与明细", "Interact and Inspect"));
+    insert(_el$224, () => tr(locale(), "只有锁定目标后才进入这里。聊天优先，Prompt 与对象核查继续后置。", "Enter this column only after locking a target. Chat comes first; prompt controls and raw inspection stay behind it."));
+    insert(_el$225, createComponent(DetailsPanel, {}));
+    return _el$220;
   })()];
 }
 function mountViewerApp(root = document.getElementById("app")) {

--- a/crates/oasis7_viewer/software_safe_src/legacy_core.js
+++ b/crates/oasis7_viewer/software_safe_src/legacy_core.js
@@ -180,6 +180,10 @@ function resolveInitialUiLocale() {
     || "en";
 }
 
+function localeText(locale, zh, en) {
+  return isLocaleZh(locale) ? zh : en;
+}
+
 function promptOverridesVisibilityStorageKey() {
   return `${PROMPT_OVERRIDES_VISIBILITY_STORAGE_PREFIX}:${window.location.pathname || "viewer.html"}`;
 }
@@ -1500,26 +1504,184 @@ function buildGameplaySummary(locale = state.uiLocale) {
   const runtimeBlockerDetail = gameplay.blocker_detail || null;
   const runtimeAlreadyPublishedEmptyEntityBlocker =
     runtimeBlockerKind === "runtime_snapshot_empty_entities";
+  const resolvedStageStatus = emptyEntityBlocker ? "blocked" : gameplay.stage_status || null;
+  const resolvedBlockerKind = runtimeAlreadyPublishedEmptyEntityBlocker
+    ? runtimeBlockerKind
+    : emptyEntityBlocker
+      ? emptyEntityBlocker.blockerKind
+      : runtimeBlockerKind;
+  const resolvedBlockerDetail = runtimeAlreadyPublishedEmptyEntityBlocker
+    ? runtimeBlockerDetail || emptyEntityBlocker?.blockerDetail || null
+    : emptyEntityBlocker
+      ? emptyEntityBlocker.blockerDetail
+      : runtimeBlockerDetail;
+  const executionState = gameplay.execution_state
+    || (() => {
+      const recentStage = String(recentFeedback?.stage || "").trim().toLowerCase();
+      if (["accepted", "submitted", "queued", "ack"].includes(recentStage)) {
+        return "accepted";
+      }
+      if (recentStage === "rejected") {
+        return "rejected";
+      }
+      if (["blocked", "completed_no_progress"].includes(recentStage)) {
+        return "blocked";
+      }
+      if (recentStage === "completed_advanced") {
+        return "completed";
+      }
+      if (resolvedStageStatus === "blocked") {
+        return "blocked";
+      }
+      if (resolvedStageStatus === "branch_ready") {
+        return "completed";
+      }
+      return "executing";
+    })();
+  const executionStateLabel = (() => {
+    switch (executionState) {
+      case "accepted":
+        return localeText(locale, "已接受", "Accepted");
+      case "blocked":
+        return localeText(locale, "已阻塞", "Blocked");
+      case "completed":
+        return localeText(locale, "已完成", "Completed");
+      case "rejected":
+        return localeText(locale, "已拒绝", "Rejected");
+      default:
+        return localeText(locale, "执行中", "Executing");
+    }
+  })();
+  const executionStateMachine = [
+    { id: "accepted", label: localeText(locale, "已接受", "Accepted") },
+    { id: "executing", label: localeText(locale, "执行中", "Executing") },
+    { id: "blocked", label: localeText(locale, "已阻塞", "Blocked") },
+    { id: "completed", label: localeText(locale, "已完成", "Completed") },
+    { id: "rejected", label: localeText(locale, "已拒绝", "Rejected") },
+  ];
+  const executionCauseKind = gameplay.causality_kind
+    || (() => {
+      if (executionState === "accepted") return "queued_for_execution";
+      if (executionState === "rejected") return "request_rejected";
+      if (executionState === "blocked") return "world_constraint";
+      if (executionState === "completed") return "goal_progressed";
+      return null;
+    })();
+  const executionCauseLabel = (() => {
+    switch (executionCauseKind) {
+      case "queued_for_execution":
+        return localeText(locale, "等待执行", "Queued for Execution");
+      case "world_constraint":
+        return localeText(locale, "世界约束", "World Constraint");
+      case "agent_override":
+        return localeText(locale, "Agent 改走了别的允许路径", "Agent Chose Differently");
+      case "goal_progressed":
+        return localeText(locale, "世界已推进", "World Progressed");
+      case "request_rejected":
+        return localeText(locale, "请求被拒绝", "Request Rejected");
+      default:
+        return null;
+    }
+  })();
+  const executionCauseDetail = gameplay.causality_detail
+    || (() => {
+      if (executionState === "blocked") {
+        return resolvedBlockerDetail || recentFeedback?.reason || null;
+      }
+      if (executionState === "accepted") {
+        return recentFeedback?.hint || recentFeedback?.effect || null;
+      }
+      if (executionState === "completed") {
+        return recentFeedback?.effect || gameplay.progress_detail || null;
+      }
+      if (executionState === "rejected") {
+        return recentFeedback?.reason || null;
+      }
+      return null;
+    })();
+  const executionSummary = (() => {
+    if (executionCauseKind === "agent_override") {
+      return localeText(
+        locale,
+        "本次目标已推动世界继续前进，但执行它的 Agent 最终采用了另一条被允许的计划。",
+        "This goal still advanced the world, but the acting agent finished it through a different allowed plan.",
+      );
+    }
+    switch (executionState) {
+      case "accepted":
+        return localeText(
+          locale,
+          "最新一条目标相关指令已经入队，正在等待 committed world delta 或后续回执。",
+          "The latest goal-affecting command is queued and waiting for committed world delta or follow-up feedback.",
+        );
+      case "blocked":
+        return localeText(
+          locale,
+          "当前目标没有继续推进，主要原因已经被归入可修复的 blocker taxonomy。",
+          "The current goal is not moving forward; the primary reason is now grouped into a repairable blocker taxonomy.",
+        );
+      case "completed":
+        return localeText(
+          locale,
+          "当前目标最近一次执行已经产生世界级结果，可以决定是继续放大、恢复，还是切到下一条主线。",
+          "The current goal's latest execution already produced a world-level result; you can now amplify it, recover it, or pivot to the next line.",
+        );
+      case "rejected":
+        return localeText(
+          locale,
+          "最新请求在执行前被拒绝，需要先修正请求本身或权限/模式前提。",
+          "The latest request was rejected before execution; fix the request itself or its permission/mode prerequisites first.",
+        );
+      default:
+        return localeText(
+          locale,
+          "当前目标正在执行中，先盯住状态机、主因果和下一步，再决定是否继续推进。",
+          "The current goal is executing; read the state machine, primary causality, and next step before pushing again.",
+        );
+    }
+  })();
+  const blockerLabel = (() => {
+    switch (resolvedBlockerKind) {
+      case "material_shortage":
+        return localeText(locale, "缺料", "Missing Material");
+      case "power_shortage":
+        return localeText(locale, "缺电", "Missing Power");
+      case "governance_gate":
+        return localeText(locale, "治理限制", "Governance Restriction");
+      case "no_progress":
+        return localeText(locale, "没有前进", "No Forward Progress");
+      case "llm_required":
+        return localeText(locale, "缺少玩法能力", "Missing Gameplay Capability");
+      case "runtime_sync_unavailable":
+        return localeText(locale, "运行时同步不可用", "Runtime Sync Unavailable");
+      case "execution_world_not_ready":
+        return localeText(locale, "执行世界未就绪", "Execution World Not Ready");
+      case "runtime_snapshot_empty_entities":
+        return localeText(locale, "空快照", "Empty Snapshot");
+      default:
+        return resolvedBlockerKind || null;
+    }
+  })();
 
   return {
     stageId: gameplay.stage_id || null,
-    stageStatus: emptyEntityBlocker ? "blocked" : gameplay.stage_status || null,
+    stageStatus: resolvedStageStatus,
+    executionState,
+    executionStateLabel,
+    executionStateMachine,
+    executionSummary,
+    executionCauseKind,
+    executionCauseLabel,
+    executionCauseDetail,
     goalId: gameplay.goal_id || null,
     goalKind: gameplay.goal_kind || null,
     goalTitle: gameplay.goal_title || null,
     objective: gameplay.objective || null,
     progressDetail: gameplay.progress_detail || null,
     progressPercent,
-    blockerKind: runtimeAlreadyPublishedEmptyEntityBlocker
-      ? runtimeBlockerKind
-      : emptyEntityBlocker
-        ? emptyEntityBlocker.blockerKind
-        : runtimeBlockerKind,
-    blockerDetail: runtimeAlreadyPublishedEmptyEntityBlocker
-      ? runtimeBlockerDetail || emptyEntityBlocker?.blockerDetail || null
-      : emptyEntityBlocker
-        ? emptyEntityBlocker.blockerDetail
-        : runtimeBlockerDetail,
+    blockerKind: resolvedBlockerKind,
+    blockerLabel,
+    blockerDetail: resolvedBlockerDetail,
     blockerSupplementalDetail: emptyEntityBlocker && runtimeBlockerDetail && !runtimeAlreadyPublishedEmptyEntityBlocker
       ? runtimeBlockerDetail
       : null,

--- a/crates/oasis7_viewer/software_safe_src/legacy_core.js
+++ b/crates/oasis7_viewer/software_safe_src/legacy_core.js
@@ -1515,7 +1515,9 @@ function buildGameplaySummary(locale = state.uiLocale) {
     : emptyEntityBlocker
       ? emptyEntityBlocker.blockerDetail
       : runtimeBlockerDetail;
-  const executionState = gameplay.execution_state
+  const executionState = emptyEntityBlocker
+    ? "blocked"
+    : gameplay.execution_state
     || (() => {
       const recentStage = String(recentFeedback?.stage || "").trim().toLowerCase();
       if (["accepted", "submitted", "queued", "ack"].includes(recentStage)) {
@@ -1559,7 +1561,9 @@ function buildGameplaySummary(locale = state.uiLocale) {
     { id: "completed", label: localeText(locale, "已完成", "Completed") },
     { id: "rejected", label: localeText(locale, "已拒绝", "Rejected") },
   ];
-  const executionCauseKind = gameplay.causality_kind
+  const executionCauseKind = emptyEntityBlocker
+    ? "world_constraint"
+    : gameplay.causality_kind
     || (() => {
       if (executionState === "accepted") return "queued_for_execution";
       if (executionState === "rejected") return "request_rejected";
@@ -1583,7 +1587,9 @@ function buildGameplaySummary(locale = state.uiLocale) {
         return null;
     }
   })();
-  const executionCauseDetail = gameplay.causality_detail
+  const executionCauseDetail = emptyEntityBlocker
+    ? resolvedBlockerDetail || emptyEntityBlocker.blockerDetail || null
+    : gameplay.causality_detail
     || (() => {
       if (executionState === "blocked") {
         return resolvedBlockerDetail || recentFeedback?.reason || null;

--- a/crates/oasis7_viewer/software_safe_src/main.jsx
+++ b/crates/oasis7_viewer/software_safe_src/main.jsx
@@ -257,6 +257,14 @@ function gameplayStageLabel(status, locale) {
   return status || tr(locale, "等待同步", "Waiting for Sync");
 }
 
+function goalExecutionBadgeClass(state) {
+  return state === "blocked" || state === "rejected"
+    ? "badge badge--warn"
+    : state === "completed"
+      ? "badge badge--good"
+      : "badge badge--accent";
+}
+
 function gameplayProgressLabel(progressPercent, locale) {
   return progressPercent == null
     ? tr(locale, "进度待发布", "Progress Pending")
@@ -519,6 +527,34 @@ function WorldSummaryPanel() {
                   {gameplayProgressLabel(gameplay().progressPercent, locale())}
                 </Badge>
               </div>
+              <EventCard
+                title={tr(locale(), "目标执行状态", "Goal Execution")}
+                badge={gameplay().executionStateLabel || gameplay().executionState || "-"}
+                badgeClass={goalExecutionBadgeClass(gameplay().executionState)}
+                meta={tr(locale(), "统一状态机：Accepted -> Executing -> Blocked / Completed / Rejected", "Unified state machine: Accepted -> Executing -> Blocked / Completed / Rejected")}
+              >
+                <div class="badge-row">
+                  <For each={gameplay().executionStateMachine || []}>
+                    {(item) => (
+                      <Badge class={gameplay().executionState === item.id ? goalExecutionBadgeClass(item.id) : "badge"}>
+                        {item.label}
+                      </Badge>
+                    )}
+                  </For>
+                </div>
+                <div class="feedback-summary">
+                  {gameplay().executionSummary
+                    || tr(locale(), "等待目标执行状态更新。", "Waiting for goal execution state updates.")}
+                </div>
+                <Show when={gameplay().executionCauseLabel}>
+                  <div class="badge-row">
+                    <Badge>{gameplay().executionCauseLabel}</Badge>
+                  </div>
+                </Show>
+                <Show when={gameplay().executionCauseDetail}>
+                  <div class="feedback-detail">{gameplay().executionCauseDetail}</div>
+                </Show>
+              </EventCard>
               <Show when={gameplay().blockerKind || gameplay().blockerDetail}>
                 <CalloutCard
                   title={
@@ -526,7 +562,7 @@ function WorldSummaryPanel() {
                       ? tr(locale(), "当前阻塞：空快照", "Current Blocker: Empty Snapshot")
                       : tr(locale(), "当前阻塞", "Current Blocker")
                   }
-                  badge={gameplay().blockerKind || "blocked"}
+                  badge={gameplay().blockerLabel || gameplay().blockerKind || "blocked"}
                   badgeClass="badge badge--warn"
                   variant="warn"
                 >

--- a/crates/oasis7_viewer/software_safe_src/main.test.jsx
+++ b/crates/oasis7_viewer/software_safe_src/main.test.jsx
@@ -49,6 +49,7 @@ function sampleSnapshot(overrides = {}) {
     player_gameplay: {
       stage_id: "post_onboarding",
       stage_status: "blocked",
+      execution_state: "blocked",
       goal_id: "post_onboarding.recover_capability",
       goal_kind: "RecoverCapability",
       goal_title: "Recover sustainable capability",
@@ -57,6 +58,8 @@ function sampleSnapshot(overrides = {}) {
       progress_percent: 68,
       blocker_kind: "material_shortage",
       blocker_detail: "iron input exhausted at factory-0",
+      causality_kind: "world_constraint",
+      causality_detail: "iron input exhausted at factory-0",
       blocker_supplemental_detail: null,
       next_step_hint: "Replenish upstream materials, then advance again to confirm the line resumes.",
       branch_hint: null,
@@ -141,6 +144,8 @@ describe("viewer web ui automation baseline", () => {
     expect(within(targetsPanel).getByText("Targets")).toBeInTheDocument();
     expect(within(stagePanel).getByText("Industrial World Command Desk")).toBeInTheDocument();
     expect(within(stagePanel).getAllByText("Recover sustainable capability").length).toBeGreaterThan(0);
+    expect(within(stagePanel).getByText("Goal Execution")).toBeInTheDocument();
+    expect(within(stagePanel).getByText("World Constraint")).toBeInTheDocument();
     expect(within(stagePanel).getByText("Current Blocker")).toBeInTheDocument();
     expect(within(stagePanel).getByText("Runtime Diagnostics")).toBeInTheDocument();
     expect(within(stagePanel).getByText("Session Ladder")).toBeInTheDocument();

--- a/crates/oasis7_viewer/software_safe_src/main.test.jsx
+++ b/crates/oasis7_viewer/software_safe_src/main.test.jsx
@@ -188,4 +188,30 @@ describe("viewer web ui automation baseline", () => {
     expect(within(stagePanel).getAllByText("Next Step").length).toBeGreaterThan(0);
     expect(within(stagePanel).getByText("Actions Not Exposed On This Page")).toBeInTheDocument();
   });
+
+  it("forces goal execution blocked when the empty-entity guard trips", async () => {
+    const { container } = await renderViewerApp({
+      snapshot: sampleSnapshot({
+        model: {
+          agents: {},
+          locations: {},
+          agent_prompt_profiles: {},
+          agent_execution_debug_contexts: {},
+        },
+        player_gameplay: {
+          ...sampleSnapshot().player_gameplay,
+          stage_status: "active",
+          execution_state: "completed",
+          blocker_kind: null,
+          blocker_detail: null,
+        },
+      }),
+    });
+
+    const stagePanel = container.querySelector("#viewer-stage-panel");
+    expect(stagePanel).toBeTruthy();
+    expect(within(stagePanel).getByText("Goal Execution")).toBeInTheDocument();
+    expect(within(stagePanel).getAllByText("Blocked").length).toBeGreaterThan(0);
+    expect(within(stagePanel).getByText("World Constraint")).toBeInTheDocument();
+  });
 });

--- a/doc/game/gameplay/gameplay-top-level-design.project.md
+++ b/doc/game/gameplay/gameplay-top-level-design.project.md
@@ -66,6 +66,7 @@
 口径更新（2026-04-15）: T8 当前已将 producer verdict 拆成两层。`10-minute trust gate` 只判断“是否已经值得继续玩”，`first capability gate` 再判断“首个持续能力是否已闭环”。当前 active-LLM formal truth 仍是 `trust gate = hold`、`capability gate = not_run`；原因不是 capability 已独立判失败，而是 trust floor 再次回退后 capability gate 当前未进入。
 
 - [x] gameplay-early-retention-focus-order (PRD-GAME-012) [test_tier_required]: `producer_system_designer` 已把当前 gameplay scope freeze 正式改写为“`trust gate` 地板恢复 -> `PostOnboarding` capability closure -> 工业停机/修复可读 -> 间接控制因果与下一步”四级优先顺序，并补充 defer 规则：在这些 blocker 清空前，不扩大战争/治理/元进度在首局中的曝光，也不允许用 `--no-llm` / operator-only lane 充当正式放行依据。 Trace: .pm/tasks/task_886e2ef4878645a6a6ab69c588dce57e.yaml
+- [x] issue-161-action-causality-blocker-taxonomy (PRD-GAME-012) [test_tier_required]: `viewer_engineer` 已把玩家目标反馈的统一执行状态机与小型 blocker taxonomy 下沉到 canonical `player_gameplay` snapshot，并在 `software_safe` 正式 Web 主入口显式区分 `world_constraint` 与 `agent_override`，让玩家可以直接判断“世界条件阻塞”还是“agent 改走了另一条已接受的执行路径”。 Trace: .pm/tasks/task_b3a14c16dbf04258865c10c80a9fa460.yaml
 
 ### T9 物理尺度与间接控制对齐（2026-05-07）
 - [x] gameplay-physical-scale-contract-freeze (PRD-GAME-013) [test_tier_required]: `producer_system_designer` 已新增 `PRD-GAME-013` 专题 PRD / design / project，正式冻结“厘米真值 / coarse-grained 子系统 / 玩家动作粒度 / 表现层夸张”四层尺度合同，并完成 `game` 根入口、`gameplay` 主文档、索引与当前 task execution log 挂载。 Trace: .pm/tasks/task_5dfbbe7c8c0c4557bef2b49612da3081.yaml


### PR DESCRIPTION
## Summary
- unify player-issued goal execution state into canonical `player_gameplay` snapshot fields
- derive actionable blocker/causality labels from runtime feedback and rule override events
- surface `Goal Execution` plus `World Constraint` / `Agent Chose Differently` semantics in `software_safe`

## Testing
- `rtk env -u RUSTC_WRAPPER cargo test -p oasis7 viewer::runtime_live::tests::snapshot_progress -- --nocapture`
- `rtk node crates/oasis7_viewer/scripts/software-safe-feedback-contract.test.mjs`
- `rtk npm run test:ui -- software_safe_src/main.test.jsx`
- `rtk env OASIS7_CI_RUN_OASIS7_REQUIRED_TESTS=true OASIS7_CI_RUN_CONSENSUS_TESTS=false OASIS7_CI_RUN_DISTFS_TESTS=false OASIS7_CI_RUN_VIEWER_CONTRACT_TESTS=true OASIS7_CI_RUN_VIEWER_WASM_CHECK=true OASIS7_CI_RUN_LAUNCHER_WEB_BUILD=true ./scripts/ci-tests.sh required`

Closes #161
