### PR TITLE
viewer: reclose hosted p0 auth surface truth

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -60,6 +60,7 @@ jobs:
           echo "run_viewer_wasm_check=${{ steps.scope.outputs.run_viewer_wasm_check }}"
           echo "run_launcher_web_build=${{ steps.scope.outputs.run_launcher_web_build }}"
           echo "needs_node=${{ steps.scope.outputs.needs_node }}"
+          echo "needs_trunk=${{ steps.scope.outputs.needs_trunk }}"
       - name: Install pinned Rust toolchains
         run: |
           rustup toolchain install "${RUST_TOOLCHAIN}" --profile default --component rustfmt
@@ -78,6 +79,9 @@ jobs:
         if: ${{ steps.scope.outputs.run_oasis7_required_tests == 'true' || steps.scope.outputs.run_consensus_tests == 'true' || steps.scope.outputs.run_distfs_tests == 'true' || steps.scope.outputs.run_viewer_wasm_check == 'true' || steps.scope.outputs.run_viewer_contract_tests == 'true' || steps.scope.outputs.run_launcher_web_build == 'true' }}
         with:
           shared-key: ci-required-gate-v1
+      - name: Install trunk
+        if: ${{ steps.scope.outputs.needs_trunk == 'true' }}
+        run: cargo install trunk --locked
       - name: Install system deps
         if: ${{ steps.scope.outputs.needs_system_deps == 'true' }}
         run: |

--- a/.pm/roles/viewer_engineer/backlog/committed.yaml
+++ b/.pm/roles/viewer_engineer/backlog/committed.yaml
@@ -2,6 +2,20 @@ version: 1
 role: viewer_engineer
 status: committed
 tasks:
+  - task_uid: task_7693ba2463d841f8aa8675fa12b982c0
+    title: "viewer hosted p0 truth reclosure"
+    priority: P0
+    source_signal: null
+    related_prd:
+      - PRD-P2P-023
+      - PRD-WORLD_SIMULATOR-039
+    acceptance:
+      - "viewer auth/session surface no longer reports hosted preview strong-auth and session recovery as not implemented when the lane is available"
+      - "repo-owned ui regression covers hosted player-session acquire/release, session ladder semantics, and reconnect messaging"
+      - "viewer docs reflect actual hosted preview boundary: prompt-control preview strong-auth works, main_token_transfer remains blocked"
+    handoff_to: []
+    status: committed
+    task_path: .pm/tasks/task_7693ba2463d841f8aa8675fa12b982c0.yaml
   - task_uid: task_41236b37e7a0493fa4f20424cc465eeb
     title: "Switch GitHub Release downloads to direct installers"
     priority: P1

--- a/.pm/tasks/task_7693ba2463d841f8aa8675fa12b982c0.execution.md
+++ b/.pm/tasks/task_7693ba2463d841f8aa8675fa12b982c0.execution.md
@@ -24,3 +24,9 @@ Example:
 - 完成内容: 将分支 rebase 到最新 `origin/main`，保留主线新增的 empty-entity guard UI 回归，并创建 Draft PR `#219`（`viewer: reclose hosted p0 auth surface truth`）。
 - 验证: `npm --prefix crates/oasis7_viewer run test:ui`、`npm --prefix crates/oasis7_viewer run build:software-safe`、`./scripts/doc-governance-check.sh`、`git diff --check`、`OASIS7_CI_RUN_OASIS7_REQUIRED_TESTS=false OASIS7_CI_RUN_CONSENSUS_TESTS=false OASIS7_CI_RUN_DISTFS_TESTS=false OASIS7_CI_RUN_VIEWER_CONTRACT_TESTS=true OASIS7_CI_RUN_VIEWER_WASM_CHECK=true OASIS7_CI_RUN_LAUNCHER_WEB_BUILD=false ./scripts/ci-tests.sh required`
 - 遗留事项: 仓库真值仍显示 shared-network verdict=`partial`，且 `shared_access / rollback_target_ready` 只有 draft/partial 证据，没有 formal shared-devnet `pass` fallback；这两项需真实 shared endpoint、独立 operator 验证与 fallback candidate 证据，不属于当前 viewer PR 可本地单独关掉的范围。
+
+## 2026-05-14 15:25:00 CST / producer_system_designer
+- 完成内容: 延续同一 PR `#219` 收口 shared-network P0 合同，把 `mixed_topology_baseline` 从 `partial` 升到 `pass` 所需的 producer/QA 联审决议升级为正式 repo 真值，而不是停留在模板备注或脚本开关语义里。
+- 完成内容: 为 `scripts/shared-devnet-blocker-packet.sh` 新增 `--mixed-topology-pass-decision-ref`，并在 `mixed_topology lane_result=pass` 时强制要求 same-window shared evidence 与 audited pass-uplift decision 同时存在；同步补齐 smoke、`shared-devnet-rehearsal` mixed-topology note 字段、示例 evidence 以及 PRD/design/runbook/project/testing-manual 的合同表述。
+- 验证: `./scripts/shared-devnet-blocker-packet-smoke.sh`、`./scripts/shared-devnet-rehearsal-smoke.sh`、`./scripts/doc-governance-check.sh`、`git diff --check`
+- 遗留事项: 当前只把 mixed-topology pass-uplift 合同写成统一真值，没有新增 live shared-window 证据；shared-network verdict 仍必须保持 `partial`，后续仍需真实 `shared_access`、formal `rollback_target_ready`，以及 producer/QA 是否接受现有 proxy/shared-window 近似作为 mixed-topology `pass` 依据的正式裁决。

--- a/.pm/tasks/task_7693ba2463d841f8aa8675fa12b982c0.execution.md
+++ b/.pm/tasks/task_7693ba2463d841f8aa8675fa12b982c0.execution.md
@@ -18,3 +18,9 @@ Example:
 - 完成内容: 回写 `doc/world-simulator/viewer/viewer-manual.manual.md`，明确 `hosted_public_join` 下已支持获取/释放 `player_session`、`reconnect_sync` 恢复和 `prompt_control` preview-grade `strong_auth`，同时继续声明 `main_token_transfer` 仍保持阻断。
 - 验证: `npm --prefix crates/oasis7_viewer run test:ui`、`npm --prefix crates/oasis7_viewer run build:software-safe`、`./scripts/doc-governance-check.sh`、`git diff --check`
 - 遗留事项: `shared_access / rollback_target_ready` 仍是 shared-network live evidence blocker，不属于本轮 viewer 代码漂移修复可单独关闭的范围；若继续推进 P0，需要切到 shared-network / liveops 真实窗口补 shared endpoint 与 fallback candidate 证据。
+
+## 2026-05-14 11:31:47 CST / viewer_engineer
+- 完成内容: 处理 subagent review 指出的 hosted strong-auth 中间态问题，确保 `registrationStatus=issued/registering` 时 `strong_auth` 只显示 `issued_pending_register`，不会过早误报 `preview_backend_reauth_available`；同时保留 `registered` 后的 `Release Player Session`、`reconnect_sync` 与 hosted recovery/revoke 文案真值。
+- 完成内容: 将分支 rebase 到最新 `origin/main`，保留主线新增的 empty-entity guard UI 回归，并创建 Draft PR `#219`（`viewer: reclose hosted p0 auth surface truth`）。
+- 验证: `npm --prefix crates/oasis7_viewer run test:ui`、`npm --prefix crates/oasis7_viewer run build:software-safe`、`./scripts/doc-governance-check.sh`、`git diff --check`、`OASIS7_CI_RUN_OASIS7_REQUIRED_TESTS=false OASIS7_CI_RUN_CONSENSUS_TESTS=false OASIS7_CI_RUN_DISTFS_TESTS=false OASIS7_CI_RUN_VIEWER_CONTRACT_TESTS=true OASIS7_CI_RUN_VIEWER_WASM_CHECK=true OASIS7_CI_RUN_LAUNCHER_WEB_BUILD=false ./scripts/ci-tests.sh required`
+- 遗留事项: 仓库真值仍显示 shared-network verdict=`partial`，且 `shared_access / rollback_target_ready` 只有 draft/partial 证据，没有 formal shared-devnet `pass` fallback；这两项需真实 shared endpoint、独立 operator 验证与 fallback candidate 证据，不属于当前 viewer PR 可本地单独关掉的范围。

--- a/.pm/tasks/task_7693ba2463d841f8aa8675fa12b982c0.execution.md
+++ b/.pm/tasks/task_7693ba2463d841f8aa8675fa12b982c0.execution.md
@@ -30,3 +30,9 @@ Example:
 - 完成内容: 为 `scripts/shared-devnet-blocker-packet.sh` 新增 `--mixed-topology-pass-decision-ref`，并在 `mixed_topology lane_result=pass` 时强制要求 same-window shared evidence 与 audited pass-uplift decision 同时存在；同步补齐 smoke、`shared-devnet-rehearsal` mixed-topology note 字段、示例 evidence 以及 PRD/design/runbook/project/testing-manual 的合同表述。
 - 验证: `./scripts/shared-devnet-blocker-packet-smoke.sh`、`./scripts/shared-devnet-rehearsal-smoke.sh`、`./scripts/doc-governance-check.sh`、`git diff --check`
 - 遗留事项: 当前只把 mixed-topology pass-uplift 合同写成统一真值，没有新增 live shared-window 证据；shared-network verdict 仍必须保持 `partial`，后续仍需真实 `shared_access`、formal `rollback_target_ready`，以及 producer/QA 是否接受现有 proxy/shared-window 近似作为 mixed-topology `pass` 依据的正式裁决。
+
+## 2026-05-14 15:48:00 CST / producer_system_designer
+- 完成内容: 继续在同一 PR `#219` 收口 `shared_access` lane 的 pass 合同，把 endpoint、independent operator handoff 和 access evidence 提升为模板/脚本/编排输出的正式字段，不再允许只靠 lane 状态翻转来声称 shared access 已通过。
+- 完成内容: 为 `scripts/shared-devnet-rehearsal.sh` 新增 `--shared-access-evidence-ref` 并在 `--shared-access-pass` 时强制要求 endpoint/operator/evidence 三类 ref 同时存在；同步为 `scripts/shared-devnet-blocker-packet.sh` 增加 `access-lane-result=pass` 的正式字段校验，并回写 shared-access template、PRD/design/runbook/project/testing-manual。
+- 验证: `./scripts/shared-devnet-rehearsal-smoke.sh`、`./scripts/shared-devnet-blocker-packet-smoke.sh`、`./scripts/doc-governance-check.sh`、`git diff --check`
+- 遗留事项: 当前只是把 `shared_access` 的 pass 语义写成统一真值，没有新增真实 shared endpoint、独立 operator handoff 或 access proof；shared-network verdict 仍必须保持 `partial`，后续仍需 live shared-access evidence 与 formal `rollback_target_ready`。

--- a/.pm/tasks/task_7693ba2463d841f8aa8675fa12b982c0.execution.md
+++ b/.pm/tasks/task_7693ba2463d841f8aa8675fa12b982c0.execution.md
@@ -48,3 +48,9 @@ Example:
 - 完成内容: 在 `testing-manual.md` 增加同一 `window_id` / `candidate_bundle` 下补齐三条 lane 证据的标准 `shared-devnet-rehearsal.sh` 命令，方便 liveops/QA 按手册直接落真实窗口证据。
 - 验证: `./scripts/doc-governance-check.sh`、`git diff --check`
 - 遗留事项: 这次仍只补“如何留证”的 repo 内说明，没有新增真实 shared endpoint、fallback gate 或 producer/QA mixed-topology pass decision；shared-network 总 verdict 继续保持 `partial`。
+
+## 2026-05-15 10:18:04 CST / qa_engineer
+- 完成内容: 排查 PR `#219` 的 GitHub `required-gate` 失败，确认新 head `9ed06e4157f602c5eabd83f41aabc5f11c473529` 在 `2026-05-14 23:35:34 CST` 卡在 `launcher web build` 分支，失败签名为 `env: 'trunk': No such file or directory`；根因不是 viewer/shared-network 逻辑回归，而是 `scripts/plan-rust-required-scope.sh` 已产出 `needs_trunk=true`，但 `.github/workflows/rust.yml` 没有在该条件下安装 `trunk`。
+- 完成内容: 为 `required-gate` 补上 `needs_trunk` 调试输出，并在 `steps.scope.outputs.needs_trunk == 'true'` 时显式执行 `cargo install trunk --locked`，保证 launcher web build 被 planner 打开时不会再因 CI 环境缺少 `trunk` 而假失败。
+- 验证: `./scripts/plan-rust-required-scope.sh --event-name pull_request --changed-path crates/oasis7_client_launcher/src/main.rs`、`git diff --check`、`bash -n scripts/ci-tests.sh`、`CI_VERBOSE=1 OASIS7_CI_RUN_OASIS7_REQUIRED_TESTS=false OASIS7_CI_RUN_CONSENSUS_TESTS=false OASIS7_CI_RUN_DISTFS_TESTS=false OASIS7_CI_RUN_VIEWER_CONTRACT_TESTS=false OASIS7_CI_RUN_VIEWER_WASM_CHECK=false OASIS7_CI_RUN_LAUNCHER_WEB_BUILD=true ./scripts/ci-tests.sh required`
+- 遗留事项: 本地已打穿原始 `trunk missing` 断点，但 GitHub 上仍需等修复 commit 推送后重新跑一轮 `required-gate` 才能确认 PR 回绿；当前 task 的 shared-network live evidence blocker 结论不变。

--- a/.pm/tasks/task_7693ba2463d841f8aa8675fa12b982c0.execution.md
+++ b/.pm/tasks/task_7693ba2463d841f8aa8675fa12b982c0.execution.md
@@ -36,3 +36,9 @@ Example:
 - 完成内容: 为 `scripts/shared-devnet-rehearsal.sh` 新增 `--shared-access-evidence-ref` 并在 `--shared-access-pass` 时强制要求 endpoint/operator/evidence 三类 ref 同时存在；同步为 `scripts/shared-devnet-blocker-packet.sh` 增加 `access-lane-result=pass` 的正式字段校验，并回写 shared-access template、PRD/design/runbook/project/testing-manual。
 - 验证: `./scripts/shared-devnet-rehearsal-smoke.sh`、`./scripts/shared-devnet-blocker-packet-smoke.sh`、`./scripts/doc-governance-check.sh`、`git diff --check`
 - 遗留事项: 当前只是把 `shared_access` 的 pass 语义写成统一真值，没有新增真实 shared endpoint、独立 operator handoff 或 access proof；shared-network verdict 仍必须保持 `partial`，后续仍需 live shared-access evidence 与 formal `rollback_target_ready`。
+
+## 2026-05-14 16:00:00 CST / producer_system_designer
+- 完成内容: 继续在同一 PR `#219` 收口 `rollback_target_ready` lane 的 pass 合同，修正 `shared-devnet-rehearsal` 里“只要给了 fallback bundle 就记 pass”的漂移，把 fallback gate、fallback owner、restore steps、restoration scope 全部提升为正式 pass 前置条件。
+- 完成内容: 为 `scripts/shared-devnet-rehearsal.sh` 增加 rollback 合同参数并补齐 partial/pass 两条 smoke；同步为 `scripts/shared-devnet-blocker-packet.sh` 增加 `rollback-lane-result=pass` 的正式字段校验，并回写 design/runbook/project/testing-manual，明确仅有 fallback bundle 仍只能算 `partial`。
+- 验证: `./scripts/shared-devnet-rehearsal-smoke.sh`、`./scripts/shared-devnet-blocker-packet-smoke.sh`
+- 遗留事项: 当前只是把 rollback 的 pass 语义写成统一真值，没有新增真实 audited fallback gate/owner/restore scope；shared-network verdict 仍必须保持 `partial`，后续仍需真实 live shared-access evidence、formal rollback truth，以及 producer/QA 对 mixed-topology 是否可升 `pass` 的正式裁决。

--- a/.pm/tasks/task_7693ba2463d841f8aa8675fa12b982c0.execution.md
+++ b/.pm/tasks/task_7693ba2463d841f8aa8675fa12b982c0.execution.md
@@ -42,3 +42,9 @@ Example:
 - 完成内容: 为 `scripts/shared-devnet-rehearsal.sh` 增加 rollback 合同参数并补齐 partial/pass 两条 smoke；同步为 `scripts/shared-devnet-blocker-packet.sh` 增加 `rollback-lane-result=pass` 的正式字段校验，并回写 design/runbook/project/testing-manual，明确仅有 fallback bundle 仍只能算 `partial`。
 - 验证: `./scripts/shared-devnet-rehearsal-smoke.sh`、`./scripts/shared-devnet-blocker-packet-smoke.sh`
 - 遗留事项: 当前只是把 rollback 的 pass 语义写成统一真值，没有新增真实 audited fallback gate/owner/restore scope；shared-network verdict 仍必须保持 `partial`，后续仍需真实 live shared-access evidence、formal rollback truth，以及 producer/QA 对 mixed-topology 是否可升 `pass` 的正式裁决。
+
+## 2026-05-14 16:18:00 CST / producer_system_designer
+- 完成内容: 把三份 blocker evidence 草稿改成可执行的待填 checklist 版：`shared_access`、`rollback_target_ready`、`mixed_topology_baseline` 现在都明确列出缺失字段、pass closure rule 和标准更新命令，不再依赖口头说明补证据。
+- 完成内容: 在 `testing-manual.md` 增加同一 `window_id` / `candidate_bundle` 下补齐三条 lane 证据的标准 `shared-devnet-rehearsal.sh` 命令，方便 liveops/QA 按手册直接落真实窗口证据。
+- 验证: `./scripts/doc-governance-check.sh`、`git diff --check`
+- 遗留事项: 这次仍只补“如何留证”的 repo 内说明，没有新增真实 shared endpoint、fallback gate 或 producer/QA mixed-topology pass decision；shared-network 总 verdict 继续保持 `partial`。

