### PR TITLE
Define indirect-control control-feeling contract

### DIFF
--- a/.pm/tasks/task_89828a4d2c1b4e73987103699c10fa7d.execution.md
+++ b/.pm/tasks/task_89828a4d2c1b4e73987103699c10fa7d.execution.md
@@ -1,0 +1,16 @@
+# task_89828a4d2c1b4e73987103699c10fa7d Execution Log
+
+- task_uid: task_89828a4d2c1b4e73987103699c10fa7d
+- title: define the player control-feeling contract for indirect agent gameplay
+- owner_role: producer_system_designer
+- worktree_hint: /home/scc/worktrees/oasis7-game-issue-164-control-feeling-contract
+
+<!-- Append entries using:
+Example:
+  ## YYYY-MM-DD HH:MM:SS CST / role_name
+  - 完成内容: ...
+  - 遗留事项: ...
+-->
+## 2026-05-14 22:28:00 CST / producer_system_designer
+- 完成内容: 基于 `#164`、`PRD-GAME-012` 第 4 条 lane、`PRD-GAME-007/008/013` 现状，新增 `PRD-GAME-014` 专题三件套 `gameplay-indirect-control-feeling-contract-2026-05-14.{prd,design,project}.md`，把间接控制下的 control-feeling 正式冻结为 accepted intent、主因果、打断/重排、续玩恢复四项 guarantees；同时回挂 `doc/game/prd.md`、`doc/game/project.md`、`doc/game/README.md`、`doc/game/prd.index.md`、`gameplay-top-level-design.{prd,project}.md`。
+- 遗留事项: 仍需后续 owner 继续推进 `TASK-GAME-072~075`，把 canonical accepted-intent/causality truth、Viewer/API agency surface、agent reprioritize contract 与 QA control-feeling matrix 落成正式实现与验证；当前不改变 `trust gate = hold`、`first capability gate = not_run`。

--- a/.pm/tasks/task_89828a4d2c1b4e73987103699c10fa7d.yaml
+++ b/.pm/tasks/task_89828a4d2c1b4e73987103699c10fa7d.yaml
@@ -1,0 +1,22 @@
+task_uid: task_89828a4d2c1b4e73987103699c10fa7d
+title: "define the player control-feeling contract for indirect agent gameplay"
+owner_role: producer_system_designer
+worktree_hint: /home/scc/worktrees/oasis7-game-issue-164-control-feeling-contract
+execution_log_path: .pm/tasks/task_89828a4d2c1b4e73987103699c10fa7d.execution.md
+status: done
+priority: P2
+source_signal: null
+source_refs:
+  - doc/game/prd.md
+  - doc/game/project.md
+  - doc/game/gameplay/gameplay-top-level-design.prd.md
+doc_refs: []
+related_prd:
+  - PRD-GAME-004
+acceptance:
+  - "Define at least 3 interaction guarantees that preserve agency under indirect agent execution."
+  - "Produce a canonical gameplay design contract that future UX changes can be evaluated against."
+handoff_to: []
+updated_at: 2026-05-14T11:41:44+08:00
+last_started_at: 2026-05-14T11:23:01+08:00
+last_closed_at: 2026-05-14T11:41:44+08:00

--- a/doc/game/README.md
+++ b/doc/game/README.md
@@ -8,6 +8,7 @@
 - 想直接按文件名定位某个 gameplay 专题：先读 `doc/game/prd.index.md`。
 - 想快速理解核心玩法骨架，而不是顺扫近期长名单：先读 `doc/game/gameplay/gameplay-top-level-design.prd.md`。
 - 想直接看“接下来两周只做什么”：先读 `doc/game/gameplay/gameplay-ten-minute-retention-recovery-2026-04-09.prd.md`。
+- 想确认“间接控制为什么仍然应该感觉像我在控制，而不是旁观 AI”：先读 `doc/game/gameplay/gameplay-indirect-control-feeling-contract-2026-05-14.prd.md`。
 - 想确认当前试玩放行、limited preview 与 closed beta 口径：先读 `doc/game/gameplay/gameplay-limited-preview-execution-2026-03-22.prd.md` 与 `doc/game/gameplay/gameplay-closed-beta-readiness-2026-03-21.prd.md`。
 - 想跟进最近最活跃的经济/运营规则变化：先读 `doc/game/gameplay/gameplay-agent-claim-token-cost-2026-03-27.prd.md`，再按需进入对应 design / project / runbook。
 
@@ -22,7 +23,7 @@
 - `prd.md` 是玩法目标态与阶段口径真值，适合先理解当前 game 模块在管什么、哪些边界已经冻结。
 - `project.md` 是执行入口，适合确认 retention、preview、经济规则与放行门禁当前推进到哪一步。
 - `prd.index.md` 是精确检索索引，适合已经知道专题名或需要完整文件清单时使用，不适合作为第一次进入模块时的首读入口。
-- 高频专题文档继续承担专题真值：`gameplay-top-level-design` 管核心玩法骨架，`gameplay-ten-minute-retention-recovery-2026-04-09` 管当前冲刺窗口，`gameplay-limited-preview-execution-2026-03-22` / `gameplay-closed-beta-readiness-2026-03-21` 管试玩与放行边界，`gameplay-agent-claim-token-cost-2026-03-27` 管近期高频经济规则。
+- 高频专题文档继续承担专题真值：`gameplay-top-level-design` 管核心玩法骨架，`gameplay-ten-minute-retention-recovery-2026-04-09` 管当前冲刺窗口，`gameplay-indirect-control-feeling-contract-2026-05-14` 管间接控制下的 agency 合同，`gameplay-limited-preview-execution-2026-03-22` / `gameplay-closed-beta-readiness-2026-03-21` 管试玩与放行边界，`gameplay-agent-claim-token-cost-2026-03-27` 管近期高频经济规则。
 
 ## 活跃阅读面边界
 - 当前页只保留 `what / where / next / risk` 所需入口，不再把 `gameplay/` 下近期专题长名单直接平铺在首屏。

