### PR TITLE
feat: add hosted account login broker

### DIFF
--- a/.pm/tasks/task_b837ca5ee1b34439a9c581ad6ab87a64.execution.md
+++ b/.pm/tasks/task_b837ca5ee1b34439a9c581ad6ab87a64.execution.md
@@ -1,0 +1,19 @@
+# task_b837ca5ee1b34439a9c581ad6ab87a64 Execution Log
+
+- task_uid: task_b837ca5ee1b34439a9c581ad6ab87a64
+- title: hosted account identity broker server for phone or email login
+- owner_role: runtime_engineer
+- worktree_hint: /home/scc/worktrees/oasis7-p2p-hosted-public-join-centralized-kms-login
+
+<!-- Append entries using:
+Example:
+  ## YYYY-MM-DD HH:MM:SS CST / role_name
+  - 完成内容: ...
+  - 遗留事项: ...
+-->
+## 2026-05-18 23:10:00 CST / runtime_engineer
+- 完成内容: 已在 `oasis7_game_launcher` 的 public HTTP server 上新增中心化 hosted account 登录 broker，提供 `/api/public/hosted-account/login/start` 与 `/api/public/hosted-account/login/complete` 两条 route，支持 `email/phone` challenge、稳定 `hosted_account_id -> player_id` JSON 持久化、以及验证通过后换发 `device_session + player_session`。`hosted_player_session.rs` 也已补 `issue_for_player(...)`，使同一 hosted account 可以恢复到稳定 `player_id`，而不是每次匿名生成新玩家身份。
+- 完成内容: viewer 已从“直接 Acquire Player Session”切到 hosted account login 流程。`legacy_core.js` 和 `main.jsx` 现在会展示 phone/email + OTP 表单，先请求 challenge，再完成登录，最后把 `hosted_account_id/login_channel/masked_login_hint/device_session_id/release_token` 写入浏览器恢复态；长期 player signer 仍不落盘到 `localStorage`。
+- 完成内容: 当前 challenge delivery 先按 preview transport 落地：server 支持 `preview_inline` 与 `server_log_only` 两种模式，便于 repo-owned 测试和后续替换到真实短信/邮件 provider。
+- 完成内容: 本轮验证已通过 `env -u RUSTC_WRAPPER cargo test -p oasis7 --bin oasis7_game_launcher hosted_ -- --nocapture`、`node crates/oasis7_viewer/scripts/software-safe-feedback-contract.test.mjs`、`npm --prefix crates/oasis7_viewer run test:ui` 与 `npm --prefix crates/oasis7_viewer run build:software-safe`。
+- 遗留事项: 尚未接真实短信/邮件 provider、magic link/passkey、账户冻结/恢复策略和 custody sign lane；当前完成的是 hosted account 中心化登录 server 与 viewer onboarding 的第一版可运行 contract，不代表生产级登录投递或托管签名后端已经 ready。

--- a/.pm/tasks/task_b837ca5ee1b34439a9c581ad6ab87a64.execution.md
+++ b/.pm/tasks/task_b837ca5ee1b34439a9c581ad6ab87a64.execution.md
@@ -1,7 +1,7 @@
 # task_b837ca5ee1b34439a9c581ad6ab87a64 Execution Log
 
 - task_uid: task_b837ca5ee1b34439a9c581ad6ab87a64
-- title: hosted account identity broker server for phone or email login
+- title: hosted account identity broker server for email login
 - owner_role: runtime_engineer
 - worktree_hint: /home/scc/worktrees/oasis7-p2p-hosted-public-join-centralized-kms-login
 
@@ -12,8 +12,14 @@ Example:
   - 遗留事项: ...
 -->
 ## 2026-05-18 23:10:00 CST / runtime_engineer
-- 完成内容: 已在 `oasis7_game_launcher` 的 public HTTP server 上新增中心化 hosted account 登录 broker，提供 `/api/public/hosted-account/login/start` 与 `/api/public/hosted-account/login/complete` 两条 route，支持 `email/phone` challenge、稳定 `hosted_account_id -> player_id` JSON 持久化、以及验证通过后换发 `device_session + player_session`。`hosted_player_session.rs` 也已补 `issue_for_player(...)`，使同一 hosted account 可以恢复到稳定 `player_id`，而不是每次匿名生成新玩家身份。
-- 完成内容: viewer 已从“直接 Acquire Player Session”切到 hosted account login 流程。`legacy_core.js` 和 `main.jsx` 现在会展示 phone/email + OTP 表单，先请求 challenge，再完成登录，最后把 `hosted_account_id/login_channel/masked_login_hint/device_session_id/release_token` 写入浏览器恢复态；长期 player signer 仍不落盘到 `localStorage`。
-- 完成内容: 当前 challenge delivery 先按 preview transport 落地：server 支持 `preview_inline` 与 `server_log_only` 两种模式，便于 repo-owned 测试和后续替换到真实短信/邮件 provider。
+- 完成内容: 已在 `oasis7_game_launcher` 的 public HTTP server 上新增中心化 hosted account 登录 broker，提供 `/api/public/hosted-account/login/start` 与 `/api/public/hosted-account/login/complete` 两条 route，支持 email challenge、稳定 `hosted_account_id -> player_id` JSON 持久化、以及验证通过后换发 `device_session + player_session`。`hosted_player_session.rs` 也已补 `issue_for_player(...)`，使同一 hosted account 可以恢复到稳定 `player_id`，而不是每次匿名生成新玩家身份。
+- 完成内容: viewer 已从“直接 Acquire Player Session”切到 hosted account login 流程。`legacy_core.js` 和 `main.jsx` 现在会展示 email + OTP 表单，先请求 challenge，再完成登录，最后把 `hosted_account_id/login_channel/masked_login_hint/device_session_id/release_token` 写入浏览器恢复态；长期 player signer 仍不落盘到 `localStorage`。
+- 完成内容: 当前 challenge delivery 先按 preview transport 落地：server 支持 `preview_inline` 与 `server_log_only` 两种模式，便于 repo-owned 测试和后续替换到真实邮件 provider。
 - 完成内容: 本轮验证已通过 `env -u RUSTC_WRAPPER cargo test -p oasis7 --bin oasis7_game_launcher hosted_ -- --nocapture`、`node crates/oasis7_viewer/scripts/software-safe-feedback-contract.test.mjs`、`npm --prefix crates/oasis7_viewer run test:ui` 与 `npm --prefix crates/oasis7_viewer run build:software-safe`。
-- 遗留事项: 尚未接真实短信/邮件 provider、magic link/passkey、账户冻结/恢复策略和 custody sign lane；当前完成的是 hosted account 中心化登录 server 与 viewer onboarding 的第一版可运行 contract，不代表生产级登录投递或托管签名后端已经 ready。
+- 遗留事项: 尚未接真实邮件 provider、magic link、账户冻结/恢复策略和 custody sign lane；当前完成的是 hosted account 中心化登录 server 与 viewer onboarding 的第一版可运行 contract，不代表生产级登录投递或托管签名后端已经 ready。
+
+## 2026-05-19 00:35:00 CST / runtime_engineer
+- 完成内容: 按当前产品决策移除了 hosted account 短信路径，`hosted_account_identity.rs` 现在只接受 `email` 作为 `login_channel`，并把非 email 渠道视为 `unsupported_login_channel`。
+- 完成内容: Viewer hosted onboarding 已删掉 channel selector，正式 Web 入口只保留邮箱输入与验证码流程；同时补了旧浏览器状态兜底，避免历史 `phone` 状态继续打到后端。
+- 完成内容: 同步回写 `doc/p2p/prd.md`、模块 `project.md`、专题 PRD/design/project 与本 execution log，把“手机号/邮箱登录”统一收口成“邮箱登录”，避免产品文档继续漂移。
+- 遗留事项: 仍需把 preview `preview_inline/server_log_only` 挑战投递替换成真实邮件 delivery provider，并补 magic link、恢复/冻结策略与 custody sign lane。

--- a/.pm/tasks/task_b837ca5ee1b34439a9c581ad6ab87a64.yaml
+++ b/.pm/tasks/task_b837ca5ee1b34439a9c581ad6ab87a64.yaml
@@ -1,0 +1,27 @@
+task_uid: task_b837ca5ee1b34439a9c581ad6ab87a64
+title: "hosted account identity broker server for phone or email login"
+owner_role: runtime_engineer
+worktree_hint: /home/scc/worktrees/oasis7-p2p-hosted-public-join-centralized-kms-login
+execution_log_path: .pm/tasks/task_b837ca5ee1b34439a9c581ad6ab87a64.execution.md
+status: done
+priority: P2
+source_signal: null
+source_refs:
+  - doc/p2p/prd.md
+  - doc/p2p/project.md
+  - doc/p2p/blockchain/p2p-hosted-public-join-managed-identity-custody-2026-05-18.prd.md
+  - doc/p2p/blockchain/p2p-hosted-public-join-managed-identity-custody-2026-05-18.project.md
+  - crates/oasis7/src/bin/oasis7_game_launcher/static_http.rs
+  - crates/oasis7/src/bin/oasis7_game_launcher/hosted_player_session.rs
+doc_refs:
+  - doc/p2p/blockchain/p2p-hosted-public-join-managed-identity-custody-2026-05-18.prd.md
+related_prd:
+  - PRD-P2P-029
+acceptance:
+  - "implement a centralized hosted-account identity broker route set for phone-or-email login on hosted_public_join"
+  - "persist hosted_account_id to stable player_id bindings and exchange verified login for device_session plus player_session grant"
+  - "wire viewer hosted onboarding to the new login flow without restoring browser long-lived private-key persistence"
+handoff_to: []
+updated_at: 2026-05-19T09:12:48+08:00
+last_started_at: 2026-05-18T22:57:04+08:00
+last_closed_at: 2026-05-19T09:12:48+08:00

--- a/crates/oasis7/src/bin/oasis7_game_launcher.rs
+++ b/crates/oasis7/src/bin/oasis7_game_launcher.rs
@@ -20,6 +20,8 @@ use tracing::{error, info, Level};
 mod cli;
 #[path = "../hosted_access.rs"]
 mod hosted_access;
+#[path = "oasis7_game_launcher/hosted_account_identity.rs"]
+mod hosted_account_identity;
 #[path = "oasis7_game_launcher/hosted_player_session.rs"]
 mod hosted_player_session;
 #[path = "oasis7_game_launcher/hosted_strong_auth.rs"]
@@ -39,6 +41,7 @@ use cli::{
     uses_provider_http_transport,
 };
 use hosted_access::{DeploymentMode, DEFAULT_DEPLOYMENT_MODE};
