### PR TITLE
Freeze mature-world small-player progression lane

### DIFF
--- a/.pm/tasks/task_7aaccc0bf0094d64ab0e155087610eae.yaml
+++ b/.pm/tasks/task_7aaccc0bf0094d64ab0e155087610eae.yaml
@@ -7,7 +7,7 @@ status: done
 priority: P2
 source_signal: null
 source_refs:
-  - /home/scc/worktrees/oasis7-viewer-bevy-embedded-pixel-world-canvas/doc/world-simulator/viewer/viewer-bevy-embedded-pixel-world-canvas-2026-05-11.prd.md
+  - doc/world-simulator/viewer/viewer-web-entry-visual-redesign-2026-05-12.prd.md
   - doc/world-simulator/project.md
 doc_refs: []
 related_prd:

--- a/.pm/tasks/task_d97dfa29208444a9b6a652f2a12fb65d.execution.md
+++ b/.pm/tasks/task_d97dfa29208444a9b6a652f2a12fb65d.execution.md
@@ -1,0 +1,24 @@
+# task_d97dfa29208444a9b6a652f2a12fb65d Execution Log
+
+- task_uid: task_d97dfa29208444a9b6a652f2a12fb65d
+- title: freeze meaningful small-player progression lane in mature world states
+- owner_role: producer_system_designer
+- worktree_hint: /home/scc/worktrees/oasis7-game-issue-165-small-player-progression-lane
+
+<!-- Append entries using:
+Example:
+  ## YYYY-MM-DD HH:MM:SS CST / role_name
+  - 完成内容: ...
+  - 遗留事项: ...
+-->
+
+## 2026-05-17 20:10:00 CST / producer_system_designer
+- 完成内容: 已完成 issue #165 对应的产品冻结切片，新增 `doc/game/gameplay/gameplay-small-player-progression-lane-2026-05-17.{prd,design,project}.md`，把 mature-world 小玩家正式主线冻结为 `local operator -> regional specialist -> limited-scope regional influence`；同时把 `protected first industrial win` 明确定义为低爆炸半径、可恢复与 leverage 可见，而不是免战/免政治豁免。
+- 完成内容: 已同步回挂 `doc/game/prd.md`、`doc/game/project.md`、`doc/game/gameplay/gameplay-top-level-design.{prd,project}.md`、`doc/game/README.md` 与 `doc/game/prd.index.md`，把 `PRD-GAME-015` 纳入根入口、主文档、索引、traceability 与决策记录；并显式声明该专题不改写当前 `PRD-GAME-012` 的 early-retention 主优先级，也不放宽现有 preview / stage claim envelope。
+- 遗留事项: 后续仍需对应 owner 继续推进 `runtime-small-player-lane-state-contract`、`viewer-small-player-lane-surface-alignment`、`agent-small-player-specialization-contract` 与 `qa-small-player-progression-matrix`，把合同落成 canonical truth、玩家 surface、agent specialization contract 与 QA blocker 矩阵。
+
+## 2026-05-17 21:08:00 CST / producer_system_designer
+- 完成内容: 已完成本轮收口审阅，修正 `doc/game/project.md` 中误挂在 `T10` 下的重复 `small-player-progression-contract-freeze` 行，确保 `PRD-GAME-015` 只在 `T11` 归档。
+- 完成内容: 已复核 `doc/game/README.md` 与 `doc/game/prd.index.md` 的文件数快照，把 `gameplay/` 补充材料计数从 `19` 更正为实际的 `18`。
+- 完成内容: 已通过 `git diff --check`、`rg` 互链核验与 `./scripts/doc-governance-check.sh`，确认专题文档、根入口、索引与 execution log 当前可追溯且满足文档治理门禁。
+- 遗留事项: 本 task 只冻结 `PRD-GAME-015` 合同与 follow-up 路线，不包含 runtime/viewer/agent/QA 的实现落地。

--- a/.pm/tasks/task_d97dfa29208444a9b6a652f2a12fb65d.yaml
+++ b/.pm/tasks/task_d97dfa29208444a9b6a652f2a12fb65d.yaml
@@ -1,0 +1,23 @@
+task_uid: task_d97dfa29208444a9b6a652f2a12fb65d
+title: "freeze meaningful small-player progression lane in mature world states"
+owner_role: producer_system_designer
+worktree_hint: /home/scc/worktrees/oasis7-game-issue-165-small-player-progression-lane
+execution_log_path: .pm/tasks/task_d97dfa29208444a9b6a652f2a12fb65d.execution.md
+status: done
+priority: P2
+source_signal: null
+source_refs:
+  - doc/game/prd.md
+  - doc/game/project.md
+  - doc/game/gameplay/gameplay-top-level-design.prd.md
+doc_refs:
+  - doc/game/gameplay/gameplay-top-level-design.project.md
+related_prd: []
+acceptance:
+  - "define at least one credible early-game lane that does not require immediate alignment with major powers"
+  - "new player can achieve a meaningful outcome before engaging deep governance or large-scale conflict"
+  - "lane remains valuable even in mature world states"
+handoff_to: []
+updated_at: 2026-05-17T20:04:27+08:00
+last_started_at: 2026-05-17T19:36:31+08:00
+last_closed_at: 2026-05-17T20:04:27+08:00

--- a/doc/game/README.md
+++ b/doc/game/README.md
@@ -9,6 +9,7 @@
 - 想快速理解核心玩法骨架，而不是顺扫近期长名单：先读 `doc/game/gameplay/gameplay-top-level-design.prd.md`。
 - 想直接看“接下来两周只做什么”：先读 `doc/game/gameplay/gameplay-ten-minute-retention-recovery-2026-04-09.prd.md`。
 - 想确认“间接控制为什么仍然应该感觉像我在控制，而不是旁观 AI”：先读 `doc/game/gameplay/gameplay-indirect-control-feeling-contract-2026-05-14.prd.md`。
+- 想确认“成熟世界里小玩家/新玩家靠什么继续有独立价值，而不是只能投靠大组织”：先读 `doc/game/gameplay/gameplay-small-player-progression-lane-2026-05-17.prd.md`。
 - 想确认当前试玩放行、limited preview 与 closed beta 口径：先读 `doc/game/gameplay/gameplay-limited-preview-execution-2026-03-22.prd.md` 与 `doc/game/gameplay/gameplay-closed-beta-readiness-2026-03-21.prd.md`。
 - 想跟进最近最活跃的经济/运营规则变化：先读 `doc/game/gameplay/gameplay-agent-claim-token-cost-2026-03-27.prd.md`，再按需进入对应 design / project / runbook。
 
@@ -24,6 +25,7 @@
 - `project.md` 是执行入口，适合确认 retention、preview、经济规则与放行门禁当前推进到哪一步。
 - `prd.index.md` 是精确检索索引，适合已经知道专题名或需要完整文件清单时使用，不适合作为第一次进入模块时的首读入口。
 - 高频专题文档继续承担专题真值：`gameplay-top-level-design` 管核心玩法骨架，`gameplay-ten-minute-retention-recovery-2026-04-09` 管当前冲刺窗口，`gameplay-indirect-control-feeling-contract-2026-05-14` 管间接控制下的 agency 合同，`gameplay-limited-preview-execution-2026-03-22` / `gameplay-closed-beta-readiness-2026-03-21` 管试玩与放行边界，`gameplay-agent-claim-token-cost-2026-03-27` 管近期高频经济规则。
+- `gameplay-small-player-progression-lane-2026-05-17` 管 mature-world 小玩家承接：首个持续能力之后，如何通过受保护 first win、专业化与局部影响力继续形成独立价值。
 
 ## 活跃阅读面边界
 - 当前页只保留 `what / where / next / risk` 所需入口，不再把 `gameplay/` 下近期专题长名单直接平铺在首屏。
@@ -40,13 +42,13 @@
 - 承接 agent 认领的 token 成本、claim bond、upkeep 与 reclaim 规则。
 - 承接 agent claim restricted grant 的运营发放、撤销、过期与 incident runbook。
 
-## 热点子域导航（2026-04-10 快照）
-- `gameplay/` 正式专题三件套（54）：玩法骨架、留存修复、preview/beta gate、claim economy、长稳治理与发布闭环。
+## 热点子域导航（2026-05-17 快照）
+- `gameplay/` 正式专题三件套（63）：玩法骨架、留存修复、preview/beta gate、claim economy、长稳治理、agency 合同与 mature-world 小玩家承接。
 - `gameplay/` 补充材料（18）：runbook、evidence、checklist、handoff 与跨角色执行留痕。
 - 模块根入口（5）：`README.md`、`prd.md`、`project.md`、`design.md`、`prd.index.md`。
 
 ## 高密度提示
-- `doc/game/` 当前共有 77 份文件，其中 `doc/game/gameplay/` 占 72 份；默认入口不再尝试把 gameplay 长表直接摊平到模块首页。
+- `doc/game/` 当前共有 87 份文件，其中 `doc/game/gameplay/` 占 82 份；默认入口不再尝试把 gameplay 长表直接摊平到模块首页。
 - 需要完整活跃专题清单时，进入 `doc/game/prd.index.md`；需要 runbook、evidence、handoff 或 checklist 时，再按 `gameplay/` 中的补充文件精确进入。
 
 ## 共享约定