--- a/.pm/tasks/task_7693ba2463d841f8aa8675fa12b982c0.execution.md
+++ b/.pm/tasks/task_7693ba2463d841f8aa8675fa12b982c0.execution.md
@@ -1,0 +1,20 @@
+# task_7693ba2463d841f8aa8675fa12b982c0 Execution Log
+
+- task_uid: task_7693ba2463d841f8aa8675fa12b982c0
+- title: viewer hosted p0 truth reclosure
+- owner_role: viewer_engineer
+- worktree_hint: /home/scc/worktrees/oasis7-viewer-hosted-p0-reclosure
+
+<!-- Append entries using:
+Example:
+  ## YYYY-MM-DD HH:MM:SS CST / role_name
+  - 完成内容: ...
+  - 遗留事项: ...
+-->
+
+## 2026-05-14 10:17:43 CST / viewer_engineer
+- 完成内容: 核对 `doc/p2p` hosted P0 专题与当前 `viewer` 源码后，确认后端 `player_session / reconnect_sync / preview-grade strong_auth` 链路仍在，当前缺口主要是 `software_safe_src/legacy_core.js` 的 auth surface 漂移；已修正 hosted public join deployment hint 识别、`strong_auth` tier 状态语义、guest/recovery reconnect 文案，以及 `main.jsx` 对 hosted/preview badge 的展示分级。
+- 完成内容: 为 hosted P0 真值补 repo-owned UI 回归：新增 `sampleHostedPublicJoinAccess` 与挂载后状态注入，覆盖 revoked guest lane 的 `Re-acquire Hosted Player Session`、`upgrade_after_player_session`、recovery 文案，以及 registered browser session 的 `Release Player Session`、`preview_backend_reauth_available` 与 `reconnect_sync` 提示。
+- 完成内容: 回写 `doc/world-simulator/viewer/viewer-manual.manual.md`，明确 `hosted_public_join` 下已支持获取/释放 `player_session`、`reconnect_sync` 恢复和 `prompt_control` preview-grade `strong_auth`，同时继续声明 `main_token_transfer` 仍保持阻断。
+- 验证: `npm --prefix crates/oasis7_viewer run test:ui`、`npm --prefix crates/oasis7_viewer run build:software-safe`、`./scripts/doc-governance-check.sh`、`git diff --check`
+- 遗留事项: `shared_access / rollback_target_ready` 仍是 shared-network live evidence blocker，不属于本轮 viewer 代码漂移修复可单独关闭的范围；若继续推进 P0，需要切到 shared-network / liveops 真实窗口补 shared endpoint 与 fallback candidate 证据。

--- a/.pm/tasks/task_7693ba2463d841f8aa8675fa12b982c0.yaml
+++ b/.pm/tasks/task_7693ba2463d841f8aa8675fa12b982c0.yaml
@@ -1,0 +1,25 @@
+task_uid: task_7693ba2463d841f8aa8675fa12b982c0
+title: "viewer hosted p0 truth reclosure"
+owner_role: viewer_engineer
+worktree_hint: /home/scc/worktrees/oasis7-viewer-hosted-p0-reclosure
+execution_log_path: .pm/tasks/task_7693ba2463d841f8aa8675fa12b982c0.execution.md
+status: committed
+priority: P0
+source_signal: null
+source_refs:
+  - doc/p2p/blockchain/p2p-hosted-world-player-access-and-session-auth-2026-03-25.prd.md
+  - doc/p2p/blockchain/p2p-hosted-world-player-access-and-session-auth-2026-03-25.project.md
+  - doc/world-simulator/viewer/viewer-manual.manual.md
+doc_refs:
+  - doc/p2p/blockchain/p2p-hosted-world-player-access-and-session-auth-2026-03-25.project.md
+  - doc/world-simulator/viewer/viewer-manual.manual.md
+related_prd:
+  - PRD-P2P-023
+  - PRD-WORLD_SIMULATOR-039
+acceptance:
+  - "viewer auth/session surface no longer reports hosted preview strong-auth and session recovery as not implemented when the lane is available"
+  - "repo-owned ui regression covers hosted player-session acquire/release, session ladder semantics, and reconnect messaging"
+  - "viewer docs reflect actual hosted preview boundary: prompt-control preview strong-auth works, main_token_transfer remains blocked"
+handoff_to: []
+updated_at: 2026-05-14T10:03:53+08:00
+last_started_at: 2026-05-14T10:03:53+08:00