--- a/doc/game/gameplay/gameplay-indirect-control-feeling-contract-2026-05-14.design.md
+++ b/doc/game/gameplay/gameplay-indirect-control-feeling-contract-2026-05-14.design.md
@@ -1,0 +1,95 @@
+# Gameplay 间接控制 control-feeling 合同（2026-05-14）设计文档
+
+- 对应需求文档: `doc/game/gameplay/gameplay-indirect-control-feeling-contract-2026-05-14.prd.md`
+- 对应项目管理文档: `doc/game/gameplay/gameplay-indirect-control-feeling-contract-2026-05-14.project.md`
+
+审计轮次: 1
+
+## 设计目标
+- 把“间接控制仍然像控制”收成 gameplay 正式合同，而不是零散体验判断。
+- 给 runtime / viewer / agent / QA 一套共同 agency 坐标系，避免只在单侧补丁式修复。
+- 明确本专题如何承接 `PRD-GAME-012` 的第 4 条 lane“间接控制因果与下一步”。
+
+## 四项 guarantees
+
+### 1. Intent Legibility Before/At Commit
+- 玩家必须能知道当前被系统接受的主意图是什么。
+- 可以是 commit 前预览，也可以是 commit 后立即确认，但不能完全隐形。
+- 一旦新意图取代旧意图，必须显式标记 `replaced`、`reprioritized` 或等价结果。
+
+### 2. Execution Acknowledgement With Causality
+- 玩家不能只看到世界有变化。
+- 必须看到“这个变化与我刚刚发出的意图是什么关系”。
+- canonical 状态至少要区分：
+  - `executing`
+  - `blocked`
+  - `overridden`
+  - `completed_no_progress`
+  - `completed_with_progress`
+
+### 3. Interrupt / Reprioritize / Recover Hooks
+- 玩家必须有方式改变当前方向，而不是只能被动等待。
+- 允许不同 surface 的入口不同，但必须在同一语义层里解释“新旧意图如何交接”。
+- 重连与回流时必须恢复 agency 面，而不是只恢复原始事件流。
+
+### 4. Bounded Consequence Readability
+- 玩家必须看懂 4 件事：
+  - 付出了什么
+  - 世界改了什么
+  - 为什么当前卡住
+  - 下一步最值得做什么
+- 这不是“全知全能预测器”，而是“足够做下一步决策”的最小后果面。
+
+## 设计原则
+- 先 accepted intent，再 debug history：主意图必须优先于原始日志。
+- 先主因果，再次级噪音：玩家第一眼看到的必须是“为什么现在这样”。
+- 先可重排，再谈更宽动作面：agency 地板优先于功能扩张。
+- 先 canonical truth，再多端展示：Viewer 与 pure API 不得各自拼装出不同的控制叙事。
+
+## 与现有专题的边界
+- `PRD-GAME-004`
+  - 管“反馈可见性”和节奏可靠性。
+  - 本专题更窄，专门管“间接控制如何仍然像控制”。
+- `PRD-GAME-007`
+  - 管 `PostOnboarding` 目标链。
+  - 本专题要求该目标链必须被玩家感知为“我在推动”，而不是系统自走。
+- `PRD-GAME-008`
+  - 管 pure API 与 UI 的正式玩家等价。
+  - 本专题要求 parity 不仅是字段有无，还包括 control-feeling guarantees 的等价。
+- `PRD-GAME-012`
+  - 管 trust gate / capability gate 的当前冲刺与 verdict。
+  - 本专题是 lane-4 的正式合同，不替代 gate verdict。
+
+## 角色切片
+- `producer_system_designer`
+  - 冻结 guarantees、失败签名与 scope boundary。
+  - 裁决哪些 future 变更是增强还是削弱 agency。
+- `runtime_engineer`
+  - 对齐 canonical accepted intent、execution status、blocker/override reason、resume anchor。
+- `viewer_engineer`
+  - 收口 headed Web/UI 首屏与续玩 surface，确保主意图、主因果、下一步不被噪音淹没。
+- `agent_engineer`
+  - 对齐 dual-mode / action contract 的 interruption、reprioritization 与 override 语义。
+- `qa_engineer`
+  - 建立 control-feeling matrix，并把 failed guarantee 作为正式 blocker 分类。
+
+## 实施顺序
+1. `TASK-GAME-071`: 冻结专题并回挂根入口、主文档、索引、execution log。
+2. `TASK-GAME-072`: 对齐 canonical accepted intent / status / blocker / next-step truth。
+3. `TASK-GAME-073`: 对齐 Viewer / pure API control-feeling surface。
+4. `TASK-GAME-074`: 对齐 agent/action contract 的 interrupt / reprioritize / override semantics。
+5. `TASK-GAME-075`: QA 建立矩阵并接入 trust/capability 样本解释。
+
+## 验证口径
+- required:
+  - 文档互链与任务映射。
+  - runtime/viewer/API/agent contract 对账。
+  - QA control-feeling matrix 与 blocker 签名。
+- full:
+  - fresh bundle active-LLM 正式样本复核。
+  - pure API / headed Web agency surface 等价抽样。
+
+## 风险
+- 如果只在 Viewer 表面补提示，而 canonical truth 仍不完整，合同会再次回退成文案层错觉。
+- 如果只把 issue #164 解释成“增加 direct control”，会偏离当前间接控制主路线并冲淡 retention 主 blocker。
+- 如果不把 failed guarantee 写成独立 blocker，后续很容易再次出现“系统能跑但像旁观”的静默退化。