--- a/doc/game/gameplay/gameplay-small-player-progression-lane-2026-05-17.design.md
+++ b/doc/game/gameplay/gameplay-small-player-progression-lane-2026-05-17.design.md
@@ -1,0 +1,105 @@
+# Gameplay 小玩家成长线与成熟世界承接（2026-05-17）设计文档
+
+- 对应需求文档: `doc/game/gameplay/gameplay-small-player-progression-lane-2026-05-17.prd.md`
+- 对应项目管理文档: `doc/game/gameplay/gameplay-small-player-progression-lane-2026-05-17.project.md`
+
+审计轮次: 1
+
+## 设计目标
+- 给 mature world state 下一条“小玩家还能继续玩什么”的正式玩法答案。
+- 明确该答案如何承接现有 `PostOnboarding`、`slot-1` claim、first capability、player leverage 与 control-feeling 合同。
+- 把“受保护 first win、专业化、小范围影响力、恢复路径”拆成 runtime / viewer / agent / QA 共同实现的合同，而不是一段愿景口号。
+
+## Canonical Lane
+
+### 1. Entry Gate
+- 该线不属于首个 10 分钟 onboarding。
+- canonical entry gate 是：
+  - `PostOnboarding` 已进入正式阶段；
+  - `first capability gate` 已达成或至少已有明确 canonical entry；
+  - 玩家拥有可操作的 `slot-1` claim / starter funding / equivalent local foothold。
+
+### 2. Default Mainline: Local Operator
+- 第 1 条正式 small-player 主线不是“立刻建联盟”或“立刻进全球治理”。
+- 默认主线是 `local operator`：
+  - 在一个有限区域内把 1 条小规模工业能力稳定下来；
+  - 产出至少 1 次对世界有可见后果的结果；
+  - 让玩家能清楚回答“我刚刚让这个地方变得更好了什么”。
+
+### 3. Protected First Win
+- `protected first industrial win` 的保护含义不等于免战、免竞争、免治理。
+- 这里的“保护”拆成 3 层：
+  - `low strategic footprint`: 早期小玩家的首个胜利体量较小，不应一上来就与 major-power 主战略面重叠。
+  - `bounded downside`: 失败时不应直接把账号打回“只能重开号或只能投靠大组织”的死局。
+  - `recoverable path`: 玩家必须拥有 repair / rebuild / pivot 的显式下一步。
+
+### 4. Specialization After Stability
+- `local operator` 不该无限重复同一件事。
+- 在完成首个稳定胜利后，小玩家应切到至少 1 条专业化方向。当前设计冻结 3 类候选：
+  - `recovery-operator`: 擅长恢复停机、补齐缺口、保持局部韧性。
+  - `conversion-specialist`: 把局部丰富原料转成区域更紧缺的中间品或制成品。
+  - `regional-service-runner`: 提供局部 upkeep / 补给 / 维护类服务，形成稳定 return hook。
+
+### 5. Limited-Scope Regional Influence
+- 小玩家路线必须在 mature world 中拥有“局部有用”的后果，而不是只能赚钱或存活。
+- 但这层后果必须小于 global governance / alliance leadership：
+  - 更接近 `regional priority / local opportunity / local visibility / local trust`；
+  - 不直接等价为“全局投票权、主链治理主导、跨区军政控制”。
+
+### 6. Recoverable Failure
+- small-player lane 的失败不允许默认收束为“只能归顺大组织”。
+- 当前要求至少提供 3 类恢复语义：
+  - `repair`: 维持同一路线，修复停机或缺口。
+  - `rebuild`: 更换据点或重新建立同类小规模能力。
+  - `pivot`: 改做另一条专业化角色，而不是继续硬顶当前失败链。
+
+## 与现有专题的边界
+- `PRD-GAME-007`
+  - 管 `PostOnboarding` 从 onboarding 过渡到 first capability。
+  - 本专题管理 first capability 之后的小玩家承接。
+- `PRD-GAME-011`
+  - 管 `slot-1` claim、starter funding 与非免费 claim 经济边界。
+  - 本专题复用这些 foothold，不重开免费路径。
+- `PRD-GAME-012`
+  - 管当前 early-retention 主冲刺与 trust/capability verdict。
+  - 本专题不改写当前主 blocker 顺序，只定义后续路线。
+- `PRD-GAME-014`
+  - 管 accepted intent、主因果、打断重排与续玩恢复的 agency 合同。
+  - 本专题要求 small-player lane 也必须回答“我做了什么、为什么现在这样、下一步该做什么”。
+- `player leverage rubric`
+  - 本专题把 `player leverage != world activity` 当成硬门槛，而不是补充说明。
+
+## 角色切片
+- `producer_system_designer`
+  - 冻结 lane、边界、恢复与区域影响上限。
+  - 裁决哪些专业化仍属于“小玩家路线”，哪些已经属于 major-power escalation。
+- `runtime_engineer`
+  - 把 lane entry、checkpoint、failure signature、recovery option 写成 canonical truth。
+- `viewer_engineer`
+  - 把 lane、首个胜利、区域价值与恢复路径做成显式 surface。
+- `agent_engineer`
+  - 对齐 specialization / recovery / org-independence 行为合同，避免默认把玩家推向依附。
+- `qa_engineer`
+  - 建立 mature-world small-player matrix，阻断 `world_activity_only` 误报。
+
+## 实施顺序
+1. `small-player-progression-contract-freeze`: 冻结专题并回挂根入口、主文档、索引、execution log。
+2. `runtime-small-player-lane-state-contract`: 下沉 lane state / checkpoint / recovery truth。
+3. `viewer-small-player-lane-surface-alignment`: 收口 headed Web/UI 与 pure API 承接 surface。
+4. `agent-small-player-specialization-contract`: 对齐专业化、恢复与 org-independence contract。
+5. `qa-small-player-progression-matrix`: 建立 mature-world 小玩家矩阵与 blocker 签名。
+
+## 验证口径
+- required:
+  - 文档互链与任务映射。
+  - lane、player leverage、recovery 与 limited-scope influence 边界可 grep、可对账。
+  - headed Web/UI 与 pure API 至少能表达当前小玩家 lane 的主语义。
+- full:
+  - mature-world playability 样本复核。
+  - `player leverage` / `world_activity_only` 抽样。
+  - failure -> repair/rebuild/pivot 代表性样本。
+
+## 风险
+- 如果只定义“更多工业”，而不定义区域性 usefulness，小玩家路线会退化成 grind。
+- 如果把局部影响力定义得太强，会抢占 mature-world 大组织路线并引发 claim drift。
+- 如果不把恢复路径写进合同，任何局部失败都会把玩家再次打回“要么退坑、要么依附”的旧结构。