--- a/crates/oasis7_viewer/software_safe.js
+++ b/crates/oasis7_viewer/software_safe.js
@@ -1436,6 +1436,7 @@ function authDeploymentHint(auth) {
 function isHostedPublicJoinHint(deploymentHint) {
   return [
     "hosted_public_join_contract",
+    "hosted_public_join_contract_with_browser_session",
     "hosted_public_join_contract_with_legacy_bootstrap",
     "hosted_public_join_likely"
   ].includes(deploymentHint);
@@ -1473,6 +1474,43 @@ function playerSessionReason(auth, deploymentHint) {
 }
 function strongAuthReason() {
   return "strong auth remains a separate upgrade plane; viewer only previews backend reauth for prompt_control and still does not issue hosted-ready asset/governance proofs";
+}
+function buildStrongAuthTier(promptCapability) {
+  const promptPolicy = hostedActionPolicy("prompt_control");
+  if (!promptPolicy || promptPolicy.required_auth !== "strong_auth") {
+    return {
+      status: "separate_upgrade_plane",
+      reason: strongAuthReason()
+    };
+  }
+  if (promptPolicy.availability === "public_player_plane_with_backend_reauth_preview") {
+    if (!state.auth.available) {
+      return {
+        status: "upgrade_after_player_session",
+        reason: "hosted preview backend reauth is available on this join lane after the browser acquires a player_session"
+      };
+    }
+    if (state.auth.registrationStatus === "registered") {
+      return {
+        status: "preview_backend_reauth_available",
+        reason: promptCapability.reason || strongAuthReason()
+      };
+    }
+    return {
+      status: "issued_pending_register",
+      reason: "hosted preview backend reauth stays pending until the browser-local player_session finishes runtime registration"
+    };
+  }
+  if (promptPolicy.availability === "trusted_local_preview_only") {
+    return {
+      status: state.auth.available ? "active_legacy_preview" : "trusted_local_only",
+      reason: promptCapability.reason || strongAuthReason()
+    };
+  }
+  return {
+    status: "blocked_until_strong_auth",
+    reason: promptPolicy.reason || strongAuthReason()
+  };
 }
 function isStrongAuthSensitiveAction(actionId) {
   const policy = hostedActionPolicy(actionId);
@@ -1549,7 +1587,7 @@ function buildSemanticCapability(actionId) {
       actionId,
       enabled: false,
       code: "strong_auth_required",
-      reason: `${actionId} requires strong_auth on the hosted public join path; this browser is still guest_session only and the strong-auth upgrade lane is not implemented yet`
+      reason: `${actionId} requires strong_auth on the hosted public join path; acquire a player_session first, then complete the hosted re-authorization step for this action`
     };
   }
   if (strongAuthSensitive && state.auth.available && deploymentHint === "remote_origin_legacy_bootstrap") {
@@ -1581,6 +1619,7 @@ function buildAuthSurfaceModel() {
   const promptCapability = buildSemanticCapability("prompt_control");
   const chatCapability = buildSemanticCapability("agent_chat");
   const mainTokenTransferCapability = buildSemanticCapability("main_token_transfer");
+  const strongAuthTier = buildStrongAuthTier(promptCapability);
   const currentTier = state.auth.available ? "player_session" : "guest_session";
   const source = state.hostedAccess ? state.auth.available ? state.auth.source === "legacy_viewer_auth_bootstrap" ? "legacy_viewer_auth_bootstrap+hosted_access_hint" : "hosted_player_issue+browser_local_ephemeral_key" : "hosted_access_hint" : state.auth.available ? state.auth.source : "guest_only";
   return {
@@ -1604,8 +1643,8 @@ function buildAuthSurfaceModel() {
       {
         id: "strong_auth",
         label: "strong_auth",
-        status: "not_implemented",
-        reason: strongAuthReason()
+        status: strongAuthTier.status,
+        reason: strongAuthTier.reason
       }
     ],
     capabilities: {
@@ -1614,7 +1653,7 @@ function buildAuthSurfaceModel() {
       main_token_transfer: mainTokenTransferCapability,
       strong_auth_actions: mainTokenTransferCapability
     },
-    reconnect: state.auth.available ? state.auth.source === "legacy_viewer_auth_bootstrap" ? "reconnect still depends on the current preview bootstrap; hosted resume/revoke tokens are not wired yet" : state.auth.registrationStatus === "registered" ? "page reload will reuse the browser-local hosted key and attempt reconnect_sync first" : "browser-local hosted key is persisted, but runtime session restore is still pending this page load" : "page reload is possible, but player-session reconnect/resume is not implemented yet"
+    reconnect: state.auth.available ? state.auth.source === "legacy_viewer_auth_bootstrap" ? "reconnect still depends on the current preview bootstrap; hosted resume/revoke tokens are not wired yet" : state.auth.registrationStatus === "registered" ? "page reload will reuse the browser-local hosted key and attempt reconnect_sync first" : "browser-local hosted key is persisted, but runtime session restore is still pending this page load" : isHostedPublicJoinHint(deploymentHint) ? buildHostedRecoveryHint("en")?.detail || "hosted public join recovers by acquiring a player_session first, then re-registering it through reconnect_sync" : "page reload is possible, but player-session reconnect/resume is not implemented yet"
   };
 }
 function buildHostedActionMatrixView() {
@@ -5377,7 +5416,7 @@ function WorldSummaryPanel() {
   const hostedActionMatrixView = () => buildHostedActionMatrixView();
   const hostedRecoveryHint = () => buildHostedRecoveryHint(locale());
   const selectedDebug = () => selectedAgentExecutionDebugContext();
-  const tierBadgeClass = (status) => status === "active" || status === "active_legacy_preview" ? "badge badge--good" : status === "superseded" ? "badge" : "badge badge--warn";
+  const tierBadgeClass = (status) => status === "active" || status === "active_legacy_preview" || status === "active_hosted_issue" || status === "preview_backend_reauth_available" ? "badge badge--good" : status === "issued_pending_register" || status === "upgrade_after_player_session" ? "badge badge--accent" : status === "superseded" ? "badge" : "badge badge--warn";
   const showRebindNotice = () => Boolean(state$1.auth.pendingRequestedAgentId) && (state$1.auth.pendingForceRebind || state$1.auth.runtimeStatus === "rebind_retrying" || state$1.auth.runtimeStatus === "rebind_registering");
   const showPlayerSessionSurface = () => !!hostedRecoveryHint() || !state$1.auth.available && String(state$1.hostedAccess?.deployment_mode || "").trim() === "hosted_public_join" || showRebindNotice();
   const diagnosticsSummaryBadges = () => [`debugViewer=${state$1.debugViewerMode}:${state$1.debugViewerStatus}`, `auth=${state$1.auth.available ? state$1.auth.registrationStatus || "ready" : "missing"}`, `events=${state$1.recentEvents.length}`];

--- a/crates/oasis7_viewer/software_safe_src/legacy_core.js
+++ b/crates/oasis7_viewer/software_safe_src/legacy_core.js
@@ -902,7 +902,8 @@ function buildStrongAuthTier(promptCapability) {
     if (state.auth.registrationStatus === "registered") {
       return {
         status: "preview_backend_reauth_available",
-        reason: promptCapability.reason || strongAuthReason(),
+        reason:
+          "hosted preview backend reauth is available after the browser-local player_session has completed runtime registration for prompt_control",
       };
     }
     return {
@@ -914,7 +915,8 @@ function buildStrongAuthTier(promptCapability) {
   if (promptPolicy.availability === "trusted_local_preview_only") {
     return {
       status: state.auth.available ? "active_legacy_preview" : "trusted_local_only",
-      reason: promptCapability.reason || strongAuthReason(),
+      reason:
+        "trusted_local_preview keeps prompt_control on the legacy local preview lane; hosted/public strong_auth still remains outside this window",
     };
   }
   return {

--- a/crates/oasis7_viewer/software_safe_src/legacy_core.js
+++ b/crates/oasis7_viewer/software_safe_src/legacy_core.js
@@ -835,6 +835,7 @@ function authDeploymentHint(auth) {
 function isHostedPublicJoinHint(deploymentHint) {
   return [
     "hosted_public_join_contract",
+    "hosted_public_join_contract_with_browser_session",
     "hosted_public_join_contract_with_legacy_bootstrap",
     "hosted_public_join_likely",
   ].includes(deploymentHint);
@@ -880,6 +881,46 @@ function playerSessionReason(auth, deploymentHint) {
 
 function strongAuthReason() {
   return "strong auth remains a separate upgrade plane; viewer only previews backend reauth for prompt_control and still does not issue hosted-ready asset/governance proofs";
+}
+
+function buildStrongAuthTier(promptCapability) {
+  const promptPolicy = hostedActionPolicy("prompt_control");
+  if (!promptPolicy || promptPolicy.required_auth !== "strong_auth") {
+    return {
+      status: "separate_upgrade_plane",
+      reason: strongAuthReason(),
+    };
+  }
+  if (promptPolicy.availability === "public_player_plane_with_backend_reauth_preview") {
+    if (!state.auth.available) {
+      return {
+        status: "upgrade_after_player_session",
+        reason:
+          "hosted preview backend reauth is available on this join lane after the browser acquires a player_session",
+      };
+    }
+    if (state.auth.registrationStatus === "registered") {
+      return {
+        status: "preview_backend_reauth_available",
+        reason: promptCapability.reason || strongAuthReason(),
+      };
+    }
+    return {
+      status: "issued_pending_register",
+      reason:
+        "hosted preview backend reauth stays pending until the browser-local player_session finishes runtime registration",
+    };
+  }
+  if (promptPolicy.availability === "trusted_local_preview_only") {
+    return {
+      status: state.auth.available ? "active_legacy_preview" : "trusted_local_only",
+      reason: promptCapability.reason || strongAuthReason(),
+    };
+  }
+  return {
+    status: "blocked_until_strong_auth",
+    reason: promptPolicy.reason || strongAuthReason(),
+  };
 }
 
 function isStrongAuthSensitiveAction(actionId) {
@@ -959,7 +1000,7 @@ function buildSemanticCapability(actionId) {
       actionId,
       enabled: false,
       code: "strong_auth_required",
-      reason: `${actionId} requires strong_auth on the hosted public join path; this browser is still guest_session only and the strong-auth upgrade lane is not implemented yet`,
+      reason: `${actionId} requires strong_auth on the hosted public join path; acquire a player_session first, then complete the hosted re-authorization step for this action`,
     };
   }
   if (strongAuthSensitive && state.auth.available && deploymentHint === "remote_origin_legacy_bootstrap") {
@@ -996,6 +1037,7 @@ function buildAuthSurfaceModel() {
   const promptCapability = buildSemanticCapability("prompt_control");
   const chatCapability = buildSemanticCapability("agent_chat");
   const mainTokenTransferCapability = buildSemanticCapability("main_token_transfer");
+  const strongAuthTier = buildStrongAuthTier(promptCapability);
   const currentTier = state.auth.available ? "player_session" : "guest_session";
   const source = state.hostedAccess
     ? state.auth.available
@@ -1036,8 +1078,8 @@ function buildAuthSurfaceModel() {
       {
         id: "strong_auth",
         label: "strong_auth",
-        status: "not_implemented",
-        reason: strongAuthReason(),
+        status: strongAuthTier.status,
+        reason: strongAuthTier.reason,
       },
     ],
     capabilities: {
@@ -1052,7 +1094,10 @@ function buildAuthSurfaceModel() {
         : state.auth.registrationStatus === "registered"
           ? "page reload will reuse the browser-local hosted key and attempt reconnect_sync first"
           : "browser-local hosted key is persisted, but runtime session restore is still pending this page load"
-      : "page reload is possible, but player-session reconnect/resume is not implemented yet",
+      : isHostedPublicJoinHint(deploymentHint)
+        ? buildHostedRecoveryHint("en")?.detail
+          || "hosted public join recovers by acquiring a player_session first, then re-registering it through reconnect_sync"
+        : "page reload is possible, but player-session reconnect/resume is not implemented yet",
   };
 }
 

--- a/crates/oasis7_viewer/software_safe_src/main.jsx
+++ b/crates/oasis7_viewer/software_safe_src/main.jsx
@@ -483,8 +483,13 @@ function WorldSummaryPanel() {
   const hostedRecoveryHint = () => core.buildHostedRecoveryHint(locale());
   const selectedDebug = () => core.selectedAgentExecutionDebugContext();
   const tierBadgeClass = (status) =>
-    status === "active" || status === "active_legacy_preview"
+    status === "active"
+      || status === "active_legacy_preview"
+      || status === "active_hosted_issue"
+      || status === "preview_backend_reauth_available"
       ? "badge badge--good"
+      : status === "issued_pending_register" || status === "upgrade_after_player_session"
+        ? "badge badge--accent"
       : status === "superseded"
         ? "badge"
         : "badge badge--warn";

--- a/crates/oasis7_viewer/software_safe_src/main.test.jsx
+++ b/crates/oasis7_viewer/software_safe_src/main.test.jsx
@@ -78,7 +78,33 @@ function sampleSnapshot(overrides = {}) {
   };
 }
 
-async function renderViewerApp({ snapshot = sampleSnapshot(), selection = null } = {}) {
+function sampleHostedPublicJoinAccess(overrides = {}) {
+  return {
+    deployment_mode: "hosted_public_join",
+    action_matrix: [
+      {
+        action_id: "prompt_control_apply",
+        required_auth: "strong_auth",
+        availability: "public_player_plane_with_backend_reauth_preview",
+        reason: "prompt_control_apply is available through browser-local player auth plus backend re-authorization",
+      },
+      {
+        action_id: "main_token_transfer",
+        required_auth: "strong_auth",
+        availability: "blocked_until_strong_auth",
+        reason: "main_token_transfer remains blocked until a higher-trust hosted strong-auth lane exists",
+      },
+    ],
+    ...overrides,
+  };
+}
+
+async function renderViewerApp({
+  snapshot = sampleSnapshot(),
+  selection = null,
+  setupCore = null,
+  setupAfterMount = null,
+} = {}) {
   activeCleanup?.();
   activeCleanup = null;
   vi.resetModules();
@@ -97,8 +123,15 @@ async function renderViewerApp({ snapshot = sampleSnapshot(), selection = null }
   if (selection) {
     core.applySelection(selection);
   }
+  if (setupCore) {
+    setupCore(core);
+  }
 
   const dispose = mountViewerApp(appRoot);
+  if (setupAfterMount) {
+    setupAfterMount(core);
+    core.requestRender();
+  }
   const cleanup = () => {
     dispose();
     if (activeCleanup === cleanup) {
@@ -213,5 +246,82 @@ describe("viewer web ui automation baseline", () => {
     expect(within(stagePanel).getByText("Goal Execution")).toBeInTheDocument();
     expect(within(stagePanel).getAllByText("Blocked").length).toBeGreaterThan(0);
     expect(within(stagePanel).getByText("World Constraint")).toBeInTheDocument();
+  });
+
+  it("surfaces hosted recovery and preview strong-auth truth without not-implemented drift", async () => {
+    await renderViewerApp({
+      setupAfterMount(core) {
+        core.state.hostedAccess = sampleHostedPublicJoinAccess();
+        core.state.auth.error = "session_revoked";
+        core.state.auth.revokeReason = "qa-kick";
+        core.state.auth.revokedBy = "qa";
+      },
+    });
+
+    screen.getByText("Runtime Diagnostics").click();
+    expect(screen.getAllByRole("button", { name: "Re-acquire Hosted Player Session" }).length).toBeGreaterThan(0);
+    expect(screen.getByText("upgrade_after_player_session")).toBeInTheDocument();
+    expect(
+      screen.getAllByText(
+        "The runtime or operator revoked this browser session by qa. Reason: qa-kick. You need to acquire a fresh hosted player session before gameplay, chat, or prompt actions can continue.",
+      ).length,
+    ).toBeGreaterThan(0);
+    expect(screen.queryByText("not_implemented")).not.toBeInTheDocument();
+    expect(screen.queryByText(/not implemented yet/i)).not.toBeInTheDocument();
+  });
+
+  it("marks hosted backend reauth as available once a browser player session is registered", async () => {
+    await renderViewerApp({
+      setupAfterMount(core) {
+        core.state.hostedAccess = sampleHostedPublicJoinAccess();
+        core.state.auth = {
+          ...core.state.auth,
+          available: true,
+          playerId: "hosted-player-1",
+          publicKey: "oc:pk:test-player",
+          privateKey: "ed25519-secret",
+          releaseToken: "hosted-release-1",
+          source: "hosted_browser_storage",
+          registrationStatus: "registered",
+          runtimeStatus: "registered",
+        };
+      },
+    });
+
+    screen.getByText("Runtime Diagnostics").click();
+    expect(screen.getAllByRole("button", { name: "Release Player Session" }).length).toBeGreaterThan(0);
+    expect(screen.getByText("preview_backend_reauth_available")).toBeInTheDocument();
+    expect(
+      screen.getByText("page reload will reuse the browser-local hosted key and attempt reconnect_sync first"),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("not_implemented")).not.toBeInTheDocument();
+  });
+
+  it("keeps hosted backend reauth pending until runtime registration finishes", async () => {
+    await renderViewerApp({
+      setupAfterMount(core) {
+        core.state.hostedAccess = sampleHostedPublicJoinAccess();
+        core.state.auth = {
+          ...core.state.auth,
+          available: true,
+          playerId: "hosted-player-2",
+          publicKey: "oc:pk:test-player-2",
+          privateKey: "ed25519-secret-2",
+          releaseToken: "hosted-release-2",
+          source: "hosted_browser_storage",
+          registrationStatus: "issued",
+          runtimeStatus: "issued",
+        };
+      },
+    });
+
+    screen.getByText("Runtime Diagnostics").click();
+    expect(screen.getAllByText("issued_pending_register").length).toBeGreaterThan(0);
+    expect(screen.queryByText("preview_backend_reauth_available")).not.toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "hosted preview backend reauth stays pending until the browser-local player_session finishes runtime registration",
+      ),
+    ).toBeInTheDocument();
   });
 });

--- a/crates/oasis7_viewer/software_safe_src/main.test.jsx
+++ b/crates/oasis7_viewer/software_safe_src/main.test.jsx
@@ -292,6 +292,11 @@ describe("viewer web ui automation baseline", () => {
     expect(screen.getAllByRole("button", { name: "Release Player Session" }).length).toBeGreaterThan(0);
     expect(screen.getByText("preview_backend_reauth_available")).toBeInTheDocument();
     expect(
+      screen.getByText(
+        "hosted preview backend reauth is available after the browser-local player_session has completed runtime registration for prompt_control",
+      ),
+    ).toBeInTheDocument();
+    expect(
       screen.getByText("page reload will reuse the browser-local hosted key and attempt reconnect_sync first"),
     ).toBeInTheDocument();
     expect(screen.queryByText("not_implemented")).not.toBeInTheDocument();

--- a/doc/p2p/blockchain/p2p-shared-network-release-train-minimum-2026-03-24.design.md
+++ b/doc/p2p/blockchain/p2p-shared-network-release-train-minimum-2026-03-24.design.md
@@ -107,7 +107,7 @@
 1. 任何 candidate 必须先完成本地 gate，再进入 `shared_devnet`。
 2. 只有上一轨道结论为 `pass`，才允许 promotion 到下一轨道。
 3. 一旦发现 commit/world/governance 真值漂移，立即 `freeze` 并退回重新编号。
-4. `staging/canary` 的 `rollback` 目标必须是最近一次通过的 candidate bundle；首条 `shared_devnet pass` 若尚无历史 `pass` candidate`，可接受受审计的 `bootstrap_restore_ready` fallback，但必须固定 restore steps、fallback owner ref 与 restoration scope。
+4. `staging/canary` 的 `rollback` 目标必须是最近一次通过的 candidate bundle；首条 `shared_devnet pass` 若尚无历史 `pass` candidate，可接受受审计的 `bootstrap_restore_ready` fallback，但必须固定 restore steps、fallback owner ref 与 restoration scope。
 5. `mixed_topology_baseline` 若要从 `partial` 升到 `pass`，必须满足三项同时成立：
    - same-window shared mixed-topology evidence 已固定并与当前 `candidate_id` 对账；
    - producer/QA 联审通过的 `pass_uplift_decision_ref` 已固定；

--- a/doc/p2p/blockchain/p2p-shared-network-release-train-minimum-2026-03-24.design.md
+++ b/doc/p2p/blockchain/p2p-shared-network-release-train-minimum-2026-03-24.design.md
@@ -116,6 +116,12 @@
    - shared endpoint 已固定，且不再是单 owner 私有入口；
    - independent operator handoff / duty ref 已固定；
    - 独立 access evidence 已固定，并与当前 `candidate_id` 对账。
+7. `rollback_target_ready` 若要从 `partial` 升到 `pass`，必须满足五项同时成立：
+   - fallback bundle 已固定；
+   - fallback gate ref 已固定；
+   - fallback owner ref 已固定；
+   - restore step ref 已固定；
+   - restoration scope 已固定，并与当前 `candidate_id` 对账。
 
 ## LiveOps Window 规则
 1. 每个 track 必须冻结唯一 `window_id`、`candidate_id`、`fallback_candidate_id`、`fallback_class`、`owners_on_duty` 和 `claim_envelope`。
@@ -132,6 +138,7 @@
 5. 造成 `partial` 的主因已明确收敛到 `shared_access / rollback_target_ready / mixed_topology_baseline` 三条 lane；其中 mixed-topology 现在已有正式 `partial` 证据，但仍未达到 shared-window `pass`。
 6. mixed-topology 的剩余缺口不再是“没有模板”，而是“没有被正式采纳的 pass-uplift 合同与对应真值”；因此后续收口必须优先保证模板/脚本/编排输出的字段一致，再决定是否接受 proxy/shared-window 近似作为当前 track 的 `pass` 依据。
 7. shared-access 的剩余缺口也不再是“没有结构”，而是“没有真实共享入口与独立 operator/access evidence”；因此后续若要宣称 `pass`，必须先补真实 shared endpoint/operator/access proof，而不是只修改 lane 状态。
+8. rollback 的剩余缺口同样不再是“缺少字段名”，而是“缺少受审计 fallback gate/owner/restore scope 真值”；因此后续若要宣称 `pass`，必须先补完整 rollback 合同，而不是只挂一个 fallback bundle。
 
 ## Partial / Block 语义
 | 状态 | 含义 |

--- a/doc/p2p/blockchain/p2p-shared-network-release-train-minimum-2026-03-24.design.md
+++ b/doc/p2p/blockchain/p2p-shared-network-release-train-minimum-2026-03-24.design.md
@@ -108,6 +108,10 @@
 2. 只有上一轨道结论为 `pass`，才允许 promotion 到下一轨道。
 3. 一旦发现 commit/world/governance 真值漂移，立即 `freeze` 并退回重新编号。
 4. `staging/canary` 的 `rollback` 目标必须是最近一次通过的 candidate bundle；首条 `shared_devnet pass` 若尚无历史 `pass` candidate`，可接受受审计的 `bootstrap_restore_ready` fallback，但必须固定 restore steps、fallback owner ref 与 restoration scope。
+5. `mixed_topology_baseline` 若要从 `partial` 升到 `pass`，必须满足三项同时成立：
+   - same-window shared mixed-topology evidence 已固定并与当前 `candidate_id` 对账；
+   - producer/QA 联审通过的 `pass_uplift_decision_ref` 已固定；
+   - gate/evidence 输出中把 proxy drill 明确标注为近似，而不是 dedicated sentry/NAT lab 真值。
 
 ## LiveOps Window 规则
 1. 每个 track 必须冻结唯一 `window_id`、`candidate_id`、`fallback_candidate_id`、`fallback_class`、`owners_on_duty` 和 `claim_envelope`。
@@ -122,6 +126,7 @@
 3. follow-up window `shared-devnet-20260324-06` 已把 `short_window_longrun` 提升到 `pass`，并留下真实 S9/S10 short-window evidence。
 4. 当前 `shared_devnet` gate 结论仍为 `partial`，promotion recommendation 仍为 `hold_promotion`。
 5. 造成 `partial` 的主因已明确收敛到 `shared_access / rollback_target_ready / mixed_topology_baseline` 三条 lane；其中 mixed-topology 现在已有正式 `partial` 证据，但仍未达到 shared-window `pass`。
+6. mixed-topology 的剩余缺口不再是“没有模板”，而是“没有被正式采纳的 pass-uplift 合同与对应真值”；因此后续收口必须优先保证模板/脚本/编排输出的字段一致，再决定是否接受 proxy/shared-window 近似作为当前 track 的 `pass` 依据。
 
 ## Partial / Block 语义
 | 状态 | 含义 |

--- a/doc/p2p/blockchain/p2p-shared-network-release-train-minimum-2026-03-24.design.md
+++ b/doc/p2p/blockchain/p2p-shared-network-release-train-minimum-2026-03-24.design.md
@@ -112,6 +112,10 @@
    - same-window shared mixed-topology evidence 已固定并与当前 `candidate_id` 对账；
    - producer/QA 联审通过的 `pass_uplift_decision_ref` 已固定；
    - gate/evidence 输出中把 proxy drill 明确标注为近似，而不是 dedicated sentry/NAT lab 真值。
+6. `shared_access` 若要从 `partial` 升到 `pass`，必须满足三项同时成立：
+   - shared endpoint 已固定，且不再是单 owner 私有入口；
+   - independent operator handoff / duty ref 已固定；
+   - 独立 access evidence 已固定，并与当前 `candidate_id` 对账。
 
 ## LiveOps Window 规则
 1. 每个 track 必须冻结唯一 `window_id`、`candidate_id`、`fallback_candidate_id`、`fallback_class`、`owners_on_duty` 和 `claim_envelope`。
@@ -127,6 +131,7 @@
 4. 当前 `shared_devnet` gate 结论仍为 `partial`，promotion recommendation 仍为 `hold_promotion`。
 5. 造成 `partial` 的主因已明确收敛到 `shared_access / rollback_target_ready / mixed_topology_baseline` 三条 lane；其中 mixed-topology 现在已有正式 `partial` 证据，但仍未达到 shared-window `pass`。
 6. mixed-topology 的剩余缺口不再是“没有模板”，而是“没有被正式采纳的 pass-uplift 合同与对应真值”；因此后续收口必须优先保证模板/脚本/编排输出的字段一致，再决定是否接受 proxy/shared-window 近似作为当前 track 的 `pass` 依据。
+7. shared-access 的剩余缺口也不再是“没有结构”，而是“没有真实共享入口与独立 operator/access evidence”；因此后续若要宣称 `pass`，必须先补真实 shared endpoint/operator/access proof，而不是只修改 lane 状态。
 
 ## Partial / Block 语义
 | 状态 | 含义 |

--- a/doc/p2p/blockchain/p2p-shared-network-release-train-minimum-2026-03-24.design.md
+++ b/doc/p2p/blockchain/p2p-shared-network-release-train-minimum-2026-03-24.design.md
@@ -107,10 +107,10 @@
 1. 任何 candidate 必须先完成本地 gate，再进入 `shared_devnet`。
 2. 只有上一轨道结论为 `pass`，才允许 promotion 到下一轨道。
 3. 一旦发现 commit/world/governance 真值漂移，立即 `freeze` 并退回重新编号。
-4. `rollback` 目标必须是最近一次通过的 candidate bundle。
+4. `staging/canary` 的 `rollback` 目标必须是最近一次通过的 candidate bundle；首条 `shared_devnet pass` 若尚无历史 `pass` candidate`，可接受受审计的 `bootstrap_restore_ready` fallback，但必须固定 restore steps、fallback owner ref 与 restoration scope。
 
 ## LiveOps Window 规则
-1. 每个 track 必须冻结唯一 `window_id`、`candidate_id`、`fallback_candidate_id`、`owners_on_duty` 和 `claim_envelope`。
+1. 每个 track 必须冻结唯一 `window_id`、`candidate_id`、`fallback_candidate_id`、`fallback_class`、`owners_on_duty` 和 `claim_envelope`。
 2. `shared_devnet` 必须先留下 `promotion_record`，再开共享访问窗口。
 3. `staging` 必须有独立的 upgrade window、incident template 和 rollback rehearsal 记录。
 4. `canary` 必须有固定观察窗、`incident_review` 和 `exit_decision`，否则只能维持 `hold`。
@@ -127,7 +127,7 @@
 | 状态 | 含义 |
 | --- | --- |
 | `pass` | 轨道目标与证据完整，允许推进 |
-| `partial` | 有环境或运行，但仍缺 shared access、mixed-topology、rollback 或其他 required lane 的 shared-grade 结论 |
+| `partial` | 有环境或运行，但仍缺 shared access、mixed-topology、rollback，或 rollback 还只停留在未审计 bootstrap/provisional 级别 |
 | `block` | 未满足 promotion 必需条件，不允许推进 |
 | `frozen` | 事故或漂移导致临时冻结推进 |
 | `restored` | 已回滚到上一通过 bundle，并留下恢复证据 |

--- a/doc/p2p/blockchain/p2p-shared-network-release-train-minimum-2026-03-24.prd.md
+++ b/doc/p2p/blockchain/p2p-shared-network-release-train-minimum-2026-03-24.prd.md
@@ -54,6 +54,7 @@
   - AC-8: 本专题必须给出 first shared-devnet dry run、first staging rehearsal、first canary rehearsal 的顺序与阻断条件。
   - AC-9: 本专题必须明确 mixed-topology 是 `shared_devnet/staging/canary` 的 required lane；`P2PARCH-6` matrix baseline 只能作为 shared-devnet 的起始输入，不能单独构成 shared-network `pass` 或 public claim 升级依据。
   - AC-10: 本专题必须明确 `mixed_topology_baseline` 从 `partial` 升到 `pass` 时，至少同时固定 same-window shared evidence、producer/QA 联审通过的 `pass_uplift_decision_ref`，并在 evidence 模板/脚本中保留为显式字段。
+  - AC-11: 本专题必须明确 `shared_access` 从 `partial` 升到 `pass` 时，至少同时固定 shared endpoint、independent operator handoff 与 access evidence，并在 evidence 模板/脚本中保留为显式字段。
 - Non-Goals:
   - 不在本专题内直接搭建真实 shared devnet/testnet/canary 环境。
   - 不在本专题内升级 `limited playable technical preview` 或 `crypto-hardened preview` 口径。
@@ -94,6 +95,7 @@
 - NFR-P2P-RTMIN-7: mixed-topology required lane 必须显式区分 `baseline/rehearsal/claim review` 三种阶段；proxy drill 不得在 runbook 或 claims gate 中冒充 dedicated sentry/NAT lab 真值。
 - NFR-P2P-RTMIN-8: 任何把 shared-devnet mixed-topology lane 提升为 `pass` 的结论，都必须同时固定 same-window evidence ref 与 producer/QA 审计通过的 pass-uplift decision ref，避免仅靠脚本开关改变 gate 语义。
 - NFR-P2P-RTMIN-10: mixed-topology 的 `pass_uplift_decision_ref` 必须进入模板、草稿脚本与编排输出的正式字段集合；不得只在自由文本备注里出现，避免 QA/liveops 在后续 promotion 审计时丢失合同真值。
+- NFR-P2P-RTMIN-11: shared-access 的 endpoint / operator handoff / access evidence 必须进入模板、草稿脚本与编排输出的正式字段集合；不得只在 duty chat、口头交接或 lane 状态翻转中隐含成立。
 - NFR-P2P-RTMIN-9: 首条 `shared_devnet pass` 若尚无历史 `pass` candidate，可接受受审计的 `bootstrap_restore_ready` fallback，但必须同时固定 `restore_steps_ref`、`fallback_owner_ref`、`restoration_scope` 与 candidate truth 对账证据；否则 `rollback_target_ready` 只能记为 `partial`。
 - Security & Privacy: 本专题涉及共享环境与升级轨道，但不引入新的密钥托管方案。任何 candidate bundle、运行记录与证据都只能引用公钥、版本号、world snapshot 标识和审计结论，不得把敏感 custody 材料写入仓库。
 

--- a/doc/p2p/blockchain/p2p-shared-network-release-train-minimum-2026-03-24.prd.md
+++ b/doc/p2p/blockchain/p2p-shared-network-release-train-minimum-2026-03-24.prd.md
@@ -53,6 +53,7 @@
   - AC-7: 本专题必须明确 shared-network 当前状态仍是 `specified_not_executed`，不得把建档误写成完成执行。
   - AC-8: 本专题必须给出 first shared-devnet dry run、first staging rehearsal、first canary rehearsal 的顺序与阻断条件。
   - AC-9: 本专题必须明确 mixed-topology 是 `shared_devnet/staging/canary` 的 required lane；`P2PARCH-6` matrix baseline 只能作为 shared-devnet 的起始输入，不能单独构成 shared-network `pass` 或 public claim 升级依据。
+  - AC-10: 本专题必须明确 `mixed_topology_baseline` 从 `partial` 升到 `pass` 时，至少同时固定 same-window shared evidence、producer/QA 联审通过的 `pass_uplift_decision_ref`，并在 evidence 模板/脚本中保留为显式字段。
 - Non-Goals:
   - 不在本专题内直接搭建真实 shared devnet/testnet/canary 环境。
   - 不在本专题内升级 `limited playable technical preview` 或 `crypto-hardened preview` 口径。
@@ -92,6 +93,7 @@
   - NFR-P2P-RTMIN-6: shared-network 证据不得包含私钥、助记词、离线签名材料或 operator 私密基础设施细节。
 - NFR-P2P-RTMIN-7: mixed-topology required lane 必须显式区分 `baseline/rehearsal/claim review` 三种阶段；proxy drill 不得在 runbook 或 claims gate 中冒充 dedicated sentry/NAT lab 真值。
 - NFR-P2P-RTMIN-8: 任何把 shared-devnet mixed-topology lane 提升为 `pass` 的结论，都必须同时固定 same-window evidence ref 与 producer/QA 审计通过的 pass-uplift decision ref，避免仅靠脚本开关改变 gate 语义。
+- NFR-P2P-RTMIN-10: mixed-topology 的 `pass_uplift_decision_ref` 必须进入模板、草稿脚本与编排输出的正式字段集合；不得只在自由文本备注里出现，避免 QA/liveops 在后续 promotion 审计时丢失合同真值。
 - NFR-P2P-RTMIN-9: 首条 `shared_devnet pass` 若尚无历史 `pass` candidate，可接受受审计的 `bootstrap_restore_ready` fallback，但必须同时固定 `restore_steps_ref`、`fallback_owner_ref`、`restoration_scope` 与 candidate truth 对账证据；否则 `rollback_target_ready` 只能记为 `partial`。
 - Security & Privacy: 本专题涉及共享环境与升级轨道，但不引入新的密钥托管方案。任何 candidate bundle、运行记录与证据都只能引用公钥、版本号、world snapshot 标识和审计结论，不得把敏感 custody 材料写入仓库。
 

--- a/doc/p2p/blockchain/p2p-shared-network-release-train-minimum-2026-03-24.prd.md
+++ b/doc/p2p/blockchain/p2p-shared-network-release-train-minimum-2026-03-24.prd.md
@@ -41,12 +41,12 @@
 | Shared track 定义 | `track_id/purpose/world_scope/access_mode/owner_roles/min_entry_gate` | 冻结 `shared_devnet`、`staging`、`canary` 的用途与入口门禁 | `draft -> frozen` | 至少三层；缺任一层则 release train 仍为 `blocked` | `producer_system_designer` 拍板，`runtime_engineer`/`qa_engineer`/`liveops_community` 联审 |
 | Release candidate bundle | `candidate_id/git_commit/runtime_build/world_snapshot_ref/governance_manifest_ref/evidence_refs` | 把单一候选版本推进到共享轨道 | `draft -> promoted -> retired` | 三个轨道必须引用同一 `candidate_id`；字段缺失则不得 promotion | `runtime_engineer` 生成，`qa_engineer` 校验 |
 | Promotion gate | `from_track/to_track/gate_inputs/gate_result/approved_by` | 根据证据决定是否升级到下一轨道 | `pending -> pass/block` | 上一轨道未 `pass`、无 rollback bundle、缺 mixed-topology required lane、或 evidence 不全时一律 `block/hold` | `qa_engineer` 给出结论，`producer_system_designer`/`liveops_community` 审批 |
-| Freeze / rollback | `incident_id/affected_track/fallback_candidate_id/freeze_reason/recovery_status` | 事故时冻结 promotion 并回滚到前一 bundle | `idle -> frozen -> restored` | 回滚目标必须是最近一次 `pass` 的 candidate；只有“停在当前环境观察”不算恢复 | `liveops_community` 执行，`runtime_engineer` 支持 |
+| Freeze / rollback | `incident_id/affected_track/fallback_candidate_id/fallback_class/freeze_reason/recovery_status` | 事故时冻结 promotion 并回滚到前一 bundle，或在首条 `shared_devnet pass` 前回退到受审计 bootstrap fallback | `idle -> frozen -> restored` | `staging/canary` 的回滚目标必须是最近一次 `pass` 的 candidate；首条 `shared_devnet pass` 允许使用受审计 `bootstrap_restore_ready` fallback，但必须固定 restore steps、owner ref 与恢复范围；只有“停在当前环境观察”不算恢复 | `liveops_community` 执行，`runtime_engineer` 支持 |
 | Claims gate | `claim_phrase/min_track_status/reject_reason` | 根据 shared-network 真值决定对外口径 | `draft -> enforced` | 只要 `shared_devnet/staging/canary` 任一缺失或仅 `partial`，就不得说 release train 已建立 | `liveops_community` 执行，producer 审批 |
 - Acceptance Criteria:
   - AC-1: 本专题必须冻结 `shared_devnet`、`staging`、`canary` 三层 shared track 的目标、owner、最小入口门禁和通过标准。
   - AC-2: 本专题必须冻结统一的 `release_candidate_bundle` 字段集合，至少包含 `candidate_id`、`git_commit`、`runtime_build`、`world_snapshot_ref`、`governance_manifest_ref`、`evidence_refs`。
-  - AC-3: 本专题必须明确什么情况只能记为 `partial`，至少包括：仅本地单机运行、没有共享访问、没有固定 candidate id、没有 rollback bundle、没有 QA 证据。
+  - AC-3: 本专题必须明确什么情况只能记为 `partial`，至少包括：仅本地单机运行、没有共享访问、没有固定 candidate id、没有可审计 rollback target、没有 QA 证据。
   - AC-4: 本专题必须明确：shared network / release train 未完成前，仍不得使用 `production release train is established`、`mainnet-grade testing maturity` 或任何高于当前 preview 的口径。
   - AC-5: `testing-manual.md` 必须能找到本专题入口，并明确它是 benchmark `L5` 的正式 execution 入口，而不是已完成能力。
   - AC-6: `doc/p2p/project.md` 必须建立 `TASK-P2P-040` 任务链，并拆出后续 runtime/QA/liveops 子任务。
@@ -76,7 +76,7 @@
 - Edge Cases & Error Handling:
   - 若一个环境只有单 owner 本地访问、没有共享节点或共享运维窗口，则最多记为 `partial_local_only`，不能记为 shared track。
   - 若 `shared_devnet`、`staging`、`canary` 跑的是不同 commit、不同 world snapshot 或不同 governance manifest，则 promotion 直接 `block_version_drift`。
-  - 若没有最近一次 `pass` 的 fallback candidate，就不得进入下一轨道；发生事故时只能 `freeze`，不能宣称可回滚。
+  - 若 `staging/canary` 没有最近一次 `pass` 的 fallback candidate，就不得进入下一轨道；若 `shared_devnet` 还在争取首条 `pass`，则至少要固定一条受审计的 `bootstrap_restore_ready` fallback，并写清 restore steps / owner ref / restoration scope，否则只能维持 `partial`。
   - 若 staging 只是 shared_devnet 的别名、没有独立升级窗口/恢复演练/QA 判定，则不得记为 `staging_ready`。
   - 若 canary 没有明确的 duration、incident review 与 freeze 条件，则不得记为 `canary_complete`。
   - 若 governance truth、genesis truth 或 claims boundary 发生变化但未更新 candidate bundle 编号，则该 bundle 失效，必须重新编号。
@@ -90,8 +90,9 @@
   - NFR-P2P-RTMIN-4: 所有 shared-network 结论必须使用 `pass/partial/block/frozen/restored` 这些显式状态，不得使用 `looks_good` 一类口头结论。
   - NFR-P2P-RTMIN-5: 在 `shared_devnet/staging/canary` 三层都有最新审计轮次的正式证据前，公开口径不得出现 `release train established`、`shared network validated` 或更高成熟度描述。
   - NFR-P2P-RTMIN-6: shared-network 证据不得包含私钥、助记词、离线签名材料或 operator 私密基础设施细节。
-  - NFR-P2P-RTMIN-7: mixed-topology required lane 必须显式区分 `baseline/rehearsal/claim review` 三种阶段；proxy drill 不得在 runbook 或 claims gate 中冒充 dedicated sentry/NAT lab 真值。
-  - NFR-P2P-RTMIN-8: 任何把 shared-devnet mixed-topology lane 提升为 `pass` 的结论，都必须同时固定 same-window evidence ref 与 producer/QA 审计通过的 pass-uplift decision ref，避免仅靠脚本开关改变 gate 语义。
+- NFR-P2P-RTMIN-7: mixed-topology required lane 必须显式区分 `baseline/rehearsal/claim review` 三种阶段；proxy drill 不得在 runbook 或 claims gate 中冒充 dedicated sentry/NAT lab 真值。
+- NFR-P2P-RTMIN-8: 任何把 shared-devnet mixed-topology lane 提升为 `pass` 的结论，都必须同时固定 same-window evidence ref 与 producer/QA 审计通过的 pass-uplift decision ref，避免仅靠脚本开关改变 gate 语义。
+- NFR-P2P-RTMIN-9: 首条 `shared_devnet pass` 若尚无历史 `pass` candidate，可接受受审计的 `bootstrap_restore_ready` fallback，但必须同时固定 `restore_steps_ref`、`fallback_owner_ref`、`restoration_scope` 与 candidate truth 对账证据；否则 `rollback_target_ready` 只能记为 `partial`。
 - Security & Privacy: 本专题涉及共享环境与升级轨道，但不引入新的密钥托管方案。任何 candidate bundle、运行记录与证据都只能引用公钥、版本号、world snapshot 标识和审计结论，不得把敏感 custody 材料写入仓库。
 
 ## 5. Risks & Roadmap

--- a/doc/p2p/blockchain/p2p-shared-network-release-train-minimum-2026-03-24.project.md
+++ b/doc/p2p/blockchain/p2p-shared-network-release-train-minimum-2026-03-24.project.md
@@ -102,6 +102,7 @@
   - `shared_access` 的 endpoint / operator handoff / access evidence 现在也已被提升为模板/脚本/编排输出的正式字段；后续若要在这个 PR 里继续推进，重点不再是“补结构”，而是拿到真实 shared endpoint 与独立 operator/access proof
   - mixed-topology 的 `pass_uplift_decision_ref` 现在已被提升为模板/脚本/编排输出的正式字段；后续若要在这个 PR 里继续推进，重点不再是“补结构”，而是决定 repo 已有 proxy/shared-window 证据是否足以支撑真实 `pass` 裁决
   - `rollback_target_ready` 的 first-pass 语义已收口为：`staging/canary` 仍要求最近一次 formal `pass` candidate，但首条 `shared_devnet pass` 可接受受审计 `bootstrap_restore_ready` fallback；若 `restore_steps_ref/fallback_owner_ref/restoration_scope` 不完整，仍只能记 `partial`
+  - `rollback_target_ready` 的脚本合同也已收口为：只有 fallback bundle + fallback gate + fallback owner + restore steps + restoration scope 全部齐全时，repo 才允许把该 lane 记为 `pass`
   - 没有正式 `staging/canary`
 
 ## 依赖

--- a/doc/p2p/blockchain/p2p-shared-network-release-train-minimum-2026-03-24.project.md
+++ b/doc/p2p/blockchain/p2p-shared-network-release-train-minimum-2026-03-24.project.md
@@ -99,6 +99,7 @@
   - 剩余 blocker 已收敛到 `shared_access / rollback_target_ready / mixed_topology_baseline`
   - `P2PARCH-6` matrix baseline 已成为 shared-network required lane，但它当前只足以阻止 claims 越界，不等价于 shared-window `pass`
   - `shared_access / rollback_target_ready` draft 已生成；`mixed_topology_baseline` 现在也已有正式 `partial` 证据文档，但仍等待更强 same-window mixed-topology 真值或 dedicated lab 裁决，并需要 producer/QA pass-uplift decision ref，才能升到 `pass`
+  - `rollback_target_ready` 的 first-pass 语义已收口为：`staging/canary` 仍要求最近一次 formal `pass` candidate，但首条 `shared_devnet pass` 可接受受审计 `bootstrap_restore_ready` fallback；若 `restore_steps_ref/fallback_owner_ref/restoration_scope` 不完整，仍只能记 `partial`
   - 没有正式 `staging/canary`
 
 ## 依赖

--- a/doc/p2p/blockchain/p2p-shared-network-release-train-minimum-2026-03-24.project.md
+++ b/doc/p2p/blockchain/p2p-shared-network-release-train-minimum-2026-03-24.project.md
@@ -99,6 +99,7 @@
   - 剩余 blocker 已收敛到 `shared_access / rollback_target_ready / mixed_topology_baseline`
   - `P2PARCH-6` matrix baseline 已成为 shared-network required lane，但它当前只足以阻止 claims 越界，不等价于 shared-window `pass`
   - `shared_access / rollback_target_ready` draft 已生成；`mixed_topology_baseline` 现在也已有正式 `partial` 证据文档，但仍等待更强 same-window mixed-topology 真值或 dedicated lab 裁决，并需要 producer/QA pass-uplift decision ref，才能升到 `pass`
+  - mixed-topology 的 `pass_uplift_decision_ref` 现在已被提升为模板/脚本/编排输出的正式字段；后续若要在这个 PR 里继续推进，重点不再是“补结构”，而是决定 repo 已有 proxy/shared-window 证据是否足以支撑真实 `pass` 裁决
   - `rollback_target_ready` 的 first-pass 语义已收口为：`staging/canary` 仍要求最近一次 formal `pass` candidate，但首条 `shared_devnet pass` 可接受受审计 `bootstrap_restore_ready` fallback；若 `restore_steps_ref/fallback_owner_ref/restoration_scope` 不完整，仍只能记 `partial`
   - 没有正式 `staging/canary`
 

--- a/doc/p2p/blockchain/p2p-shared-network-release-train-minimum-2026-03-24.project.md
+++ b/doc/p2p/blockchain/p2p-shared-network-release-train-minimum-2026-03-24.project.md
@@ -99,6 +99,7 @@
   - 剩余 blocker 已收敛到 `shared_access / rollback_target_ready / mixed_topology_baseline`
   - `P2PARCH-6` matrix baseline 已成为 shared-network required lane，但它当前只足以阻止 claims 越界，不等价于 shared-window `pass`
   - `shared_access / rollback_target_ready` draft 已生成；`mixed_topology_baseline` 现在也已有正式 `partial` 证据文档，但仍等待更强 same-window mixed-topology 真值或 dedicated lab 裁决，并需要 producer/QA pass-uplift decision ref，才能升到 `pass`
+  - `shared_access` 的 endpoint / operator handoff / access evidence 现在也已被提升为模板/脚本/编排输出的正式字段；后续若要在这个 PR 里继续推进，重点不再是“补结构”，而是拿到真实 shared endpoint 与独立 operator/access proof
   - mixed-topology 的 `pass_uplift_decision_ref` 现在已被提升为模板/脚本/编排输出的正式字段；后续若要在这个 PR 里继续推进，重点不再是“补结构”，而是决定 repo 已有 proxy/shared-window 证据是否足以支撑真实 `pass` 裁决
   - `rollback_target_ready` 的 first-pass 语义已收口为：`staging/canary` 仍要求最近一次 formal `pass` candidate，但首条 `shared_devnet pass` 可接受受审计 `bootstrap_restore_ready` fallback；若 `restore_steps_ref/fallback_owner_ref/restoration_scope` 不完整，仍只能记 `partial`
   - 没有正式 `staging/canary`

--- a/doc/p2p/blockchain/p2p-shared-network-release-train-minimum-2026-03-24.runbook.md
+++ b/doc/p2p/blockchain/p2p-shared-network-release-train-minimum-2026-03-24.runbook.md
@@ -29,7 +29,9 @@
 
 - 同一份已校验的 `release_candidate_bundle`
 - 当前 track 的 QA gate `summary.json/md`
-- 最近一次 `pass` 的 `fallback_candidate_id`
+- `fallback_candidate_id` 与 `fallback_class`
+  - `formal_pass_candidate`
+  - `bootstrap_restore_ready`（仅允许首条 `shared_devnet pass` 使用）
 - 窗口元数据：
   - `window_id`
   - `track`
@@ -48,7 +50,8 @@
 - `release_candidate_bundle` 缺字段、路径失效或 hash 漂移：立即 `freeze`
 - 当前 track QA gate 为 `block`：不得开窗
 - 上一轨不是 `pass` 却申请 promotion：直接 `hold`
-- 没有 fallback candidate 却申请下一轨：直接 `hold`
+- `staging/canary` 没有 formal fallback candidate 却申请下一轨：直接 `hold`
+- `shared_devnet` 若还在争取首条 `pass` 且没有受审计 `bootstrap_restore_ready` fallback：直接 `hold`
 - 共享访问入口、值班 owner、evidence root 未冻结：直接 `hold`
 - required mixed-topology lane 仍停留在 baseline / proxy 近似、没有对应 track 的正式结论：直接 `hold`
 - mixed-topology lane 试图记 `pass` 但没有 same-window evidence 对账或缺少 producer/QA pass-uplift decision ref：直接 `hold`
@@ -65,10 +68,12 @@
   - 固定 `P2PARCH-6` mixed-topology baseline evidence
   - 生成 `promotion_record`
   - 固定 `rollback_target_candidate_id`
+  - 若尚无历史 `shared_devnet pass` candidate`，则补齐一条受审计 `bootstrap_restore_ready` fallback：至少包含 `restore_steps_ref`、`fallback_owner_ref`、`restoration_scope`
 - 收窗判定：
   - `shared-network-track-gate` 为 `pass` 才可申请进入 `staging`
   - 若 shared access 退化成单 owner 私有访问，最多只能记 `partial`
   - 若 mixed-topology 仍只有 baseline / proxy 近似，没有 same-window shared 结论，最多只能记 `partial`
+  - 若 rollback target 只有“未来再补”的占位，没有受审计 restore steps / owner ref / scope，最多只能记 `partial`
   - 若 mixed-topology 想记 `pass`，除 same-window shared evidence 外还必须固定 producer/QA 联审通过的 pass-uplift decision ref
   - 可先用 `shared-devnet-blocker-packet` 生成 `shared_access` / `mixed_topology_baseline` / `rollback_target_ready` 三份 draft，再等待真实窗口证据填充
 

--- a/doc/p2p/blockchain/p2p-shared-network-release-train-minimum-2026-03-24.runbook.md
+++ b/doc/p2p/blockchain/p2p-shared-network-release-train-minimum-2026-03-24.runbook.md
@@ -56,6 +56,7 @@
 - required mixed-topology lane 仍停留在 baseline / proxy 近似、没有对应 track 的正式结论：直接 `hold`
 - mixed-topology lane 试图记 `pass` 但没有 same-window evidence 对账或缺少 producer/QA pass-uplift decision ref：直接 `hold`
 - mixed-topology lane 的 `pass_uplift_decision_ref` 只出现在备注、聊天记录或口头结论里，没有进入正式模板/脚本产物：也视为 `hold`
+- shared-access lane 试图记 `pass` 但没有 shared endpoint、independent operator handoff 或 access evidence 任一正式字段：直接 `hold`
 - 对外口径越过 preview 边界：立即 `freeze`
 
 ## 4. 三层执行循环
@@ -73,6 +74,7 @@
 - 收窗判定：
   - `shared-network-track-gate` 为 `pass` 才可申请进入 `staging`
   - 若 shared access 退化成单 owner 私有访问，最多只能记 `partial`
+  - 若 shared-access 想记 `pass`，除 shared endpoint 与 operator handoff 外，还必须固定独立 access evidence；三项缺任一都只能继续 `partial`
   - 若 mixed-topology 仍只有 baseline / proxy 近似，没有 same-window shared 结论，最多只能记 `partial`
   - 若 rollback target 只有“未来再补”的占位，没有受审计 restore steps / owner ref / scope，最多只能记 `partial`
   - 若 mixed-topology 想记 `pass`，除 same-window shared evidence 外还必须固定 producer/QA 联审通过的 pass-uplift decision ref

--- a/doc/p2p/blockchain/p2p-shared-network-release-train-minimum-2026-03-24.runbook.md
+++ b/doc/p2p/blockchain/p2p-shared-network-release-train-minimum-2026-03-24.runbook.md
@@ -55,6 +55,7 @@
 - 共享访问入口、值班 owner、evidence root 未冻结：直接 `hold`
 - required mixed-topology lane 仍停留在 baseline / proxy 近似、没有对应 track 的正式结论：直接 `hold`
 - mixed-topology lane 试图记 `pass` 但没有 same-window evidence 对账或缺少 producer/QA pass-uplift decision ref：直接 `hold`
+- mixed-topology lane 的 `pass_uplift_decision_ref` 只出现在备注、聊天记录或口头结论里，没有进入正式模板/脚本产物：也视为 `hold`
 - 对外口径越过 preview 边界：立即 `freeze`
 
 ## 4. 三层执行循环
@@ -75,6 +76,7 @@
   - 若 mixed-topology 仍只有 baseline / proxy 近似，没有 same-window shared 结论，最多只能记 `partial`
   - 若 rollback target 只有“未来再补”的占位，没有受审计 restore steps / owner ref / scope，最多只能记 `partial`
   - 若 mixed-topology 想记 `pass`，除 same-window shared evidence 外还必须固定 producer/QA 联审通过的 pass-uplift decision ref
+  - mixed-topology 的 pass-uplift 决议必须进入正式 evidence 字段，而不是只写在 Notes；否则即使 reviewer 同意，也不能把 lane 升到 `pass`
   - 可先用 `shared-devnet-blocker-packet` 生成 `shared_access` / `mixed_topology_baseline` / `rollback_target_ready` 三份 draft，再等待真实窗口证据填充
 
 ### 4.2 `staging`
@@ -177,4 +179,4 @@
   - `shared_access`
   - `rollback_target_ready`
   - `mixed_topology_baseline`
-- 下一步不是升级 public claims，也不是直接进 `staging`，而是先把这三条 lane 提升到 `pass`；如果 mixed-topology 继续停留在 proxy/shared-window 近似，或没有 pass-uplift decision ref，就必须显式保持 `partial`，不能口头升级。
+- 下一步不是升级 public claims，也不是直接进 `staging`，而是先把这三条 lane 提升到 `pass`；如果 mixed-topology 继续停留在 proxy/shared-window 近似、没有 pass-uplift decision ref，或该 decision ref 没进入正式 evidence 字段，就必须显式保持 `partial`，不能口头升级。

--- a/doc/p2p/blockchain/p2p-shared-network-release-train-minimum-2026-03-24.runbook.md
+++ b/doc/p2p/blockchain/p2p-shared-network-release-train-minimum-2026-03-24.runbook.md
@@ -57,6 +57,7 @@
 - mixed-topology lane 试图记 `pass` 但没有 same-window evidence 对账或缺少 producer/QA pass-uplift decision ref：直接 `hold`
 - mixed-topology lane 的 `pass_uplift_decision_ref` 只出现在备注、聊天记录或口头结论里，没有进入正式模板/脚本产物：也视为 `hold`
 - shared-access lane 试图记 `pass` 但没有 shared endpoint、independent operator handoff 或 access evidence 任一正式字段：直接 `hold`
+- rollback lane 试图记 `pass` 但没有 fallback gate、fallback owner、restore steps 或 restoration scope 任一正式字段：直接 `hold`
 - 对外口径越过 preview 边界：立即 `freeze`
 
 ## 4. 三层执行循环
@@ -76,7 +77,7 @@
   - 若 shared access 退化成单 owner 私有访问，最多只能记 `partial`
   - 若 shared-access 想记 `pass`，除 shared endpoint 与 operator handoff 外，还必须固定独立 access evidence；三项缺任一都只能继续 `partial`
   - 若 mixed-topology 仍只有 baseline / proxy 近似，没有 same-window shared 结论，最多只能记 `partial`
-  - 若 rollback target 只有“未来再补”的占位，没有受审计 restore steps / owner ref / scope，最多只能记 `partial`
+  - 若 rollback target 只有 fallback bundle 或“未来再补”的占位，没有受审计 fallback gate / restore steps / owner ref / scope，最多只能记 `partial`
   - 若 mixed-topology 想记 `pass`，除 same-window shared evidence 外还必须固定 producer/QA 联审通过的 pass-uplift decision ref
   - mixed-topology 的 pass-uplift 决议必须进入正式 evidence 字段，而不是只写在 Notes；否则即使 reviewer 同意，也不能把 lane 升到 `pass`
   - 可先用 `shared-devnet-blocker-packet` 生成 `shared_access` / `mixed_topology_baseline` / `rollback_target_ready` 三份 draft，再等待真实窗口证据填充

--- a/doc/testing/evidence/shared-network-shared-devnet-dry-run-2026-03-24.md
+++ b/doc/testing/evidence/shared-network-shared-devnet-dry-run-2026-03-24.md
@@ -101,14 +101,14 @@
   - 共享访问仍是 local-only
   - multi-entry closure 还没在同一 candidate 上重跑
   - governance / short-window longrun 还没有 shared-devnet 窗口内的新样本
-  - rollback target 还没有“上一条 shared-devnet pass candidate”真值
+  - rollback target 还没有可审计的 shared-grade fallback；即便首条 `shared_devnet pass` 允许 `bootstrap_restore_ready` fallback，本轮也还没补齐 restore steps / owner ref / scope
 - 因此当前不能 promotion 到 `staging`，更不能升级 public claims。
 
 ## 边界与遗留
 1. 本轮使 shared-network 从 `specified_not_executed` 升到 `partial`，但绝不等于 `shared network validated`。
 2. benchmark `L5` 可以从 `missing` 调整为 `partial`，因为已有首轮可审计 dry run；但 shared execution 仍未达 `pass`。
 3. 下一步不是直接做 `staging`，而是先把 `shared_devnet` 从 `partial` 提升到 `pass`，至少补齐：
-   - 真实 shared access
-   - 同一 candidate 的 multi-entry closure
-   - shared-devnet short-window longrun
-   - 可追溯 fallback candidate
+  - 真实 shared access
+  - 同一 candidate 的 multi-entry closure
+  - shared-devnet short-window longrun
+  - 可追溯 fallback candidate 或受审计 `bootstrap_restore_ready` fallback

--- a/doc/testing/evidence/shared-network-shared-devnet-follow-up-promotion-record-2026-03-24.md
+++ b/doc/testing/evidence/shared-network-shared-devnet-follow-up-promotion-record-2026-03-24.md
@@ -8,6 +8,7 @@
 - `candidate_id`: `shared-devnet-20260324-05`
 - `approved_from_track`: `local_required_full_and_governance_baseline`
 - `fallback_candidate_id`: `none_formal_shared_devnet_pass_candidate_yet`
+- `fallback_class`: `bootstrap_restore_ready_not_yet_audited`
 - `approved_by`: `liveops_community`
 - `approved_at`: `2026-03-24 17:12:48 CST`
 
@@ -39,12 +40,12 @@
   - 但 QA gate 仍为 `partial`，shared-devnet 尚未满足 promotion 所需 `pass`。
   - 剩余 blocker 已收敛为 `shared_access`、`short_window_longrun`、`rollback_target_ready`。
 - `follow_up`:
-  - 下一轮 shared-devnet 窗口应直接补 shared access、真实 short-window soak 与 formal fallback candidate。
+  - 下一轮 shared-devnet 窗口应直接补 shared access、真实 short-window soak，以及受审计 rollback contract：若仍无历史 formal `pass` candidate，则至少补齐 `bootstrap_restore_ready` fallback 的 restore steps / owner ref / scope。
 
 ## Residual Risks
 - 风险-1:
   - 当前仍无独立 shared operator / shared endpoint 证据。
 - 风险-2:
-  - 当前 `fallback_candidate_id` 仍没有正式 shared-devnet `pass` 历史真值。
+  - 当前既没有正式 shared-devnet `pass` 历史真值，也没有审计完成的 `bootstrap_restore_ready` fallback contract。
 - 风险-3:
   - 当前 short-window 仍是 dry-run command path，不足以支撑 promotion。

--- a/doc/testing/evidence/shared-network-shared-devnet-mixed-topology-draft-2026-04-03.md
+++ b/doc/testing/evidence/shared-network-shared-devnet-mixed-topology-draft-2026-04-03.md
@@ -44,6 +44,8 @@
   - `partial`
 - `reason`:
   - `P2PARCH-6` matrix baseline and same-window shared-devnet rehearsal evidence are now pinned together, but the latest 2026-04-07 full proxy execution still fails with audited consensus/recovery signatures and has not crossed the dedicated shared-window pass bar.
+- `pass_uplift_decision_ref`:
+  - `<not applicable while lane_result=partial; required for pass uplift>`
 
 ## Notes
 - This document upgrades the lane from an implicit missing scaffold to an explicit audited `partial` evidence packet.

--- a/doc/testing/evidence/shared-network-shared-devnet-mixed-topology-draft-2026-04-03.md
+++ b/doc/testing/evidence/shared-network-shared-devnet-mixed-topology-draft-2026-04-03.md
@@ -47,6 +47,40 @@
 - `pass_uplift_decision_ref`:
   - `<not applicable while lane_result=partial; required for pass uplift>`
 
+## Pending Checklist
+- [ ] 固定可接受的 `same_window_shared_evidence_ref`
+- [ ] 固定 producer/QA 联审通过的 `pass_uplift_decision_ref`
+- [ ] 回填 `validated_by`
+- [ ] 回填 `validated_at`
+- [ ] 若仍引用 `proxy_drill_ref`，明确它只是近似而非 dedicated sentry/NAT lab 真值
+
+## Pass Closure Rule
+- 只有以下两类字段同时齐全时，`mixed_topology_baseline` 才能升到 `pass`：
+  - same-window mixed-topology evidence：`same_window_shared_evidence_ref`
+  - producer/QA audited uplift decision：`pass_uplift_decision_ref`
+
+## Suggested Window Promotion Command
+```bash
+./scripts/shared-devnet-rehearsal.sh \
+  --window-id <shared-devnet-window-id> \
+  --candidate-bundle <output/release-candidates/current.json> \
+  --out-dir <output/shared-network/...> \
+  --release-gate-mode skip \
+  --web-mode evidence \
+  --web-evidence-ref <same-window web evidence> \
+  --headless-mode evidence \
+  --headless-evidence-ref <same-window no-ui evidence> \
+  --pure-api-mode evidence \
+  --pure-api-evidence-ref <same-window pure-api evidence> \
+  --governance-mode evidence \
+  --governance-window-evidence-ref <same-window governance evidence> \
+  --longrun-mode evidence \
+  --longrun-window-evidence-ref <same-window longrun evidence> \
+  --mixed-topology-pass \
+  --mixed-topology-shared-evidence-ref <same-window mixed-topology evidence> \
+  --mixed-topology-pass-decision-ref <producer/QA decision ref>
+```
+
 ## Notes
 - This document upgrades the lane from an implicit missing scaffold to an explicit audited `partial` evidence packet.
 - It is sufficient to keep `shared_devnet` gate semantics honest, but not sufficient to promote `shared_devnet` to `pass`.

--- a/doc/testing/evidence/shared-network-shared-devnet-rollback-target-draft-2026-03-24.md
+++ b/doc/testing/evidence/shared-network-shared-devnet-rollback-target-draft-2026-03-24.md
@@ -48,6 +48,44 @@
 - `reason`:
   - first shared-devnet pass may use a `bootstrap_restore_ready` fallback, but this draft still lacks audited `restore_steps_ref`, `fallback_owner_ref`, and concrete restoration scope evidence
 
+## Pending Checklist
+- [ ] 固定 `fallback_candidate_bundle_ref`
+- [ ] 固定 `fallback_gate_ref`
+- [ ] 固定 `fallback_owner_ref`
+- [ ] 固定至少一条 `restore_steps_ref`
+- [ ] 固定 `restoration_scope`
+- [ ] 回填 `validated_by`
+- [ ] 回填 `validated_at`
+
+## Pass Closure Rule
+- 只有以下五类字段同时齐全时，`rollback_target_ready` 才能升到 `pass`：
+  - fallback bundle：`fallback_candidate_bundle_ref`
+  - fallback gate：`fallback_gate_ref`
+  - fallback owner：`fallback_owner_ref`
+  - restore steps：`restore_steps_ref`
+  - restoration scope：`restoration_scope`
+
+## Suggested Update Command
+```bash
+./scripts/shared-devnet-blocker-packet.sh \
+  --window-id shared-devnet-20260324-06 \
+  --candidate-bundle output/release-candidates/shared-devnet-20260324-05.json \
+  --candidate-gate-summary output/shared-network/shared-devnet-20260324-06/gate/shared_devnet-20260324-175501/summary.md \
+  --access-out doc/testing/evidence/shared-network-shared-devnet-shared-access-draft-2026-03-24.md \
+  --mixed-topology-out doc/testing/evidence/shared-network-shared-devnet-mixed-topology-draft-2026-04-03.md \
+  --rollback-out doc/testing/evidence/shared-network-shared-devnet-rollback-target-draft-2026-03-24.md \
+  --fallback-candidate-bundle <output/release-candidates/fallback.json> \
+  --fallback-class bootstrap_restore_ready \
+  --fallback-gate-summary <audited fallback gate/checklist ref> \
+  --fallback-owner-ref <approval/handoff ref> \
+  --restore-steps-ref <restore checklist/log ref> \
+  --restoration-scope "runtime build | world snapshot | governance manifest" \
+  --rollback-validated-by "<liveops owner / runtime owner>" \
+  --rollback-validated-at "<YYYY-MM-DD HH:MM:SS TZ>" \
+  --rollback-lane-result pass \
+  --rollback-reason "audited fallback contract is pinned for the current shared-devnet window"
+```
+
 ## Notes
 - `pass` if:
   - `fallback_class=formal_pass_candidate` and fallback candidate is a formal previous shared-devnet `pass` candidate; or

--- a/doc/testing/evidence/shared-network-shared-devnet-rollback-target-draft-2026-03-24.md
+++ b/doc/testing/evidence/shared-network-shared-devnet-rollback-target-draft-2026-03-24.md
@@ -20,15 +20,17 @@
 
 ## Fallback Candidate
 - `fallback_candidate_id`:
-  - `<previous-pass-candidate-id>`
+  - `shared-devnet-bootstrap-fallback`
+- `fallback_class`:
+  - `bootstrap_restore_ready`
 - `fallback_candidate_bundle_ref`:
-  - `<output/release-candidates/fallback.json>`
+  - `<output/release-candidates/bootstrap-fallback.json>`
 - `fallback_gate_ref`:
-  - `<output/shared-network/.../gate/.../summary.md>`
+  - `<bootstrap restore checklist or audited fallback summary>`
 - `fallback_track_result`:
-  - `pass`
+  - `bootstrap_restore_ready`
 - `fallback_owner_ref`:
-  - `<promotion record | incident review | approval record>`
+  - `<operator checklist | approval record>`
 
 ## Rollback Readiness
 - `restore_steps_ref`:
@@ -44,9 +46,11 @@
 - `lane_result`:
   - `partial`
 - `reason`:
-  - formal previous shared-devnet pass fallback is not pinned yet
+  - first shared-devnet pass may use a `bootstrap_restore_ready` fallback, but this draft still lacks audited `restore_steps_ref`, `fallback_owner_ref`, and concrete restoration scope evidence
 
 ## Notes
-- `pass` only if fallback candidate is a formal previous shared-devnet `pass` candidate.
-- `partial` if there is only a local/provisional fallback but no formal shared-devnet `pass` history.
+- `pass` if:
+  - `fallback_class=formal_pass_candidate` and fallback candidate is a formal previous shared-devnet `pass` candidate; or
+  - `fallback_class=bootstrap_restore_ready`, current track is still pursuing the first shared-devnet `pass`, and `restore_steps_ref` + `fallback_owner_ref` + `restoration_scope` are all pinned and audited.
+- `partial` if there is only a local/provisional fallback, or a bootstrap fallback is named but the audited restore contract is incomplete.
 - `block` if fallback truth is missing, inconsistent, or not restorable.

--- a/doc/testing/evidence/shared-network-shared-devnet-shared-access-draft-2026-03-24.md
+++ b/doc/testing/evidence/shared-network-shared-devnet-shared-access-draft-2026-03-24.md
@@ -46,7 +46,42 @@
 - `reason`:
   - shared access input is still draft; convert to pass only after independent operator access is verified
 
+## Pending Checklist
+- [ ] 固定真实 `viewer_url`
+- [ ] 固定真实 `live_addr`
+- [ ] 固定 `operator_contact_ref`
+- [ ] 固定 `independent_operator_ref`
+- [ ] 固定至少一条 `evidence_ref`（截图、访问日志或 duty record）
+- [ ] 回填 `validated_by`
+- [ ] 回填 `validated_at`
+
+## Pass Closure Rule
+- 只有以下三类字段同时齐全时，`shared_access` 才能升到 `pass`：
+  - 真实 shared endpoint：`viewer_url` + `live_addr`
+  - 独立 operator/handoff：`operator_contact_ref` + `independent_operator_ref`
+  - 独立访问证据：`evidence_ref`
+
+## Suggested Update Command
+```bash
+./scripts/shared-devnet-blocker-packet.sh \
+  --window-id shared-devnet-20260324-06 \
+  --candidate-bundle output/release-candidates/shared-devnet-20260324-05.json \
+  --candidate-gate-summary output/shared-network/shared-devnet-20260324-06/gate/shared_devnet-20260324-175501/summary.md \
+  --access-out doc/testing/evidence/shared-network-shared-devnet-shared-access-draft-2026-03-24.md \
+  --mixed-topology-out doc/testing/evidence/shared-network-shared-devnet-mixed-topology-draft-2026-04-03.md \
+  --rollback-out doc/testing/evidence/shared-network-shared-devnet-rollback-target-draft-2026-03-24.md \
+  --viewer-url <https://shared-viewer.example/...> \
+  --live-addr <host:port> \
+  --operator-contact-ref <handoff/oncall/runbook ref> \
+  --independent-operator-ref <independent operator proof ref> \
+  --access-evidence-ref <screenshot/log/duty record ref> \
+  --access-validated-by "<qa operator / runtime operator>" \
+  --access-validated-at "<YYYY-MM-DD HH:MM:SS TZ>" \
+  --access-lane-result pass \
+  --access-reason "independent operator access is verified for this shared-devnet window"
+```
+
 ## Notes
-- `pass` only if access is not single-owner local-only rehearsal.
+- `pass` only if access is not single-owner local-only rehearsal and the endpoint, operator handoff, and independent access evidence refs are all pinned.
 - `partial` if endpoint exists but still depends on one local operator or one private machine.
 - `block` if endpoint is unreachable, candidate truth mismatches, or owner handoff is missing.

--- a/doc/testing/evidence/shared-network-shared-devnet-short-window-incident-2026-03-24.md
+++ b/doc/testing/evidence/shared-network-shared-devnet-short-window-incident-2026-03-24.md
@@ -24,6 +24,8 @@
 - `rollback_required`: `no`
 - `rollback_target_candidate_id`:
   - `none_formal_shared_devnet_pass_candidate_yet`
+- `rollback_target_class`:
+  - `bootstrap_restore_ready_not_yet_audited`
 
 ## Follow-up
 - `runtime_owner_action`:
@@ -31,4 +33,4 @@
 - `qa_owner_action`:
   - 下一轮只需复核 `shared_access` 与 `rollback_target_ready` 两条 lane。
 - `liveops_owner_action`:
-  - 准备 shared operator access 记录，并在出现首条 formal shared-devnet `pass` candidate 后再解除 `hold_promotion`。
+  - 准备 shared operator access 记录，并补齐 rollback contract：若仍无历史 formal shared-devnet `pass` candidate`，则至少把 `bootstrap_restore_ready` fallback 的 restore steps / owner ref / scope 审计完成，再解除 `hold_promotion`。

--- a/doc/testing/evidence/shared-network-shared-devnet-short-window-incident-2026-03-24.md
+++ b/doc/testing/evidence/shared-network-shared-devnet-short-window-incident-2026-03-24.md
@@ -33,4 +33,4 @@
 - `qa_owner_action`:
   - 下一轮只需复核 `shared_access` 与 `rollback_target_ready` 两条 lane。
 - `liveops_owner_action`:
-  - 准备 shared operator access 记录，并补齐 rollback contract：若仍无历史 formal shared-devnet `pass` candidate`，则至少把 `bootstrap_restore_ready` fallback 的 restore steps / owner ref / scope 审计完成，再解除 `hold_promotion`。
+  - 准备 shared operator access 记录，并补齐 rollback contract：若仍无历史 formal shared-devnet `pass` candidate，则至少把 `bootstrap_restore_ready` fallback 的 restore steps / owner ref / scope 审计完成，再解除 `hold_promotion`。

--- a/doc/testing/templates/shared-network-incident-template.md
+++ b/doc/testing/templates/shared-network-incident-template.md
@@ -20,6 +20,7 @@
 - `freeze_reason`:
 - `rollback_required`: `yes` / `no`
 - `rollback_target_candidate_id`:
+- `rollback_target_class`:
 
 ## Communication Boundary
 - `public_message_state`:

--- a/doc/testing/templates/shared-network-promotion-record-template.md
+++ b/doc/testing/templates/shared-network-promotion-record-template.md
@@ -8,6 +8,7 @@
 - `candidate_id`:
 - `approved_from_track`:
 - `fallback_candidate_id`:
+- `fallback_class`:
 - `approved_by`:
 - `approved_at`:
 

--- a/doc/testing/templates/shared-network-rollback-target-template.md
+++ b/doc/testing/templates/shared-network-rollback-target-template.md
@@ -21,6 +21,8 @@
 ## Fallback Candidate
 - `fallback_candidate_id`:
   - `<previous-pass-candidate-id>`
+- `fallback_class`:
+  - `formal_pass_candidate | bootstrap_restore_ready`
 - `fallback_candidate_bundle_ref`:
   - `<output/release-candidates/fallback.json>`
 - `fallback_gate_ref`:
@@ -47,6 +49,8 @@
   - `<why this is pass/partial/block>`
 
 ## Notes
-- `pass` only if fallback candidate is a formal previous shared-devnet `pass` candidate.
-- `partial` if there is only a local/provisional fallback but no formal shared-devnet `pass` history.
+- `pass` if:
+  - `fallback_class=formal_pass_candidate` and the fallback candidate is a formal previous shared-devnet `pass` candidate; or
+  - `fallback_class=bootstrap_restore_ready`, the current track is still pursuing the first shared-devnet `pass`, and `restore_steps_ref` + `fallback_owner_ref` + `restoration_scope` are all pinned and audited.
+- `partial` if there is only a local/provisional fallback, or a bootstrap fallback is mentioned but the audited restore contract is incomplete.
 - `block` if fallback truth is missing, inconsistent, or not restorable.

--- a/doc/testing/templates/shared-network-shared-access-check-template.md
+++ b/doc/testing/templates/shared-network-shared-access-check-template.md
@@ -33,6 +33,10 @@
   - `<independent operator opened viewer endpoint>`
   - `<independent operator reached live endpoint>`
   - `<candidate_id matched bundle truth>`
+- `candidate_bundle_ref`:
+  - `<output/release-candidates/current.json>`
+- `candidate_gate_summary_ref`:
+  - `<output/shared-network/.../gate/.../summary.md>`
 - `evidence_ref`:
   - `<screenshots | logs | duty record>`
 
@@ -43,6 +47,6 @@
   - `<why this is pass/partial/block>`
 
 ## Notes
-- `pass` only if access is not single-owner local-only rehearsal.
+- `pass` only if access is not single-owner local-only rehearsal and the endpoint, operator handoff, and independent access evidence refs are all pinned.
 - `partial` if endpoint exists but still depends on one local operator or one private machine.
 - `block` if endpoint is unreachable, candidate truth mismatches, or owner handoff is missing.

--- a/doc/world-simulator/viewer/viewer-manual.manual.md
+++ b/doc/world-simulator/viewer/viewer-manual.manual.md
@@ -50,6 +50,8 @@ env -u NO_COLOR ./scripts/run-viewer-web.sh --address 127.0.0.1 --port 4173
 - 当前页面聚焦 `viewer` 实时观察与正式玩法摘要。
 - 支持 `locale=zh|en` 初始化和页面内中英文切换。
 - 支持最小 prompt/chat 控制面；仅在 auth/bootstrap 可用时开放。
+- 在 `hosted_public_join` 路径下，页面支持获取/释放 hosted `player_session`、`reconnect_sync` 恢复，以及 `prompt_control` 的 preview-grade `strong_auth`（需 `Backend Approval Code`）。
+- `main_token_transfer` 仍保持阻断，页面只显示 lane verdict，不提供资产转账表单。
 - 页面不再提供 `standard Viewer` 跳转，也不再承担材质/theme/3D 视觉 QA 职责。
 
 ## Web 闭环

--- a/scripts/shared-devnet-blocker-packet-smoke.sh
+++ b/scripts/shared-devnet-blocker-packet-smoke.sh
@@ -109,6 +109,25 @@ run ./scripts/shared-devnet-blocker-packet.sh \
 ensure_file_contains "$pass_access_out" 'shared.example.invalid:443'
 ensure_file_contains "$pass_access_out" 'screenshot.md'
 
+pass_rollback_out="$smoke_root/rollback-pass.md"
+run ./scripts/shared-devnet-blocker-packet.sh \
+  --window-id shared-devnet-20260324-09 \
+  --candidate-bundle "$current_bundle" \
+  --candidate-gate-summary "$smoke_root/evidence/current-gate.md" \
+  --access-out "$smoke_root/shared-access-rollback-pass.md" \
+  --mixed-topology-out "$smoke_root/mixed-topology-rollback-pass.md" \
+  --rollback-out "$pass_rollback_out" \
+  --fallback-candidate-bundle "$fallback_bundle" \
+  --fallback-class bootstrap_restore_ready \
+  --fallback-gate-summary "$smoke_root/evidence/fallback-gate.md" \
+  --fallback-owner-ref "$smoke_root/evidence/oncall.md" \
+  --restore-steps-ref "$smoke_root/evidence/restore.md" \
+  --restoration-scope "runtime build | world snapshot | governance manifest" \
+  --rollback-lane-result pass
+
+ensure_file_contains "$pass_rollback_out" 'shared-devnet-fallback-01'
+ensure_file_contains "$pass_rollback_out" 'runtime build | world snapshot | governance manifest'
+
 pass_mixed_topology_out="$smoke_root/mixed-topology-pass.md"
 run ./scripts/shared-devnet-blocker-packet.sh \
   --window-id shared-devnet-20260324-07 \

--- a/scripts/shared-devnet-blocker-packet-smoke.sh
+++ b/scripts/shared-devnet-blocker-packet-smoke.sh
@@ -91,6 +91,24 @@ ensure_file_contains "$rollback_out" 'shared-devnet-fallback-01'
 ensure_file_contains "$rollback_out" 'bootstrap_restore_ready'
 ensure_file_contains "$rollback_out" 'fallback-gate.md'
 
+pass_access_out="$smoke_root/shared-access-pass.md"
+run ./scripts/shared-devnet-blocker-packet.sh \
+  --window-id shared-devnet-20260324-08 \
+  --candidate-bundle "$current_bundle" \
+  --candidate-gate-summary "$smoke_root/evidence/current-gate.md" \
+  --access-out "$pass_access_out" \
+  --mixed-topology-out "$smoke_root/mixed-topology-access-pass.md" \
+  --rollback-out "$smoke_root/rollback-access-pass.md" \
+  --viewer-url "https://shared.example.invalid/viewer" \
+  --live-addr "shared.example.invalid:443" \
+  --operator-contact-ref "$smoke_root/evidence/operator.md" \
+  --independent-operator-ref "$smoke_root/evidence/oncall.md" \
+  --access-evidence-ref "$smoke_root/evidence/screenshot.md" \
+  --access-lane-result pass
+
+ensure_file_contains "$pass_access_out" 'shared.example.invalid:443'
+ensure_file_contains "$pass_access_out" 'screenshot.md'
+
 pass_mixed_topology_out="$smoke_root/mixed-topology-pass.md"
 run ./scripts/shared-devnet-blocker-packet.sh \
   --window-id shared-devnet-20260324-07 \

--- a/scripts/shared-devnet-blocker-packet-smoke.sh
+++ b/scripts/shared-devnet-blocker-packet-smoke.sh
@@ -35,6 +35,7 @@ printf '# screenshot\n' >"$smoke_root/evidence/screenshot.md"
 printf '# mixed topology baseline\n' >"$smoke_root/evidence/mixed-topology-baseline.md"
 printf '# mixed topology shared window\n' >"$smoke_root/evidence/mixed-topology-shared.md"
 printf '# proxy drill\n' >"$smoke_root/evidence/mixed-topology-proxy.md"
+printf '# pass uplift review\n' >"$smoke_root/evidence/mixed-topology-pass-decision.md"
 
 current_bundle="$smoke_root/current.json"
 fallback_bundle="$smoke_root/fallback.json"
@@ -85,8 +86,25 @@ ensure_file_contains "$access_out" 'shared-devnet-current-01'
 ensure_file_contains "$access_out" 'https://shared.example.invalid/viewer'
 ensure_file_contains "$mixed_topology_out" 'mixed-topology-baseline.md'
 ensure_file_contains "$mixed_topology_out" 'mixed-topology-shared.md'
+ensure_file_contains "$mixed_topology_out" 'required when lane_result=pass'
 ensure_file_contains "$rollback_out" 'shared-devnet-fallback-01'
 ensure_file_contains "$rollback_out" 'bootstrap_restore_ready'
 ensure_file_contains "$rollback_out" 'fallback-gate.md'
+
+pass_mixed_topology_out="$smoke_root/mixed-topology-pass.md"
+run ./scripts/shared-devnet-blocker-packet.sh \
+  --window-id shared-devnet-20260324-07 \
+  --candidate-bundle "$current_bundle" \
+  --candidate-gate-summary "$smoke_root/evidence/current-gate.md" \
+  --access-out "$smoke_root/shared-access-pass.md" \
+  --mixed-topology-out "$pass_mixed_topology_out" \
+  --rollback-out "$smoke_root/rollback-pass.md" \
+  --mixed-topology-baseline-ref "$smoke_root/evidence/mixed-topology-baseline.md" \
+  --mixed-topology-shared-evidence-ref "$smoke_root/evidence/mixed-topology-shared.md" \
+  --mixed-topology-pass-decision-ref "$smoke_root/evidence/mixed-topology-pass-decision.md" \
+  --mixed-topology-lane-result pass
+
+ensure_file_contains "$pass_mixed_topology_out" 'mixed-topology-pass-decision.md'
+ensure_file_contains "$pass_mixed_topology_out" '`pass_uplift_decision_ref`:'
 
 echo "shared-devnet blocker packet smoke checks passed"

--- a/scripts/shared-devnet-blocker-packet-smoke.sh
+++ b/scripts/shared-devnet-blocker-packet-smoke.sh
@@ -76,6 +76,7 @@ run ./scripts/shared-devnet-blocker-packet.sh \
   --mixed-topology-shared-evidence-ref "$smoke_root/evidence/mixed-topology-shared.md" \
   --mixed-topology-proxy-ref "$smoke_root/evidence/mixed-topology-proxy.md" \
   --fallback-candidate-bundle "$fallback_bundle" \
+  --fallback-class bootstrap_restore_ready \
   --fallback-gate-summary "$smoke_root/evidence/fallback-gate.md" \
   --fallback-owner-ref "$smoke_root/evidence/oncall.md" \
   --restore-steps-ref "$smoke_root/evidence/restore.md"
@@ -85,6 +86,7 @@ ensure_file_contains "$access_out" 'https://shared.example.invalid/viewer'
 ensure_file_contains "$mixed_topology_out" 'mixed-topology-baseline.md'
 ensure_file_contains "$mixed_topology_out" 'mixed-topology-shared.md'
 ensure_file_contains "$rollback_out" 'shared-devnet-fallback-01'
+ensure_file_contains "$rollback_out" 'bootstrap_restore_ready'
 ensure_file_contains "$rollback_out" 'fallback-gate.md'
 
 echo "shared-devnet blocker packet smoke checks passed"

--- a/scripts/shared-devnet-blocker-packet.sh
+++ b/scripts/shared-devnet-blocker-packet.sh
@@ -39,6 +39,7 @@ Mixed-topology flags:
   --mixed-topology-baseline-ref <ref>
   --mixed-topology-shared-evidence-ref <ref>   Repeatable
   --mixed-topology-proxy-ref <ref>             Repeatable
+  --mixed-topology-pass-decision-ref <ref>
   --mixed-topology-validated-by <text>
   --mixed-topology-validated-at <text>
   --mixed-topology-lane-result <pass|partial|block>
@@ -159,6 +160,7 @@ mixed_topology_validated_by="<qa owner / runtime owner>"
 mixed_topology_validated_at="<YYYY-MM-DD HH:MM:SS TZ>"
 mixed_topology_lane_result="partial"
 mixed_topology_reason="P2PARCH-6 matrix baseline is pinned, but same-window shared mixed-topology evidence is still missing or only proxy-level"
+mixed_topology_pass_decision_ref=""
 fallback_candidate_bundle=""
 fallback_gate_summary=""
 fallback_owner_ref=""
@@ -249,6 +251,10 @@ while [[ $# -gt 0 ]]; do
       mixed_topology_proxy_refs+=("${2:-}")
       shift 2
       ;;
+    --mixed-topology-pass-decision-ref)
+      mixed_topology_pass_decision_ref=${2:-}
+      shift 2
+      ;;
     --mixed-topology-validated-by)
       mixed_topology_validated_by=${2:-}
       shift 2
@@ -330,6 +336,16 @@ ensure_lane_result "--mixed-topology-lane-result" "$mixed_topology_lane_result"
 ensure_lane_result "--rollback-lane-result" "$rollback_lane_result"
 if [[ -n "$mixed_topology_baseline_ref" ]]; then
   require_file "--mixed-topology-baseline-ref" "$mixed_topology_baseline_ref"
+fi
+if [[ -n "$mixed_topology_pass_decision_ref" ]]; then
+  require_file "--mixed-topology-pass-decision-ref" "$mixed_topology_pass_decision_ref"
+fi
+if [[ "$mixed_topology_lane_result" == "pass" ]]; then
+  if [[ "${#mixed_topology_shared_evidence_refs[@]}" -eq 0 ]]; then
+    echo "error: --mixed-topology-lane-result pass requires --mixed-topology-shared-evidence-ref" >&2
+    exit 2
+  fi
+  require_non_empty "--mixed-topology-pass-decision-ref" "$mixed_topology_pass_decision_ref"
 fi
 
 ./scripts/release-candidate-bundle.sh validate --bundle "$candidate_bundle" >/dev/null
@@ -465,6 +481,8 @@ cat >>"$mixed_topology_out" <<EOF
   - \`$mixed_topology_lane_result\`
 - \`reason\`:
   - $mixed_topology_reason
+- \`pass_uplift_decision_ref\`:
+  - \`${mixed_topology_pass_decision_ref:-<required when lane_result=pass; producer/QA decision note or review doc>}\`
 
 ## Notes
 - \`pass\` only if same-window shared mixed-topology evidence is pinned, reviewed against the current candidate truth, and backed by an audited producer/QA pass-uplift decision ref.

--- a/scripts/shared-devnet-blocker-packet.sh
+++ b/scripts/shared-devnet-blocker-packet.sh
@@ -368,6 +368,19 @@ fi
 if [[ -n "$fallback_gate_summary" ]]; then
   require_file "--fallback-gate-summary" "$fallback_gate_summary"
 fi
+if [[ -n "$fallback_owner_ref" ]]; then
+  require_file "--fallback-owner-ref" "$fallback_owner_ref"
+fi
+if [[ "$rollback_lane_result" == "pass" ]]; then
+  require_non_empty "--fallback-candidate-bundle" "$fallback_candidate_bundle"
+  require_non_empty "--fallback-gate-summary" "$fallback_gate_summary"
+  require_non_empty "--fallback-owner-ref" "$fallback_owner_ref"
+  require_non_empty "--restoration-scope" "$restoration_scope"
+  if [[ "${#restore_steps_refs[@]}" -eq 0 ]]; then
+    echo "error: --rollback-lane-result pass requires --restore-steps-ref" >&2
+    exit 2
+  fi
+fi
 case "$fallback_class" in
   formal_pass_candidate|bootstrap_restore_ready)
     ;;
@@ -529,7 +542,7 @@ cat >"$rollback_out" <<EOF
 - \`fallback_gate_ref\`:
   - \`${fallback_gate_summary:-<output/shared-network/.../gate/.../summary.md>}\`
 - \`fallback_track_result\`:
-  - \`pass\`
+  - \`${fallback_class/formal_pass_candidate/pass}\`
 - \`fallback_owner_ref\`:
   - \`${fallback_owner_ref:-<promotion record | incident review | approval record>}\`
 

--- a/scripts/shared-devnet-blocker-packet.sh
+++ b/scripts/shared-devnet-blocker-packet.sh
@@ -36,10 +36,10 @@ Shared access flags:
   --access-reason <text>
 
 Mixed-topology flags:
-  --mixed-topology-baseline-ref <ref>
-  --mixed-topology-shared-evidence-ref <ref>   Repeatable
-  --mixed-topology-proxy-ref <ref>             Repeatable
-  --mixed-topology-pass-decision-ref <ref>
+  --mixed-topology-baseline-ref <path>
+  --mixed-topology-shared-evidence-ref <path>   Repeatable
+  --mixed-topology-proxy-ref <path>             Repeatable
+  --mixed-topology-pass-decision-ref <path>
   --mixed-topology-validated-by <text>
   --mixed-topology-validated-at <text>
   --mixed-topology-lane-result <pass|partial|block>
@@ -49,8 +49,8 @@ Rollback flags:
   --fallback-candidate-bundle <bundle.json>
   --fallback-class <formal_pass_candidate|bootstrap_restore_ready>
   --fallback-gate-summary <summary.md>
-  --fallback-owner-ref <ref>
-  --restore-steps-ref <ref>           Repeatable
+  --fallback-owner-ref <path>
+  --restore-steps-ref <path>          Repeatable
   --rollback-validated-by <text>
   --rollback-validated-at <text>
   --restoration-scope <text>

--- a/scripts/shared-devnet-blocker-packet.sh
+++ b/scripts/shared-devnet-blocker-packet.sh
@@ -46,6 +46,7 @@ Mixed-topology flags:
 
 Rollback flags:
   --fallback-candidate-bundle <bundle.json>
+  --fallback-class <formal_pass_candidate|bootstrap_restore_ready>
   --fallback-gate-summary <summary.md>
   --fallback-owner-ref <ref>
   --restore-steps-ref <ref>           Repeatable
@@ -69,6 +70,7 @@ Examples:
     --independent-operator-ref doc/ops/oncall.md \
     --mixed-topology-baseline-ref doc/testing/evidence/p2p-mixed-topology-validation-matrix-2026-04-03.md \
     --fallback-candidate-bundle output/release-candidates/shared-devnet-20260324-05.json \
+    --fallback-class bootstrap_restore_ready \
     --fallback-gate-summary output/shared-network/shared-devnet-20260324-06/gate/shared_devnet-20260324-175501/summary.md \
     --fallback-owner-ref doc/testing/evidence/shared-network-shared-devnet-short-window-promotion-record-2026-03-24.md
 USAGE
@@ -160,11 +162,12 @@ mixed_topology_reason="P2PARCH-6 matrix baseline is pinned, but same-window shar
 fallback_candidate_bundle=""
 fallback_gate_summary=""
 fallback_owner_ref=""
+fallback_class="formal_pass_candidate"
 rollback_validated_by="<liveops owner / runtime owner>"
 rollback_validated_at="<YYYY-MM-DD HH:MM:SS TZ>"
 restoration_scope="<runtime build | world snapshot | governance manifest>"
 rollback_lane_result="partial"
-rollback_reason="formal previous shared-devnet pass fallback is not pinned yet"
+rollback_reason="no audited formal fallback is pinned yet; for the first shared-devnet pass, provide a bootstrap_restore_ready fallback with restore steps, owner ref, and restoration scope"
 declare -a operator_contact_refs=()
 declare -a independent_operator_refs=()
 declare -a access_evidence_refs=()
@@ -274,6 +277,10 @@ while [[ $# -gt 0 ]]; do
       fallback_owner_ref=${2:-}
       shift 2
       ;;
+    --fallback-class)
+      fallback_class=${2:-}
+      shift 2
+      ;;
     --restore-steps-ref)
       restore_steps_refs+=("${2:-}")
       shift 2
@@ -337,6 +344,14 @@ fi
 if [[ -n "$fallback_gate_summary" ]]; then
   require_file "--fallback-gate-summary" "$fallback_gate_summary"
 fi
+case "$fallback_class" in
+  formal_pass_candidate|bootstrap_restore_ready)
+    ;;
+  *)
+    echo "error: unsupported --fallback-class: $fallback_class" >&2
+    exit 2
+    ;;
+esac
 
 mkdir -p "$(dirname "$access_out")" "$(dirname "$mixed_topology_out")" "$(dirname "$rollback_out")"
 
@@ -481,6 +496,8 @@ cat >"$rollback_out" <<EOF
 ## Fallback Candidate
 - \`fallback_candidate_id\`:
   - \`$fallback_candidate_id\`
+- \`fallback_class\`:
+  - \`$fallback_class\`
 - \`fallback_candidate_bundle_ref\`:
   - \`${fallback_candidate_bundle:-<output/release-candidates/fallback.json>}\`
 - \`fallback_gate_ref\`:
@@ -509,8 +526,10 @@ cat >>"$rollback_out" <<EOF
   - $rollback_reason
 
 ## Notes
-- \`pass\` only if fallback candidate is a formal previous shared-devnet \`pass\` candidate.
-- \`partial\` if there is only a local/provisional fallback but no formal shared-devnet \`pass\` history.
+- \`pass\` if:
+  - \`fallback_class=formal_pass_candidate\` and fallback candidate is a formal previous shared-devnet \`pass\` candidate; or
+  - \`fallback_class=bootstrap_restore_ready\`, current track is still pursuing the first shared-devnet \`pass\`, and \`restore_steps_ref\` + \`fallback_owner_ref\` + \`restoration_scope\` are all pinned and audited.
+- \`partial\` if there is only a local/provisional fallback, or a bootstrap fallback is named but the audited restore contract is incomplete.
 - \`block\` if fallback truth is missing, inconsistent, or not restorable.
 EOF
 

--- a/scripts/shared-devnet-blocker-packet.sh
+++ b/scripts/shared-devnet-blocker-packet.sh
@@ -334,6 +334,14 @@ require_file "--candidate-gate-summary" "$candidate_gate_summary"
 ensure_lane_result "--access-lane-result" "$access_lane_result"
 ensure_lane_result "--mixed-topology-lane-result" "$mixed_topology_lane_result"
 ensure_lane_result "--rollback-lane-result" "$rollback_lane_result"
+if [[ "$access_lane_result" == "pass" ]]; then
+  require_non_empty "--viewer-url" "$viewer_url"
+  require_non_empty "--live-addr" "$live_addr"
+  if [[ "${#operator_contact_refs[@]}" -eq 0 || "${#independent_operator_refs[@]}" -eq 0 || "${#access_evidence_refs[@]}" -eq 0 ]]; then
+    echo "error: --access-lane-result pass requires --operator-contact-ref, --independent-operator-ref, and --access-evidence-ref" >&2
+    exit 2
+  fi
+fi
 if [[ -n "$mixed_topology_baseline_ref" ]]; then
   require_file "--mixed-topology-baseline-ref" "$mixed_topology_baseline_ref"
 fi
@@ -427,7 +435,7 @@ cat >>"$access_out" <<EOF
   - $access_reason
 
 ## Notes
-- \`pass\` only if access is not single-owner local-only rehearsal.
+- \`pass\` only if access is not single-owner local-only rehearsal and the endpoint, operator handoff, and independent access evidence refs are all pinned.
 - \`partial\` if endpoint exists but still depends on one local operator or one private machine.
 - \`block\` if endpoint is unreachable, candidate truth mismatches, or owner handoff is missing.
 EOF

--- a/scripts/shared-devnet-rehearsal-smoke.sh
+++ b/scripts/shared-devnet-rehearsal-smoke.sh
@@ -35,6 +35,7 @@ printf '# governance evidence\n' >"$smoke_root/evidence/governance.md"
 printf '# longrun evidence\n' >"$smoke_root/evidence/longrun.md"
 printf '# mixed topology evidence\n' >"$smoke_root/evidence/mixed-topology.md"
 printf '# mixed topology pass decision\n' >"$smoke_root/evidence/mixed-topology-pass-decision.md"
+printf '# shared access evidence\n' >"$smoke_root/evidence/shared-access.md"
 printf '{"candidate":"fallback"}\n' >"$smoke_root/fallback/pass-bundle.json"
 
 partial_out="$smoke_root/output-partial"
@@ -85,6 +86,30 @@ if ./scripts/shared-devnet-rehearsal.sh \
 fi
 ensure_file_contains "$smoke_root/missing-decision.stderr" '--mixed-topology-pass requires --mixed-topology-pass-decision-ref'
 
+if ./scripts/shared-devnet-rehearsal.sh \
+  --window-id shared-devnet-orch-smoke-missing-access-evidence \
+  --candidate-id shared-devnet-orch-smoke-missing-access-evidence \
+  --candidate-bundle-out "$smoke_root/shared-devnet-orch-smoke-missing-access-evidence.json" \
+  --runtime-build-ref "$smoke_root/runtime/runtime.bin" \
+  --world-snapshot-ref "$smoke_root/world" \
+  --governance-manifest-ref "$smoke_root/world/public_manifest.json" \
+  --allow-dirty-worktree \
+  --out-dir "$smoke_root/output-missing-access-evidence" \
+  --release-gate-mode skip \
+  --web-mode skip \
+  --headless-mode skip \
+  --pure-api-mode skip \
+  --governance-mode skip \
+  --longrun-mode skip \
+  --shared-access-pass \
+  --shared-endpoint-ref "$smoke_root/evidence/shared-endpoint.md" \
+  --shared-operator-ref "$smoke_root/evidence/shared-operator.md" \
+  >/dev/null 2>"$smoke_root/missing-access-evidence.stderr"; then
+  echo "error: shared-access pass should require an access-evidence ref" >&2
+  exit 1
+fi
+ensure_file_contains "$smoke_root/missing-access-evidence.stderr" '--shared-access-pass requires at least one --shared-endpoint-ref, one --shared-operator-ref, and one --shared-access-evidence-ref'
+
 pass_out="$smoke_root/output-pass"
 run ./scripts/shared-devnet-rehearsal.sh \
   --window-id shared-devnet-orch-smoke-pass \
@@ -112,6 +137,7 @@ run ./scripts/shared-devnet-rehearsal.sh \
   --shared-access-pass \
   --shared-endpoint-ref "$smoke_root/evidence/shared-endpoint.md" \
   --shared-operator-ref "$smoke_root/evidence/shared-operator.md" \
+  --shared-access-evidence-ref "$smoke_root/evidence/shared-access.md" \
   --fallback-candidate-bundle "$smoke_root/fallback/pass-bundle.json"
 
 pass_gate=$(find "$pass_out/shared-devnet-orch-smoke-pass/gate" -mindepth 2 -maxdepth 2 -type f -name summary.json | sort | tail -n 1)
@@ -122,5 +148,6 @@ ensure_file_contains "$pass_lanes" $'shared_access\tqa_engineer\tpass'
 ensure_file_contains "$pass_lanes" $'mixed_topology_baseline\tqa_engineer\tpass'
 ensure_file_contains "$pass_lanes" $'governance_live_drill\truntime_engineer\tpass'
 ensure_file_contains "$pass_out/shared-devnet-orch-smoke-pass/mixed-topology-gate.md" 'pass-uplift decision ref'
+ensure_file_contains "$pass_out/shared-devnet-orch-smoke-pass/access-check.md" 'shared access evidence refs'
 
 echo "shared-devnet rehearsal smoke checks passed"

--- a/scripts/shared-devnet-rehearsal-smoke.sh
+++ b/scripts/shared-devnet-rehearsal-smoke.sh
@@ -36,6 +36,9 @@ printf '# longrun evidence\n' >"$smoke_root/evidence/longrun.md"
 printf '# mixed topology evidence\n' >"$smoke_root/evidence/mixed-topology.md"
 printf '# mixed topology pass decision\n' >"$smoke_root/evidence/mixed-topology-pass-decision.md"
 printf '# shared access evidence\n' >"$smoke_root/evidence/shared-access.md"
+printf '# fallback gate\n' >"$smoke_root/evidence/fallback-gate.md"
+printf '# fallback owner\n' >"$smoke_root/evidence/fallback-owner.md"
+printf '# rollback restore step\n' >"$smoke_root/evidence/rollback-restore.md"
 printf '{"candidate":"fallback"}\n' >"$smoke_root/fallback/pass-bundle.json"
 
 partial_out="$smoke_root/output-partial"
@@ -110,6 +113,24 @@ if ./scripts/shared-devnet-rehearsal.sh \
 fi
 ensure_file_contains "$smoke_root/missing-access-evidence.stderr" '--shared-access-pass requires at least one --shared-endpoint-ref, one --shared-operator-ref, and one --shared-access-evidence-ref'
 
+run ./scripts/shared-devnet-rehearsal.sh \
+  --window-id shared-devnet-orch-smoke-rollback-partial \
+  --candidate-id shared-devnet-orch-smoke-rollback-partial \
+  --candidate-bundle-out "$smoke_root/shared-devnet-orch-smoke-rollback-partial.json" \
+  --runtime-build-ref "$smoke_root/runtime/runtime.bin" \
+  --world-snapshot-ref "$smoke_root/world" \
+  --governance-manifest-ref "$smoke_root/world/public_manifest.json" \
+  --allow-dirty-worktree \
+  --out-dir "$smoke_root/output-rollback-partial" \
+  --release-gate-mode skip \
+  --web-mode skip \
+  --headless-mode skip \
+  --pure-api-mode skip \
+  --governance-mode skip \
+  --longrun-mode skip \
+  --fallback-candidate-bundle "$smoke_root/fallback/pass-bundle.json"
+ensure_file_contains "$smoke_root/output-rollback-partial/shared-devnet-orch-smoke-rollback-partial/rollback-target.md" 'fallback bundle is pinned, but audited fallback gate/owner/restore scope contract is still incomplete'
+
 pass_out="$smoke_root/output-pass"
 run ./scripts/shared-devnet-rehearsal.sh \
   --window-id shared-devnet-orch-smoke-pass \
@@ -138,7 +159,12 @@ run ./scripts/shared-devnet-rehearsal.sh \
   --shared-endpoint-ref "$smoke_root/evidence/shared-endpoint.md" \
   --shared-operator-ref "$smoke_root/evidence/shared-operator.md" \
   --shared-access-evidence-ref "$smoke_root/evidence/shared-access.md" \
-  --fallback-candidate-bundle "$smoke_root/fallback/pass-bundle.json"
+  --fallback-candidate-bundle "$smoke_root/fallback/pass-bundle.json" \
+  --fallback-gate-ref "$smoke_root/evidence/fallback-gate.md" \
+  --fallback-owner-ref "$smoke_root/evidence/fallback-owner.md" \
+  --fallback-class bootstrap_restore_ready \
+  --rollback-restore-step-ref "$smoke_root/evidence/rollback-restore.md" \
+  --rollback-restoration-scope "runtime build | world snapshot | governance manifest"
 
 pass_gate=$(find "$pass_out/shared-devnet-orch-smoke-pass/gate" -mindepth 2 -maxdepth 2 -type f -name summary.json | sort | tail -n 1)
 pass_lanes="$pass_out/shared-devnet-orch-smoke-pass/lanes.shared_devnet.tsv"
@@ -147,7 +173,10 @@ ensure_file_contains "$pass_gate" '"promotion_recommendation": "eligible_for_pro
 ensure_file_contains "$pass_lanes" $'shared_access\tqa_engineer\tpass'
 ensure_file_contains "$pass_lanes" $'mixed_topology_baseline\tqa_engineer\tpass'
 ensure_file_contains "$pass_lanes" $'governance_live_drill\truntime_engineer\tpass'
+ensure_file_contains "$pass_lanes" $'rollback_target_ready\tliveops_community\tpass'
 ensure_file_contains "$pass_out/shared-devnet-orch-smoke-pass/mixed-topology-gate.md" 'pass-uplift decision ref'
 ensure_file_contains "$pass_out/shared-devnet-orch-smoke-pass/access-check.md" 'shared access evidence refs'
+ensure_file_contains "$pass_out/shared-devnet-orch-smoke-pass/rollback-target.md" 'fallback gate ref'
+ensure_file_contains "$pass_out/shared-devnet-orch-smoke-pass/rollback-target.md" 'restore step refs'
 
 echo "shared-devnet rehearsal smoke checks passed"

--- a/scripts/shared-devnet-rehearsal.sh
+++ b/scripts/shared-devnet-rehearsal.sh
@@ -1074,6 +1074,11 @@ if [[ -n "$mixed_topology_pass_decision_ref" ]]; then
 - pass-uplift decision ref:
   - \`$mixed_topology_pass_decision_ref\`
 EOF
+else
+  cat >>"$mixed_topology_summary_path" <<EOF
+- pass-uplift decision ref:
+  - missing; required before mixed-topology lane can be promoted to \`pass\`
+EOF
 fi
 cat >>"$mixed_topology_summary_path" <<EOF
 

--- a/scripts/shared-devnet-rehearsal.sh
+++ b/scripts/shared-devnet-rehearsal.sh
@@ -51,11 +51,11 @@ Access / rollback:
   --shared-operator-ref <ref>             Shared operator / handoff / runbook ref; repeatable
   --shared-access-evidence-ref <ref>      Independent access proof / screenshot / log ref; repeatable
   --fallback-candidate-bundle <path>      Previous shared-devnet pass bundle to use as rollback target
-  --fallback-gate-ref <ref>               Audited fallback gate / checklist / summary ref
-  --fallback-owner-ref <ref>              Owner handoff / approval ref for fallback execution
+  --fallback-gate-ref <path>              Audited fallback gate / checklist / summary file ref
+  --fallback-owner-ref <path>             Owner handoff / approval file ref for fallback execution
   --fallback-class <formal_pass_candidate|bootstrap_restore_ready>
                                          Rollback fallback class (default: formal_pass_candidate)
-  --rollback-restore-step-ref <ref>       Restore step / checklist ref; repeatable
+  --rollback-restore-step-ref <path>      Restore step / checklist file ref; repeatable
   --rollback-restoration-scope <text>     Audited restoration scope for rollback readiness
 
 Multi-entry evidence:

--- a/scripts/shared-devnet-rehearsal.sh
+++ b/scripts/shared-devnet-rehearsal.sh
@@ -51,6 +51,12 @@ Access / rollback:
   --shared-operator-ref <ref>             Shared operator / handoff / runbook ref; repeatable
   --shared-access-evidence-ref <ref>      Independent access proof / screenshot / log ref; repeatable
   --fallback-candidate-bundle <path>      Previous shared-devnet pass bundle to use as rollback target
+  --fallback-gate-ref <ref>               Audited fallback gate / checklist / summary ref
+  --fallback-owner-ref <ref>              Owner handoff / approval ref for fallback execution
+  --fallback-class <formal_pass_candidate|bootstrap_restore_ready>
+                                         Rollback fallback class (default: formal_pass_candidate)
+  --rollback-restore-step-ref <ref>       Restore step / checklist ref; repeatable
+  --rollback-restoration-scope <text>     Audited restoration scope for rollback readiness
 
 Multi-entry evidence:
   --web-evidence-ref <path>               Reuse existing same-window Web evidence
@@ -257,6 +263,10 @@ governance_mode="skip"
 longrun_mode="dry-run"
 shared_access_pass=0
 fallback_candidate_bundle=""
+fallback_gate_ref=""
+fallback_owner_ref=""
+fallback_class="formal_pass_candidate"
+rollback_restoration_scope=""
 allow_dirty_worktree=0
 multi_entry_startup_timeout=240
 s9_duration_secs=300
@@ -292,6 +302,7 @@ declare -a candidate_notes=()
 declare -a shared_endpoint_refs=()
 declare -a shared_operator_refs=()
 declare -a shared_access_evidence_refs=()
+declare -a rollback_restore_step_refs=()
 declare -a passthrough_args=()
 
 while [[ $# -gt 0 ]]; do
@@ -386,6 +397,26 @@ while [[ $# -gt 0 ]]; do
       ;;
     --fallback-candidate-bundle)
       fallback_candidate_bundle=${2:-}
+      shift 2
+      ;;
+    --fallback-gate-ref)
+      fallback_gate_ref=${2:-}
+      shift 2
+      ;;
+    --fallback-owner-ref)
+      fallback_owner_ref=${2:-}
+      shift 2
+      ;;
+    --fallback-class)
+      fallback_class=${2:-}
+      shift 2
+      ;;
+    --rollback-restore-step-ref)
+      rollback_restore_step_refs+=("${2:-}")
+      shift 2
+      ;;
+    --rollback-restoration-scope)
+      rollback_restoration_scope=${2:-}
       shift 2
       ;;
     --web-evidence-ref)
@@ -1018,8 +1049,27 @@ rollback_status="partial"
 rollback_note="there is no previous shared-devnet pass candidate pinned as formal fallback"
 if [[ -n "$fallback_candidate_bundle" ]]; then
   require_file "--fallback-candidate-bundle" "$fallback_candidate_bundle"
-  rollback_status="pass"
-  rollback_note="fallback candidate bundle is pinned for rollback"
+  case "$fallback_class" in
+    formal_pass_candidate|bootstrap_restore_ready)
+      ;;
+    *)
+      echo "error: unsupported --fallback-class: $fallback_class" >&2
+      exit 2
+      ;;
+  esac
+  if [[ -n "$fallback_gate_ref" ]]; then
+    require_file "--fallback-gate-ref" "$fallback_gate_ref"
+  fi
+  if [[ -n "$fallback_owner_ref" ]]; then
+    require_file "--fallback-owner-ref" "$fallback_owner_ref"
+  fi
+  if [[ -n "$fallback_gate_ref" && -n "$fallback_owner_ref" && "${#rollback_restore_step_refs[@]}" -gt 0 && -n "$rollback_restoration_scope" ]]; then
+    rollback_status="pass"
+    rollback_note="fallback bundle, gate ref, owner ref, restore steps, and restoration scope are pinned for rollback"
+  else
+    rollback_status="partial"
+    rollback_note="fallback bundle is pinned, but audited fallback gate/owner/restore scope contract is still incomplete"
+  fi
 fi
 cat >"$rollback_summary_path" <<EOF
 # Shared Devnet Rollback Target Note
@@ -1035,6 +1085,36 @@ if [[ -n "$fallback_candidate_bundle" ]]; then
   cat >>"$rollback_summary_path" <<EOF
 - fallback candidate bundle:
   - \`$fallback_candidate_bundle\`
+- fallback class:
+  - \`$fallback_class\`
+EOF
+fi
+if [[ -n "$fallback_gate_ref" ]]; then
+  cat >>"$rollback_summary_path" <<EOF
+- fallback gate ref:
+  - \`$fallback_gate_ref\`
+EOF
+fi
+if [[ -n "$fallback_owner_ref" ]]; then
+  cat >>"$rollback_summary_path" <<EOF
+- fallback owner ref:
+  - \`$fallback_owner_ref\`
+EOF
+fi
+if [[ "${#rollback_restore_step_refs[@]}" -gt 0 ]]; then
+  cat >>"$rollback_summary_path" <<EOF
+- restore step refs:
+EOF
+  for ref in "${rollback_restore_step_refs[@]}"; do
+    cat >>"$rollback_summary_path" <<EOF
+  - \`$ref\`
+EOF
+  done
+fi
+if [[ -n "$rollback_restoration_scope" ]]; then
+  cat >>"$rollback_summary_path" <<EOF
+- restoration scope:
+  - \`$rollback_restoration_scope\`
 EOF
 fi
 cat >>"$rollback_summary_path" <<EOF

--- a/scripts/shared-devnet-rehearsal.sh
+++ b/scripts/shared-devnet-rehearsal.sh
@@ -49,6 +49,7 @@ Access / rollback:
   --shared-access-pass                    Mark shared_access as pass; requires refs below
   --shared-endpoint-ref <ref>             Shared endpoint / URL / operator-facing access ref; repeatable
   --shared-operator-ref <ref>             Shared operator / handoff / runbook ref; repeatable
+  --shared-access-evidence-ref <ref>      Independent access proof / screenshot / log ref; repeatable
   --fallback-candidate-bundle <path>      Previous shared-devnet pass bundle to use as rollback target
 
 Multi-entry evidence:
@@ -290,6 +291,7 @@ declare -a candidate_evidence_refs=()
 declare -a candidate_notes=()
 declare -a shared_endpoint_refs=()
 declare -a shared_operator_refs=()
+declare -a shared_access_evidence_refs=()
 declare -a passthrough_args=()
 
 while [[ $# -gt 0 ]]; do
@@ -376,6 +378,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --shared-operator-ref)
       shared_operator_refs+=("${2:-}")
+      shift 2
+      ;;
+    --shared-access-evidence-ref)
+      shared_access_evidence_refs+=("${2:-}")
       shift 2
       ;;
     --fallback-candidate-bundle)
@@ -788,12 +794,12 @@ shared_access_summary_path="$window_dir/access-check.md"
 shared_access_status="partial"
 shared_access_note="access is local-only rehearsal and does not yet prove independent shared operator access"
 if [[ "$shared_access_pass" -eq 1 ]]; then
-  if [[ "${#shared_endpoint_refs[@]}" -eq 0 || "${#shared_operator_refs[@]}" -eq 0 ]]; then
-    echo "error: --shared-access-pass requires at least one --shared-endpoint-ref and one --shared-operator-ref" >&2
+  if [[ "${#shared_endpoint_refs[@]}" -eq 0 || "${#shared_operator_refs[@]}" -eq 0 || "${#shared_access_evidence_refs[@]}" -eq 0 ]]; then
+    echo "error: --shared-access-pass requires at least one --shared-endpoint-ref, one --shared-operator-ref, and one --shared-access-evidence-ref" >&2
     exit 2
   fi
   shared_access_status="pass"
-  shared_access_note="shared endpoint and operator handoff refs are pinned for this window"
+  shared_access_note="shared endpoint, operator handoff, and independent access evidence refs are pinned for this window"
 fi
 {
   echo "# Shared Devnet Access Check"
@@ -825,6 +831,12 @@ fi
   if [[ "${#shared_operator_refs[@]}" -gt 0 ]]; then
     echo "- shared operator refs:"
     for ref in "${shared_operator_refs[@]}"; do
+      echo "  - \`$ref\`"
+    done
+  fi
+  if [[ "${#shared_access_evidence_refs[@]}" -gt 0 ]]; then
+    echo "- shared access evidence refs:"
+    for ref in "${shared_access_evidence_refs[@]}"; do
       echo "  - \`$ref\`"
     done
   fi

--- a/testing-manual.md
+++ b/testing-manual.md
@@ -855,6 +855,8 @@ env -u RUSTC_WRAPPER cargo test -p oasis7 --features test_tier_required longrun_
 - 当前 `shared-devnet-blocker-packet` 最小职责：
   - 基于已通过的 candidate bundle 和当前 gate 输出，生成 `shared_access` / `mixed_topology_baseline` / `rollback_target_ready` 的实例草稿
   - 固定三条 blocker 的留证字段，避免后续 shared operator / fallback candidate / same-window mixed-topology 输入到位后还要手工重写结构
+  - mixed-topology 若准备从 `partial` 升到 `pass`，必须把 `pass_uplift_decision_ref` 作为正式字段写入草稿；脚本层面也必须与 same-window evidence 一起提供，不能只改 lane 状态
+  - 仅生成 `partial` draft 时不需要提供 `--mixed-topology-pass-decision-ref`；只有 lane 要升到 `pass` 时才补这条 audited decision ref
 - 当前 QA gate 最小职责：
   - 按 `shared_devnet / staging / canary` 校验 required lanes 是否齐全
   - `shared_devnet` 必须包含 `candidate_bundle_integrity / shared_access / multi_entry_closure / mixed_topology_baseline / governance_live_drill / short_window_longrun / rollback_target_ready`

--- a/testing-manual.md
+++ b/testing-manual.md
@@ -881,7 +881,7 @@ env -u RUSTC_WRAPPER cargo test -p oasis7 --features test_tier_required longrun_
 - 当前 liveops 最小职责：
   - 每个窗口固定 `window_id/candidate_id/fallback_candidate_id/owners_on_duty/claim_envelope`
   - 发现真值漂移、QA `block`、共享访问失效或 preview 口径越界时立即 `freeze`
-  - `rollback` 只能回到最近一次 `pass` 的 candidate bundle
+  - `staging/canary` 的 `rollback` 只能回到最近一次 `pass` 的 candidate bundle；首条 `shared_devnet pass` 若尚无历史 `pass` candidate，则至少要固定一条受审计 `bootstrap_restore_ready` fallback，并补齐 `restore_steps_ref/fallback_owner_ref/restoration_scope`
   - 没有 `promotion_record`、`incident_review`、`exit_decision` 的 track 不得记完成
 - 当前 `shared_devnet` dry-run 结论：
   - `gate_result=partial`

--- a/testing-manual.md
+++ b/testing-manual.md
@@ -861,6 +861,38 @@ env -u RUSTC_WRAPPER cargo test -p oasis7 --features test_tier_required longrun_
   - `rollback_target_ready` 若准备从 `partial` 升到 `pass`，必须把 fallback gate、fallback owner、restore steps 和 restoration scope 同时写成正式字段；脚本层面也必须一起提供，不能只改 lane 状态
   - mixed-topology 若准备从 `partial` 升到 `pass`，必须把 `pass_uplift_decision_ref` 作为正式字段写入草稿；脚本层面也必须与 same-window evidence 一起提供，不能只改 lane 状态
   - 仅生成 `partial` draft 时不需要提供 `--mixed-topology-pass-decision-ref`；只有 lane 要升到 `pass` 时才补这条 audited decision ref
+- 当前补证据标准命令：
+```bash
+./scripts/shared-devnet-rehearsal.sh \
+  --window-id <shared-devnet-window-id> \
+  --candidate-bundle <output/release-candidates/current.json> \
+  --out-dir <output/shared-network/...> \
+  --release-gate-mode skip \
+  --web-mode evidence \
+  --web-evidence-ref <same-window web evidence> \
+  --headless-mode evidence \
+  --headless-evidence-ref <same-window no-ui evidence> \
+  --pure-api-mode evidence \
+  --pure-api-evidence-ref <same-window pure-api evidence> \
+  --governance-mode evidence \
+  --governance-window-evidence-ref <same-window governance evidence> \
+  --longrun-mode evidence \
+  --longrun-window-evidence-ref <same-window longrun evidence> \
+  --shared-access-pass \
+  --shared-endpoint-ref <shared endpoint ref> \
+  --shared-operator-ref <shared operator/handoff ref> \
+  --shared-access-evidence-ref <independent access evidence ref> \
+  --fallback-candidate-bundle <output/release-candidates/fallback.json> \
+  --fallback-gate-ref <audited fallback gate ref> \
+  --fallback-owner-ref <approval/handoff ref> \
+  --fallback-class <formal_pass_candidate|bootstrap_restore_ready> \
+  --rollback-restore-step-ref <restore checklist/log ref> \
+  --rollback-restoration-scope "runtime build | world snapshot | governance manifest" \
+  --mixed-topology-pass \
+  --mixed-topology-shared-evidence-ref <same-window mixed-topology evidence> \
+  --mixed-topology-pass-decision-ref <producer/QA decision ref>
+```
+- 上述命令适用于：同一 `window_id`、同一 `candidate_bundle` 下，把 `shared_access / rollback_target_ready / mixed_topology_baseline` 一次性从 `partial` 补到 `pass`。
 - 当前 QA gate 最小职责：
   - 按 `shared_devnet / staging / canary` 校验 required lanes 是否齐全
   - `shared_devnet` 必须包含 `candidate_bundle_integrity / shared_access / multi_entry_closure / mixed_topology_baseline / governance_live_drill / short_window_longrun / rollback_target_ready`

--- a/testing-manual.md
+++ b/testing-manual.md
@@ -851,10 +851,12 @@ env -u RUSTC_WRAPPER cargo test -p oasis7 --features test_tier_required longrun_
   - 用 execute/evidence/skip 模式统一收口 same-candidate `headed Web + no-ui + pure_api`
   - 统一生成 `multi-entry-summary`、mixed-topology gate note、lane scaffold、`lanes.shared_devnet.tsv` 与 gate 输出
   - 未提供 shared access / rollback / governance / short-window / same-window mixed-topology 新证据时，默认保持保守 `partial`，避免误判为已 `pass`
+  - 若要把 `shared_access` 标为 `pass`，必须同时提供 shared endpoint ref、shared operator/handoff ref 和 independent access evidence ref；仅有 endpoint 或 duty ref 不算通过
   - 若要把 mixed-topology lane 标为 `pass`，必须同时提供 same-window evidence 和 producer/QA 审计通过的 pass-uplift decision ref；仅有脚本开关不算通过
 - 当前 `shared-devnet-blocker-packet` 最小职责：
   - 基于已通过的 candidate bundle 和当前 gate 输出，生成 `shared_access` / `mixed_topology_baseline` / `rollback_target_ready` 的实例草稿
   - 固定三条 blocker 的留证字段，避免后续 shared operator / fallback candidate / same-window mixed-topology 输入到位后还要手工重写结构
+  - `shared_access` 若准备从 `partial` 升到 `pass`，必须把 endpoint、operator handoff 和 independent access evidence 同时写成正式字段；脚本层面也必须一起提供，不能只改 lane 状态
   - mixed-topology 若准备从 `partial` 升到 `pass`，必须把 `pass_uplift_decision_ref` 作为正式字段写入草稿；脚本层面也必须与 same-window evidence 一起提供，不能只改 lane 状态
   - 仅生成 `partial` draft 时不需要提供 `--mixed-topology-pass-decision-ref`；只有 lane 要升到 `pass` 时才补这条 audited decision ref
 - 当前 QA gate 最小职责：

--- a/testing-manual.md
+++ b/testing-manual.md
@@ -852,11 +852,13 @@ env -u RUSTC_WRAPPER cargo test -p oasis7 --features test_tier_required longrun_
   - 统一生成 `multi-entry-summary`、mixed-topology gate note、lane scaffold、`lanes.shared_devnet.tsv` 与 gate 输出
   - 未提供 shared access / rollback / governance / short-window / same-window mixed-topology 新证据时，默认保持保守 `partial`，避免误判为已 `pass`
   - 若要把 `shared_access` 标为 `pass`，必须同时提供 shared endpoint ref、shared operator/handoff ref 和 independent access evidence ref；仅有 endpoint 或 duty ref 不算通过
+  - 若要把 `rollback_target_ready` 标为 `pass`，必须同时提供 fallback bundle、fallback gate ref、fallback owner ref、restore step ref 和 restoration scope；仅有 fallback bundle 不算通过
   - 若要把 mixed-topology lane 标为 `pass`，必须同时提供 same-window evidence 和 producer/QA 审计通过的 pass-uplift decision ref；仅有脚本开关不算通过
 - 当前 `shared-devnet-blocker-packet` 最小职责：
   - 基于已通过的 candidate bundle 和当前 gate 输出，生成 `shared_access` / `mixed_topology_baseline` / `rollback_target_ready` 的实例草稿
   - 固定三条 blocker 的留证字段，避免后续 shared operator / fallback candidate / same-window mixed-topology 输入到位后还要手工重写结构
   - `shared_access` 若准备从 `partial` 升到 `pass`，必须把 endpoint、operator handoff 和 independent access evidence 同时写成正式字段；脚本层面也必须一起提供，不能只改 lane 状态
+  - `rollback_target_ready` 若准备从 `partial` 升到 `pass`，必须把 fallback gate、fallback owner、restore steps 和 restoration scope 同时写成正式字段；脚本层面也必须一起提供，不能只改 lane 状态
   - mixed-topology 若准备从 `partial` 升到 `pass`，必须把 `pass_uplift_decision_ref` 作为正式字段写入草稿；脚本层面也必须与 same-window evidence 一起提供，不能只改 lane 状态
   - 仅生成 `partial` draft 时不需要提供 `--mixed-topology-pass-decision-ref`；只有 lane 要升到 `pass` 时才补这条 audited decision ref
 - 当前 QA gate 最小职责：


### PR DESCRIPTION
## Summary
- reclose hosted Viewer P0 auth-surface truth for `hosted_public_join`
- stop reporting hosted recovery / preview strong-auth as `not_implemented` when the hosted lane already exists
- add repo-owned UI regressions for revoked guest recovery, registered player-session release/reconnect, and issued-before-register pending strong-auth semantics

## What Changed
- `legacy_core.js`
  - recognize `hosted_public_join_contract_with_browser_session`
  - derive hosted `strong_auth` tier from the actual hosted action matrix instead of falling back to `not_implemented`
  - keep backend reauth in `issued_pending_register` until runtime registration is actually `registered`
  - reuse hosted recovery wording for guest/reconnect hints instead of stale legacy copy
- `main.jsx`
  - align badge semantics for hosted preview / pending-registration states
- `main.test.jsx`
  - add hosted regression coverage for:
    - revoked guest lane -> `Re-acquire Hosted Player Session`
    - registered browser session -> `Release Player Session` + `preview_backend_reauth_available`
    - issued/registering intermediate state -> `issued_pending_register`
- `viewer-manual.manual.md`
  - document the current hosted preview boundary: player-session acquire/release + reconnect + prompt-control preview strong-auth are implemented, while `main_token_transfer` remains blocked

## Validation
- `npm --prefix crates/oasis7_viewer run test:ui`
- `npm --prefix crates/oasis7_viewer run build:software-safe`
- `./scripts/doc-governance-check.sh`
- `git diff --check`
- `OASIS7_CI_RUN_OASIS7_REQUIRED_TESTS=false OASIS7_CI_RUN_CONSENSUS_TESTS=false OASIS7_CI_RUN_DISTFS_TESTS=false OASIS7_CI_RUN_VIEWER_CONTRACT_TESTS=true OASIS7_CI_RUN_VIEWER_WASM_CHECK=true OASIS7_CI_RUN_LAUNCHER_WEB_BUILD=false ./scripts/ci-tests.sh required`

## Scope Boundary
- This PR closes the remaining Viewer-side truth drift for hosted P0.
- It does **not** close shared-network live-evidence blockers. Repo truth still keeps shared-network at `partial`, with `shared_access` and `rollback_target_ready` lacking formal `pass` evidence. Those require a real shared window, independent operator validation, and a formal fallback candidate; they cannot be honestly closed by local Viewer code changes in this PR.