--- a/doc/game/gameplay/gameplay-indirect-control-feeling-contract-2026-05-14.prd.md
+++ b/doc/game/gameplay/gameplay-indirect-control-feeling-contract-2026-05-14.prd.md
@@ -1,0 +1,152 @@
+# Gameplay 间接控制 control-feeling 合同（2026-05-14） PRD v0.1
+
+- 对应设计文档: `doc/game/gameplay/gameplay-indirect-control-feeling-contract-2026-05-14.design.md`
+- 对应项目管理文档: `doc/game/gameplay/gameplay-indirect-control-feeling-contract-2026-05-14.project.md`
+
+审计轮次: 1
+
+## 1. Executive Summary
+
+- Problem Statement: oasis7 当前正式主路线已经明确是“通过 agent 间接控制文明”，但还缺少一份正式合同来回答：玩家在不直接操纵每一步执行的前提下，什么时候仍然会觉得“这是我在控制”，而不是“我只是在旁观 AI 自己决定”。缺少这份合同会让 retention、Viewer 表达、action contract 与 playability verdict 继续各说各话。
+- Proposed Solution: 新增 `PRD-GAME-014`，把间接控制的 control-feeling 正式拆成一组可验证的交互保证：`intent legibility before/at commit`、`execution acknowledgement with causality`、`interrupt/reprioritize/recover hooks`、`bounded consequence readability`。同时明确这些保证怎样映射到 headed Web/UI、pure API、runtime canonical 语义与 QA gate。
+- Success Criteria:
+  - SC-1: `game` 根 PRD、`gameplay` 主文档与本专题对“间接控制下何谓玩家仍然在控制”采用统一口径，不再只停留在笼统的“有 goal/progress/blocker/next_step”描述。
+  - SC-2: 至少冻结 3 条可验证的 interaction guarantees，并明确每条 guarantee 的字段、状态、失败签名与 owner role。
+  - SC-3: headed Web/UI 与 pure API 都能直接回答 4 个问题：`我刚刚让系统做什么`、`系统是否接受了`、`为什么当前这样推进/没推进`、`我现在最有效的下一步是什么`。
+  - SC-4: future UX / runtime / agent contract 变更可以被 QA 按本专题直接判定为 `strengthens / preserves / weakens control-feeling`，而不是只看 smoke 是否还能跑。
+  - SC-5: 本专题不改变 `PRD-GAME-012` 当前正式 verdict；它负责定义 trust/capability 修复所依赖的“控制感合同”，而不是替代 active-LLM 留存验证本身。
+
+## 2. User Experience & Functionality
+
+- User Personas:
+  - 新玩家 / 试玩玩家：需要在不直接操控每一步的前提下，仍然感觉“我的决定真的改变了世界”。
+  - 回流玩家：需要快速恢复上一次意图、当前执行状态、阻塞原因与最短下一步，而不是重新猜测 agent 在做什么。
+  - `producer_system_designer`: 需要把“间接控制是否仍然像控制”冻结成正式可裁决合同。
+  - `viewer_engineer`: 需要知道哪些首屏与反馈语义是正式能力地板，而不是可有可无的 polish。
+  - `runtime_engineer` / `agent_engineer`: 需要知道哪些 canonical 状态、ack、override、blocked reason 与 resume hook 是产品合同，而不是实现细节。
+  - `qa_engineer`: 需要一个比“能点按钮、有日志”更强的 playability 验收基准。
+- User Scenarios & Frequency:
+  - 首次正式会话：每位新玩家首次进入 `PostOnboarding` 后都会经历。
+  - active-LLM 10 分钟 trust gate 回归：每个候选版本至少 3 条正式样本。
+  - `PostOnboarding -> first capability gate` 跟踪：每个候选版本至少 1 组 `30` 分钟或 `1~3` 次会话样本。
+  - headed Web/UI 或 pure API 行为面变更：每个影响 action/ack/goal/blocker/next_step 的改动至少 1 次合同复核。
+- User Stories:
+  - PRD-GAME-014: As a 玩家, I want indirect agent gameplay to preserve a concrete sense of control, so that I feel I am directing outcomes rather than merely observing an autonomous simulation.
+  - PRD-GAME-014-A: As a 玩家, I want the system to show what intent it accepted and why it changed course or got blocked, so that I can still trust my decisions.
+  - PRD-GAME-014-B: As a 回流玩家, I want clear resume and reprioritization hooks, so that I can recover agency without rereading raw logs.
+  - PRD-GAME-014-C: As a QA / gameplay owner, I want future UX and runtime changes to be evaluated against an explicit control-feeling contract, so that “still playable” does not silently drift into “technically alive but emotionally passive”.
+- Critical User Flows:
+  1. Flow-CFC-001: `玩家给出目标/动作 -> 系统在 commit 前展示意图边界或提交后立即回写 accepted intent -> 玩家确认“系统正在执行我刚让它做的事”`
+  2. Flow-CFC-002: `执行中出现等待/阻塞/改道 -> 系统把当前状态归类为 executing / blocked / overridden / completed_no_progress 之一 -> 玩家读懂主因果`
+  3. Flow-CFC-003: `玩家对当前方向不满意 -> 使用 interrupt / reprioritize / focus goal / change target -> 系统在同一语义面上反馈新旧意图交接`
+  4. Flow-CFC-004: `玩家中断会话后返回 -> 系统恢复最近 accepted intent、当前主阻塞、最近可见后果与下一步建议 -> 玩家无需翻 raw history 即可继续`
+  5. Flow-CFC-005: `QA 评审某项 UX/runtime/agent 变更 -> 对照 guarantees 判断该改动是增强、保持还是削弱 control-feeling -> 输出 blocker 或 pass`
+- Functional Specification Matrix:
+
+| 功能点 | 字段定义 | 按钮/动作行为 | 状态转换 | 排序/计算规则 | 权限逻辑 |
+| --- | --- | --- | --- | --- | --- |
+| 意图可见性保证 | `accepted_intent_id`、`intent_summary`、`intent_scope`、`intent_target`、`intent_age_ms` | 玩家发出 `play/step/select/gameplay_action/prompt_control` 后，界面或 API 必须能回读当前被接受的主意图 | `implicit -> acknowledged -> stale/replaced` | 最近一次仍有效的 accepted intent 优先；若被新意图取代，旧意图必须显式标记 `replaced` | 已认证玩家可见自己的当前主意图；不得暴露他人私有 prompt 细节 |
+| 因果反馈保证 | `execution_status`、`status_reason`、`blocker_type`、`override_reason`、`last_world_change` | 玩家查看当前结果时，必须看到 “accepted / executing / blocked / overridden / completed_no_progress / completed_with_progress” 之一 | `acknowledged -> executing -> blocked/overridden/completed_*` | 当前主目标相关的执行状态优先于历史日志噪音；同一时刻只高亮 1 个主因果 | 玩家可读；runtime/canonical snapshot 为真值来源，Viewer/API 不得各算一套 |
+| 可打断与重排保证 | `can_interrupt`、`can_reprioritize`、`replacement_intent_summary`、`handoff_result` | 提供 `focus goal`、重新选目标、重新提交 prompt/动作等显式重排入口；不允许只剩“等 AI 自己继续” | `continuing -> interrupt_requested -> reprioritized / resume_required` | 当前主阻塞若持续存在且玩家可采取更高收益动作，应优先暴露 reprioritize hook | 正式玩家可对自己的主意图重排；不允许越权改动其他玩家/组织控制面 |
+| 后果可读性保证 | `cost_summary`、`progress_delta`、`world_change_summary`、`next_step_hint` | 每次关键动作后必须给出“付出了什么 / 世界改变了什么 / 下一步最该做什么” | `opaque -> readable -> decision_ready` | 当前主目标相关的成本、产出、阻塞、恢复优先于调试日志与次级事件 | 玩家可读；系统生成，owner 冻结字段语义 |
+| 恢复与续玩保证 | `resume_anchor`、`last_accepted_intent`、`primary_blocker`、`resume_next_step` | 玩家重连或回流时，直接恢复当前 agency surface，不要求先读原始事件流 | `fresh_session -> resumed -> replanned` | 优先恢复主目标链最近一次 accepted intent；若旧意图已失效，必须显式写出失效原因 | 已认证玩家可恢复自己的续玩面板/API 字段 |
+
+- Acceptance Criteria:
+  - AC-1: 本专题至少冻结 4 条 control-feeling guarantees，其中至少 3 条具备可直接验收的字段、状态与失败签名。
+  - AC-2: “间接控制仍然像控制”在本专题中被具体定义为：玩家始终能回答 `我让系统做了什么 / 系统有没有接受 / 为什么现在这样 / 我下一步该做什么`，而不是只看到世界在变化。
+  - AC-3: 当前正式主路线不要求玩家获得第一人称逐帧操控；但若 accepted intent、主因果、打断重排或续玩恢复四者缺一，则不得宣称 control-feeling 合格。
+  - AC-4: 本专题必须显式承接 `PRD-GAME-012` 第 4 条 lane“间接控制因果与下一步”，并解释它与 `PRD-GAME-004` 微循环反馈可见性、`PRD-GAME-007` PostOnboarding、`PRD-GAME-008` pure API parity 的边界。
+  - AC-5: headed Web/UI 与 pure API 都必须具备同等级的 agency surface；API 可以更简洁，但不允许缺少 accepted intent、主因果、阻塞分类或 next-step 语义。
+  - AC-6: 若系统只是展示原始日志、世界 tick 或泛化状态，而不能把主意图和当前结果绑定到同一语义面，则判定为 control-feeling 失败。
+  - AC-7: 若玩家无法显式中断、改道或重新聚焦主目标，只能被动等待 agent 自行推进，则判定为 agency weakened，即便世界仍在持续运行。
+  - AC-8: 本专题必须给出未来 UX/runtime/agent 变更的判据：增强型变更至少强化 1 条 guarantee 且不削弱其余 guarantee；任何削弱 accepted intent、主因果、重排入口或续玩恢复的变更都必须经 `producer_system_designer` 显式裁决。
+  - AC-9: 本专题完成后，`game` 根 PRD / project、`gameplay` 主文档、索引与当前 task execution log 必须互链到 `PRD-GAME-014` 与 `TASK-GAME-071~075`。
+  - AC-10: 当前阶段口径继续保持 `internal_playable_alpha_late`、`trust gate = hold`、`first capability gate = not_run`；本专题不允许被包装成“issue #160 已解决”或“正式留存已恢复”。
+- Non-Goals:
+  - 不把 oasis7 改成第一人称直接操作或逐块建造游戏。
+  - 不在本专题中直接修复 active-LLM provider、runtime freeze 或 capability gate 本身；这些仍由对应实现任务负责。
+  - 不把“更多按钮”误当作 control-feeling 改善；本专题关注的是 agency 合同，而不是动作数量膨胀。
+  - 不要求 v1 引入复杂概率预览、未来分支树模拟器或完整 plan diff 可视化。
+
+## 3. AI System Requirements (If Applicable)
+
+- Tool Requirements:
+  - active-LLM 正式游玩样本与 `agent-browser` headed Web/UI 证据，用于验证 trust gate 语义面是否满足 control-feeling 合同。
+  - pure API 对账脚本与 canonical snapshot 检查，用于验证 accepted intent / status / blocker / next_step 没有只留在 UI 私有组装层。
+  - playability 卡片与 QA evidence，用于记录“玩家是否真的感觉在控制”而非仅依赖技术成功率。
+- Evaluation Strategy:
+  - 先做合同级评估，再做样本级评估。合同级评估检查 guarantees 是否在 surface 上存在且一致；样本级评估再看玩家能否在真实 session 中持续读懂 accepted intent、主因果、重排行为与下一步。
+  - 对 active-LLM 正式样本，若出现 `world time 没推进`、`goal regress`、`override without explanation`、`raw log 抢焦点`、`resume only through debug history` 中任一签名，则 control-feeling 至少有 1 条 guarantee 失败。
+
+## 4. Technical Specifications
+
+- Architecture Overview:
+  - `PRD-GAME-014` 是 gameplay 层的交互合同，不新增单独玩法系统，而是收束已有 `player_gameplay`、goal chain、action ack、blocker taxonomy 与 feedback surfaces 的共同完成定义。
+  - runtime / canonical snapshot 负责提供 accepted intent、execution status、blocker/override reason、world change summary、resume anchor 等真值字段。
+  - Viewer 与 pure API 负责把这些字段呈现为玩家可用的 agency surface，而不是让玩家去拼原始日志。
+  - QA 负责把这些 guarantees 固化为验证矩阵，并在 trust/capability 样本中独立记录哪一条 guarantee 失效。
+- Integration Points:
+  - `doc/game/prd.md`
+  - `doc/game/project.md`
+  - `doc/game/prd.index.md`
+  - `doc/game/gameplay/gameplay-top-level-design.prd.md`
+  - `doc/game/gameplay/gameplay-top-level-design.project.md`
+  - `doc/game/gameplay/gameplay-micro-loop-feedback-visibility-2026-03-05.prd.md`
+  - `doc/game/gameplay/gameplay-post-onboarding-stage-2026-03-18.prd.md`
+  - `doc/game/gameplay/gameplay-pure-api-client-parity-2026-03-19.prd.md`
+  - `doc/game/gameplay/gameplay-ten-minute-retention-recovery-2026-04-09.prd.md`
+  - `crates/oasis7/src/viewer/runtime_live/gameplay_snapshot.rs`
+  - `crates/oasis7/src/bin/oasis7_pure_api_client.rs`
+  - `crates/oasis7_viewer/software_safe.js`
+  - `crates/oasis7_viewer/src/egui_right_panel_player_guide/mod.rs`
+  - `testing-manual.md`
+- Edge Cases & Error Handling:
+  - accepted intent 已被新动作替换，但表面仍像旧意图在执行：必须显式标记 `replaced` 或 `reprioritized`，否则判定为因果漂移。
+  - agent 因世界约束自行改道，但玩家只看到“执行了别的事”而没有 override reason：判定为 agency break，而不是普通日志缺失。
+  - world 有变化，但当前主目标没有任何 progress/cost/next-step 解释：不得把“世界活着”视为 control-feeling pass。
+  - pure API 能读到 stage/goal，却读不到 accepted intent 或 interruption hook：判定为 parity 不完整，不得宣称 API 也满足 control-feeling 合同。
+  - 玩家重连后只能从 raw history 猜测最近状态，而没有恢复锚点：判定为 resume guarantee 失败。
+  - 系统提供过多 operator/debug 语义，淹没当前主意图与主因果：判定为 presentation-level control-feeling regression。
+  - active-LLM lane 因 provider 问题卡死时，不得用 deterministic `--no-llm` 样本代替本专题正式验收；debug lane 只能帮助定位哪条 guarantee 先失效。
+- Non-Functional Requirements:
+  - NFR-CFC-1: `PRD-GAME-014` 的 active 入口互链必须在 1 个工作日内完成，并可通过 grep 直接定位到根 PRD / project、主文档、索引与专题三件套。
+  - NFR-CFC-2: headed Web/UI 与 pure API 的 control-feeling 关键字段覆盖率必须为 100%：`accepted_intent`、`execution_status`、`primary_reason`、`next_step` 四类字段不得缺任一类。
+  - NFR-CFC-3: 任何导致 accepted intent 与当前世界结果脱钩、且没有 override/replaced 解释的回归，都必须被 QA 标记为 blocker，而不是低优先级文案问题。
+  - NFR-CFC-4: control-feeling 合同验证必须可在 fresh bundle 本地复跑，并能区分 formal active-LLM lane 与 debug/probe lane。
+  - NFR-CFC-5: 本专题下所有 follow-up 结论必须继续遵守当前 claim envelope，不得借“控制感合同已定义”扩大对外承诺。
+- Security & Privacy:
+  - 本专题不新增玩家隐私采集；accepted intent 与 resume anchor 只要求表达 canonical 玩家状态，不要求暴露私有 prompt 全文或实现内部 trace。
+
+## 5. Risks & Roadmap
+
+- Phased Rollout:
+  - R0: 冻结 `PRD-GAME-014`，完成根入口、主文档、索引与任务映射。
+  - R1: 对齐 current canonical surface，把 accepted intent / 主因果 / next-step / resume anchor 的正式合同写入 runtime/viewer/API 语义面。
+  - R2: 补齐 interrupt / reprioritize / resume hooks 的实现与表面一致性。
+  - R3: QA 建立 control-feeling matrix，并将其接入 `PRD-GAME-012` trust/capability 样本复核。
+  - R4: 只有在上述 guarantees 稳定后，才允许继续讨论更复杂的 plan preview、branch simulation 或更宽动作面。
+- Technical Risks:
+  - 风险-1: 如果只补 UI 文案、不补 canonical accepted intent / override / resume truth，合同会再次退化成展示层口号。
+  - 风险-2: 如果把 control-feeling 简化为“世界在动、按钮有响应”，会继续把系统原型误判为足够像游戏。
+  - 风险-3: 如果为了“更像控制”而盲目扩动作面，反而会打散当前间接控制主路线和 retention 修复优先级。
+
+## 6. Validation & Decision Record
+
+- Test Plan & Traceability:
+
+| PRD-ID | 对应任务 | 测试层级 | 验证方法 | 回归影响范围 |
+| --- | --- | --- | --- | --- |
+| PRD-GAME-014 | `TASK-GAME-071` | `test_tier_required` | 文档治理检查、根入口/主文档/索引/执行日志互链核验 | control-feeling 合同冻结与任务挂载 |
+| PRD-GAME-014 | `TASK-GAME-072` | `test_tier_required` | canonical snapshot / feedback surface 对账，确认 accepted intent、execution status、override/blocker reason、next-step truth 已定义 | runtime / viewer / player_gameplay 语义一致性 |
+| PRD-GAME-014 | `TASK-GAME-073` | `test_tier_required` | formal Web entry 与 pure API agency surface 对账，人工复核主意图、主因果、重排入口、续玩恢复 | headed Web/UI 与 pure API control-feeling surface |
+| PRD-GAME-014 | `TASK-GAME-074` | `test_tier_required` | dual-mode / action contract / interruption semantics 对账，确认重排与打断能力不再隐形 | agent contract、override 解释与 reprioritize hook |
+| PRD-GAME-014 | `TASK-GAME-075` | `test_tier_required` + `test_tier_full` | QA control-feeling matrix、active-LLM trust samples、pure API parity 抽样与 blocker 签名归档 | 正式 control-feeling 合同、trust/capability 样本解释力 |
+
+- Decision Log:
+
+| 决策ID | 选定方案 | 备选方案（否决） | 依据 |
+| --- | --- | --- | --- |
+| DEC-CFC-001 | 将 control-feeling 定义为一组 interaction guarantees，而不是一句“间接控制也要有控制感” | 继续让留存、Viewer、runtime、QA 各自用模糊语言描述 | issue #164 的问题不是缺观点，而是缺一份可裁决、可实现、可测试的正式合同。 |
+| DEC-CFC-002 | 把 accepted intent、主因果、打断重排、续玩恢复列为 agency 地板 | 只要求“世界在动”或“有 next_step 提示” | 玩家真正缺的不是更多世界变化，而是缺“这是我造成的、我现在能改什么”的稳定心智模型。 |
+| DEC-CFC-003 | 本专题承接 `PRD-GAME-012` 第 4 条 lane，但不替代 trust/capability gate | 直接把 issue #164 写成 retention gate verdict 本身 | control-feeling 是 formal gate 的前置合同，不是 gate 结果本身；混写会再次污染 verdict 语义。 |
+| DEC-CFC-004 | 继续坚持间接控制主路线，通过更强的 agency surface 解决“像旁观 AI”的问题 | 直接把产品方向改成更多 direct control 或 embodied 操作 | 当前主问题是间接控制表达不够完整，而不是缺一套完全不同的直接控制产品方向。 |