--- a/doc/game/gameplay/gameplay-small-player-progression-lane-2026-05-17.prd.md
+++ b/doc/game/gameplay/gameplay-small-player-progression-lane-2026-05-17.prd.md
@@ -1,0 +1,151 @@
+# Gameplay 小玩家成长线与成熟世界承接（2026-05-17） PRD v0.1
+
+- 对应设计文档: `doc/game/gameplay/gameplay-small-player-progression-lane-2026-05-17.design.md`
+- 对应项目管理文档: `doc/game/gameplay/gameplay-small-player-progression-lane-2026-05-17.project.md`
+
+审计轮次: 1
+
+## 1. Executive Summary
+
+- Problem Statement: `PRD-GAME-007/011/012/014` 已经覆盖“首个 claim、首个持续能力、10 分钟 trust gate 与间接控制 agency”，但当前仓库还缺一份正式玩法合同来回答：当世界已经存在更强组织、既有治理和长期历史时，小玩家/新玩家在不立即投靠大组织的前提下，靠什么继续有独立价值。缺少这份合同，玩家很容易在完成首个工业里程碑后退化为旁观者、打工号，或只能把“大世界很活跃”误报成“我还有 meaningful participation”。
+- Proposed Solution: 新增 `PRD-GAME-015`，冻结一条正式 `small-player lane`：`PostOnboarding / first capability` 之后，玩家默认进入“`local operator -> regional specialist -> limited-scope regional influence`”承接线。该线复用现有 `slot-1` claim、starter funding、player leverage rubric 与 control-feeling 合同，把“受保护的首个工业胜利、小规模专业化、有限区域影响力、可恢复失败路径”写成可拆任务、可验收、可回归的玩法真值。
+- Success Criteria:
+  - SC-1: `game` 根 PRD / project、`gameplay` 主文档和新专题统一采用 `small-player lane` 口径，不再把“完成首个能力”直接等同于“必须马上加入大组织或进入深治理”。
+  - SC-2: 至少冻结 1 条可信的小玩家主线，明确 entry gate、阶段检查点、专业化分支、有限区域影响力和恢复路径。
+  - SC-3: `protected first industrial win` 被正式定义为“低爆炸半径、可恢复、可见 player leverage”的 first win，而不是“军事无敌新手保护泡泡”。
+  - SC-4: 后续 runtime / viewer / agent / QA 至少各有 1 条 follow-up task，可直接验证“玩家做了什么、世界因此改变了什么、下一步为何仍值得继续”。
+  - SC-5: 本专题显式保持当前 `internal_playable_alpha_late` 与 `limited playable technical preview` 边界，不把 `#165` 的专题冻结包装成阶段升级或 broader launch 结论。
+
+## 2. User Experience & Functionality
+
+- User Personas:
+  - 小玩家 / 新玩家：已经通过首次 onboarding 与首个持续能力，但仍只有 1 个小规模 claim 或有限资源，不想立即依附大组织也希望继续有独立价值。
+  - 回流玩家：中断后回到成熟世界，需要一条能重新站稳脚跟的恢复型小玩家路线，而不是只能读 raw log 猜当前局势。
+  - `producer_system_designer`: 需要把“小玩家在成熟世界中如何不沦为旁观者”冻结成正式玩法边界，而不是临时说明。
+  - `runtime_engineer`: 需要知道哪些状态、阶段和失败签名必须成为 canonical lane truth。
+  - `viewer_engineer`: 需要把“小玩家 lane 的主目标、首个胜利、专业化选择、区域影响与恢复路径”做成玩家可见 surface。
+  - `agent_engineer`: 需要对齐 agent 在成熟世界下的专业化偏好、恢复优先级和“别自动把玩家推去投靠大组织”的边界。
+  - `qa_engineer`: 需要一套矩阵去分辨“玩家真的产生了 leverage”与“世界只是继续在自己运转”。
+- User Scenarios & Frequency:
+  - 首个持续能力达成后：每个认真进入中循环的玩家至少 1 次。
+  - 成熟世界再进入：当世界已有强组织、区域分工和既有历史时，反复发生。
+  - 失败恢复：小玩家丢失产线、缺料、被竞争者挤压或 claim 失效时，多次发生。
+  - 专业化切换：从“先活下来”切到“区域性有用角色”时至少 1 次，后续可重复。
+- User Stories:
+  - PRD-GAME-015: As a 小玩家 / 新玩家, I want a meaningful progression lane that stays viable in a mature world without immediate alignment to major powers, so that I can keep building leverage after the first capability milestone.
+  - PRD-GAME-015A: As a `producer_system_designer`, I want `protected first win`, `regional usefulness`, and `recoverable failure` formalized, so that mature-world progression stops depending on implicit tribal knowledge.
+  - PRD-GAME-015B: As a `qa_engineer`, I want the lane to require explicit player-leverage evidence rather than ambient world activity, so that “the world is busy” cannot be misreported as “the player still has agency”.
+- Critical User Flows:
+  1. Flow-SPL-001: `玩家完成 PostOnboarding / first capability -> 系统确认 slot-1 claim / starter funding / current lane entry gate -> 正式转入 small-player lane`
+  2. Flow-SPL-002: `系统展示默认 local operator 主线 -> 玩家完成一个受保护的首个工业胜利 -> surface 明确回答 player_action / world_change_due_to_player / next_step`
+  3. Flow-SPL-003: `玩家从默认主线进入 1 条短周期专业化分支 -> 持续贡献一个区域性可见价值，而不是直接进入全球治理或大规模战争`
+  4. Flow-SPL-004: `玩家遭遇缺料、停机、claim 丢失或局势挤压 -> 系统提供恢复路径或低成本改道 -> 不要求立即依附 major power 才能继续`
+  5. Flow-SPL-005: `玩家累计区域性 player leverage -> 获得 limited-scope regional influence -> 再决定保持独立专业化、局部合作，或自愿进入更大组织/更深治理`
+- Functional Specification Matrix:
+
+| 功能点 | 字段定义 | 按钮/动作行为 | 状态转换 | 排序/计算规则 | 权限逻辑 |
+| --- | --- | --- | --- | --- | --- |
+| small-player lane contract | `lane_id`、`entry_gate`、`requires_major_power_alignment`、`first_win_definition`、`mature_world_value_definition` | 不要求立即加入组织；系统在达成 `first capability` 后显式进入 lane | `not_eligible -> eligible -> active -> specialized -> regionally_useful` | 先完成首个持续能力，再进入小玩家 lane；不得把 onboarding 与 mature-world lane 混写 | `producer_system_designer` 冻结；runtime/viewer/agent/QA 依合同实施 |
+| protected first industrial win | `first_win_goal_id`、`player_action`、`world_change_due_to_player`、`player_leverage_verdict`、`blast_radius_class`、`recovery_cost_class` | 玩家完成 1 次低爆炸半径、可恢复、对世界有可见变化的工业胜利 | `not_started -> executing -> first_win_complete -> stabilized` | “受保护”优先指低战略体量、低爆炸半径和可恢复路径，不等于 PVP/治理免疫 | 任何正式放行结论都必须回答 leverage，而不是 world activity |
+| specialization pack | `specialization_id`、`input_profile`、`output_profile`、`regional_usefulness`、`switch_cost_class`、`org_independence_level` | 玩家从默认 local operator 主线切到 1 条短周期专业化角色 | `unselected -> selected -> delivering -> stable` | 先 local survival，再 specialization；默认避免一开始把玩家导向深治理/大战争 | `agent_engineer` / `viewer_engineer` 对齐；`producer_system_designer` 裁决专业化边界 |
+| limited-scope regional influence | `influence_surface_id`、`influence_scope`、`influence_cap`、`expires_on_inactivity`、`converts_to_global_governance` | 玩家通过区域性持续贡献获得有限影响力或优先级 | `locked -> visible -> earned -> decays_on_inactivity` | 区域影响力必须小于 global governance / alliance leadership；默认随停摆或长期闲置衰减 | 不得直接等价为 global vote power、主链治理权或 major-power membership |
+| recovery path | `failure_signature`、`recovery_option_id`、`restoration_scope`、`fallback_specialization_id`、`requires_major_power_sponsorship` | 玩家遭遇 claim/产线/区域性挤压失败时，系统给出恢复或改道选项 | `healthy -> disrupted -> recoverable -> restored/pivoted` | 优先提供低成本修复、局部重建或改道；默认不要求先加入大组织 | `requires_major_power_sponsorship` 默认应为 `no`；只有更高阶路线才允许提升依赖 |
+| mature-world guardrails | `world_activity_only`、`major_power_dependency_status`、`regional_pressure_level`、`return_hook` | QA / playability surface 明确区分“世界很活跃”和“玩家仍然有 lane” | `unclear -> bounded -> verified` | 只要 `world_activity_only=yes` 或 `major_power_dependency_status=forced`，该样本就不能支撑 lane `pass` | `qa_engineer` 守门，`producer_system_designer` 最终裁决 |
+
+- Acceptance Criteria:
+  - AC-1: 本专题至少定义 1 条正式 `small-player lane`，且该 lane 的 entry gate 明确发生在 `PostOnboarding / first capability` 之后，而不是回退到 onboarding。
+  - AC-2: 该 lane 明确写出 `protected first industrial win` 的定义，并说明“保护”指低爆炸半径、可恢复和 player leverage 可见，不指永久免战或特殊政治豁免。
+  - AC-3: 玩家可以在不立即加入 major power 的前提下完成 1 次 meaningful outcome；文档必须明确该 outcome 的世界变化、下一步和区域性价值。
+  - AC-4: 本专题至少定义 1 条默认主线与 2 条可延展 specialization 方向，并说明它们为何在 mature world 中仍有独立价值。
+  - AC-5: 文档必须明确 `limited-scope regional influence` 的边界：它可以改变局部优先级、区域可见度或区域性机会，但不能直接等价为 global governance 权力。
+  - AC-6: 文档必须定义 recoverable failure path；当玩家遭遇停机、claim 丢失、局部竞争失败或区域压力时，不得要求“只能投靠大组织”作为唯一继续路径。
+  - AC-7: `player leverage != world activity` 的约束必须进入本专题完成定义；任何 lane `pass` 都必须回答 `player_action / world_change_due_to_player / return_hook`。
+  - AC-8: 本专题必须显式声明不改变当前 `PRD-GAME-012` 的 early-retention 主优先级，也不把 `#165` 写成当前 stage 或 preview claim envelope 的升级依据。
+  - AC-9: `game` 根 PRD / project、`gameplay` 主文档、`README`、`prd.index` 与当前 task execution log 必须能互链到 `PRD-GAME-015`。
+  - AC-10: 至少拆出 `producer_system_designer`、`runtime_engineer`、`viewer_engineer`、`agent_engineer`、`qa_engineer` 五类后续任务，并给出 `test_tier_required` / `test_tier_full` 验收方向。
+- Non-Goals:
+  - 不在本专题里把小玩家路线直接升级为全球治理路线、联盟领袖路线或大战争主线。
+  - 不在本专题里承诺新的免费 claim、额外 unrestricted token 补贴或新的 economic bypass。
+  - 不把“受保护 first win”写成永久新手护盾、战斗无敌或不可被干预的独占区。
+  - 不把 `#165` 当作当前 `limited playable technical preview` 的放大器；它只定义玩法承接，不替代外部真实信号。
+
+## 3. AI System Requirements (If Applicable)
+
+- Tool Requirements:
+  - `PostOnboarding` / `player_gameplay` canonical snapshot。
+  - `player leverage` / `world_activity_only` 证据字段与 playability card。
+  - limited preview / trust gate / capability gate 的现有 formal evidence。
+- Evaluation Strategy:
+  - 以 `player leverage`、`return_hook`、`major_power_dependency_status` 与 `recoverable failure` 四条线评估，而不是只看“世界是否还在活跃”或“玩家是否已经看到很多系统”。
+
+## 4. Technical Specifications
+
+- Architecture Overview:
+  - `PRD-GAME-015` 建立在现有 `PRD-GAME-007` `PostOnboarding` 阶段承接、`PRD-GAME-011` `slot-1` claim / starter funding、`PRD-GAME-012` trust/capability gate、`PRD-GAME-014` control-feeling 合同之上。
+  - runtime 负责把 lane entry / checkpoint / failure signature / recovery path 下沉为 canonical truth。
+  - viewer / pure API 负责把“你当前属于哪条小玩家 lane、刚刚赢了什么、为什么仍然值得继续”做成显式 surface。
+  - agent contract 负责把 specialization / recovery 偏好写进可解释行动面，而不是默认把玩家推向 major-power dependency。
+  - QA / playability evidence 负责阻断 `world_activity_only` 误报，并确认这条 lane 在 mature world 中仍成立。
+- Integration Points:
+  - `doc/game/prd.md`
+  - `doc/game/project.md`
+  - `doc/game/prd.index.md`
+  - `doc/game/README.md`
+  - `doc/game/gameplay/gameplay-top-level-design.prd.md`
+  - `doc/game/gameplay/gameplay-top-level-design.project.md`
+  - `doc/game/gameplay/gameplay-post-onboarding-stage-2026-03-18.prd.md`
+  - `doc/game/gameplay/gameplay-agent-claim-token-cost-2026-03-27.prd.md`
+  - `doc/game/gameplay/gameplay-ten-minute-retention-recovery-2026-04-09.prd.md`
+  - `doc/game/gameplay/gameplay-indirect-control-feeling-contract-2026-05-14.prd.md`
+  - `doc/playability_test_result/prd.md`
+  - `testing-manual.md`
+- Edge Cases & Error Handling:
+  - 区域内已有大型组织垄断：lane 仍需给出局部独立价值和恢复路径，而不是默认判定“新玩家只能加入他们”。
+  - 玩家完成 first capability，但 local site 因缺料/停机/战乱无法继续：必须提供恢复或改道选项，不能让 lane 直接失效。
+  - 世界很活跃，但玩家没有造成明确世界变化：必须标记 `world_activity_only=yes`，且不得把该样本判为 lane success。
+  - 玩家主动加入大型组织：允许，但文档必须说明这属于 voluntary escalation，而不是 lane 的强制前提。
+  - 玩家失去首个 claim 或 starter industrial node：必须至少保留一条小规模 rebuild / pivot path，而不是把失败等同于“重新开号”。
+  - 区域性影响力被误写成 global governance：判定为 scope drift，必须回退。
+- Non-Functional Requirements:
+  - NFR-SPL-1: `PRD-GAME-015` 的根入口互链必须在 1 个工作日内完成并可 grep。
+  - NFR-SPL-2: 任一正式 small-player lane 样本 100% 必须明确 `player_action`、`world_change_due_to_player`、`return_hook` 与 `world_activity_only`，不得只给“世界有变化”。
+  - NFR-SPL-3: 任一正式 lane 不得把“立即加入 major power”作为唯一 entry requirement；若出现该依赖，默认判定为 lane contract 失败。
+  - NFR-SPL-4: `limited-scope regional influence` 100% 必须与 global governance / alliance leadership 分开定义，不得偷渡成更强权力口径。
+  - NFR-SPL-5: 本专题不得改写当前 `limited playable technical preview` claim envelope，也不得用来替代 `PRD-GAME-012` 的 trust/capability 样本。
+- Security & Privacy:
+  - 本专题不新增额外账号权限或经济旁路；仍遵循现有 claim / restricted starter / governance 审计边界。
+
+## 5. Risks & Roadmap
+
+- Phased Rollout:
+  - R0: 冻结 `PRD-GAME-015`，完成根入口、主文档、索引与 task 映射挂载。
+  - R1: runtime 定义 small-player lane 的 checkpoint / failure / recovery canonical truth。
+  - R2: viewer / pure API 收口 lane surface，让玩家看懂当前主线、首个胜利、专业化与恢复路径。
+  - R3: agent 对齐 specialization / recovery / org-independence contract。
+  - R4: QA 建立 mature-world small-player matrix，并与 `player leverage` rubric 联动。
+- Technical Risks:
+  - 风险-1: 如果 lane 只剩“再做更多工业”，而没有区域性价值与恢复路径，会退化成重复 grind。
+  - 风险-2: 如果 lane 一开始就给出过强区域/治理权力，会与 mature-world 大组织路线互相冲突，放大平衡风险。
+  - 风险-3: 如果 lane 只在文档里存在、没有 canonical checkpoint 和 player leverage surface，后续仍会回到“世界很热闹但我不确定自己有用”的旧问题。
+
+## 6. Validation & Decision Record
+
+- Test Plan & Traceability:
+
+| PRD-ID | 对应任务 | 测试层级 | 验证方法 | 回归影响范围 |
+| --- | --- | --- | --- | --- |
+| PRD-GAME-015 | `small-player-progression-contract-freeze` | `test_tier_required` | 文档治理检查、根入口/主文档/索引/execution log 互链核验 | mature-world 小玩家路线合同冻结 |
+| PRD-GAME-015 | `runtime-small-player-lane-state-contract` | `test_tier_required` | canonical lane state / checkpoint / failure / recovery truth 对账与定向测试 | runtime / `player_gameplay` 语义承接 |
+| PRD-GAME-015 | `viewer-small-player-lane-surface-alignment` | `test_tier_required` | headed Web/UI 与 pure API surface 复核，确认 lane、首个胜利、区域价值与恢复路径可读 | 玩家可见承接、return hook 与多端一致性 |
+| PRD-GAME-015 | `agent-small-player-specialization-contract` | `test_tier_required` | specialization / recovery / org-independence contract 对账，确认 agent 不默认把玩家推向强依附 | agent 行为边界、间接控制下的专业化表达 |
+| PRD-GAME-015 | `qa-small-player-progression-matrix` | `test_tier_required` + `test_tier_full` | player leverage rubric、mature-world small-player 样本、failure/recovery blocker 签名与 lane verdict 归档 | 玩法承接、mature-world 有效性与误报阻断 |
+
+- Decision Log:
+
+| 决策ID | 选定方案 | 备选方案（否决） | 依据 |
+| --- | --- | --- | --- |
+| DEC-SPL-001 | 新增独立 `PRD-GAME-015`，专门定义 mature-world 小玩家成长线 | 继续把“小玩家如何继续玩”散落在 PostOnboarding、claim economy、playability evidence 与 issue 讨论中 | 当前缺的不是“首个能力能否完成”，而是“完成之后为何仍有独立价值”的正式合同。 |
+| DEC-SPL-002 | 把 `small-player lane` 起点放在 `first capability` 之后，而不是重新塞回首个 10 分钟 | 让 issue #165 与当前 early-retention 冲刺混成一个问题 | `PRD-GAME-012` 当前仍是主 blocker；如果把 mature-world 设计提前塞进 first-session，会打乱当前冲刺排序。 |
+| DEC-SPL-003 | 把 `protected first industrial win` 定义为“低爆炸半径 + 可恢复 + leverage 可见” | 把“保护”写成 PVP/政治完全免疫，或继续不定义保护含义 | 完全免疫会制造失真预期；不定义又会让“首个胜利”在成熟世界里没有真实站得住脚的边界。 |
+| DEC-SPL-004 | 采用“limited-scope regional influence”，明确低于 global governance / alliance leadership | 让小玩家 first-success 直接跳到全局治理权，或反过来完全不给任何区域性影响 | 没有局部影响力，这条线会像重复打工；给太强又会破坏 mature-world 权力结构。 |
+| DEC-SPL-005 | 把 `player leverage != world activity` 写成本专题硬门槛 | 继续允许“世界很活跃”替代“玩家仍然有 meaningful participation” | `#165` 真正要解决的是小玩家是否还在推动世界，而不是世界是否本来就有很多事在发生。 |