+use hosted_account_identity::HostedAccountIdentityBroker;
 use hosted_player_session::HostedPlayerSessionIssuer;
 use oasis7::viewer::VIEWER_FORMAL_RELEASE_DEFAULT_WORLD_ID;
 use runtime_paths::{
@@ -539,6 +542,7 @@ fn start_static_http_server(
     let live_bind = Arc::new(live_bind.to_string());
     let default_viewer_player_id = Arc::new(default_viewer_player_id.map(ToOwned::to_owned));
     let hosted_session_issuer = Arc::new(Mutex::new(HostedPlayerSessionIssuer::default()));
+    let hosted_account_broker = Arc::new(Mutex::new(HostedAccountIdentityBroker::from_env()?));
     let runtime_presence_join_handle = if deployment_mode == DeploymentMode::HostedPublicJoin {
         let stop_requested = Arc::clone(&stop_requested);
         let live_bind = Arc::clone(&live_bind);
@@ -557,6 +561,7 @@ fn start_static_http_server(
             live_bind,
             default_viewer_player_id,
             hosted_session_issuer,
+            hosted_account_broker,
             stop_rx,
         ) {
             let _ = error_tx.send(err);
@@ -579,6 +584,7 @@ fn run_static_http_loop(
     live_bind: Arc<String>,
     default_viewer_player_id: Arc<Option<String>>,
     hosted_session_issuer: Arc<Mutex<HostedPlayerSessionIssuer>>,
+    hosted_account_broker: Arc<Mutex<HostedAccountIdentityBroker>>,
     stop_rx: Receiver<()>,
 ) -> Result<(), String> {
     loop {
@@ -594,6 +600,7 @@ fn run_static_http_loop(
                 let default_viewer_player_id = Arc::clone(&default_viewer_player_id);
                 let deployment_mode = deployment_mode;
                 let hosted_session_issuer = Arc::clone(&hosted_session_issuer);
+                let hosted_account_broker = Arc::clone(&hosted_account_broker);
                 thread::spawn(move || {
                     if let Err(err) = handle_http_connection(
                         stream,
@@ -602,6 +609,7 @@ fn run_static_http_loop(
                         default_viewer_player_id.as_deref(),
                         deployment_mode,
                         &hosted_session_issuer,
+                        &hosted_account_broker,
                     ) {
                         let stderr_message =
                             format!("warning: static HTTP connection failed: {err}");

--- a/crates/oasis7/src/bin/oasis7_game_launcher/hosted_account_identity.rs
+++ b/crates/oasis7/src/bin/oasis7_game_launcher/hosted_account_identity.rs
@@ -164,7 +164,7 @@ impl HostedAccountIdentityBroker {
             return HostedAccountLoginStartResponse {
                 ok: false,
                 error_code: Some("unsupported_login_channel".to_string()),
-                error: Some("login_channel must be one of: email|phone".to_string()),
+                error: Some("login_channel must be email".to_string()),
                 deployment_mode: deployment_mode.as_str().to_string(),
                 challenge: None,
             };
@@ -507,7 +507,6 @@ fn emit_delivery_notice(
 fn normalize_login_channel(raw: &str) -> Option<&'static str> {
     match raw.trim() {
         "email" => Some("email"),
-        "phone" => Some("phone"),
         _ => None,
     }
 }
@@ -519,7 +518,6 @@ fn normalize_login_hint(channel: &str, raw: &str) -> Option<String> {
     }
     match channel {
         "email" => normalize_email(trimmed),
-        "phone" => normalize_phone(trimmed),
         _ => None,
     }
 }
@@ -528,24 +526,6 @@ fn normalize_email(raw: &str) -> Option<String> {
     let normalized = raw.trim().to_ascii_lowercase();
     let (local, domain) = normalized.split_once('@')?;
     if local.is_empty() || domain.is_empty() || !domain.contains('.') {
-        return None;
-    }
-    Some(normalized)
-}
-
-fn normalize_phone(raw: &str) -> Option<String> {
-    let mut normalized = String::new();
-    for (index, ch) in raw.trim().chars().enumerate() {
-        if ch.is_ascii_digit() {
-            normalized.push(ch);
-            continue;
-        }
-        if ch == '+' && index == 0 {
-            normalized.push(ch);
-        }
-    }
-    let digits = normalized.chars().filter(|ch| ch.is_ascii_digit()).count();
-    if digits < 7 || digits > 18 {
         return None;
     }
     Some(normalized)
@@ -560,22 +540,6 @@ fn mask_login_hint(channel: &str, normalized_login_hint: &str) -> String {
             let local_chars: Vec<char> = local.chars().collect();
             let visible = local_chars.iter().take(2).collect::<String>();
             format!("{visible}***@{domain}")
-        }
-        "phone" => {
-            let suffix: String = normalized_login_hint
-                .chars()
-                .rev()
-                .take(4)
-                .collect::<String>()
-                .chars()
-                .rev()
-                .collect();
-            let prefix = if normalized_login_hint.starts_with('+') {
-                "+"
-            } else {
-                ""
-            };
-            format!("{prefix}***{suffix}")
         }
         _ => "***".to_string(),
     }
@@ -621,18 +585,19 @@ mod tests {
     }
 
     #[test]
-    fn hosted_account_login_start_rejects_invalid_channel() {
+    fn hosted_account_login_start_rejects_phone_channel() {
         let mut broker = HostedAccountIdentityBroker::with_store_path(temp_store_path("invalid"))
             .expect("broker");
-        let response = broker.start_login(
-            DeploymentMode::HostedPublicJoin,
-            "telegram",
-            "user@example.com",
-        );
+        let response =
+            broker.start_login(DeploymentMode::HostedPublicJoin, "phone", "+1 415 555 0101");
         assert!(!response.ok);
         assert_eq!(
             response.error_code.as_deref(),
             Some("unsupported_login_channel")
+        );
+        assert_eq!(
+            response.error.as_deref(),
+            Some("login_channel must be email")
         );
     }
 
@@ -693,8 +658,11 @@ mod tests {
         let mut broker = HostedAccountIdentityBroker::with_store_path(temp_store_path("wrong-otp"))
             .expect("broker");
         let mut issuer = HostedPlayerSessionIssuer::default();
-        let start =
-            broker.start_login(DeploymentMode::HostedPublicJoin, "phone", "+1 415 555 0101");
+        let start = broker.start_login(
+            DeploymentMode::HostedPublicJoin,
+            "email",
+            "player@example.com",
+        );
         let challenge = start.challenge.expect("challenge");
         let response = broker.complete_login(
             DeploymentMode::HostedPublicJoin,

--- a/crates/oasis7/src/bin/oasis7_game_launcher/hosted_account_identity.rs
+++ b/crates/oasis7/src/bin/oasis7_game_launcher/hosted_account_identity.rs
@@ -1,0 +1,708 @@
+use super::hosted_access::DeploymentMode;
+use super::hosted_player_session::{
+    HostedPlayerSessionAdmissionSnapshot, HostedPlayerSessionIssueGrant,
+    HostedPlayerSessionIssueResponse, HostedPlayerSessionIssuer,
+};
+use super::{emit_stderr_or_event, Level};
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, VecDeque};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+pub(super) const HOSTED_ACCOUNT_LOGIN_START_ROUTE: &str = "/api/public/hosted-account/login/start";
+pub(super) const HOSTED_ACCOUNT_LOGIN_COMPLETE_ROUTE: &str =
+    "/api/public/hosted-account/login/complete";
+const HOSTED_ACCOUNT_STORE_PATH_ENV: &str = "OASIS7_HOSTED_ACCOUNT_STORE_PATH";
+const HOSTED_LOGIN_DELIVERY_MODE_ENV: &str = "OASIS7_HOSTED_LOGIN_DELIVERY_MODE";
+const HOSTED_LOGIN_DELIVERY_MODE_PREVIEW_INLINE: &str = "preview_inline";
+const HOSTED_LOGIN_DELIVERY_MODE_SERVER_LOG_ONLY: &str = "server_log_only";
+const LOGIN_CHALLENGE_TTL_MS: u64 = 10 * 60 * 1000;
+const LOGIN_START_RATE_LIMIT_WINDOW_MS: u64 = 60_000;
+const LOGIN_START_RATE_LIMIT_PER_HANDLE: u64 = 3;
+
+#[derive(Debug, Clone, Serialize)]
+pub(super) struct HostedAccountLoginStartResponse {
+    pub(super) ok: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) error_code: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) error: Option<String>,
+    pub(super) deployment_mode: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) challenge: Option<HostedAccountLoginChallengeSnapshot>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(super) struct HostedAccountLoginCompleteResponse {
+    pub(super) ok: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) error_code: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) error: Option<String>,
+    pub(super) deployment_mode: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) account: Option<HostedAccountSummary>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) grant: Option<HostedPlayerSessionIssueGrant>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) admission: Option<HostedPlayerSessionAdmissionSnapshot>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(super) struct HostedAccountSummary {
+    pub(super) hosted_account_id: String,
+    pub(super) player_id: String,
+    pub(super) login_channel: String,
+    pub(super) masked_login_hint: String,
+    pub(super) status: String,
+    pub(super) last_verified_at_unix_ms: u64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(super) struct HostedAccountLoginChallengeSnapshot {
+    pub(super) challenge_id: String,
+    pub(super) login_channel: String,
+    pub(super) masked_login_hint: String,
+    pub(super) delivery_mode: String,
+    pub(super) expires_at_unix_ms: u64,
+    pub(super) account_exists: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) preview_code: Option<String>,
+}
+
+#[derive(Debug)]
+pub(super) struct HostedAccountIdentityBroker {
+    store_path: PathBuf,
+    store: HostedAccountStore,
+    delivery_mode: String,
+    next_challenge_sequence: u64,
+    recent_start_timestamps_by_factor: BTreeMap<String, VecDeque<u64>>,
+    pending_challenges: BTreeMap<String, PendingHostedLoginChallenge>,
+}
+
+#[derive(Debug, Clone)]
+struct PendingHostedLoginChallenge {
+    challenge_id: String,
+    login_channel: String,
+    normalized_login_hint: String,
+    masked_login_hint: String,
+    otp_code: String,
+    expires_at_unix_ms: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+struct HostedAccountStore {
+    next_account_sequence: u64,
+    next_player_sequence: u64,
+    accounts_by_id: BTreeMap<String, HostedAccountRecord>,
+    account_id_by_factor: BTreeMap<String, String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct HostedAccountRecord {
+    hosted_account_id: String,
+    player_id: String,
+    login_channel: String,
+    normalized_login_hint: String,
+    masked_login_hint: String,
+    status: String,
+    created_at_unix_ms: u64,
+    last_verified_at_unix_ms: u64,
+}
+
+impl HostedAccountIdentityBroker {
+    pub(super) fn from_env() -> Result<Self, String> {
+        let store_path = resolve_store_path();
+        let store = load_store(store_path.as_path())?;
+        Ok(Self {
+            store_path,
+            store,
+            delivery_mode: normalize_delivery_mode(
+                std::env::var(HOSTED_LOGIN_DELIVERY_MODE_ENV)
+                    .ok()
+                    .as_deref(),
+            ),
+            next_challenge_sequence: 0,
+            recent_start_timestamps_by_factor: BTreeMap::new(),
+            pending_challenges: BTreeMap::new(),
+        })
+    }
+
+    #[cfg(test)]
+    fn with_store_path(store_path: PathBuf) -> Result<Self, String> {
+        let store = load_store(store_path.as_path())?;
+        Ok(Self {
+            store_path,
+            store,
+            delivery_mode: HOSTED_LOGIN_DELIVERY_MODE_PREVIEW_INLINE.to_string(),
+            next_challenge_sequence: 0,
+            recent_start_timestamps_by_factor: BTreeMap::new(),
+            pending_challenges: BTreeMap::new(),
+        })
+    }
+
+    pub(super) fn start_login(
+        &mut self,
+        deployment_mode: DeploymentMode,
+        login_channel: &str,
+        login_hint: &str,
+    ) -> HostedAccountLoginStartResponse {
+        if deployment_mode != DeploymentMode::HostedPublicJoin {
+            return HostedAccountLoginStartResponse {
+                ok: false,
+                error_code: Some("hosted_account_login_disabled".to_string()),
+                error: Some(
+                    "hosted account login is only available on hosted_public_join".to_string(),
+                ),
+                deployment_mode: deployment_mode.as_str().to_string(),
+                challenge: None,
+            };
+        }
+        self.prune_expired_challenges();
+        let Some(channel) = normalize_login_channel(login_channel) else {
+            return HostedAccountLoginStartResponse {
+                ok: false,
+                error_code: Some("unsupported_login_channel".to_string()),
+                error: Some("login_channel must be one of: email|phone".to_string()),
+                deployment_mode: deployment_mode.as_str().to_string(),
+                challenge: None,
+            };
+        };
+        let Some(normalized_login_hint) = normalize_login_hint(channel, login_hint) else {
+            return HostedAccountLoginStartResponse {
+                ok: false,
+                error_code: Some("login_hint_invalid".to_string()),
+                error: Some(format!("{channel} login_hint is invalid")),
+                deployment_mode: deployment_mode.as_str().to_string(),
+                challenge: None,
+            };
+        };
+        if self.rate_limited(channel, normalized_login_hint.as_str()) {
+            return HostedAccountLoginStartResponse {
+                ok: false,
+                error_code: Some("login_rate_limited".to_string()),
+                error: Some(
+                    "too many login challenges were issued for this handle; retry in a minute"
+                        .to_string(),
+                ),
+                deployment_mode: deployment_mode.as_str().to_string(),
+                challenge: None,
+            };
+        }
+        let issued_at_unix_ms = now_unix_ms();
+        self.next_challenge_sequence = self.next_challenge_sequence.saturating_add(1);
+        let factor_key = factor_key(channel, normalized_login_hint.as_str());
+        let challenge_id =
+            build_login_challenge_id(issued_at_unix_ms, self.next_challenge_sequence);
+        let otp_code = build_preview_otp_code(issued_at_unix_ms, self.next_challenge_sequence);
+        let masked_login_hint = mask_login_hint(channel, normalized_login_hint.as_str());
+        let expires_at_unix_ms = issued_at_unix_ms.saturating_add(LOGIN_CHALLENGE_TTL_MS);
+        let account_exists = self
+            .store
+            .account_id_by_factor
+            .contains_key(factor_key.as_str());
+        self.recent_start_timestamps_by_factor
+            .entry(factor_key)
+            .or_default()
+            .push_back(issued_at_unix_ms);
+        let challenge = PendingHostedLoginChallenge {
+            challenge_id: challenge_id.clone(),
+            login_channel: channel.to_string(),
+            normalized_login_hint: normalized_login_hint.clone(),
+            masked_login_hint: masked_login_hint.clone(),
+            otp_code: otp_code.clone(),
+            expires_at_unix_ms,
+        };
+        self.pending_challenges
+            .insert(challenge_id.clone(), challenge);
+        emit_delivery_notice(
+            self.delivery_mode.as_str(),
+            channel,
+            masked_login_hint.as_str(),
+            otp_code.as_str(),
+        );
+        HostedAccountLoginStartResponse {
+            ok: true,
+            error_code: None,
+            error: None,
+            deployment_mode: deployment_mode.as_str().to_string(),
+            challenge: Some(HostedAccountLoginChallengeSnapshot {
+                challenge_id,
+                login_channel: channel.to_string(),
+                masked_login_hint,
+                delivery_mode: self.delivery_mode.clone(),
+                expires_at_unix_ms,
+                account_exists,
+                preview_code: if self.delivery_mode == HOSTED_LOGIN_DELIVERY_MODE_PREVIEW_INLINE {
+                    Some(otp_code)
+                } else {
+                    None
+                },
+            }),
+        }
+    }
+
+    pub(super) fn complete_login(
+        &mut self,
+        deployment_mode: DeploymentMode,
+        challenge_id: &str,
+        otp_code: &str,
+        issuer: &mut HostedPlayerSessionIssuer,
+    ) -> HostedAccountLoginCompleteResponse {
+        if deployment_mode != DeploymentMode::HostedPublicJoin {
+            return HostedAccountLoginCompleteResponse {
+                ok: false,
+                error_code: Some("hosted_account_login_disabled".to_string()),
+                error: Some(
+                    "hosted account login is only available on hosted_public_join".to_string(),
+                ),
+                deployment_mode: deployment_mode.as_str().to_string(),
+                account: None,
+                grant: None,
+                admission: None,
+            };
+        }
+        self.prune_expired_challenges();
+        let normalized_challenge_id = challenge_id.trim();
+        if normalized_challenge_id.is_empty() {
+            return HostedAccountLoginCompleteResponse {
+                ok: false,
+                error_code: Some("challenge_id_required".to_string()),
+                error: Some("challenge_id is required".to_string()),
+                deployment_mode: deployment_mode.as_str().to_string(),
+                account: None,
+                grant: None,
+                admission: None,
+            };
+        }
+        let Some(challenge) = self.pending_challenges.remove(normalized_challenge_id) else {
+            return HostedAccountLoginCompleteResponse {
+                ok: false,
+                error_code: Some("challenge_not_found".to_string()),
+                error: Some("login challenge is missing or expired".to_string()),
+                deployment_mode: deployment_mode.as_str().to_string(),
+                account: None,
+                grant: None,
+                admission: None,
+            };
+        };
+        if challenge.expires_at_unix_ms <= now_unix_ms() {
+            return HostedAccountLoginCompleteResponse {
+                ok: false,
+                error_code: Some("challenge_expired".to_string()),
+                error: Some("login challenge expired; request a fresh code".to_string()),
+                deployment_mode: deployment_mode.as_str().to_string(),
+                account: None,
+                grant: None,
+                admission: None,
+            };
+        }
+        if challenge.otp_code != otp_code.trim() {
+            self.pending_challenges
+                .insert(challenge.challenge_id.clone(), challenge);
+            return HostedAccountLoginCompleteResponse {
+                ok: false,
+                error_code: Some("otp_code_invalid".to_string()),
+                error: Some("login verification code is invalid".to_string()),
+                deployment_mode: deployment_mode.as_str().to_string(),
+                account: None,
+                grant: None,
+                admission: None,
+            };
+        }
+        let factor_key = factor_key(
+            challenge.login_channel.as_str(),
+            challenge.normalized_login_hint.as_str(),
+        );
+        let verified_at_unix_ms = now_unix_ms();
+        let account_id = self
+            .store
+            .account_id_by_factor
+            .get(factor_key.as_str())
+            .cloned()
+            .unwrap_or_else(|| {
+                self.store.next_account_sequence =
+                    self.store.next_account_sequence.saturating_add(1);
+                build_hosted_account_id(self.store.next_account_sequence)
+            });
+        let player_id = if let Some(record) = self.store.accounts_by_id.get_mut(account_id.as_str())
+        {
+            record.last_verified_at_unix_ms = verified_at_unix_ms;
+            record.status = "active".to_string();
+            record.player_id.clone()
+        } else {
+            self.store.next_player_sequence = self.store.next_player_sequence.saturating_add(1);
+            let player_id = build_hosted_player_id(self.store.next_player_sequence);
+            self.store.accounts_by_id.insert(
+                account_id.clone(),
+                HostedAccountRecord {
+                    hosted_account_id: account_id.clone(),
+                    player_id: player_id.clone(),
+                    login_channel: challenge.login_channel.clone(),
+                    normalized_login_hint: challenge.normalized_login_hint.clone(),
+                    masked_login_hint: challenge.masked_login_hint.clone(),
+                    status: "active".to_string(),
+                    created_at_unix_ms: verified_at_unix_ms,
+                    last_verified_at_unix_ms: verified_at_unix_ms,
+                },
+            );
+            self.store
+                .account_id_by_factor
+                .insert(factor_key, account_id.clone());
+            player_id
+        };
+        if let Err(err) = save_store(self.store_path.as_path(), &self.store) {
+            return HostedAccountLoginCompleteResponse {
+                ok: false,
+                error_code: Some("account_store_persist_failed".to_string()),
+                error: Some(err),
+                deployment_mode: deployment_mode.as_str().to_string(),
+                account: None,
+                grant: None,
+                admission: None,
+            };
+        }
+        let issue = issuer.issue_for_player(deployment_mode, player_id.as_str());
+        let account = self
+            .store
+            .accounts_by_id
+            .get(account_id.as_str())
+            .cloned()
+            .map(account_summary_from_record);
+        response_from_issue(deployment_mode, issue, account)
+    }
+
+    fn prune_expired_challenges(&mut self) {
+        let now = now_unix_ms();
+        self.pending_challenges
+            .retain(|_, challenge| challenge.expires_at_unix_ms > now);
+        for timestamps in self.recent_start_timestamps_by_factor.values_mut() {
+            while timestamps
+                .front()
+                .copied()
+                .unwrap_or(0)
+                .saturating_add(LOGIN_START_RATE_LIMIT_WINDOW_MS)
+                <= now
+            {
+                timestamps.pop_front();
+            }
+        }
+    }
+
+    fn rate_limited(&mut self, channel: &str, normalized_login_hint: &str) -> bool {
+        self.prune_expired_challenges();
+        let factor_key = factor_key(channel, normalized_login_hint);
+        self.recent_start_timestamps_by_factor
+            .get(factor_key.as_str())
+            .map(|timestamps| timestamps.len() as u64 >= LOGIN_START_RATE_LIMIT_PER_HANDLE)
+            .unwrap_or(false)
+    }
+}
+
+fn response_from_issue(
+    deployment_mode: DeploymentMode,
+    issue: HostedPlayerSessionIssueResponse,
+    account: Option<HostedAccountSummary>,
+) -> HostedAccountLoginCompleteResponse {
+    HostedAccountLoginCompleteResponse {
+        ok: issue.ok && issue.grant.is_some() && account.is_some(),
+        error_code: issue.error_code,
+        error: issue.error,
+        deployment_mode: deployment_mode.as_str().to_string(),
+        account,
+        grant: issue.grant,
+        admission: Some(issue.admission),
+    }
+}
+
+fn account_summary_from_record(record: HostedAccountRecord) -> HostedAccountSummary {
+    HostedAccountSummary {
+        hosted_account_id: record.hosted_account_id,
+        player_id: record.player_id,
+        login_channel: record.login_channel,
+        masked_login_hint: record.masked_login_hint,
+        status: record.status,
+        last_verified_at_unix_ms: record.last_verified_at_unix_ms,
+    }
+}
+
+fn resolve_store_path() -> PathBuf {
+    if let Ok(raw) = std::env::var(HOSTED_ACCOUNT_STORE_PATH_ENV) {
+        let trimmed = raw.trim();
+        if !trimmed.is_empty() {
+            return PathBuf::from(trimmed);
+        }
+    }
+    std::env::current_dir()
+        .unwrap_or_else(|_| PathBuf::from("."))
+        .join(".oasis7-hosted-account-store.json")
+}
+
+fn load_store(path: &Path) -> Result<HostedAccountStore, String> {
+    if !path.exists() {
+        return Ok(HostedAccountStore::default());
+    }
+    let raw = fs::read_to_string(path).map_err(|err| {
+        format!(
+            "failed to read hosted account store `{}`: {err}",
+            path.display()
+        )
+    })?;
+    serde_json::from_str(raw.as_str()).map_err(|err| {
+        format!(
+            "failed to parse hosted account store `{}`: {err}",
+            path.display()
+        )
+    })
+}
+
+fn save_store(path: &Path, store: &HostedAccountStore) -> Result<(), String> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|err| {
+            format!(
+                "failed to create hosted account store directory `{}`: {err}",
+                parent.display()
+            )
+        })?;
+    }
+    let raw = serde_json::to_string_pretty(store)
+        .map_err(|err| format!("failed to serialize hosted account store: {err}"))?;
+    fs::write(path, raw).map_err(|err| {
+        format!(
+            "failed to write hosted account store `{}`: {err}",
+            path.display()
+        )
+    })
+}
+
+fn normalize_delivery_mode(raw: Option<&str>) -> String {
+    match raw.unwrap_or("").trim() {
+        HOSTED_LOGIN_DELIVERY_MODE_SERVER_LOG_ONLY => {
+            HOSTED_LOGIN_DELIVERY_MODE_SERVER_LOG_ONLY.to_string()
+        }
+        _ => HOSTED_LOGIN_DELIVERY_MODE_PREVIEW_INLINE.to_string(),
+    }
+}
+
+fn emit_delivery_notice(
+    delivery_mode: &str,
+    channel: &str,
+    masked_login_hint: &str,
+    otp_code: &str,
+) {
+    if delivery_mode != HOSTED_LOGIN_DELIVERY_MODE_SERVER_LOG_ONLY {
+        return;
+    }
+    let message = format!(
+        "hosted account login challenge issued: channel={channel} target={masked_login_hint} otp={otp_code}"
+    );
+    emit_stderr_or_event(
+        Level::INFO,
+        message.as_str(),
+        "hosted account login challenge issued",
+    );
+}
+
+fn normalize_login_channel(raw: &str) -> Option<&'static str> {
+    match raw.trim() {
+        "email" => Some("email"),
+        "phone" => Some("phone"),
+        _ => None,
+    }
+}
+
+fn normalize_login_hint(channel: &str, raw: &str) -> Option<String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    match channel {
+        "email" => normalize_email(trimmed),
+        "phone" => normalize_phone(trimmed),
+        _ => None,
+    }
+}
+
+fn normalize_email(raw: &str) -> Option<String> {
+    let normalized = raw.trim().to_ascii_lowercase();
+    let (local, domain) = normalized.split_once('@')?;
+    if local.is_empty() || domain.is_empty() || !domain.contains('.') {
+        return None;
+    }
+    Some(normalized)
+}
+
+fn normalize_phone(raw: &str) -> Option<String> {
+    let mut normalized = String::new();
+    for (index, ch) in raw.trim().chars().enumerate() {
+        if ch.is_ascii_digit() {
+            normalized.push(ch);
+            continue;
+        }
+        if ch == '+' && index == 0 {
+            normalized.push(ch);
+        }
+    }
+    let digits = normalized.chars().filter(|ch| ch.is_ascii_digit()).count();
+    if digits < 7 || digits > 18 {
+        return None;
+    }
+    Some(normalized)
+}
+
+fn mask_login_hint(channel: &str, normalized_login_hint: &str) -> String {
+    match channel {
+        "email" => {
+            let (local, domain) = normalized_login_hint
+                .split_once('@')
+                .unwrap_or((normalized_login_hint, ""));
+            let local_chars: Vec<char> = local.chars().collect();
+            let visible = local_chars.iter().take(2).collect::<String>();
+            format!("{visible}***@{domain}")
+        }
+        "phone" => {
+            let suffix: String = normalized_login_hint
+                .chars()
+                .rev()
+                .take(4)
+                .collect::<String>()
+                .chars()
+                .rev()
+                .collect();
+            let prefix = if normalized_login_hint.starts_with('+') {
+                "+"
+            } else {
+                ""
+            };
+            format!("{prefix}***{suffix}")
+        }
+        _ => "***".to_string(),
+    }
+}
+
+fn factor_key(channel: &str, normalized_login_hint: &str) -> String {
+    format!("{channel}:{normalized_login_hint}")
+}
+
+fn build_login_challenge_id(issued_at_unix_ms: u64, sequence: u64) -> String {
+    format!("hosted-login-challenge-{issued_at_unix_ms:016x}-{sequence:08x}")
+}
+
+fn build_preview_otp_code(issued_at_unix_ms: u64, sequence: u64) -> String {
+    format!("{:06}", ((issued_at_unix_ms ^ sequence) % 1_000_000))
+}
+
+fn build_hosted_account_id(sequence: u64) -> String {
+    format!("oasis-account-{sequence:08x}")
+}
+
+fn build_hosted_player_id(sequence: u64) -> String {
+    format!("hosted-player-account-{sequence:08x}")
+}
+
+fn now_unix_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis()
+        .try_into()
+        .unwrap_or(u64::MAX)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    fn temp_store_path(name: &str) -> PathBuf {
+        let unique = now_unix_ms();
+        std::env::temp_dir().join(format!("oasis7-hosted-account-{name}-{unique}.json"))
+    }
+
+    #[test]
+    fn hosted_account_login_start_rejects_invalid_channel() {
+        let mut broker = HostedAccountIdentityBroker::with_store_path(temp_store_path("invalid"))
+            .expect("broker");
+        let response = broker.start_login(
+            DeploymentMode::HostedPublicJoin,
+            "telegram",
+            "user@example.com",
+        );
+        assert!(!response.ok);
+        assert_eq!(
+            response.error_code.as_deref(),
+            Some("unsupported_login_channel")
+        );
+    }
+
+    #[test]
+    fn hosted_account_login_complete_reuses_stable_player_id() {
+        let path = temp_store_path("stable-player");
+        let mut broker =
+            HostedAccountIdentityBroker::with_store_path(path.clone()).expect("broker");
+        let mut issuer = HostedPlayerSessionIssuer::default();
+
+        let start = broker.start_login(
+            DeploymentMode::HostedPublicJoin,
+            "email",
+            "player@example.com",
+        );
+        let challenge = start.challenge.expect("challenge");
+        let first = broker.complete_login(
+            DeploymentMode::HostedPublicJoin,
+            challenge.challenge_id.as_str(),
+            challenge.preview_code.as_deref().unwrap_or_default(),
+            &mut issuer,
+        );
+        assert!(first.ok);
+        let first_account = first.account.clone().expect("account");
+        let first_grant = first.grant.clone().expect("grant");
+        assert_eq!(first_account.player_id, first_grant.player_id);
+
+        std::thread::sleep(Duration::from_millis(2));
+        let start_second = broker.start_login(
+            DeploymentMode::HostedPublicJoin,
+            "email",
+            "player@example.com",
+        );
+        let challenge_second = start_second.challenge.expect("challenge");
+        let second = broker.complete_login(
+            DeploymentMode::HostedPublicJoin,
+            challenge_second.challenge_id.as_str(),
+            challenge_second.preview_code.as_deref().unwrap_or_default(),
+            &mut issuer,
+        );
+        assert!(second.ok);
+        let second_account = second.account.expect("second account");
+        let second_grant = second.grant.expect("second grant");
+        assert_eq!(
+            first_account.hosted_account_id,
+            second_account.hosted_account_id
+        );
+        assert_eq!(first_account.player_id, second_account.player_id);
+        assert_eq!(first_grant.player_id, second_grant.player_id);
+        assert_ne!(first_grant.release_token, second_grant.release_token);
+
+        let reloaded = HostedAccountIdentityBroker::with_store_path(path).expect("reloaded broker");
+        assert_eq!(reloaded.store.accounts_by_id.len(), 1);
+    }
+
+    #[test]
+    fn hosted_account_login_complete_rejects_wrong_otp() {
+        let mut broker = HostedAccountIdentityBroker::with_store_path(temp_store_path("wrong-otp"))
+            .expect("broker");
+        let mut issuer = HostedPlayerSessionIssuer::default();
+        let start =
+            broker.start_login(DeploymentMode::HostedPublicJoin, "phone", "+1 415 555 0101");
+        let challenge = start.challenge.expect("challenge");
+        let response = broker.complete_login(
+            DeploymentMode::HostedPublicJoin,
+            challenge.challenge_id.as_str(),
+            "000000",
+            &mut issuer,
+        );
+        assert!(!response.ok);
+        assert_eq!(response.error_code.as_deref(), Some("otp_code_invalid"));
+    }
+}

--- a/crates/oasis7/src/bin/oasis7_game_launcher/hosted_player_session.rs
+++ b/crates/oasis7/src/bin/oasis7_game_launcher/hosted_player_session.rs
@@ -255,6 +255,22 @@ impl HostedPlayerSessionIssuer {
         &mut self,
         deployment_mode: DeploymentMode,
     ) -> HostedPlayerSessionIssueResponse {
+        self.issue_internal(deployment_mode, None)
+    }
+
+    pub(super) fn issue_for_player(
+        &mut self,
+        deployment_mode: DeploymentMode,
+        player_id: &str,
+    ) -> HostedPlayerSessionIssueResponse {
+        self.issue_internal(deployment_mode, Some(player_id))
+    }
+
+    fn issue_internal(
+        &mut self,
+        deployment_mode: DeploymentMode,
+        player_id_override: Option<&str>,
+    ) -> HostedPlayerSessionIssueResponse {
         let contract = hosted_player_access_contract(deployment_mode);
         self.prune_old_timestamps();
         self.prune_expired_slots();
@@ -308,7 +324,12 @@ impl HostedPlayerSessionIssuer {
         self.next_sequence = self.next_sequence.saturating_add(1);
         self.issued_players_total = self.issued_players_total.saturating_add(1);
         self.issue_timestamps_unix_ms.push_back(issued_at_unix_ms);
-        let player_id = build_player_id(issued_at_unix_ms, self.next_sequence);
+        let player_id = player_id_override
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(ToOwned::to_owned)
+            .unwrap_or_else(|| build_player_id(issued_at_unix_ms, self.next_sequence));
+        let _ = self.release_slot_for_player(player_id.as_str(), true);
         let device_session_id = build_device_session_id(issued_at_unix_ms, self.next_sequence);
         let release_token = build_release_token(issued_at_unix_ms, self.next_sequence);
         self.active_release_tokens_by_player
@@ -575,6 +596,18 @@ mod tests {
         assert_eq!(response.admission.effective_player_sessions, 1);
         assert_eq!(response.admission.issued_players_total, 1);
         assert_eq!(response.admission.issued_in_current_window, 1);
+    }
+
+    #[test]
+    fn hosted_player_session_issue_for_player_reuses_stable_player_id() {
+        let mut issuer = HostedPlayerSessionIssuer::default();
+        let first = issuer.issue_for_player(DeploymentMode::HostedPublicJoin, "stable-player-1");
+        let second = issuer.issue_for_player(DeploymentMode::HostedPublicJoin, "stable-player-1");
+        let first_grant = first.grant.expect("first grant");
+        let second_grant = second.grant.expect("second grant");
+        assert_eq!(first_grant.player_id, "stable-player-1");
+        assert_eq!(second_grant.player_id, "stable-player-1");
+        assert_ne!(first_grant.release_token, second_grant.release_token);
     }
 
     #[test]

--- a/crates/oasis7/src/bin/oasis7_game_launcher/static_http.rs
+++ b/crates/oasis7/src/bin/oasis7_game_launcher/static_http.rs
@@ -1,3 +1,8 @@
+use super::hosted_account_identity::{
+    HostedAccountIdentityBroker, HostedAccountLoginCompleteResponse,
+    HostedAccountLoginStartResponse, HOSTED_ACCOUNT_LOGIN_COMPLETE_ROUTE,
+    HOSTED_ACCOUNT_LOGIN_START_ROUTE,
+};
 use super::hosted_player_session::{
     HostedPlayerSessionAdmissionResponse, HostedPlayerSessionIssueResponse,
     HostedPlayerSessionIssuer, HostedPlayerSessionReleaseResponse,
@@ -25,6 +30,7 @@ pub(super) fn handle_http_connection(
     default_viewer_player_id: Option<&str>,
     deployment_mode: DeploymentMode,
     hosted_session_issuer: &Arc<Mutex<HostedPlayerSessionIssuer>>,
+    hosted_account_broker: &Arc<Mutex<HostedAccountIdentityBroker>>,
 ) -> Result<(), String> {
     stream
         .set_read_timeout(Some(Duration::from_secs(2)))
@@ -55,14 +61,19 @@ pub(super) fn handle_http_connection(
     let is_refresh_route = path_only == HOSTED_PLAYER_SESSION_REFRESH_ROUTE;
     let is_issue_route = path_only == HOSTED_PLAYER_SESSION_ISSUE_ROUTE;
     let is_release_route = path_only == HOSTED_PLAYER_SESSION_RELEASE_ROUTE;
+    let is_login_start_route = path_only == HOSTED_ACCOUNT_LOGIN_START_ROUTE;
+    let is_login_complete_route = path_only == HOSTED_ACCOUNT_LOGIN_COMPLETE_ROUTE;
     let is_strong_auth_grant_route = path_only == HOSTED_STRONG_AUTH_GRANT_ROUTE
         || path_only == HOSTED_PROMPT_CONTROL_STRONG_AUTH_GRANT_ROUTE;
     let is_hosted_player_route = is_admission_route
         || is_refresh_route
         || is_issue_route
         || is_release_route
+        || is_login_start_route
+        || is_login_complete_route
         || is_strong_auth_grant_route;
-    let allow_post = is_release_route || is_refresh_route;
+    let allow_post =
+        is_release_route || is_refresh_route || is_login_start_route || is_login_complete_route;
     if !method.eq_ignore_ascii_case("GET")
         && !head_only
         && !(allow_post && method.eq_ignore_ascii_case("POST"))
@@ -110,6 +121,34 @@ pub(super) fn handle_http_connection(
         )?;
         write_json_response(&mut stream, 200, &response, head_only)
             .map_err(|err| format!("failed to write hosted session release response: {err}"))?;
+        return Ok(());
+    }
+    if is_login_start_route {
+        let login_channel = parse_query_value(target, "channel").unwrap_or_default();
+        let login_hint = parse_query_value(target, "handle").unwrap_or_default();
+        let response = start_hosted_account_login(
+            deployment_mode,
+            login_channel.as_str(),
+            login_hint.as_str(),
+            hosted_account_broker,
+        )?;
+        write_json_response(&mut stream, 200, &response, head_only)
+            .map_err(|err| format!("failed to write hosted account login start response: {err}"))?;
+        return Ok(());
+    }
+    if is_login_complete_route {
+        let challenge_id = parse_query_value(target, "challenge_id").unwrap_or_default();
+        let otp_code = parse_query_value(target, "otp_code").unwrap_or_default();
+        let response = complete_hosted_account_login(
+            deployment_mode,
+            challenge_id.as_str(),
+            otp_code.as_str(),
+            hosted_session_issuer,
+            hosted_account_broker,
+        )?;
+        write_json_response(&mut stream, 200, &response, head_only).map_err(|err| {
+            format!("failed to write hosted account login complete response: {err}")
+        })?;
         return Ok(());
     }
     if is_strong_auth_grant_route {
@@ -173,6 +212,34 @@ pub(super) fn handle_http_connection(
     }
 
     Ok(())
+}
+
+fn start_hosted_account_login(
+    deployment_mode: DeploymentMode,
+    login_channel: &str,
+    login_hint: &str,
+    hosted_account_broker: &Arc<Mutex<HostedAccountIdentityBroker>>,
+) -> Result<HostedAccountLoginStartResponse, String> {
+    let mut broker = hosted_account_broker
+        .lock()
+        .map_err(|_| "hosted account broker lock poisoned".to_string())?;
+    Ok(broker.start_login(deployment_mode, login_channel, login_hint))
+}
+
+fn complete_hosted_account_login(
+    deployment_mode: DeploymentMode,
+    challenge_id: &str,
+    otp_code: &str,
+    hosted_session_issuer: &Arc<Mutex<HostedPlayerSessionIssuer>>,
+    hosted_account_broker: &Arc<Mutex<HostedAccountIdentityBroker>>,
+) -> Result<HostedAccountLoginCompleteResponse, String> {
+    let mut broker = hosted_account_broker
+        .lock()
+        .map_err(|_| "hosted account broker lock poisoned".to_string())?;
+    let mut issuer = hosted_session_issuer
+        .lock()
+        .map_err(|_| "hosted session issuer lock poisoned".to_string())?;
+    Ok(broker.complete_login(deployment_mode, challenge_id, otp_code, &mut issuer))
 }
 
 fn reconcile_hosted_runtime_presence(

--- a/crates/oasis7/src/hosted_access.rs
+++ b/crates/oasis7/src/hosted_access.rs
@@ -270,6 +270,8 @@ pub(super) fn web_launcher_public_endpoints() -> &'static [&'static str] {
         "/healthz",
         "/api/public/player-session/admission",
         "/api/public/player-session/refresh",
+        "/api/public/hosted-account/login/start",
+        "/api/public/hosted-account/login/complete",
         "/api/public/state",
         "/api/public/player-session/issue",
         "/api/public/player-session/release",
@@ -410,5 +412,13 @@ mod tests {
         assert!(web_launcher_public_endpoints().contains(&"/api/public/strong-auth/grant"));
         assert!(!web_launcher_public_endpoints()
             .contains(&"/api/public/strong-auth/grant/prompt-control"));
+    }
+
+    #[test]
+    fn web_launcher_public_endpoints_expose_hosted_account_login_routes() {
+        assert!(web_launcher_public_endpoints().contains(&"/api/public/hosted-account/login/start"));
+        assert!(
+            web_launcher_public_endpoints().contains(&"/api/public/hosted-account/login/complete")
+        );
     }
 }

--- a/crates/oasis7_viewer/software_safe.js
+++ b/crates/oasis7_viewer/software_safe.js
@@ -727,8 +727,9 @@ const UI_LOCALE_STORAGE_PREFIX = "oasis7.viewer.locale.v1";
 const PROMPT_OVERRIDES_VISIBILITY_STORAGE_PREFIX = "oasis7.viewer.prompt_overrides_visible.v1";
 const HOSTED_PLAYER_SESSION_ADMISSION_ROUTE = "/api/public/player-session/admission";
 const HOSTED_PLAYER_SESSION_REFRESH_ROUTE = "/api/public/player-session/refresh";
-const HOSTED_PLAYER_SESSION_ISSUE_ROUTE = "/api/public/player-session/issue";
 const HOSTED_PLAYER_SESSION_RELEASE_ROUTE = "/api/public/player-session/release";
+const HOSTED_ACCOUNT_LOGIN_START_ROUTE = "/api/public/hosted-account/login/start";
+const HOSTED_ACCOUNT_LOGIN_COMPLETE_ROUTE = "/api/public/hosted-account/login/complete";
 const HOSTED_STRONG_AUTH_GRANT_ROUTE = "/api/public/strong-auth/grant";
 const HOSTED_PLAYER_SESSION_REFRESH_INTERVAL_MS = 3e4;
 const DEFAULT_WS_ADDR = "ws://127.0.0.1:5011";
@@ -808,7 +809,10 @@ const state = {
   selectedObject: null,
   auth: {
     available: false,
+    hostedAccountId: null,
     playerId: null,
+    loginChannel: null,
+    maskedLoginHint: null,
     deviceSessionId: null,
     publicKey: null,
     privateKey: null,
@@ -829,6 +833,20 @@ const state = {
     pendingRequestedAgentId: null,
     pendingForceRebind: false,
     rebindNotice: null
+  },
+  hostedLogin: {
+    channel: "email",
+    handle: "",
+    challengeId: null,
+    maskedLoginHint: null,
+    deliveryMode: null,
+    previewCode: null,
+    code: "",
+    expiresAtUnixMs: null,
+    accountExists: false,
+    startInFlight: false,
+    completeInFlight: false,
+    error: null
   },
   promptDraft: {
     agentId: null,
@@ -1165,7 +1183,10 @@ function resolveAuthBootstrap() {
   if (!raw || typeof raw !== "object") {
     return {
       available: false,
+      hostedAccountId: null,
       playerId: null,
+      loginChannel: null,
+      maskedLoginHint: null,
       deviceSessionId: null,
       publicKey: null,
       privateKey: null,
@@ -1194,7 +1215,10 @@ function resolveAuthBootstrap() {
   if (!playerId || !publicKey || !privateKey) {
     return {
       available: false,
+      hostedAccountId: null,
       playerId: playerId || null,
+      loginChannel: null,
+      maskedLoginHint: null,
       deviceSessionId: null,
       publicKey: publicKey || null,
       privateKey: privateKey || null,
@@ -1219,7 +1243,10 @@ function resolveAuthBootstrap() {
   }
   return {
     available: true,
+    hostedAccountId: null,
     playerId,
+    loginChannel: null,
+    maskedLoginHint: null,
     deviceSessionId: null,
     publicKey,
     privateKey,
@@ -1261,7 +1288,10 @@ function persistHostedPlayerSession(auth) {
     window.localStorage?.setItem(
       hostedPlayerSessionStorageKey(),
       JSON.stringify({
+        hostedAccountId: auth.hostedAccountId || null,
         playerId: auth.playerId,
+        loginChannel: auth.loginChannel || null,
+        maskedLoginHint: auth.maskedLoginHint || null,
         deviceSessionId: auth.deviceSessionId || auth.releaseToken || null,
         releaseToken: auth.releaseToken || null,
         issuedAtUnixMs: auth.issuedAtUnixMs || null,
@@ -1284,7 +1314,10 @@ function resolveStoredHostedPlayerSession() {
       return null;
     }
     const parsed = JSON.parse(raw);
+    const hostedAccountId = String(parsed?.hostedAccountId || parsed?.hosted_account_id || "").trim();
     const playerId = String(parsed?.playerId || "").trim();
+    const loginChannel = String(parsed?.loginChannel || parsed?.login_channel || "").trim();
+    const maskedLoginHint = String(parsed?.maskedLoginHint || parsed?.masked_login_hint || "").trim();
     const releaseToken = String(parsed?.releaseToken || "").trim();
     const deviceSessionId = String(parsed?.deviceSessionId || parsed?.device_session_id || parsed?.releaseToken || "").trim();
     if (!playerId || !releaseToken) {
@@ -1294,7 +1327,10 @@ function resolveStoredHostedPlayerSession() {
     window.localStorage?.setItem(
       hostedPlayerSessionStorageKey(),
       JSON.stringify({
+        hostedAccountId: hostedAccountId || null,
         playerId,
+        loginChannel: loginChannel || null,
+        maskedLoginHint: maskedLoginHint || null,
         deviceSessionId: deviceSessionId || releaseToken,
         releaseToken,
         issuedAtUnixMs: parsed?.issuedAtUnixMs ?? null,
@@ -1303,7 +1339,10 @@ function resolveStoredHostedPlayerSession() {
     );
     return {
       available: true,
+      hostedAccountId: hostedAccountId || null,
       playerId,
+      loginChannel: loginChannel || null,
+      maskedLoginHint: maskedLoginHint || null,
       deviceSessionId: deviceSessionId || releaseToken,
       publicKey: null,
       privateKey: null,
@@ -1336,6 +1375,16 @@ function resolveViewerAuthState() {
     return bootstrap2;
   }
   return resolveStoredHostedPlayerSession() || bootstrap2;
+}
+function resetHostedLoginChallenge() {
+  state.hostedLogin.challengeId = null;
+  state.hostedLogin.maskedLoginHint = null;
+  state.hostedLogin.deliveryMode = null;
+  state.hostedLogin.previewCode = null;
+  state.hostedLogin.code = "";
+  state.hostedLogin.expiresAtUnixMs = null;
+  state.hostedLogin.accountExists = false;
+  state.hostedLogin.completeInFlight = false;
 }
 function authHasSigningKeyMaterial(auth) {
   return !!String(auth?.publicKey || "").trim() && !!String(auth?.privateKey || "").trim();
@@ -1486,7 +1535,7 @@ function guestSessionReason(auth, deploymentHint) {
     return auth.source === "legacy_viewer_auth_bootstrap" ? "guest session has already been superseded by the current preview player auth lane" : "guest session has already been superseded by a hosted-issued player identity";
   }
   if (isHostedPublicJoinHint(deploymentHint)) {
-    return auth.error || "this browser is still guest-only; hosted public join must issue a player identity before low-risk interaction unlocks";
+    return auth.error || "this browser is still guest-only; hosted public join must complete hosted account login before low-risk interaction unlocks";
   }
   return auth.error || "viewer auth bootstrap is unavailable, so the browser cannot leave guest session";
 }
@@ -1504,7 +1553,7 @@ function playerSessionReason(auth, deploymentHint) {
     return auth.error || "hosted player identity exists, but runtime registration still needs recovery";
   }
   if (isHostedPublicJoinHint(deploymentHint)) {
-    return auth.error || "player session upgrade/login is still pending hosted issue";
+    return auth.error || "player session upgrade/login is still pending hosted account verification";
   }
   return auth.error || "viewer auth bootstrap is missing or incomplete";
 }
@@ -1690,7 +1739,7 @@ function buildAuthSurfaceModel() {
       main_token_transfer: mainTokenTransferCapability,
       strong_auth_actions: mainTokenTransferCapability
     },
-    reconnect: state.auth.available ? state.auth.source === "legacy_viewer_auth_bootstrap" ? "reconnect still depends on the current preview bootstrap; hosted player-session reconnect/release is available only after switching away from legacy bootstrap" : state.auth.registrationStatus === "registered" ? "page reload will reuse the hosted device session, mint a fresh browser session key, and attempt reconnect_sync first" : "hosted device session is persisted locally, but runtime player-session restore is still pending this page load" : isHostedPublicJoinHint(deploymentHint) ? buildHostedRecoveryHint("en")?.detail || "hosted public join recovers by acquiring a player_session first, then re-registering it through reconnect_sync" : "page reload is possible once viewer auth bootstrap or hosted player-session issue succeeds"
+    reconnect: state.auth.available ? state.auth.source === "legacy_viewer_auth_bootstrap" ? "reconnect still depends on the current preview bootstrap; hosted player-session reconnect/release is available only after switching away from legacy bootstrap" : state.auth.registrationStatus === "registered" ? "page reload will reuse the hosted device session, mint a fresh browser session key, and attempt reconnect_sync first" : "hosted device session is persisted locally, but runtime player-session restore is still pending this page load" : isHostedPublicJoinHint(deploymentHint) ? buildHostedRecoveryHint("en")?.detail || "hosted public join recovers by verifying the hosted account, acquiring a player_session, then re-registering it through reconnect_sync" : "page reload is possible once viewer auth bootstrap or hosted account login succeeds"
   };
 }
 function buildHostedActionMatrixView() {
@@ -1726,8 +1775,8 @@ function buildHostedRecoveryHint(locale = state.uiLocale) {
     return {
       kind: "released",
       title: isLocaleZh(locale) ? "托管玩家会话已释放" : "Hosted player session released",
-      detail: isLocaleZh(locale) ? "当前浏览器已经在本地释放托管玩家席位。若要继续试玩，需要重新获取托管玩家会话。" : "This browser returned its hosted player slot locally. Acquire a new hosted player session if you want to resume gameplay.",
-      cta: isLocaleZh(locale) ? "获取托管玩家会话" : "Acquire Hosted Player Session"
+      detail: isLocaleZh(locale) ? "当前浏览器已经在本地释放托管玩家席位。若要继续试玩，需要重新完成托管账户登录并获取新的玩家会话。" : "This browser returned its hosted player slot locally. Re-login to the hosted account and acquire a fresh player session if you want to resume gameplay.",
+      cta: isLocaleZh(locale) ? "重新登录托管账户" : "Re-login to Hosted Account"
     };
   }
   if (errorText.includes("revoked") || revokeReason || revokedBy) {
@@ -1736,23 +1785,23 @@ function buildHostedRecoveryHint(locale = state.uiLocale) {
     return {
       kind: "revoked",
       title: isLocaleZh(locale) ? "托管玩家会话已被撤销" : "Hosted player session was revoked",
-      detail: isLocaleZh(locale) ? `运行时或操作者撤销了这个浏览器会话${actorText}.${reasonText} 继续进行玩法、聊天或 prompt 操作前，需要重新获取新的托管玩家会话。` : `The runtime or operator revoked this browser session${actorText}.${reasonText} You need to acquire a fresh hosted player session before gameplay, chat, or prompt actions can continue.`,
-      cta: isLocaleZh(locale) ? "重新获取托管玩家会话" : "Re-acquire Hosted Player Session"
+      detail: isLocaleZh(locale) ? `运行时或操作者撤销了这个浏览器会话${actorText}.${reasonText} 继续进行玩法、聊天或 prompt 操作前，需要重新登录托管账户并获取新的玩家会话。` : `The runtime or operator revoked this browser session${actorText}.${reasonText} You need to re-login to the hosted account and acquire a fresh player session before gameplay, chat, or prompt actions can continue.`,
+      cta: isLocaleZh(locale) ? "重新登录托管账户" : "Re-login to Hosted Account"
     };
   }
   if (errorText.includes("session_not_found") || errorText.includes("not found")) {
     return {
       kind: "missing",
       title: isLocaleZh(locale) ? "运行时中找不到托管玩家会话" : "Hosted player session is missing from runtime",
-      detail: isLocaleZh(locale) ? "浏览器本地只保留了 device session，但运行时已经不再识别这个会话。请重新获取托管玩家会话并重新注册。" : "The browser only retained the local device-session handle, but the runtime no longer recognizes this session. Acquire a fresh hosted player session and register again.",
-      cta: isLocaleZh(locale) ? "重新获取托管玩家会话" : "Re-acquire Hosted Player Session"
+      detail: isLocaleZh(locale) ? "浏览器本地只保留了 device session，但运行时已经不再识别这个会话。请重新登录托管账户，获取新的玩家会话并重新注册。" : "The browser only retained the local device-session handle, but the runtime no longer recognizes this session. Re-login to the hosted account, acquire a fresh player session, and register again.",
+      cta: isLocaleZh(locale) ? "重新登录托管账户" : "Re-login to Hosted Account"
     };
   }
   return {
     kind: "guest",
     title: isLocaleZh(locale) ? "托管玩家会话不可用" : "Hosted player session is unavailable",
     detail: errorText,
-    cta: isLocaleZh(locale) ? "获取托管玩家会话" : "Acquire Hosted Player Session"
+    cta: isLocaleZh(locale) ? "登录托管账户" : "Login to Hosted Account"
   };
 }
 function nextRequestId() {
@@ -3054,34 +3103,100 @@ async function buildGameplayActionAuthProof(request, auth) {
 function canAutoIssueHostedPlayerSession() {
   return String(state.hostedAccess?.deployment_mode || "").trim() === "hosted_public_join" && state.auth.source !== "legacy_viewer_auth_bootstrap";
 }
-async function issueHostedPlayerIdentity() {
+async function startHostedAccountLogin() {
   if (!canAutoIssueHostedPlayerSession()) {
-    return state.auth;
+    return { ok: false, reason: "hosted account login is unavailable on this lane" };
   }
-  if (state.auth.available || state.auth.issueInFlight) {
-    return state.auth;
+  const channel = String(state.hostedLogin.channel || "email").trim() || "email";
+  const handle = String(state.hostedLogin.handle || "").trim();
+  if (!handle) {
+    state.hostedLogin.error = "phone number or email is required before login can start";
+    render();
+    return { ok: false, reason: state.hostedLogin.error };
   }
-  state.auth.issueInFlight = true;
-  state.auth.error = null;
+  state.hostedLogin.startInFlight = true;
+  state.hostedLogin.error = null;
   render();
   try {
-    const response = await fetch(HOSTED_PLAYER_SESSION_ISSUE_ROUTE, {
-      method: "GET",
+    const query = new URLSearchParams({
+      channel,
+      handle
+    });
+    const response = await fetch(`${HOSTED_ACCOUNT_LOGIN_START_ROUTE}?${query.toString()}`, {
+      method: "POST",
       cache: "no-store",
       headers: { Accept: "application/json" }
     });
     const payload = await response.json();
-    if (!response.ok || !payload?.ok || !payload?.grant?.player_id) {
+    if (!response.ok || !payload?.ok || !payload?.challenge?.challenge_id) {
+      throw new Error(payload?.error || payload?.error_code || `hosted account login start failed with HTTP ${response.status}`);
+    }
+    state.hostedLogin.challengeId = String(payload.challenge.challenge_id || "").trim() || null;
+    state.hostedLogin.maskedLoginHint = String(payload.challenge.masked_login_hint || "").trim() || null;
+    state.hostedLogin.deliveryMode = String(payload.challenge.delivery_mode || "").trim() || null;
+    state.hostedLogin.previewCode = String(payload.challenge.preview_code || "").trim() || null;
+    state.hostedLogin.code = state.hostedLogin.previewCode || "";
+    state.hostedLogin.expiresAtUnixMs = payload?.challenge?.expires_at_unix_ms == null ? null : Number(payload.challenge.expires_at_unix_ms);
+    state.hostedLogin.accountExists = payload?.challenge?.account_exists === true;
+    state.hostedLogin.startInFlight = false;
+    state.hostedLogin.completeInFlight = false;
+    state.hostedLogin.error = null;
+    render();
+    return { ok: true, challengeId: state.hostedLogin.challengeId };
+  } catch (error) {
+    state.hostedLogin.startInFlight = false;
+    state.hostedLogin.error = String(error);
+    render();
+    return { ok: false, reason: state.hostedLogin.error };
+  }
+}
+async function ensureHostedPlayerAuthAvailable() {
+  return state.auth;
+}
+async function completeHostedAccountLogin() {
+  if (!canAutoIssueHostedPlayerSession()) {
+    return state.auth;
+  }
+  if (state.auth.available) {
+    return state.auth;
+  }
+  const challengeId = String(state.hostedLogin.challengeId || "").trim();
+  const otpCode = String(state.hostedLogin.code || "").trim();
+  if (!challengeId || !otpCode) {
+    state.hostedLogin.error = "verification code is required before hosted login can complete";
+    render();
+    return state.auth;
+  }
+  state.auth.issueInFlight = true;
+  state.hostedLogin.completeInFlight = true;
+  state.hostedLogin.error = null;
+  state.auth.error = null;
+  render();
+  try {
+    const query = new URLSearchParams({
+      challenge_id: challengeId,
+      otp_code: otpCode
+    });
+    const response = await fetch(`${HOSTED_ACCOUNT_LOGIN_COMPLETE_ROUTE}?${query.toString()}`, {
+      method: "POST",
+      cache: "no-store",
+      headers: { Accept: "application/json" }
+    });
+    const payload = await response.json();
+    if (!response.ok || !payload?.ok || !payload?.grant?.player_id || !payload?.account?.hosted_account_id) {
       if (payload?.admission) {
         state.hostedAdmission = clone(payload.admission);
       }
-      throw new Error(payload?.error || payload?.error_code || `hosted player-session issue failed with HTTP ${response.status}`);
+      throw new Error(payload?.error || payload?.error_code || `hosted account login complete failed with HTTP ${response.status}`);
     }
     state.hostedAdmission = payload?.admission ? clone(payload.admission) : state.hostedAdmission;
     const keypair = await generateEphemeralEd25519Keypair();
     state.auth = {
       available: true,
+      hostedAccountId: String(payload.account.hosted_account_id || "").trim() || null,
       playerId: String(payload.grant.player_id || "").trim(),
+      loginChannel: String(payload.account.login_channel || "").trim() || null,
+      maskedLoginHint: String(payload.account.masked_login_hint || "").trim() || null,
       deviceSessionId: String(payload.grant.device_session_id || "").trim() || String(payload.grant.release_token || "").trim() || null,
       publicKey: keypair.publicKey,
       privateKey: keypair.privateKey,
@@ -3104,34 +3219,30 @@ async function issueHostedPlayerIdentity() {
       rebindNotice: null
     };
     persistHostedPlayerSession(state.auth);
+    resetHostedLoginChallenge();
+    state.hostedLogin.startInFlight = false;
+    state.hostedLogin.error = null;
     render();
     return state.auth;
   } catch (error) {
     state.auth.issueInFlight = false;
+    state.hostedLogin.completeInFlight = false;
+    state.hostedLogin.error = String(error);
     state.auth.error = String(error);
     render();
     return state.auth;
   }
 }
-async function ensureHostedPlayerAuthAvailable() {
-  if (state.auth.available) {
-    return state.auth;
-  }
-  if (canAutoIssueHostedPlayerSession()) {
-    return issueHostedPlayerIdentity();
-  }
-  return state.auth;
-}
 async function retryHostedPlayerIdentityIssue() {
   if (!canAutoIssueHostedPlayerSession()) {
-    return { ok: false, reason: "hosted public player-session issue is unavailable on this lane" };
+    return { ok: false, reason: "hosted account login is unavailable on this lane" };
   }
-  const auth = await issueHostedPlayerIdentity();
+  const auth = state.hostedLogin.challengeId ? await completeHostedAccountLogin() : await startHostedAccountLogin();
   render();
   return {
-    ok: auth.available,
-    playerId: auth.playerId,
-    error: auth.error
+    ok: auth?.available === true || auth?.ok === true,
+    playerId: auth?.playerId || null,
+    error: auth?.error || state.hostedLogin.error
   };
 }
 async function requestHostedStrongAuthGrant(actionId, agentId) {
@@ -3234,6 +3345,7 @@ async function releaseHostedPlayerSlot() {
 function resetHostedPlayerAuthState(errorMessage = null, revocationMeta = null) {
   stopHostedSessionRefreshLoop();
   clearHostedPlayerSession();
+  resetHostedLoginChallenge();
   const bootstrap2 = resolveAuthBootstrap();
   const revokeReason = String(revocationMeta?.revokeReason || "").trim() || null;
   const revokedBy = String(revocationMeta?.revokedBy || "").trim() || null;
@@ -3244,6 +3356,9 @@ function resetHostedPlayerAuthState(errorMessage = null, revocationMeta = null) 
     error: errorMessage,
     revokeReason,
     revokedBy,
+    hostedAccountId: null,
+    loginChannel: null,
+    maskedLoginHint: null,
     deviceSessionId: null,
     sessionEpoch: null,
     issuedAtUnixMs: null,
@@ -4053,10 +4168,6 @@ async function recoverHostedSessionFromError(error) {
     });
     resetHostedPlayerAuthState(error?.message || code || "hosted player session failed");
     render();
-    await issueHostedPlayerIdentity();
-    if (state.auth.available) {
-      await ensureRegisteredPlayerSession(latestRequestedAgentId());
-    }
   }
 }
 function handleAuthoritativeRecoveryAck(ack) {
@@ -4286,6 +4397,8 @@ function installTestApi() {
     setStrongAuthApprovalCode,
     injectSnapshot,
     logoutHostedPlayerSession,
+    startHostedAccountLogin,
+    completeHostedAccountLogin,
     retryHostedPlayerIdentityIssue,
     reportFatalError
   };

--- a/crates/oasis7_viewer/software_safe.js
+++ b/crates/oasis7_viewer/software_safe.js
@@ -1377,6 +1377,7 @@ function resolveViewerAuthState() {
   return resolveStoredHostedPlayerSession() || bootstrap2;
 }
 function resetHostedLoginChallenge() {
+  state.hostedLogin.channel = "email";
   state.hostedLogin.challengeId = null;
   state.hostedLogin.maskedLoginHint = null;
   state.hostedLogin.deliveryMode = null;
@@ -3107,10 +3108,11 @@ async function startHostedAccountLogin() {
   if (!canAutoIssueHostedPlayerSession()) {
     return { ok: false, reason: "hosted account login is unavailable on this lane" };
   }
-  const channel = String(state.hostedLogin.channel || "email").trim() || "email";
+  const channel = "email";
+  state.hostedLogin.channel = channel;
   const handle = String(state.hostedLogin.handle || "").trim();
   if (!handle) {
-    state.hostedLogin.error = "phone number or email is required before login can start";
+    state.hostedLogin.error = "email is required before login can start";
     render();
     return { ok: false, reason: state.hostedLogin.error };
   }
@@ -5266,7 +5268,7 @@ function PixelWorldHost(props) {
   })();
 }
 delegateEvents(["click"]);
-var _tmpl$ = /* @__PURE__ */ template(`<span>`), _tmpl$2 = /* @__PURE__ */ template(`<div class=empty>`), _tmpl$3 = /* @__PURE__ */ template(`<pre class=json>`), _tmpl$4 = /* @__PURE__ */ template(`<div class=feedback-detail>`), _tmpl$5 = /* @__PURE__ */ template(`<details class=diagnostic><summary></summary><div class=stack style=margin-top:10px>`), _tmpl$6 = /* @__PURE__ */ template(`<div class=feedback-card><div class=badge-row></div><div class=feedback-summary>`), _tmpl$7 = /* @__PURE__ */ template(`<div class=badge-row style=margin-top:8px>`), _tmpl$8 = /* @__PURE__ */ template(`<div class=metric><div class=metric__label></div><div class=metric__value>`), _tmpl$9 = /* @__PURE__ */ template(`<div class=event-card__meta>`), _tmpl$0 = /* @__PURE__ */ template(`<div><div class=event-card__title><span>`), _tmpl$1 = /* @__PURE__ */ template(`<div class=panel__eyebrow>`), _tmpl$10 = /* @__PURE__ */ template(`<div class=panel__meta-copy>`), _tmpl$11 = /* @__PURE__ */ template(`<div><div class=panel__header><div class=stack style=gap:4px><div class=panel__title></div></div></div><div class="panel__body stack">`), _tmpl$12 = /* @__PURE__ */ template(`<div><div class=callout__header><div class=callout__title></div></div><div class=callout__body>`), _tmpl$13 = /* @__PURE__ */ template(`<div class=feedback-summary>`), _tmpl$14 = /* @__PURE__ */ template(`<div class=badge-row>`), _tmpl$15 = /* @__PURE__ */ template(`<details class=entry-menu><summary class=entry-menu__toggle></summary><div class="entry-menu__panel stack"><div><div class=panel__title style=margin-bottom:10px></div><div class=feedback-detail></div></div><div class=toolbar><button data-locale=zh>中文</button><button data-locale=en>English</button></div><div class=badge-row></div><div class=feedback-detail>`), _tmpl$16 = /* @__PURE__ */ template(`<div class=stage-hero><div class=stage-hero__topline><div class=stack style=gap:10px><div class=stage-hero__eyebrow></div><div class=stage-hero__title></div><div class=stage-hero__lede></div></div></div><div class=hero-focus-grid><div class=hero-focus-card><div class=hero-focus-card__label></div><div></div><div class=hero-focus-card__detail></div></div><div class=hero-focus-card><div class=hero-focus-card__label></div><div class="hero-focus-card__value hero-focus-card__value--body"></div><div class=hero-focus-card__detail></div></div><div class=hero-focus-card><div class=hero-focus-card__label></div><div class="hero-focus-card__value hero-focus-card__value--body">`), _tmpl$17 = /* @__PURE__ */ template(`<nav class=mobile-rail><a class=mobile-rail__link href=#viewer-stage-panel></a><a class=mobile-rail__link href=#viewer-targets-panel></a><a class=mobile-rail__link href=#viewer-details-panel>`), _tmpl$18 = /* @__PURE__ */ template(`<div class=stack><div class=field><label for=entity-search></label><input id=entity-search type=search></div><div><div class=panel__title style=margin-bottom:10px></div><div class=list></div></div><div><div class=panel__title style=margin-bottom:10px></div><div class=list>`), _tmpl$19 = /* @__PURE__ */ template(`<button class=list-item data-select-kind=agent><div class=list-item__title></div><div class=list-item__meta>`), _tmpl$20 = /* @__PURE__ */ template(`<button class=list-item data-select-kind=location><div class=list-item__title></div><div class=list-item__meta>`), _tmpl$21 = /* @__PURE__ */ template(`<div class=toolbar><button data-auth-action=retry-issue>`), _tmpl$22 = /* @__PURE__ */ template(`<div class=toolbar><button data-auth-action=logout>`), _tmpl$23 = /* @__PURE__ */ template(`<button data-auth-action=retry-issue>`), _tmpl$24 = /* @__PURE__ */ template(`<button data-auth-action=logout>`), _tmpl$25 = /* @__PURE__ */ template(`<div class=event-list>`), _tmpl$26 = /* @__PURE__ */ template(`<div class=stack><details class="panel diagnostic-surface"><summary class="panel__header diagnostic-surface__summary"><div class=diagnostic-surface__title><div class=panel__title></div><div class=diagnostic-surface__meta></div></div><div class=badge-row></div></summary><div class="panel__body stack"><div class=badge-row></div><div class=badge-row></div><div class=toolbar></div><div class=summary-grid></div><div><div class=panel__title style=margin-bottom:10px></div><div class=event-list>`), _tmpl$27 = /* @__PURE__ */ template(`<div class=badge-row style=margin-top:10px>`), _tmpl$28 = /* @__PURE__ */ template(`<div><div class=panel__title style=margin-bottom:10px></div><div class=action-grid>`), _tmpl$29 = /* @__PURE__ */ template(`<div class=toolbar><button>`), _tmpl$30 = /* @__PURE__ */ template(`<div class=field><label for=agent-chat-message></label><textarea id=agent-chat-message rows=4>`), _tmpl$31 = /* @__PURE__ */ template(`<div class=toolbar><button data-chat-send=1>`), _tmpl$32 = /* @__PURE__ */ template(`<div><div class=panel__title style=margin-bottom:10px></div><div class=event-list>`), _tmpl$33 = /* @__PURE__ */ template(`<div class=toolbar><button data-prompt-visibility-toggle=1>`), _tmpl$34 = /* @__PURE__ */ template(`<div class=field><label for=strong-auth-approval-code></label><input id=strong-auth-approval-code type=password autocomplete=off>`), _tmpl$35 = /* @__PURE__ */ template(`<div class=field><label for=prompt-system></label><textarea id=prompt-system rows=4>`), _tmpl$36 = /* @__PURE__ */ template(`<div class=field><label for=prompt-short></label><textarea id=prompt-short rows=3>`), _tmpl$37 = /* @__PURE__ */ template(`<div class=field><label for=prompt-long></label><textarea id=prompt-long rows=3>`), _tmpl$38 = /* @__PURE__ */ template(`<div class=toolbar><button data-prompt-action=preview></button><button data-prompt-action=apply>`), _tmpl$39 = /* @__PURE__ */ template(`<div class=toolbar><div class=field style=margin:0;min-width:180px;flex:1><label for=prompt-rollback-version></label><input id=prompt-rollback-version type=number min=0 step=1></div><button data-prompt-action=rollback>`), _tmpl$40 = /* @__PURE__ */ template(`<div class=toolbar><button disabled>`), _tmpl$41 = /* @__PURE__ */ template(`<div class=stack><div class=badge-row></div><div class=badge-row>`), _tmpl$42 = /* @__PURE__ */ template(`<div><div class=panel__title style=margin-bottom:10px;color:var(--bad)></div><pre class=json>`), _tmpl$43 = /* @__PURE__ */ template(`<div class=stack><div class=badge-row></div><div><div class=panel__title style=margin-bottom:10px></div><div class=badge-row></div><div class=stack style=margin-top:10px><div class=feedback-detail></div><div class=feedback-detail></div><div><div class=panel__title style=margin-bottom:10px></div><div class=event-list>`), _tmpl$44 = /* @__PURE__ */ template(`<div class=feedback-detail>=`), _tmpl$45 = /* @__PURE__ */ template(`<section class="panel panel--targets"id=viewer-targets-panel><div class="panel__header panel__header--stack"><div class=panel__eyebrow></div><div class=panel__title></div><div class=panel__meta-copy></div></div><div class=panel__body>`), _tmpl$46 = /* @__PURE__ */ template(`<section class="panel panel--stage"id=viewer-stage-panel><div class="panel__body panel__body--stage"><div class=stack>`), _tmpl$47 = /* @__PURE__ */ template(`<section class="panel panel--details"id=viewer-details-panel><div class="panel__header panel__header--stack"><div class=panel__eyebrow></div><div class=panel__title></div><div class=panel__meta-copy></div></div><div class=panel__body>`);
+var _tmpl$ = /* @__PURE__ */ template(`<span>`), _tmpl$2 = /* @__PURE__ */ template(`<div class=empty>`), _tmpl$3 = /* @__PURE__ */ template(`<pre class=json>`), _tmpl$4 = /* @__PURE__ */ template(`<div class=feedback-detail>`), _tmpl$5 = /* @__PURE__ */ template(`<details class=diagnostic><summary></summary><div class=stack style=margin-top:10px>`), _tmpl$6 = /* @__PURE__ */ template(`<div class=feedback-card><div class=badge-row></div><div class=feedback-summary>`), _tmpl$7 = /* @__PURE__ */ template(`<div class=badge-row style=margin-top:8px>`), _tmpl$8 = /* @__PURE__ */ template(`<div class=metric><div class=metric__label></div><div class=metric__value>`), _tmpl$9 = /* @__PURE__ */ template(`<div class=event-card__meta>`), _tmpl$0 = /* @__PURE__ */ template(`<div><div class=event-card__title><span>`), _tmpl$1 = /* @__PURE__ */ template(`<div class=panel__eyebrow>`), _tmpl$10 = /* @__PURE__ */ template(`<div class=panel__meta-copy>`), _tmpl$11 = /* @__PURE__ */ template(`<div><div class=panel__header><div class=stack style=gap:4px><div class=panel__title></div></div></div><div class="panel__body stack">`), _tmpl$12 = /* @__PURE__ */ template(`<div><div class=callout__header><div class=callout__title></div></div><div class=callout__body>`), _tmpl$13 = /* @__PURE__ */ template(`<div class=badge-row>`), _tmpl$14 = /* @__PURE__ */ template(`<div class=field><label></label><input type=text autocomplete=off>`), _tmpl$15 = /* @__PURE__ */ template(`<div class=toolbar><button data-auth-action=complete-login>`), _tmpl$16 = /* @__PURE__ */ template(`<div class=stack><div class=control-grid><div class=field><label></label><input type=email autocomplete=email></div></div><div class=toolbar><button data-auth-action=start-login>`), _tmpl$17 = /* @__PURE__ */ template(`<div class=feedback-summary>`), _tmpl$18 = /* @__PURE__ */ template(`<details class=entry-menu><summary class=entry-menu__toggle></summary><div class="entry-menu__panel stack"><div><div class=panel__title style=margin-bottom:10px></div><div class=feedback-detail></div></div><div class=toolbar><button data-locale=zh>中文</button><button data-locale=en>English</button></div><div class=badge-row></div><div class=feedback-detail>`), _tmpl$19 = /* @__PURE__ */ template(`<div class=stage-hero><div class=stage-hero__topline><div class=stack style=gap:10px><div class=stage-hero__eyebrow></div><div class=stage-hero__title></div><div class=stage-hero__lede></div></div></div><div class=hero-focus-grid><div class=hero-focus-card><div class=hero-focus-card__label></div><div></div><div class=hero-focus-card__detail></div></div><div class=hero-focus-card><div class=hero-focus-card__label></div><div class="hero-focus-card__value hero-focus-card__value--body"></div><div class=hero-focus-card__detail></div></div><div class=hero-focus-card><div class=hero-focus-card__label></div><div class="hero-focus-card__value hero-focus-card__value--body">`), _tmpl$20 = /* @__PURE__ */ template(`<nav class=mobile-rail><a class=mobile-rail__link href=#viewer-stage-panel></a><a class=mobile-rail__link href=#viewer-targets-panel></a><a class=mobile-rail__link href=#viewer-details-panel>`), _tmpl$21 = /* @__PURE__ */ template(`<div class=stack><div class=field><label for=entity-search></label><input id=entity-search type=search></div><div><div class=panel__title style=margin-bottom:10px></div><div class=list></div></div><div><div class=panel__title style=margin-bottom:10px></div><div class=list>`), _tmpl$22 = /* @__PURE__ */ template(`<button class=list-item data-select-kind=agent><div class=list-item__title></div><div class=list-item__meta>`), _tmpl$23 = /* @__PURE__ */ template(`<button class=list-item data-select-kind=location><div class=list-item__title></div><div class=list-item__meta>`), _tmpl$24 = /* @__PURE__ */ template(`<div class=toolbar><button data-auth-action=logout>`), _tmpl$25 = /* @__PURE__ */ template(`<button data-auth-action=logout>`), _tmpl$26 = /* @__PURE__ */ template(`<div class=event-list>`), _tmpl$27 = /* @__PURE__ */ template(`<div class=stack><details class="panel diagnostic-surface"><summary class="panel__header diagnostic-surface__summary"><div class=diagnostic-surface__title><div class=panel__title></div><div class=diagnostic-surface__meta></div></div><div class=badge-row></div></summary><div class="panel__body stack"><div class=badge-row></div><div class=badge-row></div><div class=toolbar></div><div class=summary-grid></div><div><div class=panel__title style=margin-bottom:10px></div><div class=event-list>`), _tmpl$28 = /* @__PURE__ */ template(`<div class=badge-row style=margin-top:10px>`), _tmpl$29 = /* @__PURE__ */ template(`<div><div class=panel__title style=margin-bottom:10px></div><div class=action-grid>`), _tmpl$30 = /* @__PURE__ */ template(`<div class=toolbar><button>`), _tmpl$31 = /* @__PURE__ */ template(`<div class=field><label for=agent-chat-message></label><textarea id=agent-chat-message rows=4>`), _tmpl$32 = /* @__PURE__ */ template(`<div class=toolbar><button data-chat-send=1>`), _tmpl$33 = /* @__PURE__ */ template(`<div><div class=panel__title style=margin-bottom:10px></div><div class=event-list>`), _tmpl$34 = /* @__PURE__ */ template(`<div class=toolbar><button data-prompt-visibility-toggle=1>`), _tmpl$35 = /* @__PURE__ */ template(`<div class=field><label for=strong-auth-approval-code></label><input id=strong-auth-approval-code type=password autocomplete=off>`), _tmpl$36 = /* @__PURE__ */ template(`<div class=field><label for=prompt-system></label><textarea id=prompt-system rows=4>`), _tmpl$37 = /* @__PURE__ */ template(`<div class=field><label for=prompt-short></label><textarea id=prompt-short rows=3>`), _tmpl$38 = /* @__PURE__ */ template(`<div class=field><label for=prompt-long></label><textarea id=prompt-long rows=3>`), _tmpl$39 = /* @__PURE__ */ template(`<div class=toolbar><button data-prompt-action=preview></button><button data-prompt-action=apply>`), _tmpl$40 = /* @__PURE__ */ template(`<div class=toolbar><div class=field style=margin:0;min-width:180px;flex:1><label for=prompt-rollback-version></label><input id=prompt-rollback-version type=number min=0 step=1></div><button data-prompt-action=rollback>`), _tmpl$41 = /* @__PURE__ */ template(`<div class=toolbar><button disabled>`), _tmpl$42 = /* @__PURE__ */ template(`<div class=stack><div class=badge-row></div><div class=badge-row>`), _tmpl$43 = /* @__PURE__ */ template(`<div><div class=panel__title style=margin-bottom:10px;color:var(--bad)></div><pre class=json>`), _tmpl$44 = /* @__PURE__ */ template(`<div class=stack><div class=badge-row></div><div><div class=panel__title style=margin-bottom:10px></div><div class=badge-row></div><div class=stack style=margin-top:10px><div class=feedback-detail></div><div class=feedback-detail></div><div><div class=panel__title style=margin-bottom:10px></div><div class=event-list>`), _tmpl$45 = /* @__PURE__ */ template(`<div class=feedback-detail>=`), _tmpl$46 = /* @__PURE__ */ template(`<section class="panel panel--targets"id=viewer-targets-panel><div class="panel__header panel__header--stack"><div class=panel__eyebrow></div><div class=panel__title></div><div class=panel__meta-copy></div></div><div class=panel__body>`), _tmpl$47 = /* @__PURE__ */ template(`<section class="panel panel--stage"id=viewer-stage-panel><div class="panel__body panel__body--stage"><div class=stack>`), _tmpl$48 = /* @__PURE__ */ template(`<section class="panel panel--details"id=viewer-details-panel><div class="panel__header panel__header--stack"><div class=panel__eyebrow></div><div class=panel__title></div><div class=panel__meta-copy></div></div><div class=panel__body>`);
 function uiLocale() {
   return state.uiLocale;
 }
@@ -5490,6 +5492,119 @@ function CalloutCard(props) {
     return _el$26;
   })();
 }
+function HostedLoginForm(props) {
+  const locale = () => props.locale ?? uiLocale();
+  return (() => {
+    var _el$30 = _tmpl$16(), _el$31 = _el$30.firstChild, _el$32 = _el$31.firstChild, _el$33 = _el$32.firstChild, _el$34 = _el$33.nextSibling, _el$35 = _el$31.nextSibling, _el$36 = _el$35.firstChild;
+    insert(_el$33, () => tr(locale(), "邮箱", "Email"));
+    _el$34.$$input = (event) => {
+      state.hostedLogin.handle = String(event.currentTarget.value || "");
+      state.hostedLogin.error = null;
+      requestRender();
+    };
+    _el$36.$$click = () => {
+      void startHostedAccountLogin();
+    };
+    insert(_el$36, () => tr(locale(), "请求登录验证码", "Request Login Code"));
+    insert(_el$30, createComponent(Show, {
+      get when() {
+        return state.hostedLogin.challengeId;
+      },
+      get children() {
+        return [(() => {
+          var _el$37 = _tmpl$13();
+          insert(_el$37, createComponent(Badge, {
+            get children() {
+              return `challenge=${state.hostedLogin.challengeId}`;
+            }
+          }), null);
+          insert(_el$37, createComponent(Badge, {
+            get children() {
+              return `target=${state.hostedLogin.maskedLoginHint || "-"}`;
+            }
+          }), null);
+          insert(_el$37, createComponent(Badge, {
+            get children() {
+              return `delivery=${state.hostedLogin.deliveryMode || "-"}`;
+            }
+          }), null);
+          insert(_el$37, createComponent(Badge, {
+            get children() {
+              return state.hostedLogin.accountExists ? "account=existing" : "account=new";
+            }
+          }), null);
+          return _el$37;
+        })(), createComponent(Show, {
+          get when() {
+            return state.hostedLogin.previewCode;
+          },
+          get children() {
+            var _el$38 = _tmpl$13();
+            insert(_el$38, createComponent(Badge, {
+              "class": "badge badge--accent",
+              get children() {
+                return `previewCode=${state.hostedLogin.previewCode}`;
+              }
+            }));
+            return _el$38;
+          }
+        }), (() => {
+          var _el$39 = _tmpl$14(), _el$40 = _el$39.firstChild, _el$41 = _el$40.nextSibling;
+          insert(_el$40, () => tr(locale(), "验证码", "Verification Code"));
+          _el$41.$$input = (event) => {
+            state.hostedLogin.code = String(event.currentTarget.value || "");
+            state.hostedLogin.error = null;
+            requestRender();
+          };
+          createRenderEffect((_p$) => {
+            var _v$ = props.codeId ?? "hosted-login-code", _v$2 = props.codeId ?? "hosted-login-code";
+            _v$ !== _p$.e && setAttribute(_el$40, "for", _p$.e = _v$);
+            _v$2 !== _p$.t && setAttribute(_el$41, "id", _p$.t = _v$2);
+            return _p$;
+          }, {
+            e: void 0,
+            t: void 0
+          });
+          createRenderEffect(() => _el$41.value = state.hostedLogin.code);
+          return _el$39;
+        })(), (() => {
+          var _el$42 = _tmpl$15(), _el$43 = _el$42.firstChild;
+          _el$43.$$click = () => {
+            void completeHostedAccountLogin();
+          };
+          insert(_el$43, () => tr(locale(), "登录并领取玩家会话", "Sign In and Acquire Player Session"));
+          createRenderEffect(() => _el$43.disabled = state.hostedLogin.completeInFlight || state.auth.issueInFlight);
+          return _el$42;
+        })()];
+      }
+    }), null);
+    insert(_el$30, createComponent(Show, {
+      get when() {
+        return state.hostedLogin.error;
+      },
+      get children() {
+        return createComponent(EmptyState, {
+          get children() {
+            return state.hostedLogin.error;
+          }
+        });
+      }
+    }), null);
+    createRenderEffect((_p$) => {
+      var _v$3 = props.handleId ?? "hosted-login-handle", _v$4 = props.handleId ?? "hosted-login-handle", _v$5 = state.hostedLogin.startInFlight;
+      _v$3 !== _p$.e && setAttribute(_el$33, "for", _p$.e = _v$3);
+      _v$4 !== _p$.t && setAttribute(_el$34, "id", _p$.t = _v$4);
+      _v$5 !== _p$.a && (_el$36.disabled = _p$.a = _v$5);
+      return _p$;
+    }, {
+      e: void 0,
+      t: void 0,
+      a: void 0
+    });
+    createRenderEffect(() => _el$34.value = state.hostedLogin.handle);
+    return _el$30;
+  })();
+}
 function EmptyEntityRecoveryCard(props) {
   const locale = () => props.locale ?? uiLocale();
   const gameplay = () => typeof props.gameplay === "function" ? props.gameplay() : props.gameplay;
@@ -5504,40 +5619,40 @@ function EmptyEntityRecoveryCard(props) {
     variant: "warn",
     get children() {
       return [(() => {
-        var _el$30 = _tmpl$13();
-        insert(_el$30, () => gameplay()?.blockerDetail || tr(locale(), "runtime 已发布玩法摘要，但当前快照还没有可选 Agent 或地点。", "Runtime published gameplay summary, but the current snapshot still has no selectable agents or locations."));
-        return _el$30;
+        var _el$44 = _tmpl$17();
+        insert(_el$44, () => gameplay()?.blockerDetail || tr(locale(), "runtime 已发布玩法摘要，但当前快照还没有可选 Agent 或地点。", "Runtime published gameplay summary, but the current snapshot still has no selectable agents or locations."));
+        return _el$44;
       })(), createComponent(Show, {
         get when() {
           return gameplay()?.nextStepHint;
         },
         get children() {
-          var _el$31 = _tmpl$4();
-          insert(_el$31, () => gameplay().nextStepHint);
-          return _el$31;
+          var _el$45 = _tmpl$4();
+          insert(_el$45, () => gameplay().nextStepHint);
+          return _el$45;
         }
       }), createComponent(Show, {
         get when() {
           return gameplay()?.entityCounts;
         },
         get children() {
-          var _el$32 = _tmpl$14();
-          insert(_el$32, createComponent(Badge, {
+          var _el$46 = _tmpl$13();
+          insert(_el$46, createComponent(Badge, {
             get children() {
               return `agents=${gameplay().entityCounts.agents}`;
             }
           }), null);
-          insert(_el$32, createComponent(Badge, {
+          insert(_el$46, createComponent(Badge, {
             get children() {
               return `locations=${gameplay().entityCounts.locations}`;
             }
           }), null);
-          return _el$32;
+          return _el$46;
         }
       }), (() => {
-        var _el$33 = _tmpl$4();
-        insert(_el$33, () => tr(locale(), "如果中间栏仍保留“刷新快照”动作，先从那里重拉一次；如果数量仍然是 0，就需要修复或重启 runtime world bootstrap。", "If the middle column still exposes a refresh action, pull a fresh snapshot there first. If the counts stay at 0, repair or restart the runtime world bootstrap."));
-        return _el$33;
+        var _el$47 = _tmpl$4();
+        insert(_el$47, () => tr(locale(), "如果中间栏仍保留“刷新快照”动作，先从那里重拉一次；如果数量仍然是 0，就需要修复或重启 runtime world bootstrap。", "If the middle column still exposes a refresh action, pull a fresh snapshot there first. If the counts stay at 0, repair or restart the runtime world bootstrap."));
+        return _el$47;
       })()];
     }
   });
@@ -5546,28 +5661,28 @@ function ViewerEntryMenu() {
   const locale = () => uiLocale();
   const viewerEntryUrls = () => buildViewerEntryUrls(locale());
   return (() => {
-    var _el$34 = _tmpl$15(), _el$35 = _el$34.firstChild, _el$36 = _el$35.nextSibling, _el$37 = _el$36.firstChild, _el$38 = _el$37.firstChild, _el$39 = _el$38.nextSibling, _el$40 = _el$37.nextSibling, _el$41 = _el$40.firstChild, _el$42 = _el$41.nextSibling, _el$43 = _el$40.nextSibling, _el$44 = _el$43.nextSibling;
-    insert(_el$35, () => tr(locale(), "入口", "Entry"));
-    insert(_el$38, () => tr(locale(), "语言与 Viewer 入口", "Language and Viewer Entry"));
-    insert(_el$39, () => tr(locale(), "主玩法继续留在当前页面；这里只保留语言切换。", "Primary gameplay stays on this page. This menu only keeps locale switching."));
-    _el$41.$$click = () => setViewerLocale("zh");
-    _el$42.$$click = () => setViewerLocale("en");
-    insert(_el$43, createComponent(Badge, {
+    var _el$48 = _tmpl$18(), _el$49 = _el$48.firstChild, _el$50 = _el$49.nextSibling, _el$51 = _el$50.firstChild, _el$52 = _el$51.firstChild, _el$53 = _el$52.nextSibling, _el$54 = _el$51.nextSibling, _el$55 = _el$54.firstChild, _el$56 = _el$55.nextSibling, _el$57 = _el$54.nextSibling, _el$58 = _el$57.nextSibling;
+    insert(_el$49, () => tr(locale(), "入口", "Entry"));
+    insert(_el$52, () => tr(locale(), "语言与 Viewer 入口", "Language and Viewer Entry"));
+    insert(_el$53, () => tr(locale(), "主玩法继续留在当前页面；这里只保留语言切换。", "Primary gameplay stays on this page. This menu only keeps locale switching."));
+    _el$55.$$click = () => setViewerLocale("zh");
+    _el$56.$$click = () => setViewerLocale("en");
+    insert(_el$57, createComponent(Badge, {
       get children() {
         return `locale=${localeCode(locale())}`;
       }
     }));
-    insert(_el$44, () => viewerEntryUrls().softwareSafeUrl);
+    insert(_el$58, () => viewerEntryUrls().softwareSafeUrl);
     createRenderEffect((_p$) => {
-      var _v$ = locale() === "zh", _v$2 = locale() === "en";
-      _v$ !== _p$.e && (_el$41.disabled = _p$.e = _v$);
-      _v$2 !== _p$.t && (_el$42.disabled = _p$.t = _v$2);
+      var _v$6 = locale() === "zh", _v$7 = locale() === "en";
+      _v$6 !== _p$.e && (_el$55.disabled = _p$.e = _v$6);
+      _v$7 !== _p$.t && (_el$56.disabled = _p$.t = _v$7);
       return _p$;
     }, {
       e: void 0,
       t: void 0
     });
-    return _el$34;
+    return _el$48;
   })();
 }
 function gameplayStatusBadgeClass(status) {
@@ -5647,40 +5762,40 @@ function WorldStageHero() {
   const acceptedIntentTitle = () => gameplaySummary()?.acceptedIntentSummary || tr(locale(), "先提交一条明确意图", "Commit one clear intent first");
   const acceptedIntentDetail = () => gameplaySummary()?.acceptedIntentTarget ? tr(locale(), `当前意图正围绕 ${gameplaySummary().acceptedIntentTarget} 展开。`, `The current intent is centered on ${gameplaySummary().acceptedIntentTarget}.`) : selectionHint();
   return (() => {
-    var _el$45 = _tmpl$16(), _el$46 = _el$45.firstChild, _el$47 = _el$46.firstChild, _el$48 = _el$47.firstChild, _el$49 = _el$48.nextSibling, _el$50 = _el$49.nextSibling, _el$51 = _el$46.nextSibling, _el$52 = _el$51.firstChild, _el$53 = _el$52.firstChild, _el$54 = _el$53.nextSibling, _el$55 = _el$54.nextSibling, _el$56 = _el$52.nextSibling, _el$57 = _el$56.firstChild, _el$58 = _el$57.nextSibling, _el$59 = _el$58.nextSibling, _el$60 = _el$56.nextSibling, _el$61 = _el$60.firstChild, _el$62 = _el$61.nextSibling;
-    insert(_el$48, () => tr(locale(), "工业世界指挥桌", "Industrial World Command Desk"));
-    insert(_el$49, () => gameplaySummary()?.goalTitle || tr(locale(), "进入世界，先看局势，再做动作", "Read the world first, then act."));
-    insert(_el$50, () => gameplaySummary()?.nextStepHint || gameplaySummary()?.objective || tr(locale(), "这张入口页优先保留世界、目标和关键动作；高级诊断与治理能力按需展开。", "This entry keeps the world, objective, and primary actions in front. Advanced diagnostics and governance stay on demand."));
-    insert(_el$46, createComponent(ViewerEntryMenu, {}), null);
-    insert(_el$45, createComponent(Show, {
+    var _el$59 = _tmpl$19(), _el$60 = _el$59.firstChild, _el$61 = _el$60.firstChild, _el$62 = _el$61.firstChild, _el$63 = _el$62.nextSibling, _el$64 = _el$63.nextSibling, _el$65 = _el$60.nextSibling, _el$66 = _el$65.firstChild, _el$67 = _el$66.firstChild, _el$68 = _el$67.nextSibling, _el$69 = _el$68.nextSibling, _el$70 = _el$66.nextSibling, _el$71 = _el$70.firstChild, _el$72 = _el$71.nextSibling, _el$73 = _el$72.nextSibling, _el$74 = _el$70.nextSibling, _el$75 = _el$74.firstChild, _el$76 = _el$75.nextSibling;
+    insert(_el$62, () => tr(locale(), "工业世界指挥桌", "Industrial World Command Desk"));
+    insert(_el$63, () => gameplaySummary()?.goalTitle || tr(locale(), "进入世界，先看局势，再做动作", "Read the world first, then act."));
+    insert(_el$64, () => gameplaySummary()?.nextStepHint || gameplaySummary()?.objective || tr(locale(), "这张入口页优先保留世界、目标和关键动作；高级诊断与治理能力按需展开。", "This entry keeps the world, objective, and primary actions in front. Advanced diagnostics and governance stay on demand."));
+    insert(_el$60, createComponent(ViewerEntryMenu, {}), null);
+    insert(_el$59, createComponent(Show, {
       get when() {
         return selectedLabel();
       },
       children: (selected) => (() => {
-        var _el$64 = _tmpl$14();
-        insert(_el$64, createComponent(Badge, {
+        var _el$78 = _tmpl$13();
+        insert(_el$78, createComponent(Badge, {
           "class": "badge badge--accent",
           get children() {
             return tr(locale(), "当前选择", "Current Selection");
           }
         }), null);
-        insert(_el$64, createComponent(Badge, {
+        insert(_el$78, createComponent(Badge, {
           get children() {
             return selected();
           }
         }), null);
-        return _el$64;
+        return _el$78;
       })()
-    }), _el$51);
-    insert(_el$53, () => tr(locale(), "局势", "Situation"));
-    insert(_el$54, stageLabel);
-    insert(_el$55, () => gameplayProgressLabel(gameplaySummary()?.progressPercent, locale()));
-    insert(_el$57, () => tr(locale(), "已接受意图", "Accepted Intent"));
-    insert(_el$58, acceptedIntentTitle);
-    insert(_el$59, acceptedIntentDetail);
-    insert(_el$61, () => tr(locale(), "下一步", "Next Step"));
-    insert(_el$62, nextStepCopy);
-    insert(_el$45, createComponent(Show, {
+    }), _el$65);
+    insert(_el$67, () => tr(locale(), "局势", "Situation"));
+    insert(_el$68, stageLabel);
+    insert(_el$69, () => gameplayProgressLabel(gameplaySummary()?.progressPercent, locale()));
+    insert(_el$71, () => tr(locale(), "已接受意图", "Accepted Intent"));
+    insert(_el$72, acceptedIntentTitle);
+    insert(_el$73, acceptedIntentDetail);
+    insert(_el$75, () => tr(locale(), "下一步", "Next Step"));
+    insert(_el$76, nextStepCopy);
+    insert(_el$59, createComponent(Show, {
       get when() {
         return state.connectionStatus !== "connected";
       },
@@ -5697,26 +5812,26 @@ function WorldStageHero() {
           },
           variant: "warn",
           get children() {
-            var _el$63 = _tmpl$13();
-            insert(_el$63, () => tr(locale(), "首屏优先展示世界与目标；只有连接异常时，才把连接状态抬到这里提示你。", "This entry keeps the world and target first, and only elevates connection status when it needs attention."));
-            return _el$63;
+            var _el$77 = _tmpl$17();
+            insert(_el$77, () => tr(locale(), "首屏优先展示世界与目标；只有连接异常时，才把连接状态抬到这里提示你。", "This entry keeps the world and target first, and only elevates connection status when it needs attention."));
+            return _el$77;
           }
         });
       }
     }), null);
-    createRenderEffect(() => className(_el$54, gameplayStageToneClass(gameplaySummary()?.stageStatus)));
-    return _el$45;
+    createRenderEffect(() => className(_el$68, gameplayStageToneClass(gameplaySummary()?.stageStatus)));
+    return _el$59;
   })();
 }
 function MobileJumpRail() {
   const locale = () => uiLocale();
   return (() => {
-    var _el$65 = _tmpl$17(), _el$66 = _el$65.firstChild, _el$67 = _el$66.nextSibling, _el$68 = _el$67.nextSibling;
-    insert(_el$66, () => tr(locale(), "世界", "World"));
-    insert(_el$67, () => tr(locale(), "目标", "Targets"));
-    insert(_el$68, () => tr(locale(), "指挥", "Command"));
-    createRenderEffect(() => setAttribute(_el$65, "aria-label", tr(locale(), "主入口分区导航", "Primary entry section navigation")));
-    return _el$65;
+    var _el$79 = _tmpl$20(), _el$80 = _el$79.firstChild, _el$81 = _el$80.nextSibling, _el$82 = _el$81.nextSibling;
+    insert(_el$80, () => tr(locale(), "世界", "World"));
+    insert(_el$81, () => tr(locale(), "目标", "Targets"));
+    insert(_el$82, () => tr(locale(), "指挥", "Command"));
+    createRenderEffect(() => setAttribute(_el$79, "aria-label", tr(locale(), "主入口分区导航", "Primary entry section navigation")));
+    return _el$79;
   })();
 }
 function TargetsPanel() {
@@ -5724,36 +5839,36 @@ function TargetsPanel() {
   const locale = () => uiLocale();
   const selectedLabel = () => state.selectedKind && state.selectedId ? `${state.selectedKind}:${state.selectedId}` : null;
   return (() => {
-    var _el$69 = _tmpl$18(), _el$70 = _el$69.firstChild, _el$71 = _el$70.firstChild, _el$72 = _el$71.nextSibling, _el$73 = _el$70.nextSibling, _el$74 = _el$73.firstChild, _el$75 = _el$74.nextSibling, _el$76 = _el$73.nextSibling, _el$77 = _el$76.firstChild, _el$78 = _el$77.nextSibling;
-    insert(_el$69, createComponent(Show, {
+    var _el$83 = _tmpl$21(), _el$84 = _el$83.firstChild, _el$85 = _el$84.firstChild, _el$86 = _el$85.nextSibling, _el$87 = _el$84.nextSibling, _el$88 = _el$87.firstChild, _el$89 = _el$88.nextSibling, _el$90 = _el$87.nextSibling, _el$91 = _el$90.firstChild, _el$92 = _el$91.nextSibling;
+    insert(_el$83, createComponent(Show, {
       get when() {
         return selectedLabel();
       },
       children: (selected) => (() => {
-        var _el$79 = _tmpl$14();
-        insert(_el$79, createComponent(Badge, {
+        var _el$93 = _tmpl$13();
+        insert(_el$93, createComponent(Badge, {
           "class": "badge badge--accent",
           get children() {
             return tr(locale(), "已锁定目标", "Locked Target");
           }
         }), null);
-        insert(_el$79, createComponent(Badge, {
+        insert(_el$93, createComponent(Badge, {
           get children() {
             return selected();
           }
         }), null);
-        return _el$79;
+        return _el$93;
       })()
-    }), _el$70);
-    insert(_el$69, createComponent(EmptyState, {
+    }), _el$84);
+    insert(_el$83, createComponent(EmptyState, {
       get children() {
         return tr(locale(), "先从这里锁定一个 Agent 或地点。中间读局势，右侧只处理你当前选中的目标。", "Lock onto an agent or location here first. Read the world in the middle, then use the right column only for the selected target.");
       }
-    }), _el$70);
-    insert(_el$71, () => tr(locale(), "筛选目标", "Filter targets"));
-    _el$72.$$input = (event) => setSelectedSearch(event.currentTarget.value);
-    insert(_el$74, () => tr(locale(), "Agents", "Agents"));
-    insert(_el$75, createComponent(Show, {
+    }), _el$84);
+    insert(_el$85, () => tr(locale(), "筛选目标", "Filter targets"));
+    _el$86.$$input = (event) => setSelectedSearch(event.currentTarget.value);
+    insert(_el$88, () => tr(locale(), "Agents", "Agents"));
+    insert(_el$89, createComponent(Show, {
       get when() {
         return lists().agents.length > 0;
       },
@@ -5770,29 +5885,29 @@ function TargetsPanel() {
             return lists().agents;
           },
           children: (agent) => (() => {
-            var _el$80 = _tmpl$19(), _el$81 = _el$80.firstChild, _el$82 = _el$81.nextSibling;
-            _el$80.$$click = () => applySelection({
+            var _el$94 = _tmpl$22(), _el$95 = _el$94.firstChild, _el$96 = _el$95.nextSibling;
+            _el$94.$$click = () => applySelection({
               kind: "agent",
               id: agent.id
             });
-            insert(_el$81, () => agent.id);
-            insert(_el$82, () => `${tr(locale(), "地点", "location")}=${agent.location_id} · ${tr(locale(), "资源", "resources")}=${renderResourceSummary(agent.resources)}`);
+            insert(_el$95, () => agent.id);
+            insert(_el$96, () => `${tr(locale(), "地点", "location")}=${agent.location_id} · ${tr(locale(), "资源", "resources")}=${renderResourceSummary(agent.resources)}`);
             createRenderEffect((_p$) => {
-              var _v$3 = agent.id, _v$4 = state.selectedKind === "agent" && state.selectedId === agent.id;
-              _v$3 !== _p$.e && setAttribute(_el$80, "data-select-id", _p$.e = _v$3);
-              _v$4 !== _p$.t && setAttribute(_el$80, "data-selected", _p$.t = _v$4);
+              var _v$8 = agent.id, _v$9 = state.selectedKind === "agent" && state.selectedId === agent.id;
+              _v$8 !== _p$.e && setAttribute(_el$94, "data-select-id", _p$.e = _v$8);
+              _v$9 !== _p$.t && setAttribute(_el$94, "data-selected", _p$.t = _v$9);
               return _p$;
             }, {
               e: void 0,
               t: void 0
             });
-            return _el$80;
+            return _el$94;
           })()
         });
       }
     }));
-    insert(_el$77, () => tr(locale(), "地点", "Locations"));
-    insert(_el$78, createComponent(Show, {
+    insert(_el$91, () => tr(locale(), "地点", "Locations"));
+    insert(_el$92, createComponent(Show, {
       get when() {
         return lists().locations.length > 0;
       },
@@ -5809,30 +5924,30 @@ function TargetsPanel() {
             return lists().locations;
           },
           children: (location) => (() => {
-            var _el$83 = _tmpl$20(), _el$84 = _el$83.firstChild, _el$85 = _el$84.nextSibling;
-            _el$83.$$click = () => applySelection({
+            var _el$97 = _tmpl$23(), _el$98 = _el$97.firstChild, _el$99 = _el$98.nextSibling;
+            _el$97.$$click = () => applySelection({
               kind: "location",
               id: location.id
             });
-            insert(_el$84, () => location.name || location.id);
-            insert(_el$85, () => `id=${location.id} · ${tr(locale(), "半径", "radius")}=${formatPhysicalDistanceCm(location.profile?.radius_cm, locale()) || "-"} · ${tr(locale(), "资源", "resources")}=${renderResourceSummary(location.resources)}`);
+            insert(_el$98, () => location.name || location.id);
+            insert(_el$99, () => `id=${location.id} · ${tr(locale(), "半径", "radius")}=${formatPhysicalDistanceCm(location.profile?.radius_cm, locale()) || "-"} · ${tr(locale(), "资源", "resources")}=${renderResourceSummary(location.resources)}`);
             createRenderEffect((_p$) => {
-              var _v$5 = location.id, _v$6 = state.selectedKind === "location" && state.selectedId === location.id;
-              _v$5 !== _p$.e && setAttribute(_el$83, "data-select-id", _p$.e = _v$5);
-              _v$6 !== _p$.t && setAttribute(_el$83, "data-selected", _p$.t = _v$6);
+              var _v$0 = location.id, _v$1 = state.selectedKind === "location" && state.selectedId === location.id;
+              _v$0 !== _p$.e && setAttribute(_el$97, "data-select-id", _p$.e = _v$0);
+              _v$1 !== _p$.t && setAttribute(_el$97, "data-selected", _p$.t = _v$1);
               return _p$;
             }, {
               e: void 0,
               t: void 0
             });
-            return _el$83;
+            return _el$97;
           })()
         });
       }
     }));
-    createRenderEffect(() => setAttribute(_el$72, "placeholder", tr(locale(), "搜索 Agent 或地点", "Search agents or locations")));
-    createRenderEffect(() => _el$72.value = getSelectedSearch());
-    return _el$69;
+    createRenderEffect(() => setAttribute(_el$86, "placeholder", tr(locale(), "搜索 Agent 或地点", "Search agents or locations")));
+    createRenderEffect(() => _el$86.value = getSelectedSearch());
+    return _el$83;
   })();
 }
 function WorldSummaryPanel() {
@@ -5854,8 +5969,8 @@ function WorldSummaryPanel() {
   const showPlayerSessionSurface = () => !!hostedRecoveryHint() || !state$1.auth.available && String(state$1.hostedAccess?.deployment_mode || "").trim() === "hosted_public_join" || showRebindNotice();
   const diagnosticsSummaryBadges = () => [`debugViewer=${state$1.debugViewerMode}:${state$1.debugViewerStatus}`, `auth=${state$1.auth.available ? state$1.auth.registrationStatus || "ready" : "missing"}`, `events=${state$1.recentEvents.length}`];
   return (() => {
-    var _el$86 = _tmpl$26(), _el$92 = _el$86.firstChild, _el$93 = _el$92.firstChild, _el$94 = _el$93.firstChild, _el$95 = _el$94.firstChild, _el$96 = _el$95.nextSibling, _el$97 = _el$94.nextSibling, _el$98 = _el$93.nextSibling, _el$99 = _el$98.firstChild, _el$101 = _el$99.nextSibling, _el$102 = _el$101.nextSibling, _el$111 = _el$102.nextSibling, _el$112 = _el$111.nextSibling, _el$113 = _el$112.firstChild, _el$114 = _el$113.nextSibling;
-    insert(_el$86, createComponent(PanelSection, {
+    var _el$100 = _tmpl$27(), _el$104 = _el$100.firstChild, _el$105 = _el$104.firstChild, _el$106 = _el$105.firstChild, _el$107 = _el$106.firstChild, _el$108 = _el$107.nextSibling, _el$109 = _el$106.nextSibling, _el$110 = _el$105.nextSibling, _el$111 = _el$110.firstChild, _el$113 = _el$111.nextSibling, _el$114 = _el$113.nextSibling, _el$122 = _el$114.nextSibling, _el$123 = _el$122.nextSibling, _el$124 = _el$123.firstChild, _el$125 = _el$124.nextSibling;
+    insert(_el$100, createComponent(PanelSection, {
       get title() {
         return tr(locale(), "正式玩法摘要", "Formal Gameplay Summary");
       },
@@ -5878,8 +5993,8 @@ function WorldSummaryPanel() {
             });
           },
           children: (gameplay) => [(() => {
-            var _el$115 = _tmpl$14();
-            insert(_el$115, createComponent(Badge, {
+            var _el$126 = _tmpl$13();
+            insert(_el$126, createComponent(Badge, {
               get ["class"]() {
                 return gameplayStatusBadgeClass(gameplay().stageStatus);
               },
@@ -5887,13 +6002,13 @@ function WorldSummaryPanel() {
                 return gameplayStageLabel(gameplay().stageStatus, locale());
               }
             }), null);
-            insert(_el$115, createComponent(Badge, {
+            insert(_el$126, createComponent(Badge, {
               "class": "badge badge--accent",
               get children() {
                 return gameplayProgressLabel(gameplay().progressPercent, locale());
               }
             }), null);
-            return _el$115;
+            return _el$126;
           })(), createComponent(EventCard, {
             get title() {
               return tr(locale(), "已接受意图", "Accepted Intent");
@@ -5909,30 +6024,30 @@ function WorldSummaryPanel() {
             },
             get children() {
               return [(() => {
-                var _el$116 = _tmpl$13();
-                insert(_el$116, () => gameplay().acceptedIntentSummary);
-                return _el$116;
+                var _el$127 = _tmpl$17();
+                insert(_el$127, () => gameplay().acceptedIntentSummary);
+                return _el$127;
               })(), (() => {
-                var _el$117 = _tmpl$4();
-                insert(_el$117, () => gameplay().acceptedIntentDetail);
-                return _el$117;
+                var _el$128 = _tmpl$4();
+                insert(_el$128, () => gameplay().acceptedIntentDetail);
+                return _el$128;
               })(), createComponent(Show, {
                 get when() {
                   return gameplay().resumeAnchor;
                 },
                 get children() {
                   return [(() => {
-                    var _el$118 = _tmpl$14();
-                    insert(_el$118, createComponent(Badge, {
+                    var _el$129 = _tmpl$13();
+                    insert(_el$129, createComponent(Badge, {
                       get children() {
                         return tr(locale(), "续玩锚点", "Resume Anchor");
                       }
                     }));
-                    return _el$118;
+                    return _el$129;
                   })(), (() => {
-                    var _el$119 = _tmpl$4();
-                    insert(_el$119, () => gameplay().resumeAnchor);
-                    return _el$119;
+                    var _el$130 = _tmpl$4();
+                    insert(_el$130, () => gameplay().resumeAnchor);
+                    return _el$130;
                   })()];
                 }
               })];
@@ -5952,8 +6067,8 @@ function WorldSummaryPanel() {
             },
             get children() {
               return [(() => {
-                var _el$120 = _tmpl$14();
-                insert(_el$120, createComponent(For, {
+                var _el$131 = _tmpl$13();
+                insert(_el$131, createComponent(For, {
                   get each() {
                     return gameplay().executionStateMachine || [];
                   },
@@ -5966,32 +6081,32 @@ function WorldSummaryPanel() {
                     }
                   })
                 }));
-                return _el$120;
+                return _el$131;
               })(), (() => {
-                var _el$121 = _tmpl$13();
-                insert(_el$121, () => gameplay().executionSummary || tr(locale(), "等待目标执行状态更新。", "Waiting for goal execution state updates."));
-                return _el$121;
+                var _el$132 = _tmpl$17();
+                insert(_el$132, () => gameplay().executionSummary || tr(locale(), "等待目标执行状态更新。", "Waiting for goal execution state updates."));
+                return _el$132;
               })(), createComponent(Show, {
                 get when() {
                   return gameplay().executionCauseLabel;
                 },
                 get children() {
-                  var _el$122 = _tmpl$14();
-                  insert(_el$122, createComponent(Badge, {
+                  var _el$133 = _tmpl$13();
+                  insert(_el$133, createComponent(Badge, {
                     get children() {
                       return gameplay().executionCauseLabel;
                     }
                   }));
-                  return _el$122;
+                  return _el$133;
                 }
               }), createComponent(Show, {
                 get when() {
                   return gameplay().executionCauseDetail;
                 },
                 get children() {
-                  var _el$123 = _tmpl$4();
-                  insert(_el$123, () => gameplay().executionCauseDetail);
-                  return _el$123;
+                  var _el$134 = _tmpl$4();
+                  insert(_el$134, () => gameplay().executionCauseDetail);
+                  return _el$134;
                 }
               })];
             }
@@ -6012,9 +6127,9 @@ function WorldSummaryPanel() {
                   return gameplay().progressDetail;
                 },
                 get children() {
-                  var _el$124 = _tmpl$4();
-                  insert(_el$124, () => gameplay().progressDetail);
-                  return _el$124;
+                  var _el$135 = _tmpl$4();
+                  insert(_el$135, () => gameplay().progressDetail);
+                  return _el$135;
                 }
               }), createComponent(Show, {
                 get when() {
@@ -6022,18 +6137,18 @@ function WorldSummaryPanel() {
                 },
                 get children() {
                   return [(() => {
-                    var _el$125 = _tmpl$27();
-                    insert(_el$125, createComponent(Badge, {
+                    var _el$136 = _tmpl$28();
+                    insert(_el$136, createComponent(Badge, {
                       "class": "badge badge--warn",
                       get children() {
                         return gameplay().blockerLabel || gameplay().blockerKind || tr(locale(), "当前阻塞", "Current Blocker");
                       }
                     }));
-                    return _el$125;
+                    return _el$136;
                   })(), (() => {
-                    var _el$126 = _tmpl$4();
-                    insert(_el$126, () => gameplay().narrativeBlockerDetail || tr(locale(), "当前玩法被阻塞，需要显式恢复。", "Gameplay is blocked and needs explicit recovery."));
-                    return _el$126;
+                    var _el$137 = _tmpl$4();
+                    insert(_el$137, () => gameplay().narrativeBlockerDetail || tr(locale(), "当前玩法被阻塞，需要显式恢复。", "Gameplay is blocked and needs explicit recovery."));
+                    return _el$137;
                   })()];
                 }
               }), createComponent(Show, {
@@ -6041,49 +6156,49 @@ function WorldSummaryPanel() {
                   return gameplay().blockerSupplementalDetail;
                 },
                 get children() {
-                  var _el$127 = _tmpl$4();
-                  insert(_el$127, () => gameplay().blockerSupplementalDetail);
-                  return _el$127;
+                  var _el$138 = _tmpl$4();
+                  insert(_el$138, () => gameplay().blockerSupplementalDetail);
+                  return _el$138;
                 }
               }), (() => {
-                var _el$128 = _tmpl$27();
-                insert(_el$128, createComponent(Badge, {
+                var _el$139 = _tmpl$28();
+                insert(_el$139, createComponent(Badge, {
                   "class": "badge badge--accent",
                   get children() {
                     return tr(locale(), "下一步", "Next Step");
                   }
                 }));
-                return _el$128;
+                return _el$139;
               })(), (() => {
-                var _el$129 = _tmpl$13();
-                insert(_el$129, () => gameplay().narrativeNextStep || tr(locale(), "等待下一次 runtime 指引更新。", "Wait for the next runtime guidance update."));
-                return _el$129;
+                var _el$140 = _tmpl$17();
+                insert(_el$140, () => gameplay().narrativeNextStep || tr(locale(), "等待下一次 runtime 指引更新。", "Wait for the next runtime guidance update."));
+                return _el$140;
               })(), createComponent(Show, {
                 get when() {
                   return gameplay().branchHint;
                 },
                 get children() {
-                  var _el$130 = _tmpl$4();
-                  insert(_el$130, () => gameplay().branchHint);
-                  return _el$130;
+                  var _el$141 = _tmpl$4();
+                  insert(_el$141, () => gameplay().branchHint);
+                  return _el$141;
                 }
               }), createComponent(Show, {
                 get when() {
                   return gameplay().entityCounts;
                 },
                 get children() {
-                  var _el$131 = _tmpl$14();
-                  insert(_el$131, createComponent(Badge, {
+                  var _el$142 = _tmpl$13();
+                  insert(_el$142, createComponent(Badge, {
                     get children() {
                       return `agents=${gameplay().entityCounts.agents}`;
                     }
                   }), null);
-                  insert(_el$131, createComponent(Badge, {
+                  insert(_el$142, createComponent(Badge, {
                     get children() {
                       return `locations=${gameplay().entityCounts.locations}`;
                     }
                   }), null);
-                  return _el$131;
+                  return _el$142;
                 }
               })];
             }
@@ -6106,26 +6221,26 @@ function WorldSummaryPanel() {
               },
               get children() {
                 return [(() => {
-                  var _el$137 = _tmpl$13();
-                  insert(_el$137, () => feedback().effect || feedback().reason || tr(locale(), "最新回执已更新，但还没有新的世界级后果。", "The latest feedback is in, but there is no new world-level consequence yet."));
-                  return _el$137;
+                  var _el$148 = _tmpl$17();
+                  insert(_el$148, () => feedback().effect || feedback().reason || tr(locale(), "最新回执已更新，但还没有新的世界级后果。", "The latest feedback is in, but there is no new world-level consequence yet."));
+                  return _el$148;
                 })(), createComponent(Show, {
                   get when() {
                     return feedback().reason;
                   },
                   get children() {
-                    var _el$138 = _tmpl$4();
-                    insert(_el$138, () => feedback().reason);
-                    return _el$138;
+                    var _el$149 = _tmpl$4();
+                    insert(_el$149, () => feedback().reason);
+                    return _el$149;
                   }
                 }), createComponent(Show, {
                   get when() {
                     return feedback().hint;
                   },
                   get children() {
-                    var _el$139 = _tmpl$4();
-                    insert(_el$139, () => feedback().hint);
-                    return _el$139;
+                    var _el$150 = _tmpl$4();
+                    insert(_el$150, () => feedback().hint);
+                    return _el$150;
                   }
                 })];
               }
@@ -6156,26 +6271,26 @@ function WorldSummaryPanel() {
               badgeClass: "badge badge--good",
               get children() {
                 return [(() => {
-                  var _el$140 = _tmpl$13();
-                  insert(_el$140, () => action().label || action().actionId || tr(locale(), "当前存在一条更合适的推进动作。", "One action is currently the best next move."));
-                  return _el$140;
+                  var _el$151 = _tmpl$17();
+                  insert(_el$151, () => action().label || action().actionId || tr(locale(), "当前存在一条更合适的推进动作。", "One action is currently the best next move."));
+                  return _el$151;
                 })(), (() => {
-                  var _el$141 = _tmpl$4();
-                  insert(_el$141, () => gameplay().narrativeNextStep || tr(locale(), "先执行这一步，再判断是否需要切到聊天、恢复或改道。", "Take this action first, then decide whether to chat, resume, or reprioritize."));
-                  return _el$141;
+                  var _el$152 = _tmpl$4();
+                  insert(_el$152, () => gameplay().narrativeNextStep || tr(locale(), "先执行这一步，再判断是否需要切到聊天、恢复或改道。", "Take this action first, then decide whether to chat, resume, or reprioritize."));
+                  return _el$152;
                 })(), (() => {
-                  var _el$142 = _tmpl$29(), _el$143 = _el$142.firstChild;
-                  _el$143.$$click = () => renderGameplayAction(action());
-                  insert(_el$143, () => gameplayActionButtonLabel(action(), locale()));
-                  createRenderEffect(() => _el$143.disabled = Boolean(action().disabledReason));
-                  return _el$142;
+                  var _el$153 = _tmpl$30(), _el$154 = _el$153.firstChild;
+                  _el$154.$$click = () => renderGameplayAction(action());
+                  insert(_el$154, () => gameplayActionButtonLabel(action(), locale()));
+                  createRenderEffect(() => _el$154.disabled = Boolean(action().disabledReason));
+                  return _el$153;
                 })()];
               }
             })
           }), (() => {
-            var _el$132 = _tmpl$28(), _el$133 = _el$132.firstChild, _el$134 = _el$133.nextSibling;
-            insert(_el$133, () => tr(locale(), "可用玩法动作", "Available Gameplay Actions"));
-            insert(_el$134, createComponent(Show, {
+            var _el$143 = _tmpl$29(), _el$144 = _el$143.firstChild, _el$145 = _el$144.nextSibling;
+            insert(_el$144, () => tr(locale(), "可用玩法动作", "Available Gameplay Actions"));
+            insert(_el$145, createComponent(Show, {
               get when() {
                 return gameplay().availableActions.length > 0;
               },
@@ -6207,30 +6322,30 @@ function WorldSummaryPanel() {
                     },
                     get children() {
                       return [(() => {
-                        var _el$144 = _tmpl$4();
-                        insert(_el$144, () => action.disabledReason || tr(locale(), "无需打开 visual QA viewer，也可以直接从正式 Web 入口执行。", "Playable from the formal Web entry without opening the visual QA viewer."));
-                        return _el$144;
+                        var _el$155 = _tmpl$4();
+                        insert(_el$155, () => action.disabledReason || tr(locale(), "无需打开 visual QA viewer，也可以直接从正式 Web 入口执行。", "Playable from the formal Web entry without opening the visual QA viewer."));
+                        return _el$155;
                       })(), createComponent(Show, {
                         get when() {
                           return action.executeKind === "request_snapshot" || action.executeKind === "step" || action.executeKind === "play" || action.executeKind === "gameplay_action";
                         },
                         get children() {
-                          var _el$145 = _tmpl$29(), _el$146 = _el$145.firstChild;
-                          _el$146.$$click = () => renderGameplayAction(action);
-                          insert(_el$146, () => gameplayActionButtonLabel(action, locale()));
-                          createRenderEffect(() => _el$146.disabled = Boolean(action.disabledReason));
-                          return _el$145;
+                          var _el$156 = _tmpl$30(), _el$157 = _el$156.firstChild;
+                          _el$157.$$click = () => renderGameplayAction(action);
+                          insert(_el$157, () => gameplayActionButtonLabel(action, locale()));
+                          createRenderEffect(() => _el$157.disabled = Boolean(action.disabledReason));
+                          return _el$156;
                         }
                       }), createComponent(Show, {
                         get when() {
                           return action.executeKind === "agent_chat";
                         },
                         get children() {
-                          var _el$147 = _tmpl$29(), _el$148 = _el$147.firstChild;
-                          _el$148.$$click = () => renderGameplayAction(action);
-                          insert(_el$148, () => gameplayActionButtonLabel(action, locale()));
-                          createRenderEffect(() => _el$148.disabled = Boolean(action.disabledReason));
-                          return _el$147;
+                          var _el$158 = _tmpl$30(), _el$159 = _el$158.firstChild;
+                          _el$159.$$click = () => renderGameplayAction(action);
+                          insert(_el$159, () => gameplayActionButtonLabel(action, locale()));
+                          createRenderEffect(() => _el$159.disabled = Boolean(action.disabledReason));
+                          return _el$158;
                         }
                       })];
                     }
@@ -6238,7 +6353,7 @@ function WorldSummaryPanel() {
                 });
               }
             }));
-            return _el$132;
+            return _el$143;
           })(), createComponent(CalloutCard, {
             get title() {
               return tr(locale(), "未在此页暴露的动作", "Actions Not Exposed On This Page");
@@ -6247,20 +6362,20 @@ function WorldSummaryPanel() {
             badgeClass: "badge badge--warn",
             get children() {
               return [(() => {
-                var _el$135 = _tmpl$13();
-                insert(_el$135, () => gameplay().assetGovernanceHandoff);
-                return _el$135;
+                var _el$146 = _tmpl$17();
+                insert(_el$146, () => gameplay().assetGovernanceHandoff);
+                return _el$146;
               })(), (() => {
-                var _el$136 = _tmpl$4();
-                insert(_el$136, () => tr(locale(), "资产 / 治理相关能力请走单独 lane；这张主入口页面只保留正式玩法所需的最小动作面。", "Asset and governance actions stay on their dedicated lane; this primary entry only keeps the minimum surface needed for formal gameplay."));
-                return _el$136;
+                var _el$147 = _tmpl$4();
+                insert(_el$147, () => tr(locale(), "资产 / 治理相关能力请走单独 lane；这张主入口页面只保留正式玩法所需的最小动作面。", "Asset and governance actions stay on their dedicated lane; this primary entry only keeps the minimum surface needed for formal gameplay."));
+                return _el$147;
               })()];
             }
           })]
         });
       }
-    }), _el$92);
-    insert(_el$86, createComponent(Show, {
+    }), _el$104);
+    insert(_el$100, createComponent(Show, {
       get when() {
         return showPlayerSessionSurface();
       },
@@ -6277,8 +6392,8 @@ function WorldSummaryPanel() {
           },
           get children() {
             return [(() => {
-              var _el$87 = _tmpl$14();
-              insert(_el$87, createComponent(Badge, {
+              var _el$101 = _tmpl$13();
+              insert(_el$101, createComponent(Badge, {
                 get ["class"]() {
                   return state$1.auth.available ? "badge badge--good" : "badge badge--warn";
                 },
@@ -6286,23 +6401,23 @@ function WorldSummaryPanel() {
                   return `auth=${state$1.auth.available ? state$1.auth.registrationStatus || "ready" : "missing"}`;
                 }
               }), null);
-              insert(_el$87, createComponent(Badge, {
+              insert(_el$101, createComponent(Badge, {
                 "class": "badge badge--accent",
                 get children() {
                   return `tier=${authSurface().currentTier}`;
                 }
               }), null);
-              insert(_el$87, createComponent(Badge, {
+              insert(_el$101, createComponent(Badge, {
                 get children() {
                   return `player=${state$1.auth.playerId || "-"}`;
                 }
               }), null);
-              insert(_el$87, createComponent(Badge, {
+              insert(_el$101, createComponent(Badge, {
                 get children() {
                   return `boundAgent=${state$1.auth.boundAgentId || "-"}`;
                 }
               }), null);
-              return _el$87;
+              return _el$101;
             })(), createComponent(EmptyState, {
               get children() {
                 return hostedRecoveryHint()?.detail || state$1.auth.rebindNotice || authSurface().currentTierReason;
@@ -6311,48 +6426,42 @@ function WorldSummaryPanel() {
               get when() {
                 return hostedRecoveryHint();
               },
-              children: (hint) => (() => {
-                var _el$149 = _tmpl$21(), _el$150 = _el$149.firstChild;
-                _el$150.$$click = () => {
-                  void retryHostedPlayerIdentityIssue();
-                };
-                insert(_el$150, () => hint().cta);
-                createRenderEffect(() => _el$150.disabled = state$1.auth.issueInFlight);
-                return _el$149;
-              })()
+              children: (hint) => createComponent(EmptyState, {
+                get children() {
+                  return hint().detail;
+                }
+              })
             }), createComponent(Show, {
               get when() {
-                return memo(() => !!(!state$1.auth.available && String(state$1.hostedAccess?.deployment_mode || "").trim() === "hosted_public_join"))() && !hostedRecoveryHint();
+                return memo(() => !!!state$1.auth.available)() && String(state$1.hostedAccess?.deployment_mode || "").trim() === "hosted_public_join";
               },
               get children() {
-                var _el$88 = _tmpl$21(), _el$89 = _el$88.firstChild;
-                _el$89.$$click = () => {
-                  void retryHostedPlayerIdentityIssue();
-                };
-                insert(_el$89, () => tr(locale(), "领取玩家会话", "Acquire Player Session"));
-                createRenderEffect(() => _el$89.disabled = state$1.auth.issueInFlight);
-                return _el$88;
+                return createComponent(HostedLoginForm, {
+                  get locale() {
+                    return locale();
+                  }
+                });
               }
             }), createComponent(Show, {
               get when() {
                 return memo(() => !!state$1.auth.available)() && state$1.auth.source !== "legacy_viewer_auth_bootstrap";
               },
               get children() {
-                var _el$90 = _tmpl$22(), _el$91 = _el$90.firstChild;
-                _el$91.$$click = () => {
+                var _el$102 = _tmpl$24(), _el$103 = _el$102.firstChild;
+                _el$103.$$click = () => {
                   void logoutHostedPlayerSession();
                 };
-                insert(_el$91, () => tr(locale(), "释放玩家会话", "Release Player Session"));
-                return _el$90;
+                insert(_el$103, () => tr(locale(), "释放玩家会话", "Release Player Session"));
+                return _el$102;
               }
             })];
           }
         });
       }
-    }), _el$92);
-    insert(_el$95, () => tr(locale(), "运行诊断", "Runtime Diagnostics"));
-    insert(_el$96, () => tr(locale(), "执行 lane、auth/session、托管矩阵与最近事件都收在这里，避免它们继续抢占主玩法首屏。", "Execution lanes, auth/session truth, hosted matrix, and recent events live here so they no longer dominate the primary gameplay viewport."));
-    insert(_el$97, createComponent(For, {
+    }), _el$104);
+    insert(_el$107, () => tr(locale(), "运行诊断", "Runtime Diagnostics"));
+    insert(_el$108, () => tr(locale(), "执行 lane、auth/session、托管矩阵与最近事件都收在这里，避免它们继续抢占主玩法首屏。", "Execution lanes, auth/session truth, hosted matrix, and recent events live here so they no longer dominate the primary gameplay viewport."));
+    insert(_el$109, createComponent(For, {
       get each() {
         return diagnosticsSummaryBadges();
       },
@@ -6360,53 +6469,53 @@ function WorldSummaryPanel() {
         children: label
       })
     }));
-    insert(_el$99, createComponent(Badge, {
+    insert(_el$111, createComponent(Badge, {
       get children() {
         return `ws=${state$1.wsUrl || "-"}`;
       }
     }), null);
-    insert(_el$99, createComponent(Badge, {
+    insert(_el$111, createComponent(Badge, {
       get children() {
         return `entryReason=${state$1.viewerReason || "-"}`;
       }
     }), null);
-    insert(_el$99, createComponent(Badge, {
+    insert(_el$111, createComponent(Badge, {
       get children() {
         return `renderer=${state$1.renderer || "n/a"}`;
       }
     }), null);
-    insert(_el$99, createComponent(Badge, {
+    insert(_el$111, createComponent(Badge, {
       get children() {
         return `controlProfile=${state$1.controlProfile}`;
       }
     }), null);
-    insert(_el$98, createComponent(PanelSection, {
+    insert(_el$110, createComponent(PanelSection, {
       get title() {
         return tr(locale(), "执行 Lane", "Execution Lanes");
       },
       get children() {
         return [(() => {
-          var _el$100 = _tmpl$14();
-          insert(_el$100, createComponent(Badge, {
+          var _el$112 = _tmpl$13();
+          insert(_el$112, createComponent(Badge, {
             "class": "badge badge--accent",
             children: "debug_viewer"
           }), null);
-          insert(_el$100, createComponent(Badge, {
+          insert(_el$112, createComponent(Badge, {
             get children() {
               return `status=${state$1.debugViewerStatus}`;
             }
           }), null);
-          insert(_el$100, createComponent(Badge, {
+          insert(_el$112, createComponent(Badge, {
             get children() {
               return `renderMode=${state$1.renderMode}`;
             }
           }), null);
-          insert(_el$100, createComponent(Badge, {
+          insert(_el$112, createComponent(Badge, {
             get children() {
               return `entryReason=${state$1.viewerReason || "-"}`;
             }
           }), null);
-          return _el$100;
+          return _el$112;
         })(), createComponent(EmptyState, {
           style: "margin-top:-2px;",
           get children() {
@@ -6422,99 +6531,99 @@ function WorldSummaryPanel() {
             });
           },
           children: (debug) => [(() => {
-            var _el$151 = _tmpl$14();
-            insert(_el$151, createComponent(Badge, {
+            var _el$160 = _tmpl$13();
+            insert(_el$160, createComponent(Badge, {
               "class": "badge badge--accent",
               children: "selected agent lane"
             }), null);
-            insert(_el$151, createComponent(Badge, {
+            insert(_el$160, createComponent(Badge, {
               get children() {
                 return `provider=${debug().provider_mode || "-"}`;
               }
             }), null);
-            insert(_el$151, createComponent(Badge, {
+            insert(_el$160, createComponent(Badge, {
               get children() {
                 return `mode=${debug().execution_mode || "-"}`;
               }
             }), null);
-            insert(_el$151, createComponent(Badge, {
+            insert(_el$160, createComponent(Badge, {
               get children() {
                 return `env=${debug().environment_class || "-"}`;
               }
             }), null);
-            return _el$151;
+            return _el$160;
           })(), (() => {
-            var _el$152 = _tmpl$14();
-            insert(_el$152, createComponent(Badge, {
+            var _el$161 = _tmpl$13();
+            insert(_el$161, createComponent(Badge, {
               get children() {
                 return `obs=${debug().observation_schema_version || "-"}`;
               }
             }), null);
-            insert(_el$152, createComponent(Badge, {
+            insert(_el$161, createComponent(Badge, {
               get children() {
                 return `act=${debug().action_schema_version || "-"}`;
               }
             }), null);
-            insert(_el$152, createComponent(Badge, {
+            insert(_el$161, createComponent(Badge, {
               get children() {
                 return `agentProfile=${debug().agent_profile || "-"}`;
               }
             }), null);
-            insert(_el$152, createComponent(Badge, {
+            insert(_el$161, createComponent(Badge, {
               get children() {
                 return `providerFallback=${debug().fallback_reason || "-"}`;
               }
             }), null);
-            return _el$152;
+            return _el$161;
           })(), createComponent(EmptyState, {
             style: "margin-top:-2px;",
             get children() {
               return tr(locale(), "上面的 lane badge 表示 phase-1 期望执行 contract；下面的 provider check badge 表示 runtime_live 基于 /v1/provider/info 和 /v1/provider/health 的真实探测结果。", "Lane badges show the expected phase-1 execution contract. Provider check badges below show the actual runtime_live probe against /v1/provider/info and /v1/provider/health.");
             }
           }), (() => {
-            var _el$153 = _tmpl$14();
-            insert(_el$153, createComponent(Badge, {
+            var _el$162 = _tmpl$13();
+            insert(_el$162, createComponent(Badge, {
               "class": "badge badge--accent",
               children: "provider check"
             }), null);
-            insert(_el$153, createComponent(Badge, {
+            insert(_el$162, createComponent(Badge, {
               get children() {
                 return `status=${debug().provider_check_status || "-"}`;
               }
             }), null);
-            insert(_el$153, createComponent(Badge, {
+            insert(_el$162, createComponent(Badge, {
               get children() {
                 return `source=${debug().provider_check_source || "-"}`;
               }
             }), null);
-            insert(_el$153, createComponent(Badge, {
+            insert(_el$162, createComponent(Badge, {
               get children() {
                 return `fallback=${debug().provider_check_fallback_reason || "-"}`;
               }
             }), null);
-            return _el$153;
+            return _el$162;
           })(), createComponent(Show, {
             get when() {
               return debug().provider_check_error || debug().provider_reported_capabilities?.length || debug().provider_reported_supported_action_sets?.length;
             },
             get children() {
-              var _el$154 = _tmpl$14();
-              insert(_el$154, createComponent(Badge, {
+              var _el$163 = _tmpl$13();
+              insert(_el$163, createComponent(Badge, {
                 get children() {
                   return `actualCaps=${(debug().provider_reported_capabilities || []).join(",") || "-"}`;
                 }
               }), null);
-              insert(_el$154, createComponent(Badge, {
+              insert(_el$163, createComponent(Badge, {
                 get children() {
                   return `actualActions=${(debug().provider_reported_supported_action_sets || []).join(",") || "-"}`;
                 }
               }), null);
-              insert(_el$154, createComponent(Badge, {
+              insert(_el$163, createComponent(Badge, {
                 get children() {
                   return `checkError=${debug().provider_check_error || "-"}`;
                 }
               }), null);
-              return _el$154;
+              return _el$163;
             }
           }), createComponent(JsonBlock, {
             get value() {
@@ -6523,8 +6632,8 @@ function WorldSummaryPanel() {
           })]
         })];
       }
-    }), _el$101);
-    insert(_el$101, createComponent(Badge, {
+    }), _el$113);
+    insert(_el$113, createComponent(Badge, {
       get ["class"]() {
         return state$1.auth.available ? "badge badge--good" : "badge badge--warn";
       },
@@ -6532,215 +6641,212 @@ function WorldSummaryPanel() {
         return `auth=${state$1.auth.available ? state$1.auth.registrationStatus || "ready" : "missing"}`;
       }
     }), null);
-    insert(_el$101, createComponent(Badge, {
+    insert(_el$113, createComponent(Badge, {
       "class": "badge badge--accent",
       get children() {
         return `tier=${authSurface().currentTier}`;
       }
     }), null);
-    insert(_el$101, createComponent(Badge, {
+    insert(_el$113, createComponent(Badge, {
       get children() {
         return `source=${authSurface().source}`;
       }
     }), null);
-    insert(_el$101, createComponent(Badge, {
+    insert(_el$113, createComponent(Badge, {
       get children() {
         return `deploymentHint=${authSurface().deploymentHint}`;
       }
     }), null);
-    insert(_el$101, createComponent(Badge, {
+    insert(_el$113, createComponent(Badge, {
       get children() {
         return `player=${state$1.auth.playerId || "-"}`;
       }
     }), null);
-    insert(_el$101, createComponent(Badge, {
+    insert(_el$113, createComponent(Badge, {
       get children() {
         return `pubkey=${state$1.auth.publicKey ? `${state$1.auth.publicKey.slice(0, 10)}…` : "-"}`;
       }
     }), null);
-    insert(_el$101, createComponent(Badge, {
+    insert(_el$113, createComponent(Badge, {
       get children() {
         return `epoch=${state$1.auth.sessionEpoch == null ? "-" : state$1.auth.sessionEpoch}`;
       }
     }), null);
-    insert(_el$101, createComponent(Badge, {
+    insert(_el$113, createComponent(Badge, {
       get children() {
         return `runtime=${state$1.auth.runtimeStatus || "-"}`;
       }
     }), null);
-    insert(_el$101, createComponent(Badge, {
+    insert(_el$113, createComponent(Badge, {
       get children() {
         return `boundAgent=${state$1.auth.boundAgentId || "-"}`;
       }
     }), null);
-    insert(_el$101, createComponent(Badge, {
+    insert(_el$113, createComponent(Badge, {
       get children() {
         return `requestedAgent=${state$1.auth.pendingRequestedAgentId || "-"}`;
       }
     }), null);
-    insert(_el$101, createComponent(Badge, {
+    insert(_el$113, createComponent(Badge, {
       get children() {
         return state$1.auth.pendingForceRebind ? "rebind=forcing" : "rebind=idle";
       }
     }), null);
-    insert(_el$102, createComponent(Show, {
-      get when() {
-        return hostedRecoveryHint();
-      },
-      children: (hint) => (() => {
-        var _el$155 = _tmpl$23();
-        _el$155.$$click = () => {
-          void retryHostedPlayerIdentityIssue();
-        };
-        insert(_el$155, () => hint().cta);
-        createRenderEffect(() => _el$155.disabled = state$1.auth.issueInFlight);
-        return _el$155;
-      })()
-    }), null);
-    insert(_el$102, createComponent(Show, {
-      get when() {
-        return memo(() => !!(!state$1.auth.available && String(state$1.hostedAccess?.deployment_mode || "").trim() === "hosted_public_join"))() && !hostedRecoveryHint();
-      },
-      get children() {
-        var _el$103 = _tmpl$23();
-        _el$103.$$click = () => {
-          void retryHostedPlayerIdentityIssue();
-        };
-        insert(_el$103, () => tr(locale(), "领取玩家会话", "Acquire Player Session"));
-        createRenderEffect(() => _el$103.disabled = state$1.auth.issueInFlight);
-        return _el$103;
-      }
-    }), null);
-    insert(_el$102, createComponent(Show, {
+    insert(_el$114, createComponent(Show, {
       get when() {
         return memo(() => !!state$1.auth.available)() && state$1.auth.source !== "legacy_viewer_auth_bootstrap";
       },
       get children() {
-        var _el$104 = _tmpl$24();
-        _el$104.$$click = () => {
+        var _el$115 = _tmpl$25();
+        _el$115.$$click = () => {
           void logoutHostedPlayerSession();
         };
-        insert(_el$104, () => tr(locale(), "释放玩家会话", "Release Player Session"));
-        return _el$104;
+        insert(_el$115, () => tr(locale(), "释放玩家会话", "Release Player Session"));
+        return _el$115;
       }
-    }), null);
-    insert(_el$98, createComponent(Show, {
+    }));
+    insert(_el$110, createComponent(Show, {
+      get when() {
+        return hostedRecoveryHint();
+      },
+      children: (hint) => createComponent(EmptyState, {
+        get children() {
+          return hint().detail;
+        }
+      })
+    }), _el$122);
+    insert(_el$110, createComponent(Show, {
+      get when() {
+        return memo(() => !!!state$1.auth.available)() && String(state$1.hostedAccess?.deployment_mode || "").trim() === "hosted_public_join";
+      },
+      get children() {
+        return createComponent(HostedLoginForm, {
+          get locale() {
+            return locale();
+          },
+          channelId: "diag-hosted-login-channel",
+          handleId: "diag-hosted-login-handle",
+          codeId: "diag-hosted-login-code"
+        });
+      }
+    }), _el$122);
+    insert(_el$110, createComponent(Show, {
       get when() {
         return state$1.auth.recoveryErrorCode || state$1.auth.recoveryErrorMessage;
       },
       get children() {
-        var _el$105 = _tmpl$14();
-        insert(_el$105, createComponent(Badge, {
+        var _el$116 = _tmpl$13();
+        insert(_el$116, createComponent(Badge, {
           "class": "badge badge--warn",
           get children() {
             return `recoveryError=${state$1.auth.recoveryErrorCode || "-"}`;
           }
         }), null);
-        insert(_el$105, createComponent(Badge, {
+        insert(_el$116, createComponent(Badge, {
           get children() {
             return state$1.auth.recoveryErrorMessage || "-";
           }
         }), null);
-        return _el$105;
+        return _el$116;
       }
-    }), _el$111);
-    insert(_el$98, createComponent(Show, {
+    }), _el$122);
+    insert(_el$110, createComponent(Show, {
       get when() {
         return showRebindNotice();
       },
       get children() {
         return [(() => {
-          var _el$106 = _tmpl$14();
-          insert(_el$106, createComponent(Badge, {
+          var _el$117 = _tmpl$13();
+          insert(_el$117, createComponent(Badge, {
             "class": "badge badge--accent",
             children: "rebind"
           }), null);
-          insert(_el$106, createComponent(Badge, {
+          insert(_el$117, createComponent(Badge, {
             get children() {
               return `target=${state$1.auth.pendingRequestedAgentId || "-"}`;
             }
           }), null);
-          insert(_el$106, createComponent(Badge, {
+          insert(_el$117, createComponent(Badge, {
             get children() {
               return state$1.auth.pendingForceRebind ? "mode=force_rebind" : "mode=awaiting_retry";
             }
           }), null);
-          return _el$106;
+          return _el$117;
         })(), createComponent(EmptyState, {
           children: "Player session is switching to the requested agent and the current action will continue after registration succeeds."
         })];
       }
-    }), _el$111);
-    insert(_el$98, createComponent(Show, {
+    }), _el$122);
+    insert(_el$110, createComponent(Show, {
       get when() {
         return state$1.hostedAdmission;
       },
       children: (admission) => (() => {
-        var _el$156 = _tmpl$14();
-        insert(_el$156, createComponent(Badge, {
+        var _el$164 = _tmpl$13();
+        insert(_el$164, createComponent(Badge, {
           get children() {
             return `activeSlots=${admission().active_player_sessions}/${admission().max_player_sessions}`;
           }
         }), null);
-        insert(_el$156, createComponent(Badge, {
+        insert(_el$164, createComponent(Badge, {
           get children() {
             return `effectiveSlots=${admission().effective_player_sessions == null ? "-" : `${admission().effective_player_sessions}/${admission().max_player_sessions}`}`;
           }
         }), null);
-        insert(_el$156, createComponent(Badge, {
+        insert(_el$164, createComponent(Badge, {
           get children() {
             return `runtimeBound=${admission().runtime_bound_player_sessions ?? "-"}`;
           }
         }), null);
-        insert(_el$156, createComponent(Badge, {
+        insert(_el$164, createComponent(Badge, {
           get children() {
             return `runtimeOnly=${admission().runtime_only_player_sessions ?? "-"}`;
           }
         }), null);
-        insert(_el$156, createComponent(Badge, {
+        insert(_el$164, createComponent(Badge, {
           get children() {
             return `runtimeProbe=${admission().runtime_probe_status || "-"}`;
           }
         }), null);
-        insert(_el$156, createComponent(Badge, {
+        insert(_el$164, createComponent(Badge, {
           get children() {
             return `issueBudget=${admission().remaining_issue_budget}`;
           }
         }), null);
-        insert(_el$156, createComponent(Badge, {
+        insert(_el$164, createComponent(Badge, {
           get children() {
             return `leaseTTL=${admission().slot_lease_ttl_ms}`;
           }
         }), null);
-        insert(_el$156, createComponent(Badge, {
+        insert(_el$164, createComponent(Badge, {
           get children() {
             return `issued=${admission().issued_players_total}`;
           }
         }), null);
-        insert(_el$156, createComponent(Badge, {
+        insert(_el$164, createComponent(Badge, {
           get children() {
             return `released=${admission().released_players_total}`;
           }
         }), null);
-        return _el$156;
+        return _el$164;
       })()
-    }), _el$111);
-    insert(_el$98, createComponent(Show, {
+    }), _el$122);
+    insert(_el$110, createComponent(Show, {
       get when() {
         return state$1.hostedAdmission?.runtime_probe_error;
       },
       get children() {
-        var _el$107 = _tmpl$14();
-        insert(_el$107, createComponent(Badge, {
+        var _el$118 = _tmpl$13();
+        insert(_el$118, createComponent(Badge, {
           "class": "badge badge--warn",
           get children() {
             return `runtimeProbeError=${state$1.hostedAdmission.runtime_probe_error}`;
           }
         }));
-        return _el$107;
+        return _el$118;
       }
-    }), _el$111);
-    insert(_el$98, createComponent(PanelSection, {
+    }), _el$122);
+    insert(_el$110, createComponent(PanelSection, {
       title: "Session Ladder",
       get children() {
         return [createComponent(EmptyState, {
@@ -6748,8 +6854,8 @@ function WorldSummaryPanel() {
             return authSurface().currentTierReason;
           }
         }), (() => {
-          var _el$108 = _tmpl$25();
-          insert(_el$108, createComponent(For, {
+          var _el$119 = _tmpl$26();
+          insert(_el$119, createComponent(For, {
             get each() {
               return authSurface().tiers;
             },
@@ -6768,10 +6874,10 @@ function WorldSummaryPanel() {
               }
             })
           }));
-          return _el$108;
+          return _el$119;
         })(), (() => {
-          var _el$109 = _tmpl$14();
-          insert(_el$109, createComponent(Badge, {
+          var _el$120 = _tmpl$13();
+          insert(_el$120, createComponent(Badge, {
             get ["class"]() {
               return authSurface().capabilities.prompt_control.enabled ? "badge badge--good" : "badge badge--warn";
             },
@@ -6779,7 +6885,7 @@ function WorldSummaryPanel() {
               return `prompt=${authSurface().capabilities.prompt_control.enabled ? "enabled" : authSurface().capabilities.prompt_control.code}`;
             }
           }), null);
-          insert(_el$109, createComponent(Badge, {
+          insert(_el$120, createComponent(Badge, {
             get ["class"]() {
               return authSurface().capabilities.agent_chat.enabled ? "badge badge--good" : "badge badge--warn";
             },
@@ -6787,21 +6893,21 @@ function WorldSummaryPanel() {
               return `chat=${authSurface().capabilities.agent_chat.enabled ? "enabled" : authSurface().capabilities.agent_chat.code}`;
             }
           }), null);
-          insert(_el$109, createComponent(Badge, {
+          insert(_el$120, createComponent(Badge, {
             "class": "badge badge--warn",
             get children() {
               return `mainToken=${authSurface().capabilities.main_token_transfer.code}`;
             }
           }), null);
-          return _el$109;
+          return _el$120;
         })(), createComponent(EmptyState, {
           get children() {
             return authSurface().reconnect;
           }
         })];
       }
-    }), _el$111);
-    insert(_el$98, createComponent(Show, {
+    }), _el$122);
+    insert(_el$110, createComponent(Show, {
       get when() {
         return hostedActionMatrixView().length > 0;
       },
@@ -6816,8 +6922,8 @@ function WorldSummaryPanel() {
                 return tr(locale(), "这里是 launcher 导出的 hosted public-join 真值面。QA 应该直接读取这些 action id，而不是只靠按钮状态推断。", "This is the hosted public-join truth surface exported by the launcher. QA should read these action ids directly instead of inferring from button state alone.");
               }
             }), (() => {
-              var _el$110 = _tmpl$25();
-              insert(_el$110, createComponent(For, {
+              var _el$121 = _tmpl$26();
+              insert(_el$121, createComponent(For, {
                 get each() {
                   return hostedActionMatrixView();
                 },
@@ -6854,13 +6960,13 @@ function WorldSummaryPanel() {
                   }
                 })
               }));
-              return _el$110;
+              return _el$121;
             })()];
           }
         });
       }
-    }), _el$111);
-    insert(_el$111, createComponent(MetricCard, {
+    }), _el$122);
+    insert(_el$122, createComponent(MetricCard, {
       get label() {
         return tr(locale(), "Prompt 反馈", "Prompt Feedback");
       },
@@ -6885,7 +6991,7 @@ function WorldSummaryPanel() {
         });
       }
     }), null);
-    insert(_el$111, createComponent(MetricCard, {
+    insert(_el$122, createComponent(MetricCard, {
       get label() {
         return tr(locale(), "聊天反馈", "Chat Feedback");
       },
@@ -6910,8 +7016,8 @@ function WorldSummaryPanel() {
         });
       }
     }), null);
-    insert(_el$113, () => tr(locale(), "最近事件", "Recent Events"));
-    insert(_el$114, createComponent(Show, {
+    insert(_el$124, () => tr(locale(), "最近事件", "Recent Events"));
+    insert(_el$125, createComponent(Show, {
       get when() {
         return state$1.recentEvents.length > 0;
       },
@@ -6948,7 +7054,7 @@ function WorldSummaryPanel() {
         });
       }
     }));
-    return _el$86;
+    return _el$100;
   })();
 }
 function InteractionPanel() {
@@ -6990,19 +7096,19 @@ function InteractionPanel() {
     });
   }
   return (() => {
-    var _el$157 = _tmpl$41(), _el$158 = _el$157.firstChild, _el$160 = _el$158.nextSibling;
-    insert(_el$158, createComponent(Badge, {
+    var _el$165 = _tmpl$42(), _el$166 = _el$165.firstChild, _el$168 = _el$166.nextSibling;
+    insert(_el$166, createComponent(Badge, {
       "class": "badge badge--accent",
       get children() {
         return tr(locale(), "当前交互目标", "Current Target");
       }
     }), null);
-    insert(_el$158, createComponent(Badge, {
+    insert(_el$166, createComponent(Badge, {
       get children() {
         return `agent=${agentId()}`;
       }
     }), null);
-    insert(_el$158, createComponent(Badge, {
+    insert(_el$166, createComponent(Badge, {
       get ["class"]() {
         return chatCapability().enabled ? "badge badge--good" : "badge badge--warn";
       },
@@ -7010,7 +7116,7 @@ function InteractionPanel() {
         return memo(() => !!chatCapability().enabled)() ? tr(locale(), "聊天可用", "Chat Ready") : tr(locale(), "聊天受限", "Chat Limited");
       }
     }), null);
-    insert(_el$157, createComponent(Show, {
+    insert(_el$165, createComponent(Show, {
       get when() {
         return debugContext()?.provider_mode === "provider_loopback_http";
       },
@@ -7021,8 +7127,8 @@ function InteractionPanel() {
           }
         });
       }
-    }), _el$160);
-    insert(_el$157, createComponent(Show, {
+    }), _el$168);
+    insert(_el$165, createComponent(Show, {
       get when() {
         return debugContext()?.provider_mode !== "provider_loopback_http";
       },
@@ -7040,24 +7146,24 @@ function InteractionPanel() {
           },
           get children() {
             return [(() => {
-              var _el$159 = _tmpl$14();
-              insert(_el$159, createComponent(Badge, {
+              var _el$167 = _tmpl$13();
+              insert(_el$167, createComponent(Badge, {
                 "class": "badge badge--good",
                 get children() {
                   return authSurface().currentTier;
                 }
               }), null);
-              insert(_el$159, createComponent(Badge, {
+              insert(_el$167, createComponent(Badge, {
                 get children() {
                   return `player=${state.auth.playerId}`;
                 }
               }), null);
-              insert(_el$159, createComponent(Badge, {
+              insert(_el$167, createComponent(Badge, {
                 get children() {
                   return `source=${authSurface().source}`;
                 }
               }), null);
-              return _el$159;
+              return _el$167;
             })(), createComponent(EmptyState, {
               get children() {
                 return promptCapability().reason;
@@ -7066,18 +7172,18 @@ function InteractionPanel() {
           }
         });
       }
-    }), _el$160);
-    insert(_el$160, createComponent(Badge, {
+    }), _el$168);
+    insert(_el$168, createComponent(Badge, {
       get children() {
         return `boundPlayer=${binding()?.playerId || "-"}`;
       }
     }), null);
-    insert(_el$160, createComponent(Badge, {
+    insert(_el$168, createComponent(Badge, {
       get children() {
         return `boundKey=${binding()?.publicKey ? `${binding().publicKey.slice(0, 10)}…` : "-"}`;
       }
     }), null);
-    insert(_el$160, createComponent(Badge, {
+    insert(_el$168, createComponent(Badge, {
       get ["class"]() {
         return promptCapability().enabled ? "badge badge--good" : "badge badge--warn";
       },
@@ -7085,7 +7191,7 @@ function InteractionPanel() {
         return `prompt=${promptCapability().enabled ? "enabled" : promptCapability().code}`;
       }
     }), null);
-    insert(_el$160, createComponent(Badge, {
+    insert(_el$168, createComponent(Badge, {
       get ["class"]() {
         return chatCapability().enabled ? "badge badge--good" : "badge badge--warn";
       },
@@ -7093,7 +7199,7 @@ function InteractionPanel() {
         return `chat=${chatCapability().enabled ? "enabled" : chatCapability().code}`;
       }
     }), null);
-    insert(_el$160, createComponent(Badge, {
+    insert(_el$168, createComponent(Badge, {
       get ["class"]() {
         return mainTokenTransferCapability().enabled ? "badge badge--good" : "badge badge--warn";
       },
@@ -7101,12 +7207,12 @@ function InteractionPanel() {
         return `mainToken=${assetLaneStatusText()}`;
       }
     }), null);
-    insert(_el$157, createComponent(EmptyState, {
+    insert(_el$165, createComponent(EmptyState, {
       get children() {
         return assetLaneDetail();
       }
     }), null);
-    insert(_el$157, createComponent(PanelSection, {
+    insert(_el$165, createComponent(PanelSection, {
       get title() {
         return tr(locale(), "Agent 聊天", "Agent Chat");
       },
@@ -7118,29 +7224,29 @@ function InteractionPanel() {
       },
       get children() {
         return [(() => {
-          var _el$161 = _tmpl$30(), _el$162 = _el$161.firstChild, _el$163 = _el$162.nextSibling;
-          insert(_el$162, () => tr(locale(), "消息", "Message"));
-          _el$163.$$input = (event) => {
+          var _el$169 = _tmpl$31(), _el$170 = _el$169.firstChild, _el$171 = _el$170.nextSibling;
+          insert(_el$170, () => tr(locale(), "消息", "Message"));
+          _el$171.$$input = (event) => {
             state.chatDraft.message = String(event.currentTarget.value || "");
             state.chatDraft.dirty = true;
           };
           createRenderEffect((_p$) => {
-            var _v$7 = tr(locale(), "给当前选中的 Agent 发一条消息", "Send a message to the selected agent"), _v$8 = !chatCapability().enabled;
-            _v$7 !== _p$.e && setAttribute(_el$163, "placeholder", _p$.e = _v$7);
-            _v$8 !== _p$.t && (_el$163.disabled = _p$.t = _v$8);
+            var _v$10 = tr(locale(), "给当前选中的 Agent 发一条消息", "Send a message to the selected agent"), _v$11 = !chatCapability().enabled;
+            _v$10 !== _p$.e && setAttribute(_el$171, "placeholder", _p$.e = _v$10);
+            _v$11 !== _p$.t && (_el$171.disabled = _p$.t = _v$11);
             return _p$;
           }, {
             e: void 0,
             t: void 0
           });
-          createRenderEffect(() => _el$163.value = state.chatDraft.message);
-          return _el$161;
+          createRenderEffect(() => _el$171.value = state.chatDraft.message);
+          return _el$169;
         })(), (() => {
-          var _el$164 = _tmpl$31(), _el$165 = _el$164.firstChild;
-          _el$165.$$click = () => sendAgentChat(agentId(), state.chatDraft.message);
-          insert(_el$165, () => tr(locale(), "发送聊天", "Send Chat"));
-          createRenderEffect(() => _el$165.disabled = !chatCapability().enabled);
-          return _el$164;
+          var _el$172 = _tmpl$32(), _el$173 = _el$172.firstChild;
+          _el$173.$$click = () => sendAgentChat(agentId(), state.chatDraft.message);
+          insert(_el$173, () => tr(locale(), "发送聊天", "Send Chat"));
+          createRenderEffect(() => _el$173.disabled = !chatCapability().enabled);
+          return _el$172;
         })(), createComponent(Show, {
           get when() {
             return chatFeedback();
@@ -7161,9 +7267,9 @@ function InteractionPanel() {
             }
           })
         }), (() => {
-          var _el$166 = _tmpl$32(), _el$167 = _el$166.firstChild, _el$168 = _el$167.nextSibling;
-          insert(_el$167, () => tr(locale(), "消息流", "Message Flow"));
-          insert(_el$168, createComponent(Show, {
+          var _el$174 = _tmpl$33(), _el$175 = _el$174.firstChild, _el$176 = _el$175.nextSibling;
+          insert(_el$175, () => tr(locale(), "消息流", "Message Flow"));
+          insert(_el$176, createComponent(Show, {
             get when() {
               return chatHistory().length > 0;
             },
@@ -7198,11 +7304,11 @@ function InteractionPanel() {
               });
             }
           }));
-          return _el$166;
+          return _el$174;
         })()];
       }
     }), null);
-    insert(_el$157, createComponent(PanelSection, {
+    insert(_el$165, createComponent(PanelSection, {
       get title() {
         return tr(locale(), "高级 Prompt 设置", "Advanced Prompt Settings");
       },
@@ -7214,18 +7320,18 @@ function InteractionPanel() {
       },
       get children() {
         return [(() => {
-          var _el$169 = _tmpl$14();
-          insert(_el$169, createComponent(Badge, {
+          var _el$177 = _tmpl$13();
+          insert(_el$177, createComponent(Badge, {
             get children() {
               return `activePrompt=v${promptVersionState().currentVersion}`;
             }
           }), null);
-          insert(_el$169, createComponent(Badge, {
+          insert(_el$177, createComponent(Badge, {
             get children() {
               return `nextRollback=v${promptVersionState().nextRollbackTargetVersion}`;
             }
           }), null);
-          insert(_el$169, createComponent(Show, {
+          insert(_el$177, createComponent(Show, {
             get when() {
               return promptVersionState().restoredFromVersion != null;
             },
@@ -7237,7 +7343,7 @@ function InteractionPanel() {
               });
             }
           }), null);
-          insert(_el$169, createComponent(Badge, {
+          insert(_el$177, createComponent(Badge, {
             get ["class"]() {
               return promptOverridesVisible() ? "badge badge--good" : "badge";
             },
@@ -7245,25 +7351,25 @@ function InteractionPanel() {
               return memo(() => !!promptOverridesVisible())() ? tr(locale(), "状态=已展开", "state=expanded") : tr(locale(), "状态=默认收起", "state=hidden_by_default");
             }
           }), null);
-          insert(_el$169, createComponent(Badge, {
+          insert(_el$177, createComponent(Badge, {
             get children() {
               return tr(locale(), "本地设置持久化", "locally persisted");
             }
           }), null);
-          return _el$169;
+          return _el$177;
         })(), createComponent(EmptyState, {
           get children() {
             return promptSettingsSummary();
           }
         }), (() => {
-          var _el$170 = _tmpl$33(), _el$171 = _el$170.firstChild;
-          _el$171.$$click = () => togglePromptOverridesVisible();
-          insert(_el$171, promptSettingsButtonLabel);
-          return _el$170;
+          var _el$178 = _tmpl$34(), _el$179 = _el$178.firstChild;
+          _el$179.$$click = () => togglePromptOverridesVisible();
+          insert(_el$179, promptSettingsButtonLabel);
+          return _el$178;
         })()];
       }
     }), null);
-    insert(_el$157, createComponent(Show, {
+    insert(_el$165, createComponent(Show, {
       get when() {
         return promptOverridesVisible();
       },
@@ -7272,97 +7378,97 @@ function InteractionPanel() {
           title: "Prompt Overrides",
           get children() {
             return [(() => {
-              var _el$172 = _tmpl$4();
-              insert(_el$172, () => promptVersionState().summary);
-              return _el$172;
+              var _el$180 = _tmpl$4();
+              insert(_el$180, () => promptVersionState().summary);
+              return _el$180;
             })(), (() => {
-              var _el$173 = _tmpl$4();
-              insert(_el$173, () => promptVersionState().detail);
-              return _el$173;
+              var _el$181 = _tmpl$4();
+              insert(_el$181, () => promptVersionState().detail);
+              return _el$181;
             })(), createComponent(Show, {
               get when() {
                 return memo(() => !!authSurface().capabilities.prompt_control.enabled)() && String(state.hostedAccess?.deployment_mode || "").trim() === "hosted_public_join";
               },
               get children() {
-                var _el$174 = _tmpl$34(), _el$175 = _el$174.firstChild, _el$176 = _el$175.nextSibling;
-                insert(_el$175, () => tr(locale(), "后端审批码", "Backend Approval Code"));
-                _el$176.$$input = (event) => {
+                var _el$182 = _tmpl$35(), _el$183 = _el$182.firstChild, _el$184 = _el$183.nextSibling;
+                insert(_el$183, () => tr(locale(), "后端审批码", "Backend Approval Code"));
+                _el$184.$$input = (event) => {
                   state.strongAuth.approvalCode = String(event.currentTarget.value || "");
                 };
-                createRenderEffect(() => _el$176.value = state.strongAuth.approvalCode || "");
-                return _el$174;
+                createRenderEffect(() => _el$184.value = state.strongAuth.approvalCode || "");
+                return _el$182;
               }
             }), (() => {
-              var _el$177 = _tmpl$35(), _el$178 = _el$177.firstChild, _el$179 = _el$178.nextSibling;
-              insert(_el$178, () => tr(locale(), "System Prompt 覆盖", "System Prompt Override"));
-              _el$179.$$input = (event) => {
+              var _el$185 = _tmpl$36(), _el$186 = _el$185.firstChild, _el$187 = _el$186.nextSibling;
+              insert(_el$186, () => tr(locale(), "System Prompt 覆盖", "System Prompt Override"));
+              _el$187.$$input = (event) => {
                 state.promptDraft.systemPrompt = String(event.currentTarget.value || "");
                 state.promptDraft.dirty = true;
               };
-              createRenderEffect(() => _el$179.disabled = !promptCapability().enabled);
-              createRenderEffect(() => _el$179.value = state.promptDraft.systemPrompt);
-              return _el$177;
+              createRenderEffect(() => _el$187.disabled = !promptCapability().enabled);
+              createRenderEffect(() => _el$187.value = state.promptDraft.systemPrompt);
+              return _el$185;
             })(), (() => {
-              var _el$180 = _tmpl$36(), _el$181 = _el$180.firstChild, _el$182 = _el$181.nextSibling;
-              insert(_el$181, () => tr(locale(), "短期目标覆盖", "Short-Term Goal Override"));
-              _el$182.$$input = (event) => {
+              var _el$188 = _tmpl$37(), _el$189 = _el$188.firstChild, _el$190 = _el$189.nextSibling;
+              insert(_el$189, () => tr(locale(), "短期目标覆盖", "Short-Term Goal Override"));
+              _el$190.$$input = (event) => {
                 state.promptDraft.shortTermGoal = String(event.currentTarget.value || "");
                 state.promptDraft.dirty = true;
               };
-              createRenderEffect(() => _el$182.disabled = !promptCapability().enabled);
-              createRenderEffect(() => _el$182.value = state.promptDraft.shortTermGoal);
-              return _el$180;
+              createRenderEffect(() => _el$190.disabled = !promptCapability().enabled);
+              createRenderEffect(() => _el$190.value = state.promptDraft.shortTermGoal);
+              return _el$188;
             })(), (() => {
-              var _el$183 = _tmpl$37(), _el$184 = _el$183.firstChild, _el$185 = _el$184.nextSibling;
-              insert(_el$184, () => tr(locale(), "长期目标覆盖", "Long-Term Goal Override"));
-              _el$185.$$input = (event) => {
+              var _el$191 = _tmpl$38(), _el$192 = _el$191.firstChild, _el$193 = _el$192.nextSibling;
+              insert(_el$192, () => tr(locale(), "长期目标覆盖", "Long-Term Goal Override"));
+              _el$193.$$input = (event) => {
                 state.promptDraft.longTermGoal = String(event.currentTarget.value || "");
                 state.promptDraft.dirty = true;
               };
-              createRenderEffect(() => _el$185.disabled = !promptCapability().enabled);
-              createRenderEffect(() => _el$185.value = state.promptDraft.longTermGoal);
-              return _el$183;
+              createRenderEffect(() => _el$193.disabled = !promptCapability().enabled);
+              createRenderEffect(() => _el$193.value = state.promptDraft.longTermGoal);
+              return _el$191;
             })(), (() => {
-              var _el$186 = _tmpl$38(), _el$187 = _el$186.firstChild, _el$188 = _el$187.nextSibling;
-              _el$187.$$click = () => sendPromptControl("preview", null);
-              insert(_el$187, () => tr(locale(), "预览 Prompt", "Preview Prompt"));
-              _el$188.$$click = () => sendPromptControl("apply", null);
-              insert(_el$188, () => tr(locale(), "应用 Prompt", "Apply Prompt"));
+              var _el$194 = _tmpl$39(), _el$195 = _el$194.firstChild, _el$196 = _el$195.nextSibling;
+              _el$195.$$click = () => sendPromptControl("preview", null);
+              insert(_el$195, () => tr(locale(), "预览 Prompt", "Preview Prompt"));
+              _el$196.$$click = () => sendPromptControl("apply", null);
+              insert(_el$196, () => tr(locale(), "应用 Prompt", "Apply Prompt"));
               createRenderEffect((_p$) => {
-                var _v$9 = !promptCapability().enabled, _v$0 = !promptCapability().enabled;
-                _v$9 !== _p$.e && (_el$187.disabled = _p$.e = _v$9);
-                _v$0 !== _p$.t && (_el$188.disabled = _p$.t = _v$0);
+                var _v$12 = !promptCapability().enabled, _v$13 = !promptCapability().enabled;
+                _v$12 !== _p$.e && (_el$195.disabled = _p$.e = _v$12);
+                _v$13 !== _p$.t && (_el$196.disabled = _p$.t = _v$13);
                 return _p$;
               }, {
                 e: void 0,
                 t: void 0
               });
-              return _el$186;
+              return _el$194;
             })(), (() => {
-              var _el$189 = _tmpl$39(), _el$190 = _el$189.firstChild, _el$191 = _el$190.firstChild, _el$192 = _el$191.nextSibling, _el$193 = _el$190.nextSibling;
-              insert(_el$191, () => tr(locale(), "下一次回滚目标版本", "Next Rollback Target Version"));
-              _el$192.$$input = (event) => {
+              var _el$197 = _tmpl$40(), _el$198 = _el$197.firstChild, _el$199 = _el$198.firstChild, _el$200 = _el$199.nextSibling, _el$201 = _el$198.nextSibling;
+              insert(_el$199, () => tr(locale(), "下一次回滚目标版本", "Next Rollback Target Version"));
+              _el$200.$$input = (event) => {
                 const nextValue = Number(event.currentTarget.value || 0);
                 state.promptDraft.rollbackTargetVersion = Math.max(0, Math.floor(nextValue || 0));
                 requestRender();
               };
-              _el$193.$$click = () => {
+              _el$201.$$click = () => {
                 sendPromptControl("rollback", {
                   toVersion: Number(state.promptDraft.rollbackTargetVersion || 0)
                 });
               };
-              insert(_el$193, () => tr(locale(), "回滚 Prompt", "Rollback Prompt"));
+              insert(_el$201, () => tr(locale(), "回滚 Prompt", "Rollback Prompt"));
               createRenderEffect((_p$) => {
-                var _v$1 = !promptCapability().enabled, _v$10 = !promptCapability().enabled;
-                _v$1 !== _p$.e && (_el$192.disabled = _p$.e = _v$1);
-                _v$10 !== _p$.t && (_el$193.disabled = _p$.t = _v$10);
+                var _v$14 = !promptCapability().enabled, _v$15 = !promptCapability().enabled;
+                _v$14 !== _p$.e && (_el$200.disabled = _p$.e = _v$14);
+                _v$15 !== _p$.t && (_el$201.disabled = _p$.t = _v$15);
                 return _p$;
               }, {
                 e: void 0,
                 t: void 0
               });
-              createRenderEffect(() => _el$192.value = Number(state.promptDraft.rollbackTargetVersion || 0));
-              return _el$189;
+              createRenderEffect(() => _el$200.value = Number(state.promptDraft.rollbackTargetVersion || 0));
+              return _el$197;
             })(), createComponent(Show, {
               get when() {
                 return promptFeedback();
@@ -7410,7 +7516,7 @@ function InteractionPanel() {
         });
       }
     }), null);
-    insert(_el$157, createComponent(PanelSection, {
+    insert(_el$165, createComponent(PanelSection, {
       get title() {
         return tr(locale(), "资产 / 治理 Lane", "Asset / Governance Lane");
       },
@@ -7422,8 +7528,8 @@ function InteractionPanel() {
       },
       get children() {
         return [(() => {
-          var _el$194 = _tmpl$14();
-          insert(_el$194, createComponent(Badge, {
+          var _el$202 = _tmpl$13();
+          insert(_el$202, createComponent(Badge, {
             get ["class"]() {
               return mainTokenTransferCapability().enabled ? "badge badge--good" : "badge badge--warn";
             },
@@ -7431,17 +7537,17 @@ function InteractionPanel() {
               return `main_token_transfer=${assetLaneStatusText()}`;
             }
           }), null);
-          insert(_el$194, createComponent(Badge, {
+          insert(_el$202, createComponent(Badge, {
             get children() {
               return `required_auth=${mainTokenTransferPolicy()?.required_auth || "-"}`;
             }
           }), null);
-          insert(_el$194, createComponent(Badge, {
+          insert(_el$202, createComponent(Badge, {
             get children() {
               return `availability=${mainTokenTransferPolicy()?.availability || "-"}`;
             }
           }), null);
-          return _el$194;
+          return _el$202;
         })(), createComponent(EmptyState, {
           get children() {
             return assetLaneDetail();
@@ -7451,13 +7557,13 @@ function InteractionPanel() {
             return mainTokenTransferPolicy()?.reason || tr(locale(), "当前 lane 没有 main_token_transfer 的 hosted action policy。", "No hosted action policy is available for main_token_transfer on this lane.");
           }
         }), (() => {
-          var _el$195 = _tmpl$40(), _el$196 = _el$195.firstChild;
-          insert(_el$196, () => tr(locale(), "主代币转账（这里暂未开放）", "Main Token Transfer (Not Exposed Here Yet)"));
-          return _el$195;
+          var _el$203 = _tmpl$41(), _el$204 = _el$203.firstChild;
+          insert(_el$204, () => tr(locale(), "主代币转账（这里暂未开放）", "Main Token Transfer (Not Exposed Here Yet)"));
+          return _el$203;
         })()];
       }
     }), null);
-    return _el$157;
+    return _el$165;
   })();
 }
 function DetailsPanel() {
@@ -7484,20 +7590,20 @@ function DetailsPanel() {
   });
   const hasSnapshotDiagnostics = () => !!state.snapshot || !!state.metrics || !!state.hostedAccess;
   return (() => {
-    var _el$197 = _tmpl$43(), _el$198 = _el$197.firstChild, _el$199 = _el$198.nextSibling, _el$200 = _el$199.firstChild, _el$201 = _el$200.nextSibling, _el$202 = _el$201.nextSibling, _el$203 = _el$202.firstChild, _el$204 = _el$203.nextSibling, _el$205 = _el$204.nextSibling, _el$206 = _el$205.firstChild, _el$207 = _el$206.nextSibling;
-    insert(_el$198, createComponent(Badge, {
+    var _el$205 = _tmpl$44(), _el$206 = _el$205.firstChild, _el$207 = _el$206.nextSibling, _el$208 = _el$207.firstChild, _el$209 = _el$208.nextSibling, _el$210 = _el$209.nextSibling, _el$211 = _el$210.firstChild, _el$212 = _el$211.nextSibling, _el$213 = _el$212.nextSibling, _el$214 = _el$213.firstChild, _el$215 = _el$214.nextSibling;
+    insert(_el$206, createComponent(Badge, {
       "class": "badge badge--accent",
       get children() {
         return tr(locale(), "当前命令目标", "Current Command Target");
       }
     }), null);
-    insert(_el$198, createComponent(Badge, {
+    insert(_el$206, createComponent(Badge, {
       get children() {
         return selectedLabel();
       }
     }), null);
-    insert(_el$197, createComponent(InteractionPanel, {}), _el$199);
-    insert(_el$197, createComponent(Show, {
+    insert(_el$205, createComponent(InteractionPanel, {}), _el$207);
+    insert(_el$205, createComponent(Show, {
       get when() {
         return state.selectedObject;
       },
@@ -7528,29 +7634,29 @@ function DetailsPanel() {
         },
         value: () => clone(selected())
       })
-    }), _el$199);
-    insert(_el$200, () => tr(locale(), "世界规模", "World Scale"));
-    insert(_el$201, createComponent(Badge, {
+    }), _el$207);
+    insert(_el$208, () => tr(locale(), "世界规模", "World Scale"));
+    insert(_el$209, createComponent(Badge, {
       get children() {
         return `agents=${snapshotCounts().agents}`;
       }
     }), null);
-    insert(_el$201, createComponent(Badge, {
+    insert(_el$209, createComponent(Badge, {
       get children() {
         return `locations=${snapshotCounts().locations}`;
       }
     }), null);
-    insert(_el$201, createComponent(Badge, {
+    insert(_el$209, createComponent(Badge, {
       get children() {
         return `promptProfiles=${snapshotCounts().promptProfiles}`;
       }
     }), null);
-    insert(_el$201, createComponent(Badge, {
+    insert(_el$209, createComponent(Badge, {
       get children() {
         return `debugContexts=${snapshotCounts().executionDebugContexts}`;
       }
     }), null);
-    insert(_el$202, createComponent(MetricCard, {
+    insert(_el$210, createComponent(MetricCard, {
       get label() {
         return tr(locale(), "物理真值单位", "Canonical Physical Unit");
       },
@@ -7564,9 +7670,9 @@ function DetailsPanel() {
           }
         });
       }
-    }), _el$203);
-    insert(_el$203, () => worldScaleSurface().physicalTruth.canonicalUnitDetail);
-    insert(_el$202, createComponent(MetricCard, {
+    }), _el$211);
+    insert(_el$211, () => worldScaleSurface().physicalTruth.canonicalUnitDetail);
+    insert(_el$210, createComponent(MetricCard, {
       get label() {
         return tr(locale(), "世界边界", "World Bounds");
       },
@@ -7580,9 +7686,9 @@ function DetailsPanel() {
           }
         });
       }
-    }), _el$204);
-    insert(_el$204, () => worldScaleSurface().physicalTruth.worldBoundsDetail);
-    insert(_el$202, createComponent(Show, {
+    }), _el$212);
+    insert(_el$212, () => worldScaleSurface().physicalTruth.worldBoundsDetail);
+    insert(_el$210, createComponent(Show, {
       get when() {
         return worldScaleSurface().physicalTruth.anchor;
       },
@@ -7599,25 +7705,25 @@ function DetailsPanel() {
         },
         get children() {
           return [(() => {
-            var _el$214 = _tmpl$13();
-            insert(_el$214, () => anchor().positionLabel || tr(locale(), "缺少可读坐标。", "Missing readable coordinates."));
-            return _el$214;
+            var _el$222 = _tmpl$17();
+            insert(_el$222, () => anchor().positionLabel || tr(locale(), "缺少可读坐标。", "Missing readable coordinates."));
+            return _el$222;
           })(), createComponent(Show, {
             get when() {
               return anchor().radiusLabel;
             },
             get children() {
-              var _el$215 = _tmpl$44(), _el$216 = _el$215.firstChild;
-              insert(_el$215, () => tr(locale(), "地点半径真值", "Location radius truth"), _el$216);
-              insert(_el$215, () => anchor().radiusLabel, null);
-              return _el$215;
+              var _el$223 = _tmpl$45(), _el$224 = _el$223.firstChild;
+              insert(_el$223, () => tr(locale(), "地点半径真值", "Location radius truth"), _el$224);
+              insert(_el$223, () => anchor().radiusLabel, null);
+              return _el$223;
             }
           })];
         }
       })
-    }), _el$205);
-    insert(_el$206, () => tr(locale(), "最近距离样本", "Nearest Distance Samples"));
-    insert(_el$207, createComponent(Show, {
+    }), _el$213);
+    insert(_el$214, () => tr(locale(), "最近距离样本", "Nearest Distance Samples"));
+    insert(_el$215, createComponent(Show, {
       get when() {
         return worldScaleSurface().physicalTruth.nearestLocations.length > 0;
       },
@@ -7646,19 +7752,19 @@ function DetailsPanel() {
             },
             get children() {
               return [(() => {
-                var _el$217 = _tmpl$44(), _el$218 = _el$217.firstChild;
-                insert(_el$217, () => tr(locale(), "真实距离", "Physical distance"), _el$218);
-                insert(_el$217, () => location.distanceLabel || "-", null);
-                return _el$217;
+                var _el$225 = _tmpl$45(), _el$226 = _el$225.firstChild;
+                insert(_el$225, () => tr(locale(), "真实距离", "Physical distance"), _el$226);
+                insert(_el$225, () => location.distanceLabel || "-", null);
+                return _el$225;
               })(), createComponent(Show, {
                 get when() {
                   return location.radiusLabel;
                 },
                 get children() {
-                  var _el$219 = _tmpl$44(), _el$220 = _el$219.firstChild;
-                  insert(_el$219, () => tr(locale(), "地点半径", "Location radius"), _el$220);
-                  insert(_el$219, () => location.radiusLabel, null);
-                  return _el$219;
+                  var _el$227 = _tmpl$45(), _el$228 = _el$227.firstChild;
+                  insert(_el$227, () => tr(locale(), "地点半径", "Location radius"), _el$228);
+                  insert(_el$227, () => location.radiusLabel, null);
+                  return _el$227;
                 }
               })];
             }
@@ -7666,7 +7772,7 @@ function DetailsPanel() {
         });
       }
     }));
-    insert(_el$202, createComponent(EventCard, {
+    insert(_el$210, createComponent(EventCard, {
       get title() {
         return tr(locale(), "表现层说明", "Presentation Notes");
       },
@@ -7676,26 +7782,26 @@ function DetailsPanel() {
       badgeClass: "badge badge--warn",
       get children() {
         return [(() => {
-          var _el$208 = _tmpl$13();
-          insert(_el$208, () => worldScaleSurface().presentationScale.markerTruthNote);
-          return _el$208;
+          var _el$216 = _tmpl$17();
+          insert(_el$216, () => worldScaleSurface().presentationScale.markerTruthNote);
+          return _el$216;
         })(), (() => {
-          var _el$209 = _tmpl$4();
-          insert(_el$209, () => worldScaleSurface().presentationScale.zoomTruthNote);
-          return _el$209;
+          var _el$217 = _tmpl$4();
+          insert(_el$217, () => worldScaleSurface().presentationScale.zoomTruthNote);
+          return _el$217;
         })(), (() => {
-          var _el$210 = _tmpl$4();
-          insert(_el$210, () => worldScaleSurface().presentationScale.softwareSafeNote);
-          return _el$210;
+          var _el$218 = _tmpl$4();
+          insert(_el$218, () => worldScaleSurface().presentationScale.softwareSafeNote);
+          return _el$218;
         })()];
       }
     }), null);
-    insert(_el$202, createComponent(EmptyState, {
+    insert(_el$210, createComponent(EmptyState, {
       get children() {
         return tr(locale(), "主状态已经在中间的“世界摘要”里展示；这里现在专门保留“厘米真值 vs 表现层夸张”的读图锚点，原始快照仍按需展开。", "The main runtime state already lives in World Summary; this section now reserves the reading anchors for centimeter truth vs presentation exaggeration, while raw snapshots stay collapsible.");
       }
     }), null);
-    insert(_el$199, createComponent(Show, {
+    insert(_el$207, createComponent(Show, {
       get when() {
         return hasSnapshotDiagnostics();
       },
@@ -7714,46 +7820,46 @@ function DetailsPanel() {
         });
       }
     }), null);
-    insert(_el$197, createComponent(Show, {
+    insert(_el$205, createComponent(Show, {
       get when() {
         return state.lastError;
       },
       get children() {
-        var _el$211 = _tmpl$42(), _el$212 = _el$211.firstChild, _el$213 = _el$212.nextSibling;
-        insert(_el$212, () => tr(locale(), "最近错误", "Last Error"));
-        insert(_el$213, () => state.lastError);
-        return _el$211;
+        var _el$219 = _tmpl$43(), _el$220 = _el$219.firstChild, _el$221 = _el$220.nextSibling;
+        insert(_el$220, () => tr(locale(), "最近错误", "Last Error"));
+        insert(_el$221, () => state.lastError);
+        return _el$219;
       }
     }), null);
-    return _el$197;
+    return _el$205;
   })();
 }
 function AppShell() {
   const locale = () => uiLocale();
   return [createComponent(MobileJumpRail, {}), (() => {
-    var _el$221 = _tmpl$45(), _el$222 = _el$221.firstChild, _el$223 = _el$222.firstChild, _el$224 = _el$223.nextSibling, _el$225 = _el$224.nextSibling, _el$226 = _el$222.nextSibling;
-    insert(_el$223, () => tr(locale(), "导航", "Navigate"));
-    insert(_el$224, () => tr(locale(), "目标", "Targets"));
-    insert(_el$225, () => tr(locale(), "先锁定对象，再进入世界舞台或右侧命令面。", "Lock onto a target first, then move into the stage or command surface."));
-    insert(_el$226, createComponent(TargetsPanel, {}));
-    return _el$221;
+    var _el$229 = _tmpl$46(), _el$230 = _el$229.firstChild, _el$231 = _el$230.firstChild, _el$232 = _el$231.nextSibling, _el$233 = _el$232.nextSibling, _el$234 = _el$230.nextSibling;
+    insert(_el$231, () => tr(locale(), "导航", "Navigate"));
+    insert(_el$232, () => tr(locale(), "目标", "Targets"));
+    insert(_el$233, () => tr(locale(), "先锁定对象，再进入世界舞台或右侧命令面。", "Lock onto a target first, then move into the stage or command surface."));
+    insert(_el$234, createComponent(TargetsPanel, {}));
+    return _el$229;
   })(), (() => {
-    var _el$227 = _tmpl$46(), _el$228 = _el$227.firstChild, _el$229 = _el$228.firstChild;
-    insert(_el$229, createComponent(WorldStageHero, {}), null);
-    insert(_el$229, createComponent(PixelWorldHost, {
+    var _el$235 = _tmpl$47(), _el$236 = _el$235.firstChild, _el$237 = _el$236.firstChild;
+    insert(_el$237, createComponent(WorldStageHero, {}), null);
+    insert(_el$237, createComponent(PixelWorldHost, {
       get locale() {
         return locale();
       }
     }), null);
-    insert(_el$229, createComponent(WorldSummaryPanel, {}), null);
-    return _el$227;
+    insert(_el$237, createComponent(WorldSummaryPanel, {}), null);
+    return _el$235;
   })(), (() => {
-    var _el$230 = _tmpl$47(), _el$231 = _el$230.firstChild, _el$232 = _el$231.firstChild, _el$233 = _el$232.nextSibling, _el$234 = _el$233.nextSibling, _el$235 = _el$231.nextSibling;
-    insert(_el$232, () => tr(locale(), "指挥与核查", "Command and Inspect"));
-    insert(_el$233, () => tr(locale(), "交互与明细", "Interact and Inspect"));
-    insert(_el$234, () => tr(locale(), "只有锁定目标后才进入这里。聊天优先，Prompt 与对象核查继续后置。", "Enter this column only after locking a target. Chat comes first; prompt controls and raw inspection stay behind it."));
-    insert(_el$235, createComponent(DetailsPanel, {}));
-    return _el$230;
+    var _el$238 = _tmpl$48(), _el$239 = _el$238.firstChild, _el$240 = _el$239.firstChild, _el$241 = _el$240.nextSibling, _el$242 = _el$241.nextSibling, _el$243 = _el$239.nextSibling;
+    insert(_el$240, () => tr(locale(), "指挥与核查", "Command and Inspect"));
+    insert(_el$241, () => tr(locale(), "交互与明细", "Interact and Inspect"));
+    insert(_el$242, () => tr(locale(), "只有锁定目标后才进入这里。聊天优先，Prompt 与对象核查继续后置。", "Enter this column only after locking a target. Chat comes first; prompt controls and raw inspection stay behind it."));
+    insert(_el$243, createComponent(DetailsPanel, {}));
+    return _el$238;
   })()];
 }
 function mountViewerApp(root = document.getElementById("app")) {
@@ -7783,7 +7889,7 @@ if (autoMountRoot) {
 } else if (!shouldBypassAutoMountForTestApi()) {
   throw new Error("viewer root #app is missing");
 }
-delegateEvents(["click", "input"]);
+delegateEvents(["input", "click"]);
 export {
   AppShell,
   mountViewerApp

--- a/crates/oasis7_viewer/software_safe_src/legacy_core.js
+++ b/crates/oasis7_viewer/software_safe_src/legacy_core.js
@@ -14,6 +14,8 @@ const HOSTED_PLAYER_SESSION_ADMISSION_ROUTE = "/api/public/player-session/admiss
 const HOSTED_PLAYER_SESSION_REFRESH_ROUTE = "/api/public/player-session/refresh";
 const HOSTED_PLAYER_SESSION_ISSUE_ROUTE = "/api/public/player-session/issue";
 const HOSTED_PLAYER_SESSION_RELEASE_ROUTE = "/api/public/player-session/release";
+const HOSTED_ACCOUNT_LOGIN_START_ROUTE = "/api/public/hosted-account/login/start";
+const HOSTED_ACCOUNT_LOGIN_COMPLETE_ROUTE = "/api/public/hosted-account/login/complete";
 const HOSTED_STRONG_AUTH_GRANT_ROUTE = "/api/public/strong-auth/grant";
 const HOSTED_PLAYER_SESSION_REFRESH_INTERVAL_MS = 30000;
 const DEFAULT_WS_ADDR = "ws://127.0.0.1:5011";
@@ -80,7 +82,10 @@ export const state = {
   selectedObject: null,
   auth: {
     available: false,
+    hostedAccountId: null,
     playerId: null,
+    loginChannel: null,
+    maskedLoginHint: null,
     deviceSessionId: null,
     publicKey: null,
     privateKey: null,
@@ -101,6 +106,20 @@ export const state = {
     pendingRequestedAgentId: null,
     pendingForceRebind: false,
     rebindNotice: null,
+  },
+  hostedLogin: {
+    channel: "email",
+    handle: "",
+    challengeId: null,
+    maskedLoginHint: null,
+    deliveryMode: null,
+    previewCode: null,
+    code: "",
+    expiresAtUnixMs: null,
+    accountExists: false,
+    startInFlight: false,
+    completeInFlight: false,
+    error: null,
   },
   promptDraft: {
     agentId: null,
@@ -538,7 +557,10 @@ function resolveAuthBootstrap() {
   if (!raw || typeof raw !== "object") {
     return {
       available: false,
+      hostedAccountId: null,
       playerId: null,
+      loginChannel: null,
+      maskedLoginHint: null,
       deviceSessionId: null,
       publicKey: null,
       privateKey: null,
@@ -571,7 +593,10 @@ function resolveAuthBootstrap() {
   if (!playerId || !publicKey || !privateKey) {
     return {
       available: false,
+      hostedAccountId: null,
       playerId: playerId || null,
+      loginChannel: null,
+      maskedLoginHint: null,
       deviceSessionId: null,
       publicKey: publicKey || null,
       privateKey: privateKey || null,
@@ -596,7 +621,10 @@ function resolveAuthBootstrap() {
   }
   return {
     available: true,
+    hostedAccountId: null,
     playerId,
+    loginChannel: null,
+    maskedLoginHint: null,
     deviceSessionId: null,
     publicKey,
     privateKey,
@@ -642,7 +670,10 @@ function persistHostedPlayerSession(auth) {
     window.localStorage?.setItem(
       hostedPlayerSessionStorageKey(),
       JSON.stringify({
+        hostedAccountId: auth.hostedAccountId || null,
         playerId: auth.playerId,
+        loginChannel: auth.loginChannel || null,
+        maskedLoginHint: auth.maskedLoginHint || null,
         deviceSessionId: auth.deviceSessionId || auth.releaseToken || null,
         releaseToken: auth.releaseToken || null,
         issuedAtUnixMs: auth.issuedAtUnixMs || null,
@@ -667,7 +698,10 @@ function resolveStoredHostedPlayerSession() {
       return null;
     }
     const parsed = JSON.parse(raw);
+    const hostedAccountId = String(parsed?.hostedAccountId || parsed?.hosted_account_id || "").trim();
     const playerId = String(parsed?.playerId || "").trim();
+    const loginChannel = String(parsed?.loginChannel || parsed?.login_channel || "").trim();
+    const maskedLoginHint = String(parsed?.maskedLoginHint || parsed?.masked_login_hint || "").trim();
     const releaseToken = String(parsed?.releaseToken || "").trim();
     const deviceSessionId = String(parsed?.deviceSessionId || parsed?.device_session_id || parsed?.releaseToken || "").trim();
     if (!playerId || !releaseToken) {
@@ -677,7 +711,10 @@ function resolveStoredHostedPlayerSession() {
     window.localStorage?.setItem(
       hostedPlayerSessionStorageKey(),
       JSON.stringify({
+        hostedAccountId: hostedAccountId || null,
         playerId,
+        loginChannel: loginChannel || null,
+        maskedLoginHint: maskedLoginHint || null,
         deviceSessionId: deviceSessionId || releaseToken,
         releaseToken,
         issuedAtUnixMs: parsed?.issuedAtUnixMs ?? null,
@@ -686,7 +723,10 @@ function resolveStoredHostedPlayerSession() {
     );
     return {
       available: true,
+      hostedAccountId: hostedAccountId || null,
       playerId,
+      loginChannel: loginChannel || null,
+      maskedLoginHint: maskedLoginHint || null,
       deviceSessionId: deviceSessionId || releaseToken,
       publicKey: null,
       privateKey: null,
@@ -720,6 +760,17 @@ function resolveViewerAuthState() {
     return bootstrap;
   }
   return resolveStoredHostedPlayerSession() || bootstrap;
+}
+
+function resetHostedLoginChallenge() {
+  state.hostedLogin.challengeId = null;
+  state.hostedLogin.maskedLoginHint = null;
+  state.hostedLogin.deliveryMode = null;
+  state.hostedLogin.previewCode = null;
+  state.hostedLogin.code = "";
+  state.hostedLogin.expiresAtUnixMs = null;
+  state.hostedLogin.accountExists = false;
+  state.hostedLogin.completeInFlight = false;
 }
 
 function authHasSigningKeyMaterial(auth) {
@@ -893,7 +944,7 @@ function guestSessionReason(auth, deploymentHint) {
       : "guest session has already been superseded by a hosted-issued player identity";
   }
   if (isHostedPublicJoinHint(deploymentHint)) {
-    return auth.error || "this browser is still guest-only; hosted public join must issue a player identity before low-risk interaction unlocks";
+    return auth.error || "this browser is still guest-only; hosted public join must complete hosted account login before low-risk interaction unlocks";
   }
   return auth.error || "viewer auth bootstrap is unavailable, so the browser cannot leave guest session";
 }
@@ -912,7 +963,7 @@ function playerSessionReason(auth, deploymentHint) {
     return auth.error || "hosted player identity exists, but runtime registration still needs recovery";
   }
   if (isHostedPublicJoinHint(deploymentHint)) {
-    return auth.error || "player session upgrade/login is still pending hosted issue";
+    return auth.error || "player session upgrade/login is still pending hosted account verification";
   }
   return auth.error || "viewer auth bootstrap is missing or incomplete";
 }
@@ -1139,8 +1190,8 @@ function buildAuthSurfaceModel() {
           : "hosted device session is persisted locally, but runtime player-session restore is still pending this page load"
       : isHostedPublicJoinHint(deploymentHint)
         ? buildHostedRecoveryHint("en")?.detail
-          || "hosted public join recovers by acquiring a player_session first, then re-registering it through reconnect_sync"
-        : "page reload is possible once viewer auth bootstrap or hosted player-session issue succeeds",
+          || "hosted public join recovers by verifying the hosted account, acquiring a player_session, then re-registering it through reconnect_sync"
+        : "page reload is possible once viewer auth bootstrap or hosted account login succeeds",
   };
 }
 
@@ -1181,9 +1232,9 @@ function buildHostedRecoveryHint(locale = state.uiLocale) {
       kind: "released",
       title: isLocaleZh(locale) ? "托管玩家会话已释放" : "Hosted player session released",
       detail: isLocaleZh(locale)
-        ? "当前浏览器已经在本地释放托管玩家席位。若要继续试玩，需要重新获取托管玩家会话。"
-        : "This browser returned its hosted player slot locally. Acquire a new hosted player session if you want to resume gameplay.",
-      cta: isLocaleZh(locale) ? "获取托管玩家会话" : "Acquire Hosted Player Session",
+        ? "当前浏览器已经在本地释放托管玩家席位。若要继续试玩，需要重新完成托管账户登录并获取新的玩家会话。"
+        : "This browser returned its hosted player slot locally. Re-login to the hosted account and acquire a fresh player session if you want to resume gameplay.",
+      cta: isLocaleZh(locale) ? "重新登录托管账户" : "Re-login to Hosted Account",
     };
   }
   if (errorText.includes("revoked") || revokeReason || revokedBy) {
@@ -1195,9 +1246,9 @@ function buildHostedRecoveryHint(locale = state.uiLocale) {
       kind: "revoked",
       title: isLocaleZh(locale) ? "托管玩家会话已被撤销" : "Hosted player session was revoked",
       detail: isLocaleZh(locale)
-        ? `运行时或操作者撤销了这个浏览器会话${actorText}.${reasonText} 继续进行玩法、聊天或 prompt 操作前，需要重新获取新的托管玩家会话。`
-        : `The runtime or operator revoked this browser session${actorText}.${reasonText} You need to acquire a fresh hosted player session before gameplay, chat, or prompt actions can continue.`,
-      cta: isLocaleZh(locale) ? "重新获取托管玩家会话" : "Re-acquire Hosted Player Session",
+        ? `运行时或操作者撤销了这个浏览器会话${actorText}.${reasonText} 继续进行玩法、聊天或 prompt 操作前，需要重新登录托管账户并获取新的玩家会话。`
+        : `The runtime or operator revoked this browser session${actorText}.${reasonText} You need to re-login to the hosted account and acquire a fresh player session before gameplay, chat, or prompt actions can continue.`,
+      cta: isLocaleZh(locale) ? "重新登录托管账户" : "Re-login to Hosted Account",
     };
   }
   if (errorText.includes("session_not_found") || errorText.includes("not found")) {
@@ -1205,16 +1256,16 @@ function buildHostedRecoveryHint(locale = state.uiLocale) {
       kind: "missing",
       title: isLocaleZh(locale) ? "运行时中找不到托管玩家会话" : "Hosted player session is missing from runtime",
       detail: isLocaleZh(locale)
-        ? "浏览器本地只保留了 device session，但运行时已经不再识别这个会话。请重新获取托管玩家会话并重新注册。"
-        : "The browser only retained the local device-session handle, but the runtime no longer recognizes this session. Acquire a fresh hosted player session and register again.",
-      cta: isLocaleZh(locale) ? "重新获取托管玩家会话" : "Re-acquire Hosted Player Session",
+        ? "浏览器本地只保留了 device session，但运行时已经不再识别这个会话。请重新登录托管账户，获取新的玩家会话并重新注册。"
+        : "The browser only retained the local device-session handle, but the runtime no longer recognizes this session. Re-login to the hosted account, acquire a fresh player session, and register again.",
+      cta: isLocaleZh(locale) ? "重新登录托管账户" : "Re-login to Hosted Account",
     };
   }
   return {
     kind: "guest",
     title: isLocaleZh(locale) ? "托管玩家会话不可用" : "Hosted player session is unavailable",
     detail: errorText,
-    cta: isLocaleZh(locale) ? "获取托管玩家会话" : "Acquire Hosted Player Session",
+    cta: isLocaleZh(locale) ? "登录托管账户" : "Login to Hosted Account",
   };
 }
 
@@ -2740,34 +2791,102 @@ function canAutoIssueHostedPlayerSession() {
     && state.auth.source !== "legacy_viewer_auth_bootstrap";
 }
 
-async function issueHostedPlayerIdentity() {
+async function startHostedAccountLogin() {
   if (!canAutoIssueHostedPlayerSession()) {
-    return state.auth;
+    return { ok: false, reason: "hosted account login is unavailable on this lane" };
   }
-  if (state.auth.available || state.auth.issueInFlight) {
-    return state.auth;
+  const channel = String(state.hostedLogin.channel || "email").trim() || "email";
+  const handle = String(state.hostedLogin.handle || "").trim();
+  if (!handle) {
+    state.hostedLogin.error = "phone number or email is required before login can start";
+    render();
+    return { ok: false, reason: state.hostedLogin.error };
   }
-  state.auth.issueInFlight = true;
-  state.auth.error = null;
+  state.hostedLogin.startInFlight = true;
+  state.hostedLogin.error = null;
   render();
   try {
-    const response = await fetch(HOSTED_PLAYER_SESSION_ISSUE_ROUTE, {
-      method: "GET",
+    const query = new URLSearchParams({
+      channel,
+      handle,
+    });
+    const response = await fetch(`${HOSTED_ACCOUNT_LOGIN_START_ROUTE}?${query.toString()}`, {
+      method: "POST",
       cache: "no-store",
       headers: { Accept: "application/json" },
     });
     const payload = await response.json();
-    if (!response.ok || !payload?.ok || !payload?.grant?.player_id) {
+    if (!response.ok || !payload?.ok || !payload?.challenge?.challenge_id) {
+      throw new Error(payload?.error || payload?.error_code || `hosted account login start failed with HTTP ${response.status}`);
+    }
+    state.hostedLogin.challengeId = String(payload.challenge.challenge_id || "").trim() || null;
+    state.hostedLogin.maskedLoginHint = String(payload.challenge.masked_login_hint || "").trim() || null;
+    state.hostedLogin.deliveryMode = String(payload.challenge.delivery_mode || "").trim() || null;
+    state.hostedLogin.previewCode = String(payload.challenge.preview_code || "").trim() || null;
+    state.hostedLogin.code = state.hostedLogin.previewCode || "";
+    state.hostedLogin.expiresAtUnixMs = payload?.challenge?.expires_at_unix_ms == null ? null : Number(payload.challenge.expires_at_unix_ms);
+    state.hostedLogin.accountExists = payload?.challenge?.account_exists === true;
+    state.hostedLogin.startInFlight = false;
+    state.hostedLogin.completeInFlight = false;
+    state.hostedLogin.error = null;
+    render();
+    return { ok: true, challengeId: state.hostedLogin.challengeId };
+  } catch (error) {
+    state.hostedLogin.startInFlight = false;
+    state.hostedLogin.error = String(error);
+    render();
+    return { ok: false, reason: state.hostedLogin.error };
+  }
+}
+
+async function ensureHostedPlayerAuthAvailable() {
+  return state.auth;
+}
+
+async function completeHostedAccountLogin() {
+  if (!canAutoIssueHostedPlayerSession()) {
+    return state.auth;
+  }
+  if (state.auth.available) {
+    return state.auth;
+  }
+  const challengeId = String(state.hostedLogin.challengeId || "").trim();
+  const otpCode = String(state.hostedLogin.code || "").trim();
+  if (!challengeId || !otpCode) {
+    state.hostedLogin.error = "verification code is required before hosted login can complete";
+    render();
+    return state.auth;
+  }
+  state.auth.issueInFlight = true;
+  state.hostedLogin.completeInFlight = true;
+  state.hostedLogin.error = null;
+  state.auth.error = null;
+  render();
+  try {
+    const query = new URLSearchParams({
+      challenge_id: challengeId,
+      otp_code: otpCode,
+    });
+    const response = await fetch(`${HOSTED_ACCOUNT_LOGIN_COMPLETE_ROUTE}?${query.toString()}`, {
+      method: "POST",
+      cache: "no-store",
+      headers: { Accept: "application/json" },
+    });
+    const payload = await response.json();
+    if (!response.ok || !payload?.ok || !payload?.grant?.player_id || !payload?.account?.hosted_account_id) {
       if (payload?.admission) {
         state.hostedAdmission = clone(payload.admission);
       }
-      throw new Error(payload?.error || payload?.error_code || `hosted player-session issue failed with HTTP ${response.status}`);
+      throw new Error(payload?.error || payload?.error_code || `hosted account login complete failed with HTTP ${response.status}`);
     }
     state.hostedAdmission = payload?.admission ? clone(payload.admission) : state.hostedAdmission;
     const keypair = await generateEphemeralEd25519Keypair();
     state.auth = {
       available: true,
+      hostedAccountId: String(payload.account.hosted_account_id || "").trim() || null,
       playerId: String(payload.grant.player_id || "").trim(),
+      loginChannel: String(payload.account.login_channel || "").trim() || null,
+      maskedLoginHint: String(payload.account.masked_login_hint || "").trim() || null,
       deviceSessionId: String(payload.grant.device_session_id || "").trim()
         || String(payload.grant.release_token || "").trim()
         || null,
@@ -2792,36 +2911,37 @@ async function issueHostedPlayerIdentity() {
       rebindNotice: null,
     };
     persistHostedPlayerSession(state.auth);
+    resetHostedLoginChallenge();
+    state.hostedLogin.startInFlight = false;
+    state.hostedLogin.error = null;
     render();
     return state.auth;
   } catch (error) {
     state.auth.issueInFlight = false;
+    state.hostedLogin.completeInFlight = false;
+    state.hostedLogin.error = String(error);
     state.auth.error = String(error);
     render();
     return state.auth;
   }
 }
 
-async function ensureHostedPlayerAuthAvailable() {
-  if (state.auth.available) {
-    return state.auth;
-  }
-  if (canAutoIssueHostedPlayerSession()) {
-    return issueHostedPlayerIdentity();
-  }
-  return state.auth;
+async function issueHostedPlayerIdentity() {
+  return completeHostedAccountLogin();
 }
 
 async function retryHostedPlayerIdentityIssue() {
   if (!canAutoIssueHostedPlayerSession()) {
-    return { ok: false, reason: "hosted public player-session issue is unavailable on this lane" };
+    return { ok: false, reason: "hosted account login is unavailable on this lane" };
   }
-  const auth = await issueHostedPlayerIdentity();
+  const auth = state.hostedLogin.challengeId
+    ? await completeHostedAccountLogin()
+    : await startHostedAccountLogin();
   render();
   return {
-    ok: auth.available,
-    playerId: auth.playerId,
-    error: auth.error,
+    ok: auth?.available === true || auth?.ok === true,
+    playerId: auth?.playerId || null,
+    error: auth?.error || state.hostedLogin.error,
   };
 }
 
@@ -2936,6 +3056,7 @@ async function releaseHostedPlayerSlot() {
 function resetHostedPlayerAuthState(errorMessage = null, revocationMeta = null) {
   stopHostedSessionRefreshLoop();
   clearHostedPlayerSession();
+  resetHostedLoginChallenge();
   const bootstrap = resolveAuthBootstrap();
   const revokeReason = String(revocationMeta?.revokeReason || "").trim() || null;
   const revokedBy = String(revocationMeta?.revokedBy || "").trim() || null;
@@ -2948,6 +3069,9 @@ function resetHostedPlayerAuthState(errorMessage = null, revocationMeta = null) 
         error: errorMessage,
         revokeReason,
         revokedBy,
+        hostedAccountId: null,
+        loginChannel: null,
+        maskedLoginHint: null,
         deviceSessionId: null,
         sessionEpoch: null,
         issuedAtUnixMs: null,
@@ -3821,10 +3945,6 @@ async function recoverHostedSessionFromError(error) {
     void releaseHostedPlayerSlot().catch(() => {});
     resetHostedPlayerAuthState(error?.message || code || "hosted player session failed");
     render();
-    await issueHostedPlayerIdentity();
-    if (state.auth.available) {
-      await ensureRegisteredPlayerSession(latestRequestedAgentId());
-    }
   }
 }
 
@@ -4133,6 +4253,8 @@ function renderSummary() {
     && (state.auth.pendingForceRebind
       || state.auth.runtimeStatus === "rebind_retrying"
       || state.auth.runtimeStatus === "rebind_registering");
+  const showHostedLoginForm = !state.auth.available
+    && String(state.hostedAccess?.deployment_mode || "").trim() === "hosted_public_join";
   elements.centerPanel.innerHTML = `
     <div class="stack">
       <div class="badge-row">
@@ -4237,14 +4359,49 @@ function renderSummary() {
                 <span class="badge">${escapeHtml(hostedRecoveryHint.title)}</span>
               </div>
               <div class="empty">${escapeHtml(hostedRecoveryHint.detail)}</div>
-              <div class="toolbar"><button data-auth-action="retry-issue" ${state.auth.issueInFlight ? "disabled" : ""}>${escapeHtml(hostedRecoveryHint.cta)}</button></div>
             </div>
           </div>`
         : ""}
-      ${!state.auth.available && String(state.hostedAccess?.deployment_mode || "").trim() === "hosted_public_join"
-        ? hostedRecoveryHint
-          ? ""
-          : `<div class="toolbar"><button data-auth-action="retry-issue" ${state.auth.issueInFlight ? "disabled" : ""}>Acquire Hosted Player Session</button></div>`
+      ${showHostedLoginForm
+        ? `<div class="panel panel--nested" style="background:rgba(255,255,255,0.02);">
+            <div class="panel__header"><div class="panel__title">Hosted Account Login</div></div>
+            <div class="panel__body stack">
+              <div class="empty">Hosted public join now upgrades guest access through a centralized phone-or-email login before acquiring a player session.</div>
+              <div class="control-grid">
+                <div class="field">
+                  <label for="hosted-login-channel">Login Channel</label>
+                  <select id="hosted-login-channel">
+                    <option value="email" ${state.hostedLogin.channel === "email" ? "selected" : ""}>Email</option>
+                    <option value="phone" ${state.hostedLogin.channel === "phone" ? "selected" : ""}>Phone</option>
+                  </select>
+                </div>
+                <div class="field">
+                  <label for="hosted-login-handle">Phone or Email</label>
+                  <input id="hosted-login-handle" type="text" autocomplete="off" value="${escapeHtml(state.hostedLogin.handle || "")}" />
+                </div>
+              </div>
+              <div class="toolbar"><button data-auth-action="start-login" ${state.hostedLogin.startInFlight ? "disabled" : ""}>Request Login Code</button></div>
+              ${state.hostedLogin.challengeId
+                ? `<div class="badge-row">
+                    <span class="badge">challenge=${escapeHtml(state.hostedLogin.challengeId)}</span>
+                    <span class="badge">target=${escapeHtml(state.hostedLogin.maskedLoginHint || "-")}</span>
+                    <span class="badge">delivery=${escapeHtml(state.hostedLogin.deliveryMode || "-")}</span>
+                    <span class="badge">${escapeHtml(state.hostedLogin.accountExists ? "account=existing" : "account=new")}</span>
+                  </div>
+                  ${state.hostedLogin.previewCode
+                    ? `<div class="badge-row"><span class="badge badge--accent">previewCode=${escapeHtml(state.hostedLogin.previewCode)}</span></div>`
+                    : ""}
+                  <div class="field">
+                    <label for="hosted-login-code">Verification Code</label>
+                    <input id="hosted-login-code" type="text" autocomplete="off" value="${escapeHtml(state.hostedLogin.code || "")}" />
+                  </div>
+                  <div class="toolbar"><button data-auth-action="complete-login" ${state.hostedLogin.completeInFlight || state.auth.issueInFlight ? "disabled" : ""}>Sign In and Acquire Player Session</button></div>`
+                : ""}
+              ${state.hostedLogin.error
+                ? `<div class="empty">${escapeHtml(state.hostedLogin.error)}</div>`
+                : ""}
+            </div>
+          </div>`
         : ""}
       ${state.auth.available && state.auth.source !== "legacy_viewer_auth_bootstrap"
         ? `<div class="toolbar"><button data-auth-action="logout">Release Hosted Player Session</button></div>`
@@ -4652,11 +4809,41 @@ function bindEvents() {
         void logoutHostedPlayerSession();
         return;
       }
+      if (action === "start-login") {
+        void startHostedAccountLogin();
+        return;
+      }
+      if (action === "complete-login") {
+        void completeHostedAccountLogin();
+        return;
+      }
       if (action === "retry-issue") {
         void retryHostedPlayerIdentityIssue();
       }
     });
   });
+  const hostedLoginChannel = document.getElementById("hosted-login-channel");
+  if (hostedLoginChannel) {
+    hostedLoginChannel.addEventListener("change", (event) => {
+      state.hostedLogin.channel = String(event.target.value || "email").trim() || "email";
+      state.hostedLogin.error = null;
+      resetHostedLoginChallenge();
+    });
+  }
+  const hostedLoginHandle = document.getElementById("hosted-login-handle");
+  if (hostedLoginHandle) {
+    hostedLoginHandle.addEventListener("input", (event) => {
+      state.hostedLogin.handle = String(event.target.value || "");
+      state.hostedLogin.error = null;
+    });
+  }
+  const hostedLoginCode = document.getElementById("hosted-login-code");
+  if (hostedLoginCode) {
+    hostedLoginCode.addEventListener("input", (event) => {
+      state.hostedLogin.code = String(event.target.value || "");
+      state.hostedLogin.error = null;
+    });
+  }
 }
 
 function render() {
@@ -4709,6 +4896,8 @@ function installTestApi() {
     setStrongAuthApprovalCode,
     injectSnapshot,
     logoutHostedPlayerSession,
+    startHostedAccountLogin,
+    completeHostedAccountLogin,
     retryHostedPlayerIdentityIssue,
     reportFatalError,
   };

--- a/crates/oasis7_viewer/software_safe_src/legacy_core.js
+++ b/crates/oasis7_viewer/software_safe_src/legacy_core.js
@@ -763,6 +763,7 @@ function resolveViewerAuthState() {
 }
 
 function resetHostedLoginChallenge() {
+  state.hostedLogin.channel = "email";
   state.hostedLogin.challengeId = null;
   state.hostedLogin.maskedLoginHint = null;
   state.hostedLogin.deliveryMode = null;
@@ -2795,10 +2796,11 @@ async function startHostedAccountLogin() {
   if (!canAutoIssueHostedPlayerSession()) {
     return { ok: false, reason: "hosted account login is unavailable on this lane" };
   }
-  const channel = String(state.hostedLogin.channel || "email").trim() || "email";
+  const channel = "email";
+  state.hostedLogin.channel = channel;
   const handle = String(state.hostedLogin.handle || "").trim();
   if (!handle) {
-    state.hostedLogin.error = "phone number or email is required before login can start";
+    state.hostedLogin.error = "email is required before login can start";
     render();
     return { ok: false, reason: state.hostedLogin.error };
   }
@@ -4366,18 +4368,11 @@ function renderSummary() {
         ? `<div class="panel panel--nested" style="background:rgba(255,255,255,0.02);">
             <div class="panel__header"><div class="panel__title">Hosted Account Login</div></div>
             <div class="panel__body stack">
-              <div class="empty">Hosted public join now upgrades guest access through a centralized phone-or-email login before acquiring a player session.</div>
+              <div class="empty">Hosted public join now upgrades guest access through a centralized email login before acquiring a player session.</div>
               <div class="control-grid">
                 <div class="field">
-                  <label for="hosted-login-channel">Login Channel</label>
-                  <select id="hosted-login-channel">
-                    <option value="email" ${state.hostedLogin.channel === "email" ? "selected" : ""}>Email</option>
-                    <option value="phone" ${state.hostedLogin.channel === "phone" ? "selected" : ""}>Phone</option>
-                  </select>
-                </div>
-                <div class="field">
-                  <label for="hosted-login-handle">Phone or Email</label>
-                  <input id="hosted-login-handle" type="text" autocomplete="off" value="${escapeHtml(state.hostedLogin.handle || "")}" />
+                  <label for="hosted-login-handle">Email</label>
+                  <input id="hosted-login-handle" type="email" autocomplete="email" value="${escapeHtml(state.hostedLogin.handle || "")}" />
                 </div>
               </div>
               <div class="toolbar"><button data-auth-action="start-login" ${state.hostedLogin.startInFlight ? "disabled" : ""}>Request Login Code</button></div>
@@ -4822,14 +4817,6 @@ function bindEvents() {
       }
     });
   });
-  const hostedLoginChannel = document.getElementById("hosted-login-channel");
-  if (hostedLoginChannel) {
-    hostedLoginChannel.addEventListener("change", (event) => {
-      state.hostedLogin.channel = String(event.target.value || "email").trim() || "email";
-      state.hostedLogin.error = null;
-      resetHostedLoginChallenge();
-    });
-  }
   const hostedLoginHandle = document.getElementById("hosted-login-handle");
   if (hostedLoginHandle) {
     hostedLoginHandle.addEventListener("input", (event) => {
@@ -5002,6 +4989,8 @@ export {
   renderDetails,
   reportFatalError,
   resourceSummary,
+  startHostedAccountLogin,
+  completeHostedAccountLogin,
   retryHostedPlayerIdentityIssue,
   runSteps,
   select,

--- a/crates/oasis7_viewer/software_safe_src/main.jsx
+++ b/crates/oasis7_viewer/software_safe_src/main.jsx
@@ -141,6 +141,110 @@ function CalloutCard(props) {
   );
 }
 
+function HostedLoginForm(props) {
+  const locale = () => props.locale ?? uiLocale();
+  return (
+    <div class="stack">
+      <div class="control-grid">
+        <div class="field">
+          <label for={props.channelId ?? "hosted-login-channel"}>
+            {tr(locale(), "登录渠道", "Login Channel")}
+          </label>
+          <select
+            id={props.channelId ?? "hosted-login-channel"}
+            value={core.state.hostedLogin.channel}
+            onChange={(event) => {
+              core.state.hostedLogin.channel = String(event.currentTarget.value || "email").trim() || "email";
+              core.state.hostedLogin.error = null;
+              core.state.hostedLogin.challengeId = null;
+              core.state.hostedLogin.maskedLoginHint = null;
+              core.state.hostedLogin.deliveryMode = null;
+              core.state.hostedLogin.previewCode = null;
+              core.state.hostedLogin.code = "";
+              core.state.hostedLogin.expiresAtUnixMs = null;
+              core.state.hostedLogin.accountExists = false;
+              core.requestRender();
+            }}
+          >
+            <option value="email">{tr(locale(), "邮箱", "Email")}</option>
+            <option value="phone">{tr(locale(), "手机号", "Phone")}</option>
+          </select>
+        </div>
+        <div class="field">
+          <label for={props.handleId ?? "hosted-login-handle"}>
+            {tr(locale(), "手机号或邮箱", "Phone or Email")}
+          </label>
+          <input
+            id={props.handleId ?? "hosted-login-handle"}
+            type="text"
+            autocomplete="off"
+            value={core.state.hostedLogin.handle}
+            onInput={(event) => {
+              core.state.hostedLogin.handle = String(event.currentTarget.value || "");
+              core.state.hostedLogin.error = null;
+              core.requestRender();
+            }}
+          />
+        </div>
+      </div>
+      <div class="toolbar">
+        <button
+          data-auth-action="start-login"
+          disabled={core.state.hostedLogin.startInFlight}
+          onClick={() => {
+            void core.startHostedAccountLogin();
+          }}
+        >
+          {tr(locale(), "请求登录验证码", "Request Login Code")}
+        </button>
+      </div>
+      <Show when={core.state.hostedLogin.challengeId}>
+        <div class="badge-row">
+          <Badge>{`challenge=${core.state.hostedLogin.challengeId}`}</Badge>
+          <Badge>{`target=${core.state.hostedLogin.maskedLoginHint || "-"}`}</Badge>
+          <Badge>{`delivery=${core.state.hostedLogin.deliveryMode || "-"}`}</Badge>
+          <Badge>{core.state.hostedLogin.accountExists ? "account=existing" : "account=new"}</Badge>
+        </div>
+        <Show when={core.state.hostedLogin.previewCode}>
+          <div class="badge-row">
+            <Badge class="badge badge--accent">{`previewCode=${core.state.hostedLogin.previewCode}`}</Badge>
+          </div>
+        </Show>
+        <div class="field">
+          <label for={props.codeId ?? "hosted-login-code"}>
+            {tr(locale(), "验证码", "Verification Code")}
+          </label>
+          <input
+            id={props.codeId ?? "hosted-login-code"}
+            type="text"
+            autocomplete="off"
+            value={core.state.hostedLogin.code}
+            onInput={(event) => {
+              core.state.hostedLogin.code = String(event.currentTarget.value || "");
+              core.state.hostedLogin.error = null;
+              core.requestRender();
+            }}
+          />
+        </div>
+        <div class="toolbar">
+          <button
+            data-auth-action="complete-login"
+            disabled={core.state.hostedLogin.completeInFlight || core.state.auth.issueInFlight}
+            onClick={() => {
+              void core.completeHostedAccountLogin();
+            }}
+          >
+            {tr(locale(), "登录并领取玩家会话", "Sign In and Acquire Player Session")}
+          </button>
+        </div>
+      </Show>
+      <Show when={core.state.hostedLogin.error}>
+        <EmptyState>{core.state.hostedLogin.error}</EmptyState>
+      </Show>
+    </div>
+  );
+}
+
 function EmptyEntityRecoveryCard(props) {
   const locale = () => props.locale ?? uiLocale();
   const gameplay = () => (typeof props.gameplay === "function" ? props.gameplay() : props.gameplay);
@@ -809,38 +913,15 @@ function WorldSummaryPanel() {
             {hostedRecoveryHint()?.detail || state.auth.rebindNotice || authSurface().currentTierReason}
           </EmptyState>
           <Show when={hostedRecoveryHint()}>
-            {(hint) => (
-              <div class="toolbar">
-                <button
-                  data-auth-action="retry-issue"
-                  disabled={state.auth.issueInFlight}
-                  onClick={() => {
-                    void core.retryHostedPlayerIdentityIssue();
-                  }}
-                >
-                  {hint().cta}
-                </button>
-              </div>
-            )}
+            {(hint) => <EmptyState>{hint().detail}</EmptyState>}
           </Show>
           <Show
             when={
               !state.auth.available
               && String(state.hostedAccess?.deployment_mode || "").trim() === "hosted_public_join"
-              && !hostedRecoveryHint()
             }
           >
-            <div class="toolbar">
-              <button
-                data-auth-action="retry-issue"
-                disabled={state.auth.issueInFlight}
-                onClick={() => {
-                  void core.retryHostedPlayerIdentityIssue();
-                }}
-              >
-                {tr(locale(), "领取玩家会话", "Acquire Player Session")}
-              </button>
-            </div>
+            <HostedLoginForm locale={locale()} />
           </Show>
           <Show when={state.auth.available && state.auth.source !== "legacy_viewer_auth_bootstrap"}>
             <div class="toolbar">
@@ -967,36 +1048,6 @@ function WorldSummaryPanel() {
             <Badge>{state.auth.pendingForceRebind ? "rebind=forcing" : "rebind=idle"}</Badge>
           </div>
           <div class="toolbar">
-            <Show when={hostedRecoveryHint()}>
-              {(hint) => (
-                <button
-                  data-auth-action="retry-issue"
-                  disabled={state.auth.issueInFlight}
-                  onClick={() => {
-                    void core.retryHostedPlayerIdentityIssue();
-                  }}
-                >
-                  {hint().cta}
-                </button>
-              )}
-            </Show>
-            <Show
-              when={
-                !state.auth.available
-                && String(state.hostedAccess?.deployment_mode || "").trim() === "hosted_public_join"
-                && !hostedRecoveryHint()
-              }
-            >
-              <button
-                data-auth-action="retry-issue"
-                disabled={state.auth.issueInFlight}
-                onClick={() => {
-                  void core.retryHostedPlayerIdentityIssue();
-                }}
-              >
-                {tr(locale(), "领取玩家会话", "Acquire Player Session")}
-              </button>
-            </Show>
             <Show when={state.auth.available && state.auth.source !== "legacy_viewer_auth_bootstrap"}>
               <button
                 data-auth-action="logout"
@@ -1008,6 +1059,22 @@ function WorldSummaryPanel() {
               </button>
             </Show>
           </div>
+          <Show when={hostedRecoveryHint()}>
+            {(hint) => <EmptyState>{hint().detail}</EmptyState>}
+          </Show>
+          <Show
+            when={
+              !state.auth.available
+              && String(state.hostedAccess?.deployment_mode || "").trim() === "hosted_public_join"
+            }
+          >
+            <HostedLoginForm
+              locale={locale()}
+              channelId="diag-hosted-login-channel"
+              handleId="diag-hosted-login-handle"
+              codeId="diag-hosted-login-code"
+            />
+          </Show>
           <Show when={state.auth.recoveryErrorCode || state.auth.recoveryErrorMessage}>
             <div class="badge-row">
               <Badge class="badge badge--warn">{`recoveryError=${state.auth.recoveryErrorCode || "-"}`}</Badge>

--- a/crates/oasis7_viewer/software_safe_src/main.jsx
+++ b/crates/oasis7_viewer/software_safe_src/main.jsx
@@ -147,37 +147,13 @@ function HostedLoginForm(props) {
     <div class="stack">
       <div class="control-grid">
         <div class="field">
-          <label for={props.channelId ?? "hosted-login-channel"}>
-            {tr(locale(), "登录渠道", "Login Channel")}
-          </label>
-          <select
-            id={props.channelId ?? "hosted-login-channel"}
-            value={core.state.hostedLogin.channel}
-            onChange={(event) => {
-              core.state.hostedLogin.channel = String(event.currentTarget.value || "email").trim() || "email";
-              core.state.hostedLogin.error = null;
-              core.state.hostedLogin.challengeId = null;
-              core.state.hostedLogin.maskedLoginHint = null;
-              core.state.hostedLogin.deliveryMode = null;
-              core.state.hostedLogin.previewCode = null;
-              core.state.hostedLogin.code = "";
-              core.state.hostedLogin.expiresAtUnixMs = null;
-              core.state.hostedLogin.accountExists = false;
-              core.requestRender();
-            }}
-          >
-            <option value="email">{tr(locale(), "邮箱", "Email")}</option>
-            <option value="phone">{tr(locale(), "手机号", "Phone")}</option>
-          </select>
-        </div>
-        <div class="field">
           <label for={props.handleId ?? "hosted-login-handle"}>
-            {tr(locale(), "手机号或邮箱", "Phone or Email")}
+            {tr(locale(), "邮箱", "Email")}
           </label>
           <input
             id={props.handleId ?? "hosted-login-handle"}
-            type="text"
-            autocomplete="off"
+            type="email"
+            autocomplete="email"
             value={core.state.hostedLogin.handle}
             onInput={(event) => {
               core.state.hostedLogin.handle = String(event.currentTarget.value || "");

--- a/crates/oasis7_viewer/software_safe_src/main.test.jsx
+++ b/crates/oasis7_viewer/software_safe_src/main.test.jsx
@@ -279,8 +279,7 @@ describe("viewer web ui automation baseline", () => {
 
     screen.getByText("Runtime Diagnostics").click();
     expect(screen.getAllByRole("button", { name: "Request Login Code" }).length).toBeGreaterThan(0);
-    expect(screen.getAllByLabelText("Login Channel").length).toBeGreaterThan(0);
-    expect(screen.getAllByLabelText("Phone or Email").length).toBeGreaterThan(0);
+    expect(screen.getAllByLabelText("Email").length).toBeGreaterThan(0);
     expect(screen.getByText("upgrade_after_player_session")).toBeInTheDocument();
     expect(
       screen.getAllByText(

--- a/crates/oasis7_viewer/software_safe_src/main.test.jsx
+++ b/crates/oasis7_viewer/software_safe_src/main.test.jsx
@@ -273,15 +273,18 @@ describe("viewer web ui automation baseline", () => {
         core.state.auth.error = "session_revoked";
         core.state.auth.revokeReason = "qa-kick";
         core.state.auth.revokedBy = "qa";
+        core.state.hostedLogin.handle = "player@example.com";
       },
     });
 
     screen.getByText("Runtime Diagnostics").click();
-    expect(screen.getAllByRole("button", { name: "Re-acquire Hosted Player Session" }).length).toBeGreaterThan(0);
+    expect(screen.getAllByRole("button", { name: "Request Login Code" }).length).toBeGreaterThan(0);
+    expect(screen.getAllByLabelText("Login Channel").length).toBeGreaterThan(0);
+    expect(screen.getAllByLabelText("Phone or Email").length).toBeGreaterThan(0);
     expect(screen.getByText("upgrade_after_player_session")).toBeInTheDocument();
     expect(
       screen.getAllByText(
-        "The runtime or operator revoked this browser session by qa. Reason: qa-kick. You need to acquire a fresh hosted player session before gameplay, chat, or prompt actions can continue.",
+        "The runtime or operator revoked this browser session by qa. Reason: qa-kick. You need to re-login to the hosted account and acquire a fresh player session before gameplay, chat, or prompt actions can continue.",
       ).length,
     ).toBeGreaterThan(0);
     expect(screen.queryByText("not_implemented")).not.toBeInTheDocument();

--- a/doc/p2p/README.md
+++ b/doc/p2p/README.md
@@ -8,7 +8,7 @@
 - 想先进入 `node` 热点子域，并按奖励 / 复制 / PoS 时间 / 身份引导 / WASM 编译问题分流：`doc/p2p/node/README.md`
 - 想先看主链安全、mainnet-grade readiness 与 signer custody：`doc/p2p/blockchain/p2p-mainnet-crypto-security-baseline-2026-03-23.prd.md`、`doc/p2p/blockchain/p2p-mainnet-grade-readiness-hardening-2026-03-23.prd.md`
 - 想先看 hosted world 玩家接入与网页会话鉴权：`doc/p2p/blockchain/p2p-hosted-world-player-access-and-session-auth-2026-03-25.prd.md`
-- 想先看 `hosted_public_join` 如何让普通玩家用手机号/邮箱登录、由服务端托管 player signer，并保留后续自托管升级路径：`doc/p2p/blockchain/p2p-hosted-public-join-managed-identity-custody-2026-05-18.prd.md`
+- 想先看 `hosted_public_join` 如何让普通玩家用邮箱登录、由服务端托管 player signer，并保留后续自托管升级路径：`doc/p2p/blockchain/p2p-hosted-public-join-managed-identity-custody-2026-05-18.prd.md`
 - 想先看“没有公网 IP 也要成为正式节点”的主链级覆盖网络目标态：`doc/p2p/network/p2p-mainnet-private-reachability-architecture-2026-04-01.prd.md`
 - 想先看 Token 分配 / 治理签名 / 生产 signer 外部化 / `OC -> LetAI Run OpenAPI quota` bridge：`doc/p2p/token/mainchain-token-initial-allocation-and-early-contribution-reward-2026-03-22.prd.md`、`doc/p2p/token/mainchain-token-signed-transaction-authorization-2026-03-23.prd.md`、`doc/p2p/token/mainchain-token-newapi-quota-bridge-2026-05-06.prd.md`、`doc/p2p/blockchain/p2p-governance-signer-externalization-2026-03-23.prd.md`
 - 当前链上代币的正式产品名固定为“绿洲币 / Oasis Coin”；当前 runtime symbol/ticker 为 `OC`，公钥派生账户前缀为 `oc:pk:`；当前创世 `initial_supply` 已冻结为 `10,000,000,000 OC`。
@@ -26,7 +26,7 @@
 - `project.md` 是执行台账，适合确认当前安全硬化、signer 外部化、token 与 hosted world 相关任务的推进状态。
 - `node/README.md` 是当前最高密度热点子域 `node/` 的 canonical 入口，适合先按“奖励 / 复制 / PoS 时间 / 身份引导 / WASM 编译”分流，再进入具体专题。
 - `prd.index.md` 是精确检索索引，适合已知专题名后按文件名直达，不适合作为第一次进入 p2p 模块时的首读入口。
-- 高频专题承担主题真值：`p2p-mainnet-*` 负责主链安全与 readiness；`p2p-mainnet-private-reachability-architecture-2026-04-01` 负责 mixed-topology 覆盖网络目标态；`p2p-hosted-world-player-access-and-session-auth` 负责玩家接入与会话鉴权；`p2p-hosted-public-join-managed-identity-custody-2026-05-18` 负责手机号/邮箱 hosted login、托管 player signer 与自托管升级边界；token / signer 系列专题负责分配、签名交易与治理签名外部化。
+- 高频专题承担主题真值：`p2p-mainnet-*` 负责主链安全与 readiness；`p2p-mainnet-private-reachability-architecture-2026-04-01` 负责 mixed-topology 覆盖网络目标态；`p2p-hosted-world-player-access-and-session-auth` 负责玩家接入与会话鉴权；`p2p-hosted-public-join-managed-identity-custody-2026-05-18` 负责邮箱 hosted login、托管 player signer 与自托管升级边界；token / signer 系列专题负责分配、签名交易与治理签名外部化。
 
 ## 活跃阅读面边界
 - 当前页只保留 `what / where / next / risk` 所需入口，不再直接罗列近期专题长名单。

--- a/doc/p2p/blockchain/p2p-hosted-public-join-managed-identity-custody-2026-05-18.design.md
+++ b/doc/p2p/blockchain/p2p-hosted-public-join-managed-identity-custody-2026-05-18.design.md
@@ -1,4 +1,4 @@
-# oasis7 hosted_public_join 托管身份 / 托管密钥与手机号邮箱登录（设计文档）
+# oasis7 hosted_public_join 托管身份 / 托管密钥与邮箱登录（设计文档）
 
 - 对应需求文档: `doc/p2p/blockchain/p2p-hosted-public-join-managed-identity-custody-2026-05-18.prd.md`
 - 对应项目管理文档: `doc/p2p/blockchain/p2p-hosted-public-join-managed-identity-custody-2026-05-18.project.md`
@@ -24,7 +24,7 @@
   - 对外可见: 静态网页、世界只读快照、guest/player session 入口、低风险 gameplay 输入
   - 不可见: operator control API、长期 signer、custody backend
 - `identity plane`
-  - 负责手机号/邮箱登录、OTP / magic link / passkey、device session、account recovery、rate limit
+  - 负责邮箱登录、OTP / magic link、device session、account recovery、rate limit
   - 输出: `hosted_account_id`, `device_session_id`, `player_session`
 - `custody plane`
   - 负责 `signer_ref`、托管签名、step-up 授权、风险策略、审计日志
@@ -112,7 +112,7 @@
 ## 9. Runtime / Viewer 对接原则
 - Runtime
   - 只校验 session、capability、签名证明和 `signer_ref` 绑定
-  - 不直接关心手机号或邮箱明文
+  - 不直接关心邮箱明文
   - `player_id -> entity` 绑定继续由 runtime 真值维护
 - Viewer
   - UI 上显示 `Oasis ID`、登录状态、custody mode、设备状态
@@ -140,7 +140,7 @@
   - `hosted_public_join` 已禁止 legacy host key bootstrap 直接进入 hosted mode
   - public player session / preview strong-auth contract 已存在
 - 当前未成立:
-  - hosted account / 手机号邮箱登录
+  - hosted account / 邮箱登录
   - managed custody sign lane
   - browser local private-key debt 清退
   - self-custody bind / transfer-out 正式能力

--- a/doc/p2p/blockchain/p2p-hosted-public-join-managed-identity-custody-2026-05-18.prd.md
+++ b/doc/p2p/blockchain/p2p-hosted-public-join-managed-identity-custody-2026-05-18.prd.md
@@ -1,4 +1,4 @@
-# oasis7 hosted_public_join 托管身份 / 托管密钥与手机号邮箱登录（2026-05-18）
+# oasis7 hosted_public_join 托管身份 / 托管密钥与邮箱登录（2026-05-18）
 
 - 对应设计文档: `doc/p2p/blockchain/p2p-hosted-public-join-managed-identity-custody-2026-05-18.design.md`
 - 对应项目管理文档: `doc/p2p/blockchain/p2p-hosted-public-join-managed-identity-custody-2026-05-18.project.md`
@@ -7,7 +7,7 @@
 
 ## 目标
 - 为 `hosted_public_join` 建立一套正式的托管身份 / 托管密钥产品规格，解决“普通玩家如何登录并长期使用”而不是继续停留在 preview 会话与浏览器本地私钥。
-- 把手机号/邮箱登录、托管 player signer、step-up auth 与自托管升级路径收成统一真值，供 runtime / viewer / QA / LiveOps 继续实现。
+- 把邮箱登录、托管 player signer、step-up auth 与自托管升级路径收成统一真值，供 runtime / viewer / QA / LiveOps 继续实现。
 
 ## 范围
 - 覆盖 hosted player 的账户身份、设备会话、托管签名、风险分级、自托管升级与相关 trust boundary。
@@ -20,7 +20,7 @@
 - 关键主键: `hosted_account_id`、`player_id`、`device_session_id`、`signer_ref`
 
 ## 里程碑
-- M1 (2026-05-18): 专题 PRD / design / project 建档，冻结 hosted account、手机号/邮箱登录、device session、托管签名与自托管升级边界。
+- M1 (2026-05-18): 专题 PRD / design / project 建档，冻结 hosted account、邮箱登录、device session、托管签名与自托管升级边界。
 - M2: 落地 hosted account 与 device session，清退浏览器 `localStorage privateKey` preview debt。
 - M3: 落地 custody sign API、step-up auth 与 external wallet bind / transfer-out。
 
@@ -30,10 +30,10 @@
 - 若把 player custody 与 node/governance signer 共用一套 trust domain，会让产品问题和协议级 custody 问题互相绑死。
 
 ## 1. Executive Summary
-- Problem Statement: `hosted_public_join` 已具备 `guest/player session`、公开 admission control 与 preview `strong_auth` 的第一层 contract，但代码真值仍停留在“无 hosted account、无手机号/邮箱登录、无托管密钥服务”的阶段。`crates/oasis7/src/bin/oasis7_game_launcher/hosted_player_session.rs` 当前只签发 `player_id + release_token`，没有用户身份因子；`crates/oasis7/src/bin/oasis7_game_launcher/hosted_strong_auth.rs` 仍依赖 `OASIS7_HOSTED_STRONG_AUTH_*` 环境变量和 `approval_code`；`crates/oasis7_viewer/software_safe.js` 还会把 hosted player `publicKey/privateKey/releaseToken` 写入 `localStorage`。如果继续要求用户自己保存或输入公私钥，`public join` 很难成为面向普通玩家的产品入口。
-- Proposed Solution: 为 `hosted_public_join` 正式冻结一套 producer-owned 的“托管身份 + 托管密钥 + 自托管升级”目标态。默认玩家路径改为 `guest -> hosted account -> managed player signer -> optional self-custody bind/transfer-out`：用户用手机号或邮箱验证码 / magic link / passkey 登录，浏览器只拿 `player_session` 与设备级短期密钥；长期玩家 signer 留在服务端 custody plane，由 KMS/HSM 或 KMS-wrapped sealed-key backend 保护，并通过 step-up auth + policy engine 出签。
+- Problem Statement: `hosted_public_join` 已具备 `guest/player session`、公开 admission control 与 preview `strong_auth` 的第一层 contract，但代码真值仍停留在“无 hosted account、无邮箱登录、无托管密钥服务”的阶段。`crates/oasis7/src/bin/oasis7_game_launcher/hosted_player_session.rs` 当前只签发 `player_id + release_token`，没有用户身份因子；`crates/oasis7/src/bin/oasis7_game_launcher/hosted_strong_auth.rs` 仍依赖 `OASIS7_HOSTED_STRONG_AUTH_*` 环境变量和 `approval_code`；`crates/oasis7_viewer/software_safe.js` 还会把 hosted player `publicKey/privateKey/releaseToken` 写入 `localStorage`。如果继续要求用户自己保存或输入公私钥，`public join` 很难成为面向普通玩家的产品入口。
+- Proposed Solution: 为 `hosted_public_join` 正式冻结一套 producer-owned 的“托管身份 + 托管密钥 + 自托管升级”目标态。默认玩家路径改为 `guest -> hosted account -> managed player signer -> optional self-custody bind/transfer-out`：用户用邮箱验证码或 magic link 登录，浏览器只拿 `player_session` 与设备级短期密钥；长期玩家 signer 留在服务端 custody plane，由 KMS/HSM 或 KMS-wrapped sealed-key backend 保护，并通过 step-up auth + policy engine 出签。
 - Success Criteria:
-  - SC-1: `hosted_public_join` 必须提供“不输入原始公钥私钥也能开始玩”的正式登录路径，默认支持手机号或邮箱登录。
+  - SC-1: `hosted_public_join` 必须提供“不输入原始公钥私钥也能开始玩”的正式登录路径，默认支持邮箱登录。
   - SC-2: 浏览器在 `hosted_public_join` 下不得再持有长期资产 signer、node signer 或可长期复用的明文私钥；当前 `localStorage` 持久化 `privateKey` 只能保留为 preview debt。
   - SC-3: 玩家身份必须拆成 `hosted_account_id`、`player_id`、`device_session_id`、`signer_ref` 四类真值，不再把 `player_id` 直接当成完整账户体系。
   - SC-4: 高风险动作必须支持 `managed custody sign` lane，并由 step-up auth、风险策略和审计日志共同放行；`main_token_transfer` 不得再停留在“blocked，但没有目标方案”的状态。
@@ -43,35 +43,35 @@
 
 ## 2. User Experience & Functionality
 - User Personas:
-  - `producer_system_designer`: 需要把“手机号/邮箱登录游戏”和“链上身份/签名”收成一个不会误伤安全边界的正式产品方案。
+  - `producer_system_designer`: 需要把“邮箱登录游戏”和“链上身份/签名”收成一个不会误伤安全边界的正式产品方案。
   - 普通玩家: 希望点开公开 URL 就能试玩，升级到正式玩家时只做常见登录，不维护裸私钥。
   - `runtime_engineer`: 需要知道 runtime 应该信任什么身份断言、什么 sign API、什么 step-up 结果。
   - `viewer_engineer`: 需要知道浏览器本地还能存什么、登录/重连/升级如何表达。
   - `qa_engineer` / `liveops_community`: 需要知道托管账户、托管签名、撤销、恢复和事故处置的 pass/block 标准。
 - User Scenarios & Frequency:
   - 新用户第一次打开公开 join URL 时，需要先以 guest 方式进入，再升级为 hosted account player。
-  - 老用户换设备或清缓存时，需要通过手机号/邮箱重新登录并恢复玩家身份，而不是找回私钥文件。
+  - 老用户换设备或清缓存时，需要通过邮箱重新登录并恢复玩家身份，而不是找回私钥文件。
   - 玩家第一次执行高风险动作时，需要通过 step-up auth 触发托管签名，而不是暴露托管私钥。
   - 玩家后续若要脱离托管模式，需要显式绑定外部钱包或转移到自托管账户。
 - User Stories:
   - PRD-P2P-029-A: As a `producer_system_designer`, I want `hosted_public_join` to have a formal hosted account model, so that public onboarding does not depend on users handling raw keys.
-  - PRD-P2P-029-B: As a player, I want phone/email login to recover my game identity, so that I can re-enter the world without copying a private key around.
+  - PRD-P2P-029-B: As a player, I want email login to recover my game identity, so that I can re-enter the world without copying a private key around.
   - PRD-P2P-029-C: As a `runtime_engineer`, I want a managed signer reference and sign API boundary, so that runtime can accept hosted-custody signatures without trusting the browser.
   - PRD-P2P-029-D: As a `viewer_engineer`, I want device-session and step-up auth states to be explicit, so that login, reconnect and sensitive-action UX are predictable.
   - PRD-P2P-029-E: As a `qa_engineer` / `liveops_community`, I want abuse, recovery, revocation and transfer-out rules frozen, so that hosted login can be operated safely.
   - PRD-P2P-029-F: As a player, I want an optional path to bind an external wallet or move to self-custody later, so that managed onboarding does not lock me into browser-only trust.
 - Critical User Flows:
   1. Flow-P2P-029-001: `访客打开 hosted_public_join URL -> 先拿 guest session -> 浏览世界 -> 点击开始游玩`
-  2. Flow-P2P-029-002: `用户选择手机号或邮箱登录 -> 收到 OTP / magic link / passkey challenge -> hosted account 验证通过 -> 生成或恢复 hosted_account_id`
+  2. Flow-P2P-029-002: `用户选择邮箱登录 -> 收到 OTP / magic link challenge -> hosted account 验证通过 -> 生成或恢复 hosted_account_id`
   3. Flow-P2P-029-003: `account service 为用户恢复 signer_ref 和 player_id -> session broker 签发 player_session + device_session -> runtime 完成 entity bind`
   4. Flow-P2P-029-004: `玩家执行普通玩法输入 -> 浏览器只用 device session key 或 session token -> runtime 校验 capability，不触发 custody sign`
   5. Flow-P2P-029-005: `玩家执行 prompt_control_apply / main_token_transfer 等高风险动作 -> step-up auth -> policy engine 评估 -> custody service 出签 -> runtime 验证并执行`
   6. Flow-P2P-029-006: `玩家要退出托管 -> 绑定外部钱包或发起 transfer-out -> 进入 cooldown / 审计 -> 迁移完成后把 custody_mode 切到 self_custody`
-  7. Flow-P2P-029-007: `手机号/邮箱失效、设备丢失、账号被盗用或风控命中 -> operator/recovery runbook -> 撤销 device_session 或冻结 managed signer -> 用户重新认证`
+  7. Flow-P2P-029-007: `邮箱失效、设备丢失、账号被盗用或风控命中 -> operator/recovery runbook -> 撤销 device_session 或冻结 managed signer -> 用户重新认证`
 - Functional Specification Matrix:
 | 功能点 | 字段定义 | 动作行为 | 状态转换 | 计算/判定规则 | 权限逻辑 |
 | --- | --- | --- | --- | --- | --- |
-| Hosted account | `hosted_account_id/login_channel/login_hint/verified_at/status` | 手机号或邮箱发码、校验、恢复账户 | `guest -> challenge_issued -> verified -> active/frozen` | 同一登录因子可映射多个设备 session，但只能映射一个当前主账户真值 | `identity plane` 负责 |
+| Hosted account | `hosted_account_id/login_channel/login_hint/verified_at/status` | 邮箱发码、校验、恢复账户 | `guest -> challenge_issued -> verified -> active/frozen` | 同一登录因子可映射多个设备 session，但只能映射一个当前主账户真值 | `identity plane` 负责 |
 | Device session | `device_session_id/player_session_id/device_pubkey/expires_at/risk_level` | 浏览器建立/刷新/撤销短期设备会话 | `issued -> registered -> refreshed -> expired/revoked` | 设备会话必须有限 TTL；浏览器只允许存 `session handle + device key handle`，不存长期 signer 明文私钥 | `public player plane` + `identity plane` |
 | Managed signer reference | `signer_ref/custody_mode/algorithm/backend_class/account_binding` | 服务端创建、恢复、停用或迁移托管 signer | `provisioning -> active -> step_up_required -> frozen/migrated` | 运行时只认 `signer_ref` 及签名证明，不认浏览器自报托管私钥 | `custody plane` 负责 |
 | Sign authorization | `action_id/policy_class/step_up_result/audit_id/signature_proof` | 高风险动作先授权再出签 | `requested -> challenged -> approved -> signed -> consumed/denied` | `main_token_transfer`、治理与高风险 prompt/control 必须经过 step-up 和风控；失败时返回结构化错误 | `policy engine` + `custody plane` |
@@ -79,7 +79,7 @@
 | Audit / recovery | `risk_event_id/revoke_reason/recovered_by/evidence_ref` | 撤销设备、冻结账户、恢复访问 | `healthy -> challenged -> suspended -> recovered/closed` | 任一异常登录、设备丢失、滥用或风控命中都必须可审计 | `qa_engineer` / `liveops_community` 可追踪 |
 - Acceptance Criteria:
   - AC-1: 专题必须明确 `hosted_account_id/player_id/device_session_id/signer_ref` 的职责分离，不再把 `player_id` 既当登录账户又当 signer。
-  - AC-2: 专题必须明确手机号/邮箱登录是 hosted player 默认入口，而“输入公钥/私钥”不是默认 UX。
+  - AC-2: 专题必须明确邮箱登录是 hosted player 默认入口，而“输入公钥/私钥”不是默认 UX。
   - AC-3: 专题必须明确当前 `hosted_public_join` 代码真值仍包含 browser `localStorage` 持久化 `privateKey` 的 preview debt，并把它标记为必须清退。
   - AC-4: 专题必须明确 `managed custody sign` lane 的动作范围，至少覆盖 `prompt_control_apply` / `prompt_control_rollback` / `main_token_transfer`。
   - AC-5: 专题必须明确托管身份只适用于 player plane；node / validator / governance signer 继续由独立 custody/governance 文档约束。
@@ -91,7 +91,7 @@
 
 ## 3. Technical Requirements
 - Architecture Overview: 最合适的 hosted_public_join 目标态不是“让浏览器代持真正的玩家私钥”，也不是“强迫用户第一次进游戏就接外部钱包”，而是把登录、设备会话、托管签名和后续自托管升级拆成四层。
-  - `identity broker`: 处理手机号/邮箱 OTP、magic link、passkey challenge、rate limit 与登录风险控制。
+  - `identity broker`: 处理邮箱 OTP、magic link、rate limit 与登录风险控制。
   - `account registry`: 保存 `hosted_account_id -> player_id/signer_ref/device bindings` 映射。
   - `session broker`: 用已验证账户换发 `player_session` 与设备短期 key challenge，服务于 runtime register/reconnect。
   - `custody service`: 只暴露 `prepare_sign/approve_sign/finalize_sign` 或等价 sign API；底层可以是 KMS/HSM 直管密钥，也可以是 KMS-wrapped sealed-key backend，但浏览器不能直接拿到长期 signer。
@@ -116,7 +116,7 @@
   - `doc/p2p/token/mainchain-token-newapi-quota-bridge-2026-05-06.prd.md`
   - `testing-manual.md`
 - Edge Cases & Error Handling:
-  - 若手机号/邮箱重复绑定到多个 hosted account，必须提供 canonical merge / reject 规则，不能静默创建分叉账户。
+  - 若邮箱重复绑定到多个 hosted account，必须提供 canonical merge / reject 规则，不能静默创建分叉账户。
   - 若浏览器丢失 device session，但账户因子仍有效，必须允许重新登录恢复，而不是要求用户回忆旧私钥。
   - 若 KMS/HSM 不直接支持运行时签名算法，custody backend 可以退化为 KMS-wrapped sealed key，但对上层仍必须保持“只暴露 sign API，不暴露长期私钥”的契约。
   - 若风控判定高风险设备登录，必须把账户状态切到 `step_up_required` 或 `frozen_review`，不得继续自动签发高权限 session。
@@ -129,7 +129,7 @@
   - NFR-P2P-029-4: `managed custody` 默认适用于 hosted player surface，不得被误扩展为 node/governance/validator signer 方案。
   - NFR-P2P-029-5: 用户默认看到的是 `Oasis ID` / 账户状态 / custody mode，而不是原始公钥命名。
   - NFR-P2P-029-6: 本专题完成前，仓内与对外口径不得声称“任意新用户已经默认拥有安全托管钱包并可直接进行资产动作”。
-- Security & Privacy: 手机号、邮箱、设备标识和签名授权记录都属于敏感身份数据。本专题允许记录账户 ID、factor 类型、掩码后的联系方式、signer 引用、公钥摘要、step-up 与审计事件；禁止把真实 OTP、原始私钥、seed、magic link token 或长期签名材料写入仓库、前端 bootstrap、日志与测试证据。
+- Security & Privacy: 邮箱、设备标识和签名授权记录都属于敏感身份数据。本专题允许记录账户 ID、factor 类型、掩码后的联系方式、signer 引用、公钥摘要、step-up 与审计事件；禁止把真实 OTP、原始私钥、seed、magic link token 或长期签名材料写入仓库、前端 bootstrap、日志与测试证据。
 
 ## 4. Risks & Roadmap
 - Non-Goals:
@@ -138,11 +138,11 @@
   - 不把 hosted identity 直接等同于 bridge-service、充值或法币支付体系。
 - Phased Rollout:
   - MVP: 冻结 hosted account、device session、managed signer、step-up auth、transfer-out 的正式合同。
-  - v1.1: 落地手机号/邮箱登录、设备恢复与 runtime 账户绑定。
+  - v1.1: 落地邮箱登录、设备恢复与 runtime 账户绑定。
   - v1.2: 落地 custody sign API、`main_token_transfer` 托管签名 lane 与审计。
   - v2.0: 落地 external wallet bind / self-custody transfer-out，与桥接、资产与高级 creator 能力衔接。
 - Technical Risks:
-  - 风险-1: 如果把“手机号/邮箱登录”和“高风险动作出签”绑死在同一步，玩家体验和风控都会失衡。
+  - 风险-1: 如果把“邮箱登录”和“高风险动作出签”绑死在同一步，玩家体验和风控都会失衡。
   - 风险-2: 如果继续把浏览器本地 `privateKey` 当作 hosted player 正式方案，任何缓存泄露都可能扩大为账户接管。
   - 风险-3: 如果 KMS 选型过早写死到单一厂商 API，后续算法、成本或跨环境迁移会很难收口；因此上层必须先冻结 `signer_ref + sign API` 契约。
 
@@ -151,7 +151,7 @@
 | PRD-ID | 对应任务 | 测试层级 | 验证方法 | 回归影响范围 |
 | --- | --- | --- | --- | --- |
 | PRD-P2P-029-A | hosted-managed-identity-doc-freeze / hosted-account-identity-broker | `test_tier_required` | 专题 PRD/design/project 建档、模块入口映射、登录与 hosted account contract 冻结 | hosted onboarding、账户真值 |
-| PRD-P2P-029-B | hosted-account-identity-broker / device-session-and-runtime-binding | `test_tier_required` + `test_tier_full` | 手机号/邮箱登录、guest->player upgrade、恢复与 rebind 回归 | player login、session 生命周期 |
+| PRD-P2P-029-B | hosted-account-identity-broker / device-session-and-runtime-binding | `test_tier_required` + `test_tier_full` | 邮箱登录、guest->player upgrade、恢复与 rebind 回归 | player login、session 生命周期 |
 | PRD-P2P-029-C | managed-custody-sign-api | `test_tier_required` + `test_tier_full` | signer_ref、custody backend、sign authorization 与 runtime 验签回归 | high-risk action、资产面签名 |
 | PRD-P2P-029-D | device-session-and-runtime-binding / step-up-auth-and-risk-policy | `test_tier_required` | viewer UX、设备会话存储、step-up 状态与错误反馈回归 | 前端登录/重连/敏感动作文案 |
 | PRD-P2P-029-E | qa-abuse-and-liveops-runbook | `test_tier_required` + `test_tier_full` | 盗号、设备丢失、重复绑定、风控冻结、撤销与恢复 runbook | 运营事故、QA 阻断 |
@@ -159,7 +159,7 @@
 - Decision Log:
 | 决策ID | 选定方案 | 备选方案（否决） | 依据 |
 | --- | --- | --- | --- |
-| DEC-P2P-029-001 | `hosted_public_join` 默认走手机号/邮箱 hosted account，而不是用户手填公私钥 | 让新用户自己保存或输入公私钥 | 普通玩家 onboarding 成本过高，且无法支撑恢复、风控和运营收口。 |
+| DEC-P2P-029-001 | `hosted_public_join` 默认走邮箱 hosted account，而不是用户手填公私钥 | 让新用户自己保存或输入公私钥 | 普通玩家 onboarding 成本过高，且无法支撑恢复、风控和运营收口。 |
 | DEC-P2P-029-002 | 浏览器只持有设备级短期会话材料，长期玩家 signer 留在 custody plane | 继续把 `privateKey` 持久化到浏览器 localStorage 作为正式方案 | 这与 hosted-world “浏览器不持有长期 signer” 的既有边界冲突。 |
 | DEC-P2P-029-003 | 上层冻结 `signer_ref + sign API` 契约，底层后端允许 `KMS/HSM` 或 `KMS-wrapped sealed-key backend` | 直接把产品方案写死为单一云 KMS 的具体 key API | 产品首先需要稳定的 trust boundary，而不是把运行时算法/成本约束提前硬编码进 PRD。 |
 | DEC-P2P-029-004 | 自托管升级先支持 `bind external wallet` / `transfer-out`，不要求 MVP 导出托管私钥原文 | 把“导出原始托管私钥”当成 MVP 必备功能 | 迁移能力重要，但“把私钥直接吐给浏览器”不是 hosted onboarding 的最优安全默认值。 |

--- a/doc/p2p/blockchain/p2p-hosted-public-join-managed-identity-custody-2026-05-18.project.md
+++ b/doc/p2p/blockchain/p2p-hosted-public-join-managed-identity-custody-2026-05-18.project.md
@@ -1,4 +1,4 @@
-# oasis7 hosted_public_join 托管身份 / 托管密钥与手机号邮箱登录（项目管理文档）
+# oasis7 hosted_public_join 托管身份 / 托管密钥与邮箱登录（项目管理文档）
 
 - 对应设计文档: `doc/p2p/blockchain/p2p-hosted-public-join-managed-identity-custody-2026-05-18.design.md`
 - 对应需求文档: `doc/p2p/blockchain/p2p-hosted-public-join-managed-identity-custody-2026-05-18.prd.md`
@@ -6,7 +6,7 @@
 审计轮次: 1
 
 ## 任务拆解（含 PRD-ID 映射）
-- [x] hosted-managed-identity-doc-freeze (PRD-P2P-029) [test_tier_required]: 冻结 `hosted_public_join` 的托管身份、托管密钥、手机号/邮箱登录、自托管升级和 trust boundary 文档真值，并回写模块入口映射。 Trace: .pm/tasks/task_fd98df36264944238538dea896ce4ce0.yaml
+- [x] hosted-managed-identity-doc-freeze (PRD-P2P-029) [test_tier_required]: 冻结 `hosted_public_join` 的托管身份、托管密钥、邮箱登录、自托管升级和 trust boundary 文档真值，并回写模块入口映射。 Trace: .pm/tasks/task_fd98df36264944238538dea896ce4ce0.yaml
 - [x] hosted-browser-device-session-recovery (PRD-P2P-029) [test_tier_required]: 清退 `hosted_public_join` 浏览器 `localStorage privateKey` 持久化，引入 `device_session_id` contract，并把 hosted player-session 恢复链路改成“持久化 device session handle + 页内临时 Ed25519 会话 key”。 Trace: .pm/tasks/task_584da7818a9d42e6aae5894512413102.yaml
   - 产物文件:
     - `crates/oasis7/src/bin/oasis7_game_launcher/hosted_player_session.rs`
@@ -23,7 +23,7 @@
     - `npm --prefix crates/oasis7_viewer run test:ui`
     - `./scripts/doc-governance-check.sh`
     - `git diff --check`
-- [x] hosted-account-identity-broker-server (PRD-P2P-029) [test_tier_required]: 在 `oasis7_game_launcher` 的 public HTTP 面落地中心化 hosted account 登录 server，提供手机号/邮箱 login challenge、稳定 `hosted_account_id -> player_id` 映射持久化、验证后换发 `device_session + player_session`，并把 viewer hosted onboarding 改成 phone/email + OTP 表单。 Trace: .pm/tasks/task_b837ca5ee1b34439a9c581ad6ab87a64.yaml
+- [x] hosted-account-identity-broker-server (PRD-P2P-029) [test_tier_required]: 在 `oasis7_game_launcher` 的 public HTTP 面落地中心化 hosted account 登录 server，提供邮箱 login challenge、稳定 `hosted_account_id -> player_id` 映射持久化、验证后换发 `device_session + player_session`，并把 viewer hosted onboarding 改成 email + OTP 表单。 Trace: .pm/tasks/task_b837ca5ee1b34439a9c581ad6ab87a64.yaml
   - 产物文件:
     - `crates/oasis7/src/bin/oasis7_game_launcher/hosted_account_identity.rs`
     - `crates/oasis7/src/bin/oasis7_game_launcher/hosted_player_session.rs`
@@ -48,7 +48,7 @@
 
 ### 后续切片
 - `runtime_engineer` + `viewer_engineer` / hosted-account-identity-broker:
-  - 目标: 落地 hosted account、手机号/邮箱 OTP/magic link/passkey、`hosted_account_id` 与 `player_id` 绑定、设备识别与恢复流程。
+  - 目标: 落地 hosted account、邮箱 OTP/magic link、`hosted_account_id` 与 `player_id` 绑定、设备识别与恢复流程。
 - `runtime_engineer` + `viewer_engineer` / device-session-and-runtime-binding:
   - 目标: 用 `device_session` 替换当前浏览器 `privateKey` 持久化，打通 player-session refresh/rebind/recovery 与 runtime entity binding。
 - `runtime_engineer` / managed-custody-sign-api:
@@ -68,7 +68,7 @@
   - `doc/p2p/blockchain/p2p-hosted-world-player-access-and-session-auth-2026-03-25.prd.md`
 - 输出:
   - hosted account contract
-  - 手机号/邮箱登录入口
+  - 邮箱登录入口
   - `hosted_account_id -> player_id` 绑定规则
 - 完成定义:
   - 不输入裸公私钥也能完成 hosted player login
@@ -133,10 +133,10 @@
   - 盗号、设备丢失、重复绑定、OTP 滥刷、风控冻结、托管退出失败都能给出 block/pass 结论
 
 ## 当前结论
-- 结论-1: 对 `hosted_public_join` 而言，“手机号/邮箱登录 + 中心化托管密钥 + 可选自托管升级”是比“让普通玩家保存公私钥”更合适的正式产品路径。
+- 结论-1: 对 `hosted_public_join` 而言，“邮箱登录 + 中心化托管密钥 + 可选自托管升级”是比“让普通玩家保存公私钥”更合适的正式产品路径。
 - 结论-2: 中心化 KMS 不是直接替代全部产品语义；更准确的落法是 `identity broker + custody service + sign API`，KMS/HSM 作为 custody backend 的实现选项，而不是前端/运行时直接耦合的唯一接口。
-- 结论-3: 当前代码已经完成两刀 hosted identity 基线：其一是 `device_session` 收口，viewer 不再把 hosted player `privateKey` 持久化到 `localStorage`；其二是中心化 hosted account 登录 server，`oasis7_game_launcher` 现已提供 phone/email login challenge、稳定 `hosted_account_id -> player_id` 持久化和登录后换发 `device_session + player_session` 的 public route，viewer 也已改成 hosted account 登录表单。
-- 结论-4: 当前登录投递仍是 preview transport：server 仅支持 `preview_inline` 或 `server_log_only` 这两种 repo-owned challenge delivery mode，还没有接真实短信/邮件 provider。
+- 结论-3: 当前代码已经完成两刀 hosted identity 基线：其一是 `device_session` 收口，viewer 不再把 hosted player `privateKey` 持久化到 `localStorage`；其二是中心化 hosted account 登录 server，`oasis7_game_launcher` 现已提供 email login challenge、稳定 `hosted_account_id -> player_id` 持久化和登录后换发 `device_session + player_session` 的 public route，viewer 也已改成 hosted account 登录表单。
+- 结论-4: 当前登录投递仍是 preview transport：server 仅支持 `preview_inline` 或 `server_log_only` 这两种 repo-owned challenge delivery mode，还没有接真实邮件 provider。
 - 结论-5: 托管身份仅面向 player plane；node / validator / governance signer 继续沿用独立 custody/governance 专题。
 
 ## 依赖
@@ -154,11 +154,11 @@
 - `testing-manual.md`
 
 ## 验收命令（本轮文档冻结）
-- `rg -n "PRD-P2P-029|托管身份|托管密钥|手机号|邮箱|hosted account|signer_ref" doc/p2p/prd.md doc/p2p/project.md doc/p2p/prd.index.md doc/p2p/blockchain/p2p-hosted-public-join-managed-identity-custody-2026-05-18.prd.md doc/p2p/blockchain/p2p-hosted-public-join-managed-identity-custody-2026-05-18.design.md doc/p2p/blockchain/p2p-hosted-public-join-managed-identity-custody-2026-05-18.project.md`
+- `rg -n "PRD-P2P-029|托管身份|托管密钥|邮箱|hosted account|signer_ref" doc/p2p/prd.md doc/p2p/project.md doc/p2p/prd.index.md doc/p2p/blockchain/p2p-hosted-public-join-managed-identity-custody-2026-05-18.prd.md doc/p2p/blockchain/p2p-hosted-public-join-managed-identity-custody-2026-05-18.design.md doc/p2p/blockchain/p2p-hosted-public-join-managed-identity-custody-2026-05-18.project.md`
 - `./scripts/doc-governance-check.sh`
 - `git diff --check`
 
 ## 状态
 - 当前状态: active
-- 下一步: 优先把 `hosted-account-identity-broker` 从 preview transport 推进到真实 delivery provider，补 `magic link/passkey`、挑战发送配额与恢复/冻结策略；随后推进 `managed-custody-sign-api`，把高风险动作从 preview `approval_code + env signer` 迁移到正式托管签名后端。
+- 下一步: 优先把 `hosted-account-identity-broker` 从 preview transport 推进到真实邮件 delivery provider，补 `magic link`、挑战发送配额与恢复/冻结策略；随后推进 `managed-custody-sign-api`，把高风险动作从 preview `approval_code + env signer` 迁移到正式托管签名后端。
 - 最近更新: 2026-05-18

--- a/doc/p2p/blockchain/p2p-hosted-public-join-managed-identity-custody-2026-05-18.project.md
+++ b/doc/p2p/blockchain/p2p-hosted-public-join-managed-identity-custody-2026-05-18.project.md
@@ -23,6 +23,28 @@
     - `npm --prefix crates/oasis7_viewer run test:ui`
     - `./scripts/doc-governance-check.sh`
     - `git diff --check`
+- [x] hosted-account-identity-broker-server (PRD-P2P-029) [test_tier_required]: 在 `oasis7_game_launcher` 的 public HTTP 面落地中心化 hosted account 登录 server，提供手机号/邮箱 login challenge、稳定 `hosted_account_id -> player_id` 映射持久化、验证后换发 `device_session + player_session`，并把 viewer hosted onboarding 改成 phone/email + OTP 表单。 Trace: .pm/tasks/task_b837ca5ee1b34439a9c581ad6ab87a64.yaml
+  - 产物文件:
+    - `crates/oasis7/src/bin/oasis7_game_launcher/hosted_account_identity.rs`
+    - `crates/oasis7/src/bin/oasis7_game_launcher/hosted_player_session.rs`
+    - `crates/oasis7/src/bin/oasis7_game_launcher/static_http.rs`
+    - `crates/oasis7/src/bin/oasis7_game_launcher.rs`
+    - `crates/oasis7/src/hosted_access.rs`
+    - `crates/oasis7_viewer/software_safe_src/legacy_core.js`
+    - `crates/oasis7_viewer/software_safe_src/main.jsx`
+    - `crates/oasis7_viewer/software_safe_src/main.test.jsx`
+    - `crates/oasis7_viewer/software_safe.js`
+    - `crates/oasis7_viewer/scripts/software-safe-feedback-contract.test.mjs`
+    - `doc/p2p/blockchain/p2p-hosted-public-join-managed-identity-custody-2026-05-18.project.md`
+    - `doc/p2p/project.md`
+    - `.pm/tasks/task_b837ca5ee1b34439a9c581ad6ab87a64.execution.md`
+  - 验收命令 (`test_tier_required`):
+    - `env -u RUSTC_WRAPPER cargo test -p oasis7 --bin oasis7_game_launcher hosted_ -- --nocapture`
+    - `node crates/oasis7_viewer/scripts/software-safe-feedback-contract.test.mjs`
+    - `npm --prefix crates/oasis7_viewer run test:ui`
+    - `npm --prefix crates/oasis7_viewer run build:software-safe`
+    - `./scripts/doc-governance-check.sh`
+    - `git diff --check`
 
 ### 后续切片
 - `runtime_engineer` + `viewer_engineer` / hosted-account-identity-broker:
@@ -113,8 +135,9 @@
 ## 当前结论
 - 结论-1: 对 `hosted_public_join` 而言，“手机号/邮箱登录 + 中心化托管密钥 + 可选自托管升级”是比“让普通玩家保存公私钥”更合适的正式产品路径。
 - 结论-2: 中心化 KMS 不是直接替代全部产品语义；更准确的落法是 `identity broker + custody service + sign API`，KMS/HSM 作为 custody backend 的实现选项，而不是前端/运行时直接耦合的唯一接口。
-- 结论-3: 当前代码已经完成第一刀 `device_session` 收口：launcher grant 新增 `device_session_id`，viewer 不再把 hosted player `privateKey` 持久化到 `localStorage`，刷新页后只保留 `device_session` handle，并按需在页内重新生成临时 Ed25519 session key；但 hosted account、手机号/邮箱登录、custody sign API 与真正的托管签名后端仍未实现。
-- 结论-4: 托管身份仅面向 player plane；node / validator / governance signer 继续沿用独立 custody/governance 专题。
+- 结论-3: 当前代码已经完成两刀 hosted identity 基线：其一是 `device_session` 收口，viewer 不再把 hosted player `privateKey` 持久化到 `localStorage`；其二是中心化 hosted account 登录 server，`oasis7_game_launcher` 现已提供 phone/email login challenge、稳定 `hosted_account_id -> player_id` 持久化和登录后换发 `device_session + player_session` 的 public route，viewer 也已改成 hosted account 登录表单。
+- 结论-4: 当前登录投递仍是 preview transport：server 仅支持 `preview_inline` 或 `server_log_only` 这两种 repo-owned challenge delivery mode，还没有接真实短信/邮件 provider。
+- 结论-5: 托管身份仅面向 player plane；node / validator / governance signer 继续沿用独立 custody/governance 专题。
 
 ## 依赖
 - `doc/p2p/prd.md`
@@ -137,5 +160,5 @@
 
 ## 状态
 - 当前状态: active
-- 下一步: 优先执行 `hosted-account-identity-broker`，把 hosted account、手机号/邮箱 OTP/magic link/passkey、`hosted_account_id -> player_id` 绑定与跨设备恢复落成代码真值；随后推进 `managed-custody-sign-api`，把高风险动作从 preview `approval_code + env signer` 迁移到正式托管签名后端。
+- 下一步: 优先把 `hosted-account-identity-broker` 从 preview transport 推进到真实 delivery provider，补 `magic link/passkey`、挑战发送配额与恢复/冻结策略；随后推进 `managed-custody-sign-api`，把高风险动作从 preview `approval_code + env signer` 迁移到正式托管签名后端。
 - 最近更新: 2026-05-18

--- a/doc/p2p/prd.md
+++ b/doc/p2p/prd.md
@@ -50,7 +50,7 @@
   - SC-18: 当前链上代币的正式产品命名、runtime `main_token.symbol` / ticker 与公钥派生账户前缀已统一迁移到“绿洲币 / Oasis Coin” / `OC` / `oc:pk:`；对外 API、viewer/client、脚本与测试不得再把 `AWT` / `awt:pk:` 当作现行真值。
   - SC-19: 当前本机 + 2 ECS real-env triad 必须具备一条可审计的“三节点等权 validator”落地路径，明确 validator set、signer binding、static bootstrap、same-window snapshot evidence 与 residual legacy service naming 的边界；当 execution world 已存在 `governance_finality_signer_registry` 时，节点启动/恢复必须优先从该 world-state registry 恢复 validator membership 与 signer binding，而不是继续把 role-separated `observer + sequencer + storage` 或 operator-local env 当成唯一真值拓扑。
   - SC-20: `oasis7` 可以通过独立部署的 bridge-service，把已确认的 `OC` 充值映射为 LetAI Run OpenAPI 的用户额度与动态项目 `token_key`，同时冻结“只支持 one-way service-credit bridge，不是公开兑换所、不是 AMM、也不支持自动提现回 OC”的对外口径。
-  - SC-21: `hosted_public_join` 必须具备一条对普通玩家友好的正式身份路径：默认允许手机号/邮箱 hosted login、托管 player signer 与后续自托管升级；浏览器不再被要求作为长期玩家私钥保管面。
+  - SC-21: `hosted_public_join` 必须具备一条对普通玩家友好的正式身份路径：默认允许邮箱 hosted login、托管 player signer 与后续自托管升级；浏览器不再被要求作为长期玩家私钥保管面。
   - SC-21: validator / finality signer 必须具备一条正式的治理准入流程，至少覆盖 `apply -> approved_candidate -> probation_ready -> active -> rotate/revoke`，并明确 world-state registry 才是正式激活真值；`--node-validator*` 与 operator-local env 只能作为 bootstrap 或显式运维覆盖。
   - SC-22: p2p 模块必须具备一套正式的公共主链式网络分层机制，明确 `local_devnet -> shared_devnet -> public_testnet -> mainnet` 的 tier 边界、manifest 真值与 claims/promotion 规则，避免把 shared release-train 与正式 testnet/mainnet 继续混写。
   - SC-23: `public_testnet` 必须具备一条 repo-owned readiness review 路径，能把“只有 skeleton manifest”与“具备 live candidate evidence”明确区分，避免把 placeholder endpoint 或模板证据误报为可部署结论。
@@ -103,7 +103,7 @@
   - PRD-P2P-026: As a producer_system_designer, I want the live triad to support a three-equal-validator topology, so that the local node is no longer a permanent observer exception and triad semantics can match “three peer-equal validators” when operations explicitly choose that mode.
   - PRD-P2P-027: As a producer_system_designer, I want one canonical one-way `OC -> LetAI Run OpenAPI quota/token_key` bridge model, so that oasis7 可以把当前主链 Token 用作受控的 AI 服务额度充值资产，同时不误滑成公开兑换所、浏览器热钱包或双向提现承诺。
   - PRD-P2P-028: As a producer_system_designer, I want one formal public-chain-style network-tier mechanism, so that oasis7 can stop treating `shared_devnet`、`public_testnet` and `mainnet` as informal aliases and instead promote networks through explicit manifest + gate truth.
-  - PRD-P2P-029: As a producer_system_designer, I want one explicit hosted-public-join managed identity / custody model, so that普通玩家可以用手机号或邮箱登录游戏，而不是被迫管理裸公私钥，同时 hosted player signer、step-up auth 与自托管升级路径都保持在可审计边界内。
+  - PRD-P2P-029: As a producer_system_designer, I want one explicit hosted-public-join managed identity / custody model, so that普通玩家可以用邮箱登录游戏，而不是被迫管理裸公私钥，同时 hosted player signer、step-up auth 与自托管升级路径都保持在可审计边界内。
 - Critical User Flows:
   1. Flow-P2P-001: `网络拓扑变更 -> 共识联调 -> DistFS 同步 -> 节点状态一致性验证`
   2. Flow-P2P-002: `执行 S9/S10 长跑 -> 采集故障与恢复数据 -> 输出收敛报告`
@@ -129,7 +129,7 @@
   22. Flow-P2P-022: `读取 testing-manual 与安全/readiness 专题 -> 映射 oasis7 当前测试层 -> 对照主流公链 testing benchmark -> 冻结 gap matrix 与下一步验证优先级`
   23. Flow-P2P-023: `host 启动 hosted world -> public join 先过 admission control -> 远程访客建 guest/player session -> runtime 按 capability 绑定实体与动作 -> `gui-agent` 仅走 player-safe split surface -> 资产/治理类动作再升级 strong auth`
   24. Flow-P2P-024: `用户绑定 bridge 身份 -> bridge-service 分配唯一 deposit route -> 用户通过受信转账面支付 OC -> bridge watcher 等待确认并写入 bridge_ledger -> LetAI OpenAPI 执行 user upsert / project+token_key / topup / query verification -> operator 对账与异常收口`
-  25. Flow-P2P-025: `访客从 guest 升级到手机号/邮箱 hosted account -> identity broker 恢复账户与 signer_ref -> session broker 签发 device/player session -> 高风险动作再经 step-up + custody sign -> 如需退出托管则走 external wallet bind / transfer-out`
+  25. Flow-P2P-025: `访客从 guest 升级到邮箱 hosted account -> identity broker 恢复账户与 signer_ref -> session broker 签发 device/player session -> 高风险动作再经 step-up + custody sign -> 如需退出托管则走 external wallet bind / transfer-out`
 - Functional Specification Matrix:
 | 功能点 | 字段定义 | 按钮/动作行为 | 状态转换 | 排序/计算规则 | 权限逻辑 |
 | --- | --- | --- | --- | --- | --- |
@@ -148,7 +148,7 @@
 | 主流公链测试体系对标 | `layer_id/current_coverage/evidence_paths/gap_status/next_action` | 将 oasis7 suites/evidence 对位到主流公链测试分层，并冻结缺口矩阵与执行优先级 | `draft -> mapped -> prioritized` | 若缺共享网络、真实 drill 证据或 fuzz/property gate，则不得宣称“主流公链级测试成熟度” | `producer_system_designer` 拍板，`qa_engineer` 联审 |
 | Validator / finality signer 治理准入 | `candidate_id/node_id/finality_signer_public_key/operator_owner/public_manifest/activation_epoch/admission_status` | 受理申请、审核 reachability/registry/failover 准入条件，并在 activation 生效后把候选节点写入正式 validator truth | `applied -> approved_candidate -> probation_ready -> active -> rotated/revoked` | 只有 world-state registry 生效后才算正式 validator；`--node-validator*` 与本地 env 改动不算长期 admission 完成态 | `producer_system_designer` 拍板，`runtime_engineer`/`qa_engineer` 联审 |
 | Hosted world 玩家接入与 session auth | `deployment_mode/session_id/session_level/capability_set/control_plane_scope/strong_auth_state/admission_policy/player_safe_agent_surface` | 将网页远程玩家面、host 控制面与 signer plane 分层；签发 guest/player session，并对敏感动作要求 strong auth | `specified_not_implemented -> trusted_local_only -> hosted_ready` | 只要浏览器仍依赖 `node.private_key` bootstrap、可命中 host 控制面路由或未冻结 admission / `gui-agent` split，就不得判为 hosted-ready | `producer_system_designer` 拍板，`runtime_engineer`/`viewer_engineer`/`qa_engineer`/`liveops_community` 联审 |
-| Hosted public join 托管身份与托管密钥 | `hosted_account_id/player_id/device_session_id/signer_ref/custody_mode/step_up_state/transfer_out_state` | 为公开 join 玩家提供手机号/邮箱登录、托管 signer、step-up auth 与自托管升级路径 | `guest_only -> account_verified -> managed_custody_active -> self_custody_bound/transferred_out` | 只要 hosted player 仍要求用户保存裸私钥、浏览器仍长期持有托管 signer 或 `main_token_transfer` 没有正式 custody lane，就不得宣称“任意新用户默认可安全登录并长期使用” | `producer_system_designer` 拍板，`runtime_engineer`/`viewer_engineer`/`qa_engineer`/`liveops_community` 联审 |
+| Hosted public join 托管身份与托管密钥 | `hosted_account_id/player_id/device_session_id/signer_ref/custody_mode/step_up_state/transfer_out_state` | 为公开 join 玩家提供邮箱登录、托管 signer、step-up auth 与自托管升级路径 | `guest_only -> account_verified -> managed_custody_active -> self_custody_bound/transferred_out` | 只要 hosted player 仍要求用户保存裸私钥、浏览器仍长期持有托管 signer 或 `main_token_transfer` 没有正式 custody lane，就不得宣称“任意新用户默认可安全登录并长期使用” | `producer_system_designer` 拍板，`runtime_engineer`/`viewer_engineer`/`qa_engineer`/`liveops_community` 联审 |
 - 三线联合验收清单（TASK-P2P-002）:
 | 线别 | 必跑命令（基线） | 联合验收门禁 | 阻断条件（任一命中即 fail） | 证据产物 |
 | --- | --- | --- | --- | --- |
@@ -193,7 +193,7 @@
   - AC-35: `triad-three-equal-validator-topology` 必须把当前 real-env triad 从“本机 observer + 两台云端 validator”提升为“三节点等权 validator”可审计基线，至少覆盖：`3` 个 validator 的 stake/signer binding、local 节点不再以 observer-only 角色运行、repo-owned snapshot/manual 不再把 `partial_with_observer_blocker` 当成唯一有效 claim、same-window evidence 对 legacy service label 与真实 runtime role 的区分，以及 `oasis7_chain_runtime` 在 execution world 已落盘 `governance_finality_signer_registry` 时会优先用该 world-state registry 恢复 validator membership / signer binding；`--node-validator*` 只保留为 bootstrap 或显式运维覆盖。
   - AC-36: `mainchain-token-newapi-quota-bridge-2026-05-06` 专题文档落盘并映射任务链，明确 `one-way OC -> LetAI Run OpenAPI quota`、bridge-service 独立部署、唯一入账映射、`bridge_ledger` 幂等对账、动态 project/`token_key`、query verification 与 manual review 风控，以及“不支持自动提现/不承诺公开兑换所”边界。
   - AC-37: `p2p-formal-network-tiers-testnet-mechanism-2026-05-14` 专题文档与 repo-owned skeleton 必须落盘并映射任务链 `formal-network-tiers-testnet-mechanism (PRD-P2P-028)`，明确 `local_devnet/shared_devnet/public_testnet/mainnet` 四层模型、`network_tier_manifest` 字段集合、`public_testnet` 的 public RPC/explorer/faucet/reset 语义，以及 `mainnet` 的 `no faucet + frozen reset + MAINNET-1~4` gate。
-  - AC-38: `p2p-hosted-public-join-managed-identity-custody-2026-05-18` 专题文档必须落盘并映射任务链 `hosted-managed-identity-doc-freeze (PRD-P2P-029)`，明确 hosted account、手机号/邮箱登录、`signer_ref`、device session、step-up auth、托管退出与“默认不让玩家管理裸私钥”的正式产品边界。
+  - AC-38: `p2p-hosted-public-join-managed-identity-custody-2026-05-18` 专题文档必须落盘并映射任务链 `hosted-managed-identity-doc-freeze (PRD-P2P-029)`，明确 hosted account、邮箱登录、`signer_ref`、device session、step-up auth、托管退出与“默认不让玩家管理裸私钥”的正式产品边界。
   - AC-38: `public_testnet` 必须具备 repo-owned readiness review 入口，至少能基于 manifest + lane evidence 输出 `specified_skeleton_only|partial|block|ready_for_live_candidate`，并对 placeholder endpoint / 缺失 candidate bundle / 缺 lane evidence 保持阻断。
 - Non-Goals:
   - 不在本 PRD 细化 viewer UI 交互。
@@ -290,7 +290,7 @@
   - NFR-P2P-27: hosted world public join 必须具备有界 admission control，至少冻结 `max_guest_sessions/max_player_sessions/issue_rate_limit/world_full_policy`，且超限时返回结构化拒绝。
   - NFR-P2P-28: `doc/p2p/**` 活跃文档、token 专题、模块入口与 runtime/account 相关实现提到当前链上代币时，必须统一使用“绿洲币 / Oasis Coin” / `OC` / `oc:pk:` 作为现行真值；`AWT` / `awt:pk:` 仅允许保留在明确标注的历史语境或兼容说明中。
   - NFR-P2P-29: `OC -> LetAI Run OpenAPI` bridge 必须坚持 `one-way service-credit only`、独立 bridge-service、唯一入账映射、`bridge_ledger` 幂等对账、动态 project/`token_key` 持久化与 operator-review fallback；在公开钱包体系、生产级 custody、双向兑回与价格发现机制缺失前，任何“公开兑换所”“自动提现”“浏览器直连热钱包充值”口径都不得进入 allowlist。
-  - NFR-P2P-30: `hosted_public_join` 的正式产品路径必须允许手机号/邮箱 hosted login、服务端托管 player signer 与后续自托管升级；在浏览器仍长期持有托管私钥、账户恢复仍依赖手抄私钥或高风险动作仍没有正式 step-up + custody sign lane 之前，不得声称“任意新用户都已有安全可用的 hosted account + wallet”。
+  - NFR-P2P-30: `hosted_public_join` 的正式产品路径必须允许邮箱 hosted login、服务端托管 player signer 与后续自托管升级；在浏览器仍长期持有托管私钥、账户恢复仍依赖手抄私钥或高风险动作仍没有正式 step-up + custody sign lane 之前，不得声称“任意新用户都已有安全可用的 hosted account + wallet”。
 - Security & Privacy: 需保证节点身份、签名、账本与反馈数据链路的完整性；所有关键动作必须具备可审计记录。
 
 ## 5. Risks & Roadmap

--- a/doc/p2p/project.md
+++ b/doc/p2p/project.md
@@ -539,7 +539,7 @@
     - `./scripts/network-tier-public-testnet-readiness.sh --manifest doc/testing/templates/network-tier-public-testnet.example.json`
     - `./scripts/doc-governance-check.sh`
     - `git diff --check`
-- [x] hosted-managed-identity-doc-freeze (PRD-P2P-029) [test_tier_required]: 新增“hosted_public_join 托管身份 / 托管密钥与手机号邮箱登录”专题 PRD / design / project，并把 hosted account、手机号/邮箱登录、`signer_ref`、device session、step-up auth、自托管升级与 player-custody trust boundary 纳入模块追踪。 Trace: .pm/tasks/task_fd98df36264944238538dea896ce4ce0.yaml
+- [x] hosted-managed-identity-doc-freeze (PRD-P2P-029) [test_tier_required]: 新增“hosted_public_join 托管身份 / 托管密钥与邮箱登录”专题 PRD / design / project，并把 hosted account、邮箱登录、`signer_ref`、device session、step-up auth、自托管升级与 player-custody trust boundary 纳入模块追踪。 Trace: .pm/tasks/task_fd98df36264944238538dea896ce4ce0.yaml
   - 产物文件:
     - `doc/p2p/blockchain/p2p-hosted-public-join-managed-identity-custody-2026-05-18.prd.md`
     - `doc/p2p/blockchain/p2p-hosted-public-join-managed-identity-custody-2026-05-18.design.md`
@@ -550,7 +550,7 @@
     - `doc/p2p/README.md`
     - `.pm/tasks/task_fd98df36264944238538dea896ce4ce0.execution.md`
   - 验收命令 (`test_tier_required`):
-    - `rg -n "PRD-P2P-029|托管身份|托管密钥|手机号|邮箱|hosted account|signer_ref" doc/p2p/prd.md doc/p2p/project.md doc/p2p/prd.index.md doc/p2p/README.md doc/p2p/blockchain/p2p-hosted-public-join-managed-identity-custody-2026-05-18.prd.md doc/p2p/blockchain/p2p-hosted-public-join-managed-identity-custody-2026-05-18.design.md doc/p2p/blockchain/p2p-hosted-public-join-managed-identity-custody-2026-05-18.project.md`
+    - `rg -n "PRD-P2P-029|托管身份|托管密钥|邮箱|hosted account|signer_ref" doc/p2p/prd.md doc/p2p/project.md doc/p2p/prd.index.md doc/p2p/README.md doc/p2p/blockchain/p2p-hosted-public-join-managed-identity-custody-2026-05-18.prd.md doc/p2p/blockchain/p2p-hosted-public-join-managed-identity-custody-2026-05-18.design.md doc/p2p/blockchain/p2p-hosted-public-join-managed-identity-custody-2026-05-18.project.md`
     - `./scripts/doc-governance-check.sh`
     - `git diff --check`
 - [x] hosted-browser-device-session-recovery (PRD-P2P-029) [test_tier_required]: 移除 `hosted_public_join` 浏览器对 hosted player `privateKey` 的持久化，新增 launcher `device_session_id` contract，并把 reconnect/register 改成“持久化 device session handle + 页内临时 Ed25519 会话 key”的恢复路径。 Trace: .pm/tasks/task_584da7818a9d42e6aae5894512413102.yaml
@@ -569,7 +569,7 @@
     - `npm --prefix crates/oasis7_viewer run test:ui`
     - `./scripts/doc-governance-check.sh`
     - `git diff --check`
-- [x] hosted-account-identity-broker-server (PRD-P2P-029) [test_tier_required]: 为 `hosted_public_join` 落地中心化 hosted account 登录 server，提供手机号/邮箱 login challenge、稳定 `hosted_account_id -> player_id` 持久化和登录完成后的 `device_session + player_session` 换发，并将正式 Web 入口从“直接领 player session”改成 hosted account 登录表单。 Trace: .pm/tasks/task_b837ca5ee1b34439a9c581ad6ab87a64.yaml
+- [x] hosted-account-identity-broker-server (PRD-P2P-029) [test_tier_required]: 为 `hosted_public_join` 落地中心化 hosted account 登录 server，提供邮箱 login challenge、稳定 `hosted_account_id -> player_id` 持久化和登录完成后的 `device_session + player_session` 换发，并将正式 Web 入口从“直接领 player session”改成 hosted account 登录表单。 Trace: .pm/tasks/task_b837ca5ee1b34439a9c581ad6ab87a64.yaml
   - 产物文件:
     - `crates/oasis7/src/bin/oasis7_game_launcher/hosted_account_identity.rs`
     - `crates/oasis7/src/bin/oasis7_game_launcher/hosted_player_session.rs`
@@ -847,9 +847,9 @@
 
 ## 状态
 - 更新日期: 2026-05-18
-- 最新完成: `hosted-account-identity-broker-server`（已在 `oasis7_game_launcher` 的 public HTTP 面落地中心化 hosted account 登录 server：支持 phone/email login challenge、稳定 `hosted_account_id -> player_id` 持久化，以及登录完成后换发 `device_session + player_session`；viewer 正式入口也已改成 hosted account 登录表单。当前 challenge delivery 仍是 preview `preview_inline/server_log_only`，尚未接真实短信/邮件 provider。）
+- 最新完成: `hosted-account-identity-broker-server`（已在 `oasis7_game_launcher` 的 public HTTP 面落地中心化 hosted account 登录 server：支持 email login challenge、稳定 `hosted_account_id -> player_id` 持久化，以及登录完成后换发 `device_session + player_session`；viewer 正式入口也已改成 hosted account 登录表单。当前 challenge delivery 仍是 preview `preview_inline/server_log_only`，尚未接真实邮件 provider。）
 - 最新完成: `hosted-browser-device-session-recovery`（已把 `hosted_public_join` 的 viewer/launcher 第一刀落成代码真值：launcher grant 新增 `device_session_id`，viewer 不再把 hosted player `privateKey` 持久化到 `localStorage`，刷新页后仅保留 `device_session` handle，并按需重新生成页内临时 Ed25519 session key 以完成 reconnect/register。）
-- 最新完成: `hosted-managed-identity-doc-freeze`（已新增 hosted_public_join 托管身份 / 托管密钥专题三件套，正式冻结 hosted account、手机号/邮箱登录、`signer_ref`、device session、step-up auth 与自托管升级边界；当前剩余缺口集中在 hosted account 登录入口与托管签名后端。）
+- 最新完成: `hosted-managed-identity-doc-freeze`（已新增 hosted_public_join 托管身份 / 托管密钥专题三件套，正式冻结 hosted account、邮箱登录、`signer_ref`、device session、step-up auth 与自托管升级边界；当前剩余缺口集中在 hosted account 登录入口与托管签名后端。）
 - 最新完成: `newapi-auto-credit-closure`（已把 `oasis7_newapi_bridge_service` 收口为 LetAI OpenAPI 真链路：新增持久化 `bridge_ledger`、explorer poll watcher、block-height confirmation、exact-match `--pricing-rule` 折算、`platform_user_id/platform_project_id/token_key/external_order_id`、user upsert、project/token 创建、topup、query verification 与 retry/manual-review 状态机。）
 - 当前状态: active（ROUND-027）
 - 下一任务: 优先推进 `TASK-P2P-043` 对应的 `P2PARCH-1~3`，把 identity / transport / role policy 收成统一 substrate；在此之前，不再把“本机无公网 IP 连不上”归类为单点部署细节。

--- a/doc/p2p/project.md
+++ b/doc/p2p/project.md
@@ -569,6 +569,28 @@
     - `npm --prefix crates/oasis7_viewer run test:ui`
     - `./scripts/doc-governance-check.sh`
     - `git diff --check`
+- [x] hosted-account-identity-broker-server (PRD-P2P-029) [test_tier_required]: 为 `hosted_public_join` 落地中心化 hosted account 登录 server，提供手机号/邮箱 login challenge、稳定 `hosted_account_id -> player_id` 持久化和登录完成后的 `device_session + player_session` 换发，并将正式 Web 入口从“直接领 player session”改成 hosted account 登录表单。 Trace: .pm/tasks/task_b837ca5ee1b34439a9c581ad6ab87a64.yaml
+  - 产物文件:
+    - `crates/oasis7/src/bin/oasis7_game_launcher/hosted_account_identity.rs`
+    - `crates/oasis7/src/bin/oasis7_game_launcher/hosted_player_session.rs`
+    - `crates/oasis7/src/bin/oasis7_game_launcher/static_http.rs`
+    - `crates/oasis7/src/bin/oasis7_game_launcher.rs`
+    - `crates/oasis7/src/hosted_access.rs`
+    - `crates/oasis7_viewer/software_safe_src/legacy_core.js`
+    - `crates/oasis7_viewer/software_safe_src/main.jsx`
+    - `crates/oasis7_viewer/software_safe_src/main.test.jsx`
+    - `crates/oasis7_viewer/software_safe.js`
+    - `crates/oasis7_viewer/scripts/software-safe-feedback-contract.test.mjs`
+    - `doc/p2p/blockchain/p2p-hosted-public-join-managed-identity-custody-2026-05-18.project.md`
+    - `doc/p2p/project.md`
+    - `.pm/tasks/task_b837ca5ee1b34439a9c581ad6ab87a64.execution.md`
+  - 验收命令 (`test_tier_required`):
+    - `env -u RUSTC_WRAPPER cargo test -p oasis7 --bin oasis7_game_launcher hosted_ -- --nocapture`
+    - `node crates/oasis7_viewer/scripts/software-safe-feedback-contract.test.mjs`
+    - `npm --prefix crates/oasis7_viewer run test:ui`
+    - `npm --prefix crates/oasis7_viewer run build:software-safe`
+    - `./scripts/doc-governance-check.sh`
+    - `git diff --check`
 - [x] bridge-binding-and-route-contract (PRD-P2P-TBRIDGE-001) [test_tier_required]: 为独立 `bridge-service` 落地最小 runtime slice，提供绑定 API、deposit route API、repo-owned 状态持久化、活跃 route 复用 / 过期与冲突错误语义，作为后续 watcher / `bridge_ledger` / LetAI OpenAPI adapter 的前置基线。 Trace: .pm/tasks/task_e56e4cfdb9534919a6f7bc7c6ba62ee9.yaml
   - 产物文件:
     - `crates/oasis7/src/bin/oasis7_newapi_bridge_service.rs`
@@ -825,6 +847,7 @@
 
 ## 状态
 - 更新日期: 2026-05-18
+- 最新完成: `hosted-account-identity-broker-server`（已在 `oasis7_game_launcher` 的 public HTTP 面落地中心化 hosted account 登录 server：支持 phone/email login challenge、稳定 `hosted_account_id -> player_id` 持久化，以及登录完成后换发 `device_session + player_session`；viewer 正式入口也已改成 hosted account 登录表单。当前 challenge delivery 仍是 preview `preview_inline/server_log_only`，尚未接真实短信/邮件 provider。）
 - 最新完成: `hosted-browser-device-session-recovery`（已把 `hosted_public_join` 的 viewer/launcher 第一刀落成代码真值：launcher grant 新增 `device_session_id`，viewer 不再把 hosted player `privateKey` 持久化到 `localStorage`，刷新页后仅保留 `device_session` handle，并按需重新生成页内临时 Ed25519 session key 以完成 reconnect/register。）
 - 最新完成: `hosted-managed-identity-doc-freeze`（已新增 hosted_public_join 托管身份 / 托管密钥专题三件套，正式冻结 hosted account、手机号/邮箱登录、`signer_ref`、device session、step-up auth 与自托管升级边界；当前剩余缺口集中在 hosted account 登录入口与托管签名后端。）
 - 最新完成: `newapi-auto-credit-closure`（已把 `oasis7_newapi_bridge_service` 收口为 LetAI OpenAPI 真链路：新增持久化 `bridge_ledger`、explorer poll watcher、block-height confirmation、exact-match `--pricing-rule` 折算、`platform_user_id/platform_project_id/token_key/external_order_id`、user upsert、project/token 创建、topup、query verification 与 retry/manual-review 状态机。）


### PR DESCRIPTION
## Summary
- add a centralized hosted-account login broker to oasis7_game_launcher for hosted_public_join phone-or-email onboarding
- persist stable hosted_account_id -> player_id bindings and exchange verified login for device_session plus player_session
- update the formal web entry and runtime diagnostics surfaces to use hosted account login instead of direct player-session issuance

## Validation
- env -u RUSTC_WRAPPER cargo test -p oasis7 --bin oasis7_game_launcher hosted_ -- --nocapture
- node crates/oasis7_viewer/scripts/software-safe-feedback-contract.test.mjs
- npm --prefix crates/oasis7_viewer run test:ui
- npm --prefix crates/oasis7_viewer run build:software-safe
- ./scripts/doc-governance-check.sh
- git diff --check

## Boundary
- login challenge delivery is still preview-only via preview_inline or server_log_only transport
- this PR does not yet add a real SMS/email provider, magic link/passkey, managed custody sign API, or hosted main_token_transfer execution