--- a/doc/game/gameplay/gameplay-indirect-control-feeling-contract-2026-05-14.prd.md
+++ b/doc/game/gameplay/gameplay-indirect-control-feeling-contract-2026-05-14.prd.md
@@ -98,7 +98,8 @@
   - `crates/oasis7/src/viewer/runtime_live/gameplay_snapshot.rs`
   - `crates/oasis7/src/bin/oasis7_pure_api_client.rs`
   - `crates/oasis7_viewer/software_safe.js`
-  - `crates/oasis7_viewer/src/egui_right_panel_player_guide/mod.rs`
+  - `crates/oasis7_viewer/software_safe_src/main.jsx`
+  - `crates/oasis7_viewer/software_safe_src/legacy_core.js`
   - `testing-manual.md`
 - Edge Cases & Error Handling:
   - accepted intent 已被新动作替换，但表面仍像旧意图在执行：必须显式标记 `replaced` 或 `reprioritized`，否则判定为因果漂移。

--- a/doc/game/gameplay/gameplay-indirect-control-feeling-contract-2026-05-14.project.md
+++ b/doc/game/gameplay/gameplay-indirect-control-feeling-contract-2026-05-14.project.md
@@ -1,0 +1,98 @@
+# Gameplay 间接控制 control-feeling 合同（项目管理文档）
+
+- 对应设计文档: `doc/game/gameplay/gameplay-indirect-control-feeling-contract-2026-05-14.design.md`
+- 对应需求文档: `doc/game/gameplay/gameplay-indirect-control-feeling-contract-2026-05-14.prd.md`
+
+审计轮次: 1
+
+## 任务拆解
+
+- [x] indirect-control-feeling-contract-freeze (PRD-GAME-014) [test_tier_required]: `producer_system_designer` 已新增“间接控制 control-feeling 合同”专题 PRD / design / project，并完成 `game` 根 PRD / project、`gameplay` 主文档、索引与当前 task execution log 挂载，明确 accepted intent、主因果、重排/打断与续玩恢复四项 guarantees 是正式 agency 地板。 Trace: .pm/tasks/task_89828a4d2c1b4e73987103699c10fa7d.yaml
+
+## 后续待建任务
+
+| topic slug | owner role | status | 目标 |
+| --- | --- | --- | --- |
+| `runtime-control-feeling-canonical-contract` | `runtime_engineer` | `planned` | 对齐 canonical accepted intent、execution status、blocker/override reason、resume anchor 与 next-step truth，避免只剩 UI 私有语义。 |
+| `viewer-control-feeling-surface-alignment` | `viewer_engineer` | `planned` | 收口 headed Web/UI 首屏与续玩面，把 accepted intent、主因果、后果与下一步作为正式玩家 surface。 |
+| `agent-control-feeling-reprioritize-contract` | `agent_engineer` | `planned` | 对齐 dual-mode / action contract 的 interrupt、reprioritize、override explanation 与 handoff 语义。 |
+| `qa-control-feeling-matrix` | `qa_engineer` | `planned` | 建立 control-feeling matrix，给每条 guarantee 定义 pass/blocker 签名，并接入 trust/capability 样本复核。 |
+
+## 任务建议标题（给后续 owner 直接开 task 用）
+
+| topic slug | owner role | 建议标题 |
+| --- | --- | --- |
+| `runtime-control-feeling-canonical-contract` | `runtime_engineer` | Align canonical accepted-intent and causality contract for indirect control |
+| `viewer-control-feeling-surface-alignment` | `viewer_engineer` | Make player-facing agency surface explicit in headed Web and software_safe |
+| `agent-control-feeling-reprioritize-contract` | `agent_engineer` | Align reprioritize and override semantics with indirect-control contract |
+| `qa-control-feeling-matrix` | `qa_engineer` | Build control-feeling matrix and blocker signatures for formal gameplay lanes |
+
+## Handoff Matrix
+
+| topic slug | 发起角色 | 接收角色 | 输入 | 期望输出 |
+| --- | --- | --- | --- | --- |
+| `runtime-control-feeling-canonical-contract` | `producer_system_designer` | `runtime_engineer` | `PRD-GAME-014` guarantees、现有 `player_gameplay`/goal/blocker taxonomy、trust gate blocker 签名 | canonical accepted intent / causality / resume truth 与定向验证 |
+| `viewer-control-feeling-surface-alignment` | `producer_system_designer` | `viewer_engineer` | guarantees、首屏噪音治理现状、headed Web/UI 与 `software_safe` 现有 surface | agency surface 对齐稿、UI 语义回归与玩家入口说明 |
+| `agent-control-feeling-reprioritize-contract` | `producer_system_designer` | `agent_engineer` | dual-mode/action contract、override 与 prompt-control 现状、future embodied 边界 | reprioritize / override / interruption 语义对账结果 |
+| `qa-control-feeling-matrix` | `producer_system_designer` | `qa_engineer` | runtime/viewer/agent 对账产物、active-LLM 正式样本入口、pure API parity 现状 | control-feeling matrix、guarantee-level pass/block 结论与 blocker 归档 |
+
+## 验收命令（草案）
+
+- `indirect-control-feeling-contract-freeze` / 文档冻结与挂载
+  - `rg -n "PRD-GAME-014|TASK-GAME-071|TASK-GAME-072|TASK-GAME-073|TASK-GAME-074|TASK-GAME-075|control-feeling|accepted intent|间接控制因果与下一步" doc/game/prd.md doc/game/project.md doc/game/prd.index.md doc/game/README.md doc/game/gameplay/gameplay-top-level-design.prd.md doc/game/gameplay/gameplay-top-level-design.project.md doc/game/gameplay/gameplay-indirect-control-feeling-contract-2026-05-14.prd.md doc/game/gameplay/gameplay-indirect-control-feeling-contract-2026-05-14.project.md .pm/tasks/task_89828a4d2c1b4e73987103699c10fa7d.execution.md`
+  - `./scripts/doc-governance-check.sh`
+  - `git diff --check`
+- `runtime-control-feeling-canonical-contract` / canonical contract 对齐
+  - `rg -n "accepted_intent|execution_status|blocker|override|next_step|resume" crates/oasis7/src/viewer/runtime_live crates/oasis7/src`
+  - 定向 runtime / snapshot 测试与 contract 对账
+- `viewer-control-feeling-surface-alignment` / surface 对齐
+  - `rg -n "accepted intent|next step|blocked|override|resume" crates/oasis7_viewer crates/oasis7/src/bin/oasis7_pure_api_client.rs`
+  - headed Web/UI 与 pure API 人工复核 agency surface
+- `agent-control-feeling-reprioritize-contract` / agent reprioritize contract
+  - `rg -n "override|reprioritize|interrupt|prompt_control|accepted" doc/world-simulator/llm crates/oasis7/src/simulator`
+  - `git diff --check`
+- `qa-control-feeling-matrix` / QA matrix
+  - active-LLM trust/capability 样本复核
+  - pure API parity 抽样
+  - 输出 guarantee-level blocker 签名
+
+## Done Definition
+
+- `indirect-control-feeling-contract-freeze`
+  - [x] 新专题 PRD / design / project 已创建并回挂到 `game` 根入口、主文档、索引与 task execution log
+  - [x] 已冻结至少 4 条 control-feeling guarantees
+  - [x] 已拆出 runtime / viewer / agent / QA follow-up 任务
+- `runtime-control-feeling-canonical-contract`
+  - [ ] accepted intent、主因果、blocker/override、resume/next-step truth 已在 canonical surface 上对齐
+  - [ ] Viewer / API 不再需要私有拼装才能回答“我现在为什么在这里”
+- `viewer-control-feeling-surface-alignment`
+  - [ ] headed Web/UI 与 pure API 都能展示同等级 agency surface
+  - [ ] 主意图、主因果、后果与下一步不再被噪音淹没
+- `agent-control-feeling-reprioritize-contract`
+  - [ ] interrupt / reprioritize / override explanation 已具备正式 contract
+  - [ ] dual-mode / action contract 不再隐含“AI 自己改道但不解释”的灰区
+- `qa-control-feeling-matrix`
+  - [ ] QA control-feeling matrix 已建立
+  - [ ] 每条 guarantee 的 blocker 签名可稳定复现并回写
+
+## 依赖
+
+- `doc/game/prd.md`
+- `doc/game/project.md`
+- `doc/game/prd.index.md`
+- `doc/game/gameplay/gameplay-top-level-design.prd.md`
+- `doc/game/gameplay/gameplay-micro-loop-feedback-visibility-2026-03-05.prd.md`
+- `doc/game/gameplay/gameplay-post-onboarding-stage-2026-03-18.prd.md`
+- `doc/game/gameplay/gameplay-pure-api-client-parity-2026-03-19.prd.md`
+- `doc/game/gameplay/gameplay-ten-minute-retention-recovery-2026-04-09.prd.md`
+- `testing-manual.md`
+
+## 状态
+
+- 更新日期: 2026-05-14
+- 当前状态: in_progress
+- 当前 owner: `producer_system_designer`
+- 下一任务: `runtime-control-feeling-canonical-contract`
+- 说明:
+  - 本专题当前只完成合同冻结与任务挂载，不等于 active-LLM formal lane 的 trust/capability gate 已恢复。
+  - 本专题不改动当前“间接控制文明模拟”主路线，也不把 issue #164 解释成 direct-control 立项。