--- a/doc/game/gameplay/gameplay-small-player-progression-lane-2026-05-17.project.md
+++ b/doc/game/gameplay/gameplay-small-player-progression-lane-2026-05-17.project.md
@@ -1,0 +1,102 @@
+# Gameplay 小玩家成长线与成熟世界承接（项目管理文档）
+
+- 对应设计文档: `doc/game/gameplay/gameplay-small-player-progression-lane-2026-05-17.design.md`
+- 对应需求文档: `doc/game/gameplay/gameplay-small-player-progression-lane-2026-05-17.prd.md`
+
+审计轮次: 1
+
+## 任务拆解
+
+- [x] small-player-progression-contract-freeze (PRD-GAME-015) [test_tier_required]: `producer_system_designer` 已新增“小玩家成长线与成熟世界承接”专题 PRD / design / project，并完成 `game` 根 PRD / project、`gameplay-top-level-design` 主文档、索引与当前 task execution log 挂载；正式冻结 `local operator -> regional specialist -> limited-scope regional influence` 这条 mature-world 小玩家主线，明确 `protected first industrial win` 指低爆炸半径、可恢复与 leverage 可见，而不是新手无敌保护。 Trace: .pm/tasks/task_d97dfa29208444a9b6a652f2a12fb65d.yaml
+
+## 后续待建任务
+
+| topic slug | owner role | status | 目标 |
+| --- | --- | --- | --- |
+| `runtime-small-player-lane-state-contract` | `runtime_engineer` | `planned` | 把 small-player lane 的 entry gate、checkpoint、failure signature 与 repair/rebuild/pivot recovery 下沉到 canonical truth。 |
+| `viewer-small-player-lane-surface-alignment` | `viewer_engineer` | `planned` | 在 headed Web/UI 与 pure API 明确展示当前 lane、首个胜利、专业化价值、区域影响与恢复路径。 |
+| `agent-small-player-specialization-contract` | `agent_engineer` | `planned` | 对齐 specialization / recovery / org-independence 行为合同，避免默认把玩家推向 major-power dependency。 |
+| `qa-small-player-progression-matrix` | `qa_engineer` | `planned` | 建立 mature-world 小玩家矩阵，用 `player leverage` / `world_activity_only` 与 recovery blocker 审核 lane 是否真的成立。 |
+
+## 任务建议标题（给后续 owner 直接开 task 用）
+
+| topic slug | owner role | 建议标题 |
+| --- | --- | --- |
+| `small-player-progression-contract-freeze` | `producer_system_designer` | Freeze meaningful small-player progression lane in mature world states |
+| `runtime-small-player-lane-state-contract` | `runtime_engineer` | Define canonical lane state and recovery contract for mature-world small players |
+| `viewer-small-player-lane-surface-alignment` | `viewer_engineer` | Make the small-player lane explicit in headed Web and pure API surfaces |
+| `agent-small-player-specialization-contract` | `agent_engineer` | Align specialization and recovery behavior with the small-player lane contract |
+| `qa-small-player-progression-matrix` | `qa_engineer` | Build mature-world small-player progression matrix and blocker signatures |
+
+## Handoff Matrix
+
+| topic slug | 发起角色 | 接收角色 | 输入 | 期望输出 |
+| --- | --- | --- | --- | --- |
+| `runtime-small-player-lane-state-contract` | `producer_system_designer` | `runtime_engineer` | `PRD-GAME-015` lane / first-win / recovery / influence 边界、`PostOnboarding` 与 claim canonical truth | canonical lane state、checkpoint 与 recovery truth |
+| `viewer-small-player-lane-surface-alignment` | `producer_system_designer` | `viewer_engineer` | lane 阶段语义、player leverage rubric、现有首屏/续玩 surface | 玩家可见的 lane / first win / next-step / recovery surface |
+| `agent-small-player-specialization-contract` | `producer_system_designer` | `agent_engineer` | specialization 候选、recovery 语义、org-independence 边界 | agent specialization / recovery / escalation contract 对账 |
+| `qa-small-player-progression-matrix` | `producer_system_designer` | `qa_engineer` | runtime/viewer/agent 对账产物、`player leverage` rubric、mature-world 样本入口 | small-player matrix、pass/block 结论与 blocker 签名 |
+
+## 验收命令（草案）
+
+- `small-player-progression-contract-freeze` / 文档冻结与挂载
+  - `rg -n "PRD-GAME-015|small-player|new-player|regional influence|world_activity_only|player leverage" doc/game/prd.md doc/game/project.md doc/game/README.md doc/game/prd.index.md doc/game/gameplay/gameplay-top-level-design.prd.md doc/game/gameplay/gameplay-top-level-design.project.md doc/game/gameplay/gameplay-small-player-progression-lane-2026-05-17.prd.md doc/game/gameplay/gameplay-small-player-progression-lane-2026-05-17.project.md .pm/tasks/task_d97dfa29208444a9b6a652f2a12fb65d.execution.md`
+  - `./scripts/doc-governance-check.sh`
+  - `git diff --check`
+- `runtime-small-player-lane-state-contract` / runtime lane truth
+  - `rg -n "player_gameplay|goal|progress|blocker|recovery|claim|regional|specialization" crates/oasis7/src/viewer/runtime_live crates/oasis7/src`
+  - 定向 runtime / snapshot 测试与 canonical 字段对账
+- `viewer-small-player-lane-surface-alignment` / 玩家 surface
+  - `rg -n "claim|goal|next step|recovery|regional|specialization|player leverage" crates/oasis7_viewer crates/oasis7/src/bin/oasis7_pure_api_client.rs`
+  - headed Web/UI 与 pure API 人工复核
+- `agent-small-player-specialization-contract` / agent contract
+  - `rg -n "specialization|recovery|override|reprioritize|claim|regional" doc/world-simulator/llm crates/oasis7/src/simulator`
+  - `git diff --check`
+- `qa-small-player-progression-matrix` / QA matrix
+  - `player leverage` / `world_activity_only` 抽样
+  - mature-world small-player 样本复核
+  - 输出 pass/block 与 blocker 签名
+
+## Done Definition
+
+- `small-player-progression-contract-freeze`
+  - [x] 新专题 PRD / design / project 已创建并回挂到 `game` 根入口、`gameplay` 主文档、索引与 task execution log
+  - [x] 已冻结至少 1 条 mature-world 小玩家主线
+  - [x] 已定义 `protected first industrial win`、limited-scope regional influence 与 recoverable failure
+  - [x] 已拆出 runtime / viewer / agent / QA follow-up 任务
+- `runtime-small-player-lane-state-contract`
+  - [ ] lane entry / checkpoint / failure / recovery truth 已落成 canonical surface
+  - [ ] major-power dependency 不再是默认隐性前提
+- `viewer-small-player-lane-surface-alignment`
+  - [ ] 玩家能读懂当前 lane、首个胜利、局部价值与恢复路径
+  - [ ] headed Web/UI 与 pure API 的承接 surface 保持同等级语义
+- `agent-small-player-specialization-contract`
+  - [ ] specialization / recovery / org-independence contract 已对齐
+  - [ ] agent 不再静默把小玩家推向依附 major power
+- `qa-small-player-progression-matrix`
+  - [ ] `player leverage != world activity` 的 blocker 签名已固化
+  - [ ] mature-world 小玩家矩阵已建立并给出 pass/block 结论
+
+## 依赖
+
+- `doc/game/prd.md`
+- `doc/game/project.md`
+- `doc/game/README.md`
+- `doc/game/prd.index.md`
+- `doc/game/gameplay/gameplay-top-level-design.prd.md`
+- `doc/game/gameplay/gameplay-post-onboarding-stage-2026-03-18.prd.md`
+- `doc/game/gameplay/gameplay-agent-claim-token-cost-2026-03-27.prd.md`
+- `doc/game/gameplay/gameplay-ten-minute-retention-recovery-2026-04-09.prd.md`
+- `doc/game/gameplay/gameplay-indirect-control-feeling-contract-2026-05-14.prd.md`
+- `doc/playability_test_result/prd.md`
+- `testing-manual.md`
+
+## 状态
+
+- 更新日期: 2026-05-17
+- 当前状态: in_progress
+- 当前 owner: `producer_system_designer`
+- 下一任务: `runtime-small-player-lane-state-contract`
+- 说明:
+  - 本专题当前只完成合同冻结，不等于 runtime / viewer / agent / QA 已全部落地。
+  - 本专题不改写当前 `PRD-GAME-012` 的 early-retention 主优先级，也不把 `#165` 当作 stage / preview claim envelope 升级依据。

--- a/doc/game/gameplay/gameplay-top-level-design.prd.md
+++ b/doc/game/gameplay/gameplay-top-level-design.prd.md
@@ -238,6 +238,32 @@
 
 oasis7 的世界不是无尺度表格。
 
+## 2.9 成熟世界中的小玩家成长线
+
+在 `PostOnboarding` 与首个持续能力之后，产品还必须回答另一件事：当世界已经存在更强组织、更深政治和更长历史时，小玩家/新玩家为什么还值得继续玩。
+
+当前答案不应是“立刻加入大组织”，也不应只是“世界本来就很热闹”。正式路线应当至少提供 1 条不依赖立即站队的 `small-player lane`，让玩家能在成熟世界里继续形成独立 leverage。
+
+当前冻结的默认主线是：
+
+1. `local operator`：先稳住 1 条小规模工业或服务能力，完成 1 次对世界有可见后果的胜利。
+2. `regional specialist`：再把这条能力转成短周期、区域性有用的专业化角色，而不是马上跳到全局治理或大战争。
+3. `limited-scope regional influence`：通过持续贡献获得局部优先级、局部机会或局部可见度，但不直接等价为 global governance 权力。
+
+这里所谓 `protected first industrial win`，保护的不是“不会被碰”，而是：
+
+- 早期 footprint 小，不应一开始就与 major-power 主战略面重叠。
+- 失败后存在 repair / rebuild / pivot 路径，不会立刻把玩家打回“只能投靠别人或只能退坑”。
+- 玩家必须能明确回答“我做了什么、世界因此变了什么、下一步为什么仍值得继续”，而不是只看到世界自己在运转。
+
+这条线与当前 `PRD-GAME-012` 的 early-retention 冲刺边界保持分离：
+
+- 当前 trust gate / first capability gate 仍是最近两周主优先级。
+- `#165` 解决的是“首个持续能力之后如何继续有独立价值”，不是重新改写首个 10 分钟。
+- 只有当成熟世界下的小玩家样本能持续给出 `player leverage != world activity only` 的证据时，这条线才算正式成立。
+
+专题口径见 `doc/game/gameplay/gameplay-small-player-progression-lane-2026-05-17.prd.md`。
+
 当前正式口径必须同时成立两件事：
 
 1. 世界物理真值有尺度，而且当前 canonical 空间坐标、距离与尺寸继续以厘米整数合同落地。