--- a/doc/game/gameplay/gameplay-top-level-design.prd.md
+++ b/doc/game/gameplay/gameplay-top-level-design.prd.md
@@ -271,6 +271,34 @@ oasis7 的世界不是无尺度表格。
 - `10-minute trust gate` 负责回答“是否已经值得继续玩”。
 - `first capability gate` 负责回答“首个持续能力是否已经闭环”，并继续与 `PostOnboarding` 的 `15~45` 分钟里程碑口径对齐。
 
+## 2.9 间接控制下的 control-feeling 合同
+
+oasis7 当前正式主路线不是 direct control，而是 indirect control。
+
+这不等于玩家应该接受“AI 自己做决定，我只看结果”。
+
+当前正式口径要求，玩家在间接控制主路线里仍然必须持续回答 4 个问题：
+
+1. 我刚刚让系统做了什么。
+2. 系统有没有接受这件事。
+3. 为什么现在这样推进、没推进或改道。
+4. 我现在最有效的下一步是什么。
+
+如果任一问题不能在 headed Web/UI 或 pure API 的正式玩家 surface 上被直接回答，那么即便世界还在推进，也不能视为 control-feeling 合格。
+
+因此当前 gameplay 正式冻结 4 条 guarantees：
+
+1. `accepted intent`
+   - 玩家必须能读到当前被接受的主意图，而不是只看到原始事件流。
+2. `execution causality`
+   - 玩家必须知道当前是执行中、被阻塞、被 override、无进展完成还是有进展完成。
+3. `interrupt / reprioritize / recover`
+   - 玩家必须能打断、重排或恢复 agency，而不是只能等 AI 自己继续。
+4. `bounded consequence readability`
+   - 玩家必须看懂当前代价、世界变化、主阻塞与最短下一步。
+
+这 4 条 guarantees 的专题合同见 `doc/game/gameplay/gameplay-indirect-control-feeling-contract-2026-05-14.prd.md`。
+
 当前 defer 范围：
 - 暂不继续扩大战争/治理/元进度在首局中的曝光。
 - 暂不把新的宏系统入口包装成 first-session 主卖点。