--- a/doc/game/gameplay/gameplay-top-level-design.project.md
+++ b/doc/game/gameplay/gameplay-top-level-design.project.md
@@ -80,6 +80,10 @@
 - [x] runtime-control-feeling-canonical-contract (PRD-GAME-014) [test_tier_required]: `runtime_engineer` 已把 `player_gameplay` canonical snapshot 与 recent-feedback 真值对齐到 control-feeling 合同，正式补齐 accepted intent、intent scope/target、status reason、last world change、resume anchor、primary blocker 与 resume-next-step 字段，并让 `prompt_control` / `agent_chat` / `gameplay_action` / world-control 共享同一 runtime 语义面。 Trace: .pm/tasks/task_f3c25dd6688f40fbbcf05df9036a83ec.yaml
 - 后续待建任务统一收口在 `doc/game/gameplay/gameplay-indirect-control-feeling-contract-2026-05-14.project.md`，避免在 gameplay 主入口重复展开未绑定 Trace 的计划行。
 
+### T11 小玩家成长线与成熟世界承接（2026-05-17）
+- [x] small-player-progression-contract-freeze (PRD-GAME-015) [test_tier_required]: `producer_system_designer` 已新增 `PRD-GAME-015` 专题 PRD / design / project，并完成根入口、`gameplay` 主文档、索引与 execution log 挂载；正式冻结 mature-world 小玩家默认主线 `local operator -> regional specialist -> limited-scope regional influence`，明确 `protected first industrial win` 指低爆炸半径、可恢复和 leverage 可见，而不是新手无敌豁免。 Trace: .pm/tasks/task_d97dfa29208444a9b6a652f2a12fb65d.yaml
+- 后续待建任务统一收口在 `doc/game/gameplay/gameplay-small-player-progression-lane-2026-05-17.project.md`，避免在 gameplay 主入口重复展开未绑定 Trace 的计划行。
+
 ## 依赖
 
 - 运行时与模块治理基线：`doc/world-runtime/prd.md`
@@ -100,7 +104,7 @@
 ## 状态
 
 - 当前状态：`进行中`
-- 已完成：文档归位、命名语义化、必备字段补齐、工程分册格式修复、Gameplay Runtime/模块化/协议扩展任务拆解与落地、Gameplay 模块测试矩阵引用固化、设计评审准备与战争/政治数值基线补齐、前期工业引导闭环文档冻结（首个制成品/工厂主链）、T4 的 runtime 工业状态/事件与 viewer 主反馈闭环、T5 的 `PostOnboarding` 阶段目标链闭环、T6 的纯 API 客户端等价闭环、T7 的封闭 Beta 准入专题冻结与根入口挂载。
+- 已完成：文档归位、命名语义化、必备字段补齐、工程分册格式修复、Gameplay Runtime/模块化/协议扩展任务拆解与落地、Gameplay 模块测试矩阵引用固化、设计评审准备与战争/政治数值基线补齐、前期工业引导闭环文档冻结（首个制成品/工厂主链）、T4 的 runtime 工业状态/事件与 viewer 主反馈闭环、T5 的 `PostOnboarding` 阶段目标链闭环、T6 的纯 API 客户端等价闭环、T7 的封闭 Beta 准入专题冻结与根入口挂载、T11 的 mature-world 小玩家成长线合同冻结。
 - 未完成：当前无 `T7` 技术阻塞；后续仅保留统一 gate、trend baseline 与 liveops 节奏的持续监控。
 - 阻塞项：无统一 gate 技术阻塞；当前继续保持 `internal_playable_alpha_late` 属于 producer claim 决策，不得据此宣称 `closed beta approved`。
 

--- a/doc/game/prd.index.md
+++ b/doc/game/prd.index.md
@@ -1,7 +1,7 @@
 # game PRD 文件级索引
 审计轮次: 12
 
-更新时间：2026-05-07
+更新时间：2026-05-17
 
 ## 入口
 - 模块 PRD：`doc/game/prd.md`
@@ -15,21 +15,22 @@
 - 想先理解核心玩法骨架，而不是逐篇翻 gameplay 长表：先读 `doc/game/gameplay/gameplay-top-level-design.prd.md`
 - 想先看当前冲刺窗口与留存修复：先读 `doc/game/gameplay/gameplay-ten-minute-retention-recovery-2026-04-09.prd.md`
 - 想先看“间接控制为什么仍然要让玩家感觉自己在控制”：先读 `doc/game/gameplay/gameplay-indirect-control-feeling-contract-2026-05-14.prd.md`
+- 想先看“成熟世界里小玩家为什么不必立刻依附 major power，仍能继续形成 leverage”：先读 `doc/game/gameplay/gameplay-small-player-progression-lane-2026-05-17.prd.md`
 - 想先回答“1cm 物理世界”和“当前为什么不是 Minecraft 式逐块玩法”之间的边界：先读 `doc/game/gameplay/gameplay-physical-scale-indirect-control-2026-05-07.prd.md`
 - 想先看试玩放行与 beta 边界：先读 `doc/game/gameplay/gameplay-limited-preview-execution-2026-03-22.prd.md` 与 `doc/game/gameplay/gameplay-closed-beta-readiness-2026-03-21.prd.md`
 - 想继续按文件名、专题或补充材料下钻：使用下方密度快照、热点子域导航与补充入口
 
-## 密度快照（2026-05-07）
-- `doc/game/`：80 份文件
-- `doc/game/gameplay/`：75 份文件
-- `doc/game/gameplay/` 正式专题三件套：57 份文件
+## 密度快照（2026-05-17）
+- `doc/game/`：87 份文件
+- `doc/game/gameplay/`：82 份文件
+- `doc/game/gameplay/` 正式专题三件套：63 份文件
 - `doc/game/gameplay/` 补充材料：18 份文件
 - 模块根入口：5 份文件
 
 ## 热点子域导航
 | 子域 | 文件数 | 适合回答的问题 |
 | --- | --- | --- |
-| `gameplay/` 正式专题三件套 | 54 | 核心玩法骨架、留存修复、preview/beta gate、claim economy、治理、长稳与发布闭环 |
+| `gameplay/` 正式专题三件套 | 63 | 核心玩法骨架、留存修复、preview/beta gate、claim economy、治理、agency 合同与 mature-world 小玩家承接 |
 | `gameplay/` 补充材料 | 18 | runbook、evidence、checklist、handoff 与跨角色执行留痕 |
 | 模块根入口 | 5 | 模块目标态、执行台账、设计总览与文件级精确检索 |
 
@@ -37,6 +38,7 @@
 - `doc/game/gameplay/gameplay-top-level-design.prd.md`：核心玩法骨架主入口。
 - `doc/game/gameplay/gameplay-ten-minute-retention-recovery-2026-04-09.prd.md`：当前冲刺窗口、跨角色优先级与 10 分钟留存修复主入口。
 - `doc/game/gameplay/gameplay-indirect-control-feeling-contract-2026-05-14.prd.md`：间接控制下的 accepted intent、主因果、打断重排与续玩恢复合同主入口。
+- `doc/game/gameplay/gameplay-small-player-progression-lane-2026-05-17.prd.md`：mature-world 小玩家承接、受保护 first win、专业化与局部影响力主入口。
 - `doc/game/gameplay/gameplay-physical-scale-indirect-control-2026-05-07.prd.md`：物理尺度真值、间接控制动作粒度与表现层夸张边界主入口。
 - `doc/game/gameplay/gameplay-limited-preview-execution-2026-03-22.prd.md`：试玩执行边界与继续/暂停决策主入口。
 - `doc/game/gameplay/gameplay-closed-beta-readiness-2026-03-21.prd.md`：closed beta 放行条件与候选级门禁主入口。