--- a/doc/game/gameplay/gameplay-top-level-design.project.md
+++ b/doc/game/gameplay/gameplay-top-level-design.project.md
@@ -75,6 +75,10 @@
 - [x] agent-action-contract-boundary-alignment (PRD-GAME-013) [test_tier_required]: `agent_engineer` 已把 dual-mode / action contract 的现行动作面收口为低频间接控制白名单，并显式把 `jump / attack / use_item / block_editing` 回收到 future embodied candidate gate。 Trace: .pm/tasks/task_15890765ee3b4188a1e2766973f392fc.yaml
 - [x] qa-scale-consistency-matrix (PRD-GAME-013) [test_tier_required]: `qa_engineer` 已完成四层尺度合同一致性矩阵，确认 runtime/viewer/agent 口径一致，并把 blocker 签名归档到 `doc/testing/evidence/gameplay-scale-consistency-matrix-2026-05-07.md`。 Trace: .pm/tasks/task_8205baa6d2fb46388b11c1eed340fdf5.yaml
 
+### T10 间接控制 control-feeling 合同（2026-05-14）
+- [x] indirect-control-feeling-contract-freeze (PRD-GAME-014) [test_tier_required]: `producer_system_designer` 已新增 `PRD-GAME-014` 专题 PRD / design / project，并完成 `game` 根入口、`gameplay` 主文档、索引与当前 task execution log 挂载，正式冻结 accepted intent、主因果、打断/重排与续玩恢复四项 guarantees。 Trace: .pm/tasks/task_89828a4d2c1b4e73987103699c10fa7d.yaml
+- 后续待建任务统一收口在 `doc/game/gameplay/gameplay-indirect-control-feeling-contract-2026-05-14.project.md`，避免在 gameplay 主入口重复展开未绑定 Trace 的计划行。
+
 ## 依赖
 
 - 运行时与模块治理基线：`doc/world-runtime/prd.md`

--- a/doc/game/prd.index.md
+++ b/doc/game/prd.index.md
@@ -14,6 +14,7 @@
 - 想先回答当前还在推进什么、阻断在哪里、下一步做什么：先读 `doc/game/project.md`
 - 想先理解核心玩法骨架，而不是逐篇翻 gameplay 长表：先读 `doc/game/gameplay/gameplay-top-level-design.prd.md`
 - 想先看当前冲刺窗口与留存修复：先读 `doc/game/gameplay/gameplay-ten-minute-retention-recovery-2026-04-09.prd.md`
+- 想先看“间接控制为什么仍然要让玩家感觉自己在控制”：先读 `doc/game/gameplay/gameplay-indirect-control-feeling-contract-2026-05-14.prd.md`
 - 想先回答“1cm 物理世界”和“当前为什么不是 Minecraft 式逐块玩法”之间的边界：先读 `doc/game/gameplay/gameplay-physical-scale-indirect-control-2026-05-07.prd.md`
 - 想先看试玩放行与 beta 边界：先读 `doc/game/gameplay/gameplay-limited-preview-execution-2026-03-22.prd.md` 与 `doc/game/gameplay/gameplay-closed-beta-readiness-2026-03-21.prd.md`
 - 想继续按文件名、专题或补充材料下钻：使用下方密度快照、热点子域导航与补充入口
@@ -35,6 +36,7 @@
 ## 活跃补充文档
 - `doc/game/gameplay/gameplay-top-level-design.prd.md`：核心玩法骨架主入口。
 - `doc/game/gameplay/gameplay-ten-minute-retention-recovery-2026-04-09.prd.md`：当前冲刺窗口、跨角色优先级与 10 分钟留存修复主入口。
+- `doc/game/gameplay/gameplay-indirect-control-feeling-contract-2026-05-14.prd.md`：间接控制下的 accepted intent、主因果、打断重排与续玩恢复合同主入口。
 - `doc/game/gameplay/gameplay-physical-scale-indirect-control-2026-05-07.prd.md`：物理尺度真值、间接控制动作粒度与表现层夸张边界主入口。
 - `doc/game/gameplay/gameplay-limited-preview-execution-2026-03-22.prd.md`：试玩执行边界与继续/暂停决策主入口。
 - `doc/game/gameplay/gameplay-closed-beta-readiness-2026-03-21.prd.md`：closed beta 放行条件与候选级门禁主入口。
@@ -62,6 +64,7 @@
 | `doc/game/gameplay/gameplay-limited-preview-execution-2026-03-22.prd.md` | `doc/game/gameplay/gameplay-limited-preview-execution-2026-03-22.design.md` | `doc/game/gameplay/gameplay-limited-preview-execution-2026-03-22.project.md` |
 | `doc/game/gameplay/gameplay-physical-scale-indirect-control-2026-05-07.prd.md` | `doc/game/gameplay/gameplay-physical-scale-indirect-control-2026-05-07.design.md` | `doc/game/gameplay/gameplay-physical-scale-indirect-control-2026-05-07.project.md` |
 | `doc/game/gameplay/gameplay-distributed-consensus-governance-longrun-2026-03-06.prd.md` | `doc/game/gameplay/gameplay-distributed-consensus-governance-longrun-2026-03-06.design.md` | `doc/game/gameplay/gameplay-distributed-consensus-governance-longrun-2026-03-06.project.md` |
+| `doc/game/gameplay/gameplay-indirect-control-feeling-contract-2026-05-14.prd.md` | `doc/game/gameplay/gameplay-indirect-control-feeling-contract-2026-05-14.design.md` | `doc/game/gameplay/gameplay-indirect-control-feeling-contract-2026-05-14.project.md` |
 | `doc/game/gameplay/gameplay-layer-lifecycle-rules-closure.prd.md` | `doc/game/gameplay/gameplay-layer-lifecycle-rules-closure.design.md` | `doc/game/gameplay/gameplay-layer-lifecycle-rules-closure.project.md` |
 | `doc/game/gameplay/gameplay-layer-war-governance-crisis-meta-closure.prd.md` | `doc/game/gameplay/gameplay-layer-war-governance-crisis-meta-closure.design.md` | `doc/game/gameplay/gameplay-layer-war-governance-crisis-meta-closure.project.md` |
 | `doc/game/gameplay/gameplay-longrun-p0-production-hardening-2026-03-06.prd.md` | `doc/game/gameplay/gameplay-longrun-p0-production-hardening-2026-03-06.design.md` | `doc/game/gameplay/gameplay-longrun-p0-production-hardening-2026-03-06.project.md` |

--- a/doc/game/prd.md
+++ b/doc/game/prd.md
@@ -69,6 +69,7 @@
   - PRD-GAME-011: As a 中循环玩家与玩法 owner, I want agent claims to keep a non-zero main-token-denominated cost and require upkeep, while allowing `slot-1` to auto-draw restricted starter funding from the dedicated pool when runtime says it is available, so that agent control reflects sustained commitment without forcing limited preview users to hold transferable assets or wait for operator approval.
   - PRD-GAME-012: As a 中循环玩家与制作人 owner, I want a stable 10-minute trust loop after onboarding plus a separate first-capability proof gate, so that the game first feels trustworthy and then proves sustained playability without conflating those two verdicts.
   - PRD-GAME-013: As a 制作人与玩法 owner, I want gameplay docs to distinguish physical-world scale from player interaction scale, so that oasis7 keeps a real metric world without accidentally promising Minecraft-style direct block play before the product is ready.
+  - PRD-GAME-014: As a 玩家, I want indirect agent gameplay to preserve a concrete sense of control, so that I feel I am directing outcomes rather than merely observing an autonomous simulation.
 - 模式分层说明：按 `PRD-CORE-009`，`PRD-GAME-008` 所承接的是玩家访问模式 `pure_api`，而不是 provider-backed `headless_agent` 一类 execution lane。
 - 正式游玩前置：按最新 `PRD-CORE-009` 口径，`PRD-GAME-008` 的 `pure_api` 正式游玩与 headed Web/UI 一样，要求 active LLM access；`--no-llm` 仅保留 observer/debug，不再计入正式可玩性与 parity 放行。
 - Critical User Flows:
@@ -152,6 +153,7 @@
   - AC-15: 新增 `PRD-GAME-011` agent 认领成本专题，明确“首个也不免费”、claim bond/upkeep、`restricted starter claim balance`、闲置/欠费回收、tier cap 与 UI/API canonical 字段。
   - AC-16: 新增 `PRD-GAME-012` 10 分钟留存修复专题，明确未来两周只优先推进首次控制地板、工业中循环包、首屏降噪、后果可见化与 active-LLM `10-minute trust gate` 五条 lane，并把 `first capability gate` 作为单独 follow-up verdict。
   - AC-17: 新增 `PRD-GAME-013` 尺度语义专题，明确厘米真值、coarse-grained 子系统分辨率、当前正式玩家动作粒度与 Viewer 视觉夸张边界，并能直接拆出 runtime/viewer/agent/QA 执行任务。
+  - AC-18: 新增 `PRD-GAME-014` 间接控制 control-feeling 专题，明确 accepted intent、主因果、打断/重排与续玩恢复四项 guarantees，并能直接拆出 runtime/viewer/agent/QA 执行任务与 formal lane 验收矩阵。
 - Non-Goals:
   - 不在本 PRD 中给出逐条数值参数表。
   - 不替代 runtime/p2p 的底层实现设计。