@@ -75,6 +77,7 @@
 | `doc/game/gameplay/gameplay-release-gap-closure-2026-02-21.prd.md` | `doc/game/gameplay/gameplay-release-gap-closure-2026-02-21.design.md` | `doc/game/gameplay/gameplay-release-gap-closure-2026-02-21.project.md` |
 | `doc/game/gameplay/gameplay-release-production-closure.prd.md` | `doc/game/gameplay/gameplay-release-production-closure.design.md` | `doc/game/gameplay/gameplay-release-production-closure.project.md` |
 | `doc/game/gameplay/gameplay-runtime-governance-closure.prd.md` | `doc/game/gameplay/gameplay-runtime-governance-closure.design.md` | `doc/game/gameplay/gameplay-runtime-governance-closure.project.md` |
+| `doc/game/gameplay/gameplay-small-player-progression-lane-2026-05-17.prd.md` | `doc/game/gameplay/gameplay-small-player-progression-lane-2026-05-17.design.md` | `doc/game/gameplay/gameplay-small-player-progression-lane-2026-05-17.project.md` |
 | `doc/game/gameplay/gameplay-top-level-design.prd.md` | `doc/game/gameplay/gameplay-top-level-design.design.md` | `doc/game/gameplay/gameplay-top-level-design.project.md` |
 | `doc/game/gameplay/gameplay-ten-minute-retention-recovery-2026-04-09.prd.md` | `doc/game/gameplay/gameplay-ten-minute-retention-recovery-2026-04-09.design.md` | `doc/game/gameplay/gameplay-ten-minute-retention-recovery-2026-04-09.project.md` |
 

--- a/doc/game/prd.md
+++ b/doc/game/prd.md
@@ -70,6 +70,7 @@
   - PRD-GAME-012: As a 中循环玩家与制作人 owner, I want a stable 10-minute trust loop after onboarding plus a separate first-capability proof gate, so that the game first feels trustworthy and then proves sustained playability without conflating those two verdicts.
   - PRD-GAME-013: As a 制作人与玩法 owner, I want gameplay docs to distinguish physical-world scale from player interaction scale, so that oasis7 keeps a real metric world without accidentally promising Minecraft-style direct block play before the product is ready.
   - PRD-GAME-014: As a 玩家, I want indirect agent gameplay to preserve a concrete sense of control, so that I feel I am directing outcomes rather than merely observing an autonomous simulation.
+  - PRD-GAME-015: As a 小玩家 / 新玩家, I want a meaningful progression lane that remains viable in mature world states without immediate alignment to major powers, so that I can keep building leverage after the first capability milestone.
 - 模式分层说明：按 `PRD-CORE-009`，`PRD-GAME-008` 所承接的是玩家访问模式 `pure_api`，而不是 provider-backed `headless_agent` 一类 execution lane。
 - 正式游玩前置：按最新 `PRD-CORE-009` 口径，`PRD-GAME-008` 的 `pure_api` 正式游玩与 headed Web/UI 一样，要求 active LLM access；`--no-llm` 仅保留 observer/debug，不再计入正式可玩性与 parity 放行。
 - Critical User Flows:
@@ -83,6 +84,7 @@
   8. Flow-GAME-008: `制作人冻结当前阶段 -> runtime/viewer/QA/liveops 汇总统一 release gate -> 若任一关键门禁失败则维持 internal_playable_alpha_late -> 全部通过后才允许升级 closed_beta_candidate 口径`
   9. Flow-GAME-009: `制作人冻结 limited preview 执行边界 -> liveops 发起受控 callout -> QA 持续守门并吸收真实信号 -> 制作人决定 continue / hold / reassess`
   10. Flow-GAME-010: `玩家查看未认领 agent 的 canonical 报价 -> 系统按 slot 计算可用的 restricted/liquid funding source -> 支付 activation fee 并锁定 bond -> 进入 upkeep 结算周期 -> 在 release / delinquent reclaim / idle reclaim 中结束 claim`
+  11. Flow-GAME-011: `玩家完成 first capability -> 进入 mature-world small-player lane -> 完成 1 次受保护的首个工业胜利 -> 选择局部专业化 -> 获得 limited-scope regional influence 或恢复路径 -> 再决定继续独立、局部合作或自愿进入更大组织`
 - Functional Specification Matrix:
 | 功能点 | 字段定义 | 按钮/动作行为 | 状态转换 | 排序/计算规则 | 权限逻辑 |
 | --- | --- | --- | --- | --- | --- |
@@ -96,6 +98,7 @@
 | 阶段准入门禁 | `current_stage`、`candidate_stage`、`claim_envelope`、`trend_status`、`gate_lane_status` | 汇总 headed Web/UI、pure API、no-UI、longrun/recovery 与 liveops 口径，输出升阶或维持原阶段结论 | `internal_playable_alpha -> internal_playable_alpha_late -> closed_beta_candidate -> closed_beta` | 先统一 gate，再允许升级对外口径；任一关键 lane 阻断即整体阻断 | `producer_system_designer` 最终拍板；`qa_engineer` 可独立给阻断建议 |
 | 受控 limited preview 执行 | `preview_round_status`、`callout_id`、`signal_quality`、`claim_drift_status`、`qa_recommendation` | 发起 controlled builder-facing 预览、归档真实信号、持续校验 gate、输出 continue/hold/reassess 结论 | `ready_to_run -> running -> reviewed -> continue/hold/reassess` | 先验证口径是否受控，再判断是否扩大节奏 | `producer_system_designer` 最终拍板；`liveops_community` 执行；`qa_engineer` 守门 |
 | Agent 认领成本与维护 | `claim_owner_id`、`claim_slot_index`、`activation_fee_amount`、`claim_bond_amount`、`upkeep_per_epoch`、`restricted_starter_claim_balance`、`eligible_claim_balance`、`grace_deadline_epoch`、`release_cooldown_epochs` | 玩家确认认领、系统结算 upkeep、主动释放或强制回收 | `unclaimed -> claimed_active -> upkeep_grace -> released/forced_reclaimed -> unclaimed` | 首个 claim 也必须收费；`slot-1` 可优先消费 restricted starter bucket，`slot-2/3` 成本单调递增并受 `reputation_tier` cap 限制 | runtime 原子校验单 owner 与 funding provenance；viewer/pure API 只读取 canonical 字段 |
+| Mature-world 小玩家成长线 | `lane_id`、`entry_gate`、`first_win_goal_id`、`player_leverage_verdict`、`world_activity_only`、`specialization_id`、`regional_influence_scope`、`recovery_option_id` | 玩家在首个持续能力之后进入 `small-player lane`，完成受保护的 first win、选择局部专业化，并在失败时走 repair/rebuild/pivot 路径 | `not_eligible -> active -> first_win_complete -> specialized -> regionally_useful/recovering` | 先 first capability，再小玩家承接；先局部 leverage，再有限区域影响力；不得把 major-power alignment 作为唯一继续路径 | `producer_system_designer` 冻结合同；runtime/viewer/agent/QA 分工收口 |
 | 物理尺度与玩家交互尺度 | `space_unit_cm`、`native_resolution_kind/value`、`cm_mapping_rule`、`interaction_surface`、`visual_exaggeration_reason` | 当前正式动作继续走 `agent/location/facility/recipe/governance` 间接控制；不提供 block-editing 主按钮 | `implicit -> declared -> frozen -> audited` | 先厘米真值，再声明 coarse-grained 子系统映射，最后校验 Viewer 是否误导 | `producer_system_designer` 冻结；runtime/viewer/agent/QA 分工收口 |
 - 核心玩法循环验收矩阵（TASK-GAME-002）:
 | 循环 | 验收场景（Given / When / Then） | 规则层边界（PRD-GAME-002） | 证据事件/状态 | `test_tier_required` 入口 | 通过阈值（Done） | 失败处置 |
@@ -154,6 +157,7 @@
   - AC-16: 新增 `PRD-GAME-012` 10 分钟留存修复专题，明确未来两周只优先推进首次控制地板、工业中循环包、首屏降噪、后果可见化与 active-LLM `10-minute trust gate` 五条 lane，并把 `first capability gate` 作为单独 follow-up verdict。
   - AC-17: 新增 `PRD-GAME-013` 尺度语义专题，明确厘米真值、coarse-grained 子系统分辨率、当前正式玩家动作粒度与 Viewer 视觉夸张边界，并能直接拆出 runtime/viewer/agent/QA 执行任务。
   - AC-18: 新增 `PRD-GAME-014` 间接控制 control-feeling 专题，明确 accepted intent、主因果、打断/重排与续玩恢复四项 guarantees，并能直接拆出 runtime/viewer/agent/QA 执行任务与 formal lane 验收矩阵。
+  - AC-19: 新增 `PRD-GAME-015` mature-world 小玩家成长线专题，明确 `PostOnboarding / first capability` 之后至少 1 条不要求立即依附 major power 的正式主线，冻结 `protected first industrial win`、专业化承接、limited-scope regional influence 与 recoverable failure，并能直接拆出 runtime/viewer/agent/QA 执行任务与 `player leverage` 验收矩阵。
 - Non-Goals:
   - 不在本 PRD 中给出逐条数值参数表。
   - 不替代 runtime/p2p 的底层实现设计。