@@ -208,6 +210,7 @@
   - NFR-GAME-17: `PRD-GAME-011` 的首个 claim 免费路径命中次数必须为 `0`，并且 claim / upkeep / refund / slash / restricted grant 事件必须 100% 进入 token 审计链路。
   - NFR-GAME-18: `PRD-GAME-012` 的正式 `10-minute trust gate` 必须使用 active-LLM 样本；`--no-llm` 只允许作为 debug/probe lane，不得单独支撑“已可玩/已留存”结论；`first capability gate` 必须与 trust gate 分开判定。
   - NFR-GAME-19: `PRD-GAME-013` 所覆盖的 active 文档与玩家入口 100% 必须区分物理真值、coarse-grained 子系统分辨率、玩家动作粒度与表现层夸张，不允许把 `1cm` 直接包装成当前 block-editing 主玩法承诺。
+  - NFR-GAME-20: `PRD-GAME-014` 所覆盖的 headed Web/UI 与 pure API 正式玩家入口 100% 必须具备 accepted intent、主因果、主阻塞/override reason 与 next-step/recovery 语义，不允许只剩“世界有变化”或原始日志。
 - Security & Privacy: gameplay 不直接处理密钥；涉及玩家反馈与行为数据时遵循最小化采集与脱敏记录。
 
 ## 5. Risks & Roadmap
@@ -236,6 +239,7 @@
 | PRD-GAME-011 | TASK-GAME-039/040/041/042/043/044/045/046/047/048/049/050/051 | `test_tier_required` + `test_tier_full` | 文档治理检查、claim/upkeep/reclaim 状态机回归、restricted bucket 与 provenance 回归、grant lifecycle 与 issuer runbook、Viewer/API parity、经济审计与 abuse suite | agent 占有边界、token sink、受限启动余额、回收与可观测性 |
 | PRD-GAME-012 | TASK-GAME-061/062/063/064/065 | `test_tier_required` + `test_tier_full` | 文档治理检查、headed Web/UI 与 `software_safe` 控制 floor、active-LLM `10-minute trust gate` 样本、工业 capability follow-up 样本与 producer 双层 verdict 结论 | 10 分钟正式信任门、首屏主目标、首个持续能力门 |
 | PRD-GAME-013 | TASK-GAME-066/067/068/069/070 | `test_tier_required` + `test_tier_full` | 文档治理检查、厘米真值与 coarse-grained 子系统映射对账、Viewer 真值/夸张表达复核、dual-mode action contract 对账与 QA 尺度一致性矩阵 | 物理尺度合同、间接控制动作边界、表现层可信度 |
+| PRD-GAME-014 | `indirect-control-feeling-contract-freeze` / `runtime-control-feeling-canonical-contract` / `viewer-control-feeling-surface-alignment` / `agent-control-feeling-reprioritize-contract` / `qa-control-feeling-matrix` | `test_tier_required` + `test_tier_full` | 文档治理检查、canonical accepted-intent/causality contract 对账、headed Web/UI 与 pure API agency surface 复核、reprioritize/override 语义对账、QA control-feeling matrix 与 formal lane 样本抽样 | 间接控制下的玩家控制感、主因果、重排恢复与多端等价性 |
 - Decision Log:
 | 决策ID | 选定方案 | 备选方案（否决） | 依据 |
 | --- | --- | --- | --- |
@@ -254,3 +258,4 @@
 | DEC-GAME-013 | 对 `PRD-GAME-011` 追加 `restricted starter claim balance`，作为 `slot-1` 专用受限资金来源 | 继续要求所有首个 claim 都必须持有可转账 liquid；或直接空投可转账 main token | 受控测试需要启动资金，但不能把启动补贴变成可转账资产，也不能推翻“首个 claim 非免费”的主规则。 |
 | DEC-GAME-014 | 新增独立 `PRD-GAME-012` 作为 10 分钟留存修复专题，并把正式 verdict 拆成 `10-minute trust gate` 与 `first capability gate` | 继续把留存问题拆散到 viewer/runtime/QA 各专题自行优化，或继续要求单个 10 分钟样本同时证明“值得继续玩”和“首个持续能力已闭环” | 当前问题不是单条 lane 的点状回归，而是“控制地板、中循环、首屏和 QA 门禁”需要在同一冲刺窗口统一排序；同时 `PostOnboarding` 里程碑与 10 分钟 trust 样本本来就不是同一时间尺度。 |
 | DEC-GAME-015 | 新增独立 `PRD-GAME-013` 作为尺度语义专题，并把“厘米真值”“粗粒度子系统”“玩家动作粒度”“表现层夸张”拆成四层合同 | 继续只保留底层 `1cm` 描述，或直接把产品方向改成 Minecraft 式逐块具身玩法 | 当前问题不在有没有物理尺度，而在没有正式解释“真实尺度”和“当前交互粒度”的关系；盲目切产品主路线会稀释 `PRD-GAME-012` 的主 blocker。 |
+| DEC-GAME-016 | 新增独立 `PRD-GAME-014` 作为间接控制 control-feeling 专题，并把“accepted intent / 主因果 / 打断重排 / 续玩恢复”冻结成正式 guarantees | 继续把“控制感”分散在留存卡、Viewer 文案、runtime ack 与 issue 讨论里，或直接把问题解释成“需要更多 direct control” | 当前 issue #164 暴露的不是动作数量不足，而是间接控制缺少一份可裁决、可实现、可测试的 agency 合同；先补合同，才能稳定评审后续 UX/runtime/agent 变更。 |

--- a/doc/game/project.md
+++ b/doc/game/project.md
@@ -170,6 +170,11 @@
 - [x] qa-scale-consistency-matrix (PRD-GAME-013) [test_tier_required]: `qa_engineer` 已在 `doc/testing/evidence/gameplay-scale-consistency-matrix-2026-05-07.md` 完成最终矩阵复核，确认四层尺度合同在 runtime/viewer/agent 三侧一致，并补齐 blocker 签名归档。 Trace: .pm/tasks/task_8205baa6d2fb46388b11c1eed340fdf5.yaml
 - `PRD-GAME-013` 当前规划切片已在 `doc/game/gameplay/gameplay-physical-scale-indirect-control-2026-05-07.project.md` 全部收口；该专题完成不等于 `PRD-GAME-012` trust/capability gate 已恢复。
 
+### T10 间接控制 control-feeling 合同（2026-05-14）
+- [x] indirect-control-feeling-contract-freeze (PRD-GAME-014) [test_tier_required]: 新增“间接控制 control-feeling 合同”专题 PRD / design / project，并完成 `game` 根 PRD / project、`gameplay-top-level-design` 主文档、索引与 task execution log 挂载，正式冻结 accepted intent、主因果、打断/重排与续玩恢复四项 guarantees。 Trace: .pm/tasks/task_89828a4d2c1b4e73987103699c10fa7d.yaml
+- 后续待建任务见 `doc/game/gameplay/gameplay-indirect-control-feeling-contract-2026-05-14.project.md`：
+  `runtime-control-feeling-canonical-contract`、`viewer-control-feeling-surface-alignment`、`agent-control-feeling-reprioritize-contract`、`qa-control-feeling-matrix`。
+
 ## 依赖
 - 模块设计总览：`doc/game/design.md`
 - doc/game/prd.index.md


### PR DESCRIPTION
## Summary
- add `PRD-GAME-014` as the canonical indirect-control control-feeling contract
- define accepted intent, causality, reprioritize/recover, and consequence-readability guarantees
- wire the new topic into `game` root docs, gameplay top-level docs, project tracking, and `.pm` execution trace

## Validation
- `./scripts/doc-governance-check.sh`
- `git diff --check`

Closes #164