@@ -167,6 +171,7 @@
 - Integration Points:
   - `doc/game/gameplay/gameplay-top-level-design.prd.md`
   - `doc/game/gameplay/gameplay-physical-scale-indirect-control-2026-05-07.prd.md`
+  - `doc/game/gameplay/gameplay-small-player-progression-lane-2026-05-17.prd.md`
   - `doc/game/gameplay/gameplay-ten-minute-retention-recovery-2026-04-09.prd.md`
   - `doc/game/gameplay/gameplay-closed-beta-readiness-2026-03-21.prd.md`
   - `doc/game/gameplay/gameplay-post-onboarding-stage-2026-03-18.prd.md`
@@ -211,6 +216,7 @@
   - NFR-GAME-18: `PRD-GAME-012` 的正式 `10-minute trust gate` 必须使用 active-LLM 样本；`--no-llm` 只允许作为 debug/probe lane，不得单独支撑“已可玩/已留存”结论；`first capability gate` 必须与 trust gate 分开判定。
   - NFR-GAME-19: `PRD-GAME-013` 所覆盖的 active 文档与玩家入口 100% 必须区分物理真值、coarse-grained 子系统分辨率、玩家动作粒度与表现层夸张，不允许把 `1cm` 直接包装成当前 block-editing 主玩法承诺。
   - NFR-GAME-20: `PRD-GAME-014` 所覆盖的 headed Web/UI 与 pure API 正式玩家入口 100% 必须具备 accepted intent、主因果、主阻塞/override reason 与 next-step/recovery 语义，不允许只剩“世界有变化”或原始日志。
+  - NFR-GAME-21: `PRD-GAME-015` 所覆盖的 mature-world 小玩家路线 100% 必须显式区分 `player leverage` 与 `world activity only`，且不得把“立即加入 major power”写成唯一继续路径；区域影响力也不得偷渡成 global governance 权力。
 - Security & Privacy: gameplay 不直接处理密钥；涉及玩家反馈与行为数据时遵循最小化采集与脱敏记录。
 
 ## 5. Risks & Roadmap
@@ -240,6 +246,7 @@
 | PRD-GAME-012 | TASK-GAME-061/062/063/064/065 | `test_tier_required` + `test_tier_full` | 文档治理检查、headed Web/UI 与 `software_safe` 控制 floor、active-LLM `10-minute trust gate` 样本、工业 capability follow-up 样本与 producer 双层 verdict 结论 | 10 分钟正式信任门、首屏主目标、首个持续能力门 |
 | PRD-GAME-013 | TASK-GAME-066/067/068/069/070 | `test_tier_required` + `test_tier_full` | 文档治理检查、厘米真值与 coarse-grained 子系统映射对账、Viewer 真值/夸张表达复核、dual-mode action contract 对账与 QA 尺度一致性矩阵 | 物理尺度合同、间接控制动作边界、表现层可信度 |
 | PRD-GAME-014 | `indirect-control-feeling-contract-freeze` / `runtime-control-feeling-canonical-contract` / `viewer-control-feeling-surface-alignment` / `agent-control-feeling-reprioritize-contract` / `qa-control-feeling-matrix` | `test_tier_required` + `test_tier_full` | 文档治理检查、canonical accepted-intent/causality contract 对账、headed Web/UI 与 pure API agency surface 复核、reprioritize/override 语义对账、QA control-feeling matrix 与 formal lane 样本抽样 | 间接控制下的玩家控制感、主因果、重排恢复与多端等价性 |
+| PRD-GAME-015 | `small-player-progression-contract-freeze` / `runtime-small-player-lane-state-contract` / `viewer-small-player-lane-surface-alignment` / `agent-small-player-specialization-contract` / `qa-small-player-progression-matrix` | `test_tier_required` + `test_tier_full` | 文档治理检查、small-player lane state / first-win / recovery truth 对账、headed Web/UI 与 pure API 承接 surface 复核、specialization / org-independence contract 对账、`player leverage` 与 `world_activity_only` 矩阵抽样 | mature-world 小玩家承接、区域性价值、恢复路径与误报阻断 |
 - Decision Log:
 | 决策ID | 选定方案 | 备选方案（否决） | 依据 |
 | --- | --- | --- | --- |
@@ -259,3 +266,4 @@
 | DEC-GAME-014 | 新增独立 `PRD-GAME-012` 作为 10 分钟留存修复专题，并把正式 verdict 拆成 `10-minute trust gate` 与 `first capability gate` | 继续把留存问题拆散到 viewer/runtime/QA 各专题自行优化，或继续要求单个 10 分钟样本同时证明“值得继续玩”和“首个持续能力已闭环” | 当前问题不是单条 lane 的点状回归，而是“控制地板、中循环、首屏和 QA 门禁”需要在同一冲刺窗口统一排序；同时 `PostOnboarding` 里程碑与 10 分钟 trust 样本本来就不是同一时间尺度。 |
 | DEC-GAME-015 | 新增独立 `PRD-GAME-013` 作为尺度语义专题，并把“厘米真值”“粗粒度子系统”“玩家动作粒度”“表现层夸张”拆成四层合同 | 继续只保留底层 `1cm` 描述，或直接把产品方向改成 Minecraft 式逐块具身玩法 | 当前问题不在有没有物理尺度，而在没有正式解释“真实尺度”和“当前交互粒度”的关系；盲目切产品主路线会稀释 `PRD-GAME-012` 的主 blocker。 |
 | DEC-GAME-016 | 新增独立 `PRD-GAME-014` 作为间接控制 control-feeling 专题，并把“accepted intent / 主因果 / 打断重排 / 续玩恢复”冻结成正式 guarantees | 继续把“控制感”分散在留存卡、Viewer 文案、runtime ack 与 issue 讨论里，或直接把问题解释成“需要更多 direct control” | 当前 issue #164 暴露的不是动作数量不足，而是间接控制缺少一份可裁决、可实现、可测试的 agency 合同；先补合同，才能稳定评审后续 UX/runtime/agent 变更。 |
+| DEC-GAME-017 | 新增独立 `PRD-GAME-015` 作为 mature-world 小玩家成长线专题，并把“首个持续能力之后靠什么继续有独立价值”冻结成正式合同 | 继续把 issue #165 留在愿景层、零散借用 PostOnboarding/claim/playability 现有口径，或默认要求小玩家立刻依附 major power | 当前仓库已覆盖 first capability 与 control-feeling，但缺少“成熟世界里小玩家为何仍值得继续”的正式承接；先补合同，才能稳定裁决后续 runtime/viewer/agent/QA 实施边界。 |

--- a/doc/game/project.md
+++ b/doc/game/project.md
@@ -177,6 +177,10 @@
 - 后续待建任务见 `doc/game/gameplay/gameplay-indirect-control-feeling-contract-2026-05-14.project.md`：
   `runtime-control-feeling-canonical-contract`、`viewer-control-feeling-surface-alignment`、`agent-control-feeling-reprioritize-contract`、`qa-control-feeling-matrix`。
 
+### T11 小玩家成长线与成熟世界承接（2026-05-17）
+- [x] small-player-progression-contract-freeze (PRD-GAME-015) [test_tier_required]: `producer_system_designer` 已新增 `PRD-GAME-015` 专题 PRD / design / project，并完成 `game` 根入口、`gameplay` 主文档、索引与当前 task execution log 挂载；正式冻结 `local operator -> regional specialist -> limited-scope regional influence` 主线，并把 `protected first industrial win` 收口为低爆炸半径、可恢复和 leverage 可见的 first win，而不是新手无敌豁免。 Trace: .pm/tasks/task_d97dfa29208444a9b6a652f2a12fb65d.yaml
+- 后续待建任务统一收口在 `doc/game/gameplay/gameplay-small-player-progression-lane-2026-05-17.project.md`，避免在 gameplay 主入口重复展开未绑定 Trace 的计划行。
+
 ## 依赖
 - 模块设计总览：`doc/game/design.md`
 - doc/game/prd.index.md


### PR DESCRIPTION
## Summary
- freeze `PRD-GAME-015` for a mature-world small-player progression lane after `PostOnboarding / first capability`
- add the new gameplay PRD/design/project docs and wire them into `doc/game` root entrypoints, gameplay top-level docs, index routing, and task execution traceability
- split follow-up work for runtime, viewer, agent, and QA; close the PM task and repair one stale historical `.pm` `source_ref` so PM lint passes

## Testing
- `git diff --check`
- `./scripts/doc-governance-check.sh`
- `./scripts/pm/lint.sh`
- `cargo test -p oasis7_consensus --lib`
- `cargo test -p oasis7_distfs --lib`
- `node crates/oasis7_viewer/scripts/software-safe-feedback-contract.test.mjs`
- `npm --prefix crates/oasis7_viewer run test:ui`

Closes #165
