### PR TITLE
Deploy public testnet faucet service

### DIFF
--- a/.pm/tasks/task_eaa2499f5b38480fb1a0c3e7f1e688b3.execution.md
+++ b/.pm/tasks/task_eaa2499f5b38480fb1a0c3e7f1e688b3.execution.md
@@ -1,0 +1,18 @@
+# task_eaa2499f5b38480fb1a0c3e7f1e688b3 Execution Log
+
+- task_uid: task_eaa2499f5b38480fb1a0c3e7f1e688b3
+- title: deploy public testnet faucet service
+- owner_role: runtime_engineer
+- worktree_hint: /home/scc/worktrees/oasis7-p2p-public-testnet-faucet-service
+
+<!-- Append entries using:
+Example:
+  ## YYYY-MM-DD HH:MM:SS CST / role_name
+  - 完成内容: ...
+  - 遗留事项: ...
+-->
+
+## 2026-05-19 17:35:26 CST / runtime_engineer
+- 完成内容: 在独立 worktree 内补齐 `oasis7_testnet_faucet` 与 `main_token_submit`/governance import/validator registry 修复链路，定位并修复 `PosNodeEngine::propose_next_head()` 在非 proposer slot 提前 drain `pending_consensus_actions` 导致 transfer action 被静默丢弃、faucet claim 最终 `timeout` 的共识 bug；新增 guardrail test 后重编 `oasis7_chain_runtime`，在 `39.104.204.172` 部署 `oasis7-testnet-faucet.service`（`http://39.104.204.172:6681/`，`amount=1000000`，`cooldown_secs=3600`），并对两台 public testnet ECS 节点执行协调冷重置、重新导入 `governance-public-manifest-public-testnet-2validator.json`、重新提交 faucet genesis/vesting claim，最终完成外部 `POST /claim` 到 `oc:pk:2222...2222` 的真实转账验证。
+- 完成内容: 现场验证结果为 `GET / -> ok`、`GET /healthz -> ok`、`POST /claim -> action_id=1`，随后 `GET /v1/chain/transfer/accounts` 显示 faucet 账户余额从 `10000000000` 变为 `9999000000`，目标账户 `oc:pk:2222...2222` 获得 `1000000`，`/v1/chain/explorer/address?...2222` 中对应 transfer 记录状态为 `confirmed`。
+- 遗留事项: `/v1/chain/balances` 仍只暴露 `node_main_token_account` 绑定视角，当前不反映 faucet 热钱包余额；faucet 可用性应继续以 `transfer/accounts`、`explorer/address` 与 `snapshot.json` 为准。

--- a/.pm/tasks/task_eaa2499f5b38480fb1a0c3e7f1e688b3.yaml
+++ b/.pm/tasks/task_eaa2499f5b38480fb1a0c3e7f1e688b3.yaml
@@ -1,0 +1,24 @@
+task_uid: task_eaa2499f5b38480fb1a0c3e7f1e688b3
+title: "deploy public testnet faucet service"
+owner_role: runtime_engineer
+worktree_hint: /home/scc/worktrees/oasis7-p2p-public-testnet-faucet-service
+execution_log_path: .pm/tasks/task_eaa2499f5b38480fb1a0c3e7f1e688b3.execution.md
+status: done
+priority: P2
+source_signal: null
+source_refs:
+  - doc/p2p/prd.md
+  - doc/p2p/project.md
+  - doc/p2p/blockchain/p2p-formal-network-tiers-testnet-mechanism-2026-05-14.prd.md
+  - doc/p2p/blockchain/p2p-formal-network-tiers-testnet-mechanism-2026-05-14.project.md
+doc_refs: []
+related_prd:
+  - PRD-P2P-022
+acceptance:
+  - "public_testnet manifest uses a real faucet_ref backed by a working service on existing testnet infrastructure"
+  - "faucet service reuses canonical liveops grant entrypoints and records abuse-control boundary"
+  - "runtime evidence and readiness verdict are updated after external faucet verification"
+handoff_to: []
+updated_at: 2026-05-19T17:39:26+08:00
+last_started_at: 2026-05-19T13:14:07+08:00
+last_closed_at: 2026-05-19T17:39:26+08:00

--- a/crates/oasis7/src/bin/oasis7_chain_runtime.rs
+++ b/crates/oasis7/src/bin/oasis7_chain_runtime.rs
@@ -46,6 +46,8 @@ mod feedback_submit_api;
 mod gameplay_submit_api;
 #[path = "oasis7_chain_runtime/governance_registry.rs"]
 mod governance_registry;
+#[path = "oasis7_chain_runtime/main_token_submit_api.rs"]
+mod main_token_submit_api;
 #[path = "oasis7_chain_runtime/module_release_attestation_submit_api.rs"]
 mod module_release_attestation_submit_api;
 #[path = "oasis7_chain_runtime/node_keypair_config.rs"]

--- a/crates/oasis7/src/bin/oasis7_chain_runtime/governance_registry.rs
+++ b/crates/oasis7/src/bin/oasis7_chain_runtime/governance_registry.rs
@@ -47,8 +47,17 @@ fn node_pos_config_from_world_finality_registry(
     registry: &GovernanceFinalitySignerRegistry,
     fallback: &NodePosConfig,
 ) -> NodePosConfig {
-    let validators = registry
+    let validator_signer_public_keys = registry
         .signer_bindings
+        .iter()
+        .map(|(binding_key, public_key_hex)| {
+            (
+                validator_id_from_registry_binding(registry.slot_id.as_str(), binding_key),
+                public_key_hex.clone(),
+            )
+        })
+        .collect::<BTreeMap<String, String>>();
+    let validators = validator_signer_public_keys
         .keys()
         .cloned()
         .map(|validator_id| PosValidator {
@@ -56,8 +65,7 @@ fn node_pos_config_from_world_finality_registry(
             stake: WORLD_REGISTRY_EQUAL_VALIDATOR_STAKE,
         })
         .collect::<Vec<PosValidator>>();
-    let validator_player_ids = registry
-        .signer_bindings
+    let validator_player_ids = validator_signer_public_keys
         .keys()
         .cloned()
         .map(|validator_id| (validator_id.clone(), validator_id))
@@ -65,7 +73,7 @@ fn node_pos_config_from_world_finality_registry(
     NodePosConfig {
         validators,
         validator_player_ids,
-        validator_signer_public_keys: registry.signer_bindings.clone(),
+        validator_signer_public_keys,
         supermajority_numerator: fallback.supermajority_numerator,
         supermajority_denominator: fallback.supermajority_denominator,
         epoch_length_slots: fallback.epoch_length_slots,
@@ -76,6 +84,15 @@ fn node_pos_config_from_world_finality_registry(
         slot_clock_genesis_unix_ms: fallback.slot_clock_genesis_unix_ms,
         max_past_slot_lag: fallback.max_past_slot_lag,
     }
+}
+
+fn validator_id_from_registry_binding(slot_id: &str, binding_key: &str) -> String {
+    let prefix = format!("{slot_id}.");
+    binding_key
+        .strip_prefix(prefix.as_str())
+        .filter(|value| !value.is_empty())
+        .unwrap_or(binding_key)
+        .to_string()
 }
 
 fn node_main_token_controller_binding_from_registry(
@@ -278,6 +295,58 @@ mod tests {
         assert_eq!(config.pos_config.slot_duration_ms, 12_000);
         assert_eq!(config.pos_config.ticks_per_slot, 10);
         assert_eq!(config.pos_config.proposal_tick_phase, 9);
+    }
+
+    #[test]
+    fn world_finality_registry_strips_slot_prefix_from_validator_ids() {
+        let temp_dir = temp_dir("finality-prefix-override");
+        let mut world = World::new();
+        world
+            .set_governance_finality_signer_registry(GovernanceFinalitySignerRegistry {
+                slot_id: "governance.finality.v1".to_string(),
+                threshold: 2,
+                threshold_bps: 0,
+                signer_bindings: BTreeMap::from([
+                    (
+                        "governance.finality.v1.triad-testnet-sequencer".to_string(),
+                        "1111111111111111111111111111111111111111111111111111111111111111"
+                            .to_string(),
+                    ),
+                    (
+                        "governance.finality.v1.triad-testnet-storage".to_string(),
+                        "2222222222222222222222222222222222222222222222222222222222222222"
+                            .to_string(),
+                    ),
+                ]),
+            })
+            .expect("set finality registry");
+        world.save_to_dir(&temp_dir).expect("save execution world");
+
+        let config = apply_world_governance_registry_overrides(
+            NodeConfig::new("triad-testnet-sequencer", "world-a", NodeRole::Sequencer)
+                .expect("node config"),
+            &temp_dir,
+        )
+        .expect("apply registry overrides");
+
+        let validator_ids = config
+            .pos_config
+            .validators
+            .iter()
+            .map(|validator| validator.validator_id.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            validator_ids,
+            vec!["triad-testnet-sequencer", "triad-testnet-storage"]
+        );
+        assert_eq!(
+            config
+                .pos_config
+                .validator_signer_public_keys
+                .get("triad-testnet-sequencer")
+                .map(String::as_str),
+            Some("1111111111111111111111111111111111111111111111111111111111111111")
+        );
     }
 
     #[test]

--- a/crates/oasis7/src/bin/oasis7_chain_runtime/main_token_submit_api.rs
+++ b/crates/oasis7/src/bin/oasis7_chain_runtime/main_token_submit_api.rs
@@ -1,0 +1,360 @@
+use std::net::TcpStream;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+
+use oasis7::consensus_action_payload::{
+    encode_consensus_action_payload, verify_main_token_runtime_action_auth,
+    ConsensusActionAuthEnvelope, ConsensusActionPayloadEnvelope, MainTokenActionAuthError,
+    MainTokenActionAuthProof, MainTokenActionAuthScheme, MainTokenActionParticipantSignature,
+};
+use oasis7::runtime::{Action, MainTokenGenesisAllocationPlan};
+use oasis7_node::NodeRuntime;
+use serde::{Deserialize, Serialize};
+
+const MAIN_TOKEN_SUBMIT_PATH: &str = "/v1/chain/main-token/submit";
+const MAIN_TOKEN_ERROR_INVALID_REQUEST: &str = "invalid_request";
+const MAIN_TOKEN_ERROR_INVALID_SIGNATURE: &str = "invalid_signature";
+const MAIN_TOKEN_ERROR_ACCOUNT_AUTH_MISMATCH: &str = "account_auth_mismatch";
+const MAIN_TOKEN_ERROR_INTERNAL: &str = "internal_error";
+const MAIN_TOKEN_ERROR_SUBMIT_FAILED: &str = "submit_failed";
+
+static NEXT_MAIN_TOKEN_ACTION_ID: AtomicU64 = AtomicU64::new(1);
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct MainTokenSubmitAuthRequest {
+    scheme: MainTokenActionAuthScheme,
+    account_id: String,
+    #[serde(default)]
+    public_key: Option<String>,
+    #[serde(default)]
+    signature: Option<String>,
+    #[serde(default)]
+    threshold: Option<u16>,
+    #[serde(default)]
+    participant_signatures: Vec<MainTokenActionParticipantSignature>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(tag = "action", rename_all = "snake_case")]
+enum MainTokenSubmitRequest {
+    InitializeMainTokenGenesis {
+        allocations: Vec<MainTokenGenesisAllocationPlan>,
+        auth: MainTokenSubmitAuthRequest,
+    },
+    ClaimMainTokenVesting {
+        bucket_id: String,
+        beneficiary: String,
+        nonce: u64,
+        auth: MainTokenSubmitAuthRequest,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(super) struct ChainMainTokenSubmitResponse {
+    pub(super) ok: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) action_id: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) submitted_at_unix_ms: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) error_code: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) error: Option<String>,
+}
+
+impl ChainMainTokenSubmitResponse {
+    fn success(action_id: u64, submitted_at_unix_ms: i64) -> Self {
+        Self {
+            ok: true,
+            action_id: Some(action_id),
+            submitted_at_unix_ms: Some(submitted_at_unix_ms),
+            error_code: None,
+            error: None,
+        }
+    }
+
+    fn error(error_code: impl Into<String>, message: impl Into<String>) -> Self {
+        Self {
+            ok: false,
+            action_id: None,
+            submitted_at_unix_ms: None,
+            error_code: Some(error_code.into()),
+            error: Some(message.into()),
+        }
+    }
+}
+
+pub(super) fn maybe_handle_main_token_submit_request(
+    stream: &mut TcpStream,
+    request_bytes: &[u8],
+    runtime: &Arc<Mutex<NodeRuntime>>,
+    method: &str,
+    path: &str,
+) -> Result<bool, String> {
+    if path != MAIN_TOKEN_SUBMIT_PATH {
+        return Ok(false);
+    }
+    if !method.eq_ignore_ascii_case("POST") {
+        write_main_token_submit_error(
+            stream,
+            405,
+            MAIN_TOKEN_ERROR_INVALID_REQUEST,
+            format!("method {method} is not allowed for {MAIN_TOKEN_SUBMIT_PATH}").as_str(),
+        )?;
+        return Ok(true);
+    }
+    handle_main_token_submit(stream, request_bytes, runtime)?;
+    Ok(true)
+}
+
+fn handle_main_token_submit(
+    stream: &mut TcpStream,
+    request_bytes: &[u8],
+    runtime: &Arc<Mutex<NodeRuntime>>,
+) -> Result<(), String> {
+    let body = match super::feedback_submit_api::extract_http_json_body(request_bytes) {
+        Ok(body) => body,
+        Err(err) => {
+            write_main_token_submit_error(
+                stream,
+                400,
+                MAIN_TOKEN_ERROR_INVALID_REQUEST,
+                err.as_str(),
+            )?;
+            return Ok(());
+        }
+    };
+    let submit_request = match parse_main_token_submit_request(body) {
+        Ok(request) => request,
+        Err(err) => {
+            write_main_token_submit_error(
+                stream,
+                400,
+                MAIN_TOKEN_ERROR_INVALID_REQUEST,
+                err.as_str(),
+            )?;
+            return Ok(());
+        }
+    };
+    let action = build_main_token_submit_action(&submit_request);
+    let auth = build_main_token_submit_auth(&submit_request);
+    if let Err((code, message)) = verify_main_token_submit_request_auth(&action, &auth) {
+        write_main_token_submit_error(stream, 400, code.as_str(), message.as_str())?;
+        return Ok(());
+    }
+
+    let action_id = match next_main_token_action_id() {
+        Ok(action_id) => action_id,
+        Err(err) => {
+            write_main_token_submit_error(stream, 502, MAIN_TOKEN_ERROR_INTERNAL, err.as_str())?;
+            return Ok(());
+        }
+    };
+    let payload = match build_main_token_submit_action_payload(action, auth) {
+        Ok(payload) => payload,
+        Err(err) => {
+            write_main_token_submit_error(stream, 502, MAIN_TOKEN_ERROR_INTERNAL, err.as_str())?;
+            return Ok(());
+        }
+    };
+    if let Err(err) = runtime
+        .lock()
+        .map_err(|_| "failed to lock node runtime for main token submit".to_string())?
+        .submit_consensus_action_payload(action_id, payload)
+    {
+        write_main_token_submit_error(
+            stream,
+            502,
+            MAIN_TOKEN_ERROR_SUBMIT_FAILED,
+            format!("main token submit failed: {err}").as_str(),
+        )?;
+        return Ok(());
+    }
+
+    let response = ChainMainTokenSubmitResponse::success(action_id, super::now_unix_ms());
+    write_main_token_submit_json_response(stream, 200, &response)
+}
+
+fn parse_main_token_submit_request(body: &[u8]) -> Result<MainTokenSubmitRequest, String> {
+    let mut request = serde_json::from_slice::<MainTokenSubmitRequest>(body)
+        .map_err(|err| format!("invalid main token submit request: {err}"))?;
+    match &mut request {
+        MainTokenSubmitRequest::InitializeMainTokenGenesis { allocations, auth } => {
+            if allocations.is_empty() {
+                return Err(
+                    "main token initialize_main_token_genesis allocations cannot be empty"
+                        .to_string(),
+                );
+            }
+            normalize_auth_request(auth)?;
+            for allocation in allocations {
+                allocation.bucket_id = normalize_required_field(
+                    allocation.bucket_id.as_str(),
+                    "main token genesis bucket_id",
+                )?;
+                allocation.recipient = normalize_required_field(
+                    allocation.recipient.as_str(),
+                    "main token genesis recipient",
+                )?;
+            }
+        }
+        MainTokenSubmitRequest::ClaimMainTokenVesting {
+            bucket_id,
+            beneficiary,
+            nonce,
+            auth,
+        } => {
+            *bucket_id =
+                normalize_required_field(bucket_id.as_str(), "main token claim bucket_id")?;
+            *beneficiary =
+                normalize_required_field(beneficiary.as_str(), "main token claim beneficiary")?;
+            if *nonce == 0 {
+                return Err("main token claim nonce must be > 0".to_string());
+            }
+            normalize_auth_request(auth)?;
+        }
+    }
+    Ok(request)
+}
+
+fn normalize_auth_request(auth: &mut MainTokenSubmitAuthRequest) -> Result<(), String> {
+    auth.account_id =
+        normalize_required_field(auth.account_id.as_str(), "main token auth account_id")?;
+    auth.public_key = auth
+        .public_key
+        .as_deref()
+        .map(|value| normalize_optional_field(value, "main token auth public_key"))
+        .transpose()?;
+    auth.signature = auth
+        .signature
+        .as_deref()
+        .map(|value| normalize_optional_field(value, "main token auth signature"))
+        .transpose()?;
+    for participant in &mut auth.participant_signatures {
+        participant.public_key = normalize_required_field(
+            participant.public_key.as_str(),
+            "main token auth participant public_key",
+        )?;
+        participant.signature = normalize_required_field(
+            participant.signature.as_str(),
+            "main token auth participant signature",
+        )?;
+    }
+    Ok(())
+}
+
+fn build_main_token_submit_action(request: &MainTokenSubmitRequest) -> Action {
+    match request {
+        MainTokenSubmitRequest::InitializeMainTokenGenesis { allocations, .. } => {
+            Action::InitializeMainTokenGenesis {
+                allocations: allocations.clone(),
+            }
+        }
+        MainTokenSubmitRequest::ClaimMainTokenVesting {
+            bucket_id,
+            beneficiary,
+            nonce,
+            ..
+        } => Action::ClaimMainTokenVesting {
+            bucket_id: bucket_id.clone(),
+            beneficiary: beneficiary.clone(),
+            nonce: *nonce,
+        },
+    }
+}
+
+fn build_main_token_submit_auth(request: &MainTokenSubmitRequest) -> MainTokenActionAuthProof {
+    let auth = match request {
+        MainTokenSubmitRequest::InitializeMainTokenGenesis { auth, .. }
+        | MainTokenSubmitRequest::ClaimMainTokenVesting { auth, .. } => auth,
+    };
+    MainTokenActionAuthProof {
+        scheme: auth.scheme,
+        account_id: auth.account_id.clone(),
+        public_key: auth.public_key.clone(),
+        signature: auth.signature.clone(),
+        threshold: auth.threshold,
+        participant_signatures: auth.participant_signatures.clone(),
+    }
+}
+
+fn verify_main_token_submit_request_auth(
+    action: &Action,
+    proof: &MainTokenActionAuthProof,
+) -> Result<(), (String, String)> {
+    verify_main_token_runtime_action_auth(action, proof)
+        .map(|_| ())
+        .map_err(map_main_token_auth_error)
+}
+
+fn map_main_token_auth_error(error: MainTokenActionAuthError) -> (String, String) {
+    match error {
+        MainTokenActionAuthError::InvalidSignature(message) => {
+            (MAIN_TOKEN_ERROR_INVALID_SIGNATURE.to_string(), message)
+        }
+        MainTokenActionAuthError::AccountMismatch(message) => {
+            (MAIN_TOKEN_ERROR_ACCOUNT_AUTH_MISMATCH.to_string(), message)
+        }
+        MainTokenActionAuthError::InvalidRequest(message)
+        | MainTokenActionAuthError::UnsupportedAction(message) => {
+            (MAIN_TOKEN_ERROR_INVALID_REQUEST.to_string(), message)
+        }
+    }
+}
+
+fn build_main_token_submit_action_payload(
+    action: Action,
+    proof: MainTokenActionAuthProof,
+) -> Result<Vec<u8>, String> {
+    let envelope = ConsensusActionPayloadEnvelope::from_runtime_action_with_auth(
+        action,
+        ConsensusActionAuthEnvelope::MainTokenAction(proof),
+    );
+    encode_consensus_action_payload(&envelope)
+}
+
+fn next_main_token_action_id() -> Result<u64, String> {
+    let action_id = NEXT_MAIN_TOKEN_ACTION_ID.fetch_add(1, Ordering::Relaxed);
+    if action_id == 0 {
+        return Err("main token action id allocator exhausted".to_string());
+    }
+    Ok(action_id)
+}
+
+fn normalize_required_field(raw: &str, label: &str) -> Result<String, String> {
+    let value = raw.trim();
+    if value.is_empty() {
+        return Err(format!("{label} is empty"));
+    }
+    Ok(value.to_string())
+}
+
+fn normalize_optional_field(raw: &str, label: &str) -> Result<String, String> {
+    normalize_required_field(raw, label)
+}
+
+fn write_main_token_submit_error(
+    stream: &mut TcpStream,
+    status_code: u16,
+    error_code: &str,
+    error: &str,
+) -> Result<(), String> {
+    let payload = ChainMainTokenSubmitResponse::error(error_code, error);
+    write_main_token_submit_json_response(stream, status_code, &payload)
+}
+
+fn write_main_token_submit_json_response(
+    stream: &mut TcpStream,
+    status_code: u16,
+    payload: &ChainMainTokenSubmitResponse,
+) -> Result<(), String> {
+    let body = serde_json::to_vec_pretty(payload)
+        .map_err(|err| format!("failed to encode main token submit response: {err}"))?;
+    super::write_json_response(stream, status_code, body.as_slice(), false)
+        .map_err(|err| format!("failed to write main token submit response: {err}"))
+}
+
+#[cfg(test)]
+#[path = "main_token_submit_api_tests.rs"]
+mod tests;

--- a/crates/oasis7/src/bin/oasis7_chain_runtime/main_token_submit_api_tests.rs
+++ b/crates/oasis7/src/bin/oasis7_chain_runtime/main_token_submit_api_tests.rs
@@ -1,0 +1,251 @@
+use super::{maybe_handle_main_token_submit_request, ChainMainTokenSubmitResponse};
+use ed25519_dalek::SigningKey;
+use oasis7::consensus_action_payload::{
+    sign_main_token_runtime_action_auth, sign_threshold_main_token_runtime_action_auth,
+};
+use oasis7::runtime::{main_token_account_id_from_node_public_key, Action};
+use oasis7_node::{NodeConfig, NodeRole, NodeRuntime};
+use std::io::Read;
+use std::net::{TcpListener, TcpStream};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+fn tcp_stream_pair() -> (TcpStream, TcpStream) {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind loopback listener");
+    let bind = listener.local_addr().expect("read local addr");
+    let client = TcpStream::connect(bind).expect("connect loopback client");
+    let (server, _) = listener.accept().expect("accept loopback connection");
+    (server, client)
+}
+
+fn decode_http_json_response<T: serde::de::DeserializeOwned>(bytes: &[u8]) -> (u16, T) {
+    let boundary = bytes
+        .windows(4)
+        .position(|window| window == b"\r\n\r\n")
+        .expect("response must include HTTP body separator");
+    let header = std::str::from_utf8(&bytes[..boundary]).expect("response header utf-8");
+    let status = header
+        .split_whitespace()
+        .nth(1)
+        .and_then(|token| token.parse::<u16>().ok())
+        .expect("response status code");
+    let payload =
+        serde_json::from_slice::<T>(&bytes[(boundary + 4)..]).expect("response json payload");
+    (status, payload)
+}
+
+fn test_signer(seed: u8) -> (String, String) {
+    let private_key = [seed; 32];
+    let signing_key = SigningKey::from_bytes(&private_key);
+    (
+        hex::encode(signing_key.verifying_key().to_bytes()),
+        hex::encode(private_key),
+    )
+}
+
+#[test]
+fn claim_main_token_submit_handler_accepts_signed_request() {
+    let runtime = Arc::new(Mutex::new(NodeRuntime::new(
+        NodeConfig::new(
+            "node-main-token-claim",
+            "world-main-token-claim",
+            NodeRole::Sequencer,
+        )
+        .expect("node config"),
+    )));
+    let (public_key, private_key) = test_signer(31);
+    let beneficiary = main_token_account_id_from_node_public_key(public_key.as_str());
+    let action = Action::ClaimMainTokenVesting {
+        bucket_id: "public_testnet_faucet_genesis".to_string(),
+        beneficiary: beneficiary.clone(),
+        nonce: 1,
+    };
+    let proof = sign_main_token_runtime_action_auth(
+        &action,
+        beneficiary.as_str(),
+        public_key.as_str(),
+        private_key.as_str(),
+    )
+    .expect("sign claim action");
+    let body = serde_json::json!({
+        "action": "claim_main_token_vesting",
+        "bucket_id": "public_testnet_faucet_genesis",
+        "beneficiary": beneficiary,
+        "nonce": 1,
+        "auth": proof,
+    })
+    .to_string();
+
+    let (mut server_stream, mut client_stream) = tcp_stream_pair();
+    let request = format!(
+        "POST /v1/chain/main-token/submit HTTP/1.1\r\nHost: 127.0.0.1:5121\r\nContent-Length: {}\r\n\r\n{}",
+        body.len(),
+        body
+    );
+    let handled = maybe_handle_main_token_submit_request(
+        &mut server_stream,
+        request.as_bytes(),
+        &runtime,
+        "POST",
+        "/v1/chain/main-token/submit",
+    )
+    .expect("handler should process request");
+    assert!(handled);
+    drop(server_stream);
+
+    client_stream
+        .set_read_timeout(Some(Duration::from_secs(2)))
+        .expect("set client timeout");
+    let mut response_bytes = Vec::new();
+    client_stream
+        .read_to_end(&mut response_bytes)
+        .expect("read handler response");
+    let (status, response): (u16, ChainMainTokenSubmitResponse) =
+        decode_http_json_response(&response_bytes);
+    assert_eq!(status, 200);
+    assert!(response.ok);
+    assert!(response.action_id.is_some());
+}
+
+#[test]
+fn initialize_main_token_genesis_submit_handler_accepts_threshold_request() {
+    let (public_key_a, private_key_a) = test_signer(41);
+    let (public_key_b, private_key_b) = test_signer(42);
+    let faucet_account = main_token_account_id_from_node_public_key(public_key_a.as_str());
+    let runtime = Arc::new(Mutex::new(NodeRuntime::new(
+        NodeConfig::new(
+            "node-main-token-genesis",
+            "world-main-token-genesis",
+            NodeRole::Sequencer,
+        )
+        .expect("node config")
+        .with_main_token_controller_binding(
+            oasis7_node::NodeMainTokenControllerBindingConfig::default()
+                .with_controller_signer_policy(
+                    "msig.genesis.v1",
+                    2,
+                    vec![public_key_a.clone(), public_key_b.clone()],
+                )
+                .expect("controller signer policy"),
+        )
+        .expect("controller binding"),
+    )));
+    let action = Action::InitializeMainTokenGenesis {
+        allocations: vec![oasis7::runtime::MainTokenGenesisAllocationPlan {
+            bucket_id: "public_testnet_faucet_genesis".to_string(),
+            ratio_bps: 10_000,
+            recipient: faucet_account.clone(),
+            cliff_epochs: 0,
+            linear_unlock_epochs: 0,
+            start_epoch: 0,
+        }],
+    };
+    let proof = sign_threshold_main_token_runtime_action_auth(
+        &action,
+        "msig.genesis.v1",
+        2,
+        &[
+            (public_key_a.as_str(), private_key_a.as_str()),
+            (public_key_b.as_str(), private_key_b.as_str()),
+        ],
+    )
+    .expect("sign threshold genesis action");
+    let body = serde_json::json!({
+        "action": "initialize_main_token_genesis",
+        "allocations": [{
+            "bucket_id": "public_testnet_faucet_genesis",
+            "ratio_bps": 10000,
+            "recipient": faucet_account,
+            "cliff_epochs": 0,
+            "linear_unlock_epochs": 0,
+            "start_epoch": 0
+        }],
+        "auth": proof,
+    })
+    .to_string();
+
+    let (mut server_stream, mut client_stream) = tcp_stream_pair();
+    let request = format!(
+        "POST /v1/chain/main-token/submit HTTP/1.1\r\nHost: 127.0.0.1:5121\r\nContent-Length: {}\r\n\r\n{}",
+        body.len(),
+        body
+    );
+    let handled = maybe_handle_main_token_submit_request(
+        &mut server_stream,
+        request.as_bytes(),
+        &runtime,
+        "POST",
+        "/v1/chain/main-token/submit",
+    )
+    .expect("handler should process request");
+    assert!(handled);
+    drop(server_stream);
+
+    client_stream
+        .set_read_timeout(Some(Duration::from_secs(2)))
+        .expect("set client timeout");
+    let mut response_bytes = Vec::new();
+    client_stream
+        .read_to_end(&mut response_bytes)
+        .expect("read handler response");
+    let (status, response): (u16, ChainMainTokenSubmitResponse) =
+        decode_http_json_response(&response_bytes);
+    assert_eq!(status, 200, "{response:?}");
+    assert!(response.ok, "{response:?}");
+}
+
+#[test]
+fn main_token_submit_handler_rejects_invalid_signature() {
+    let runtime = Arc::new(Mutex::new(NodeRuntime::new(
+        NodeConfig::new(
+            "node-main-token-invalid-signature",
+            "world-main-token-invalid-signature",
+            NodeRole::Sequencer,
+        )
+        .expect("node config"),
+    )));
+    let (public_key, _) = test_signer(51);
+    let beneficiary = main_token_account_id_from_node_public_key(public_key.as_str());
+    let body = serde_json::json!({
+        "action": "claim_main_token_vesting",
+        "bucket_id": "public_testnet_faucet_genesis",
+        "beneficiary": beneficiary,
+        "nonce": 1,
+        "auth": {
+            "scheme": "ed25519",
+            "account_id": beneficiary,
+            "public_key": public_key,
+            "signature": format!("occlaimauth:v1:{}", "f".repeat(128)),
+        },
+    })
+    .to_string();
+
+    let (mut server_stream, mut client_stream) = tcp_stream_pair();
+    let request = format!(
+        "POST /v1/chain/main-token/submit HTTP/1.1\r\nHost: 127.0.0.1:5121\r\nContent-Length: {}\r\n\r\n{}",
+        body.len(),
+        body
+    );
+    maybe_handle_main_token_submit_request(
+        &mut server_stream,
+        request.as_bytes(),
+        &runtime,
+        "POST",
+        "/v1/chain/main-token/submit",
+    )
+    .expect("handler should process request");
+    drop(server_stream);
+
+    client_stream
+        .set_read_timeout(Some(Duration::from_secs(2)))
+        .expect("set client timeout");
+    let mut response_bytes = Vec::new();
+    client_stream
+        .read_to_end(&mut response_bytes)
+        .expect("read handler response");
+    let (status, response): (u16, ChainMainTokenSubmitResponse) =
+        decode_http_json_response(&response_bytes);
+    assert_eq!(status, 400);
+    assert!(!response.ok);
+    assert_eq!(response.error_code.as_deref(), Some("invalid_signature"));
+}

--- a/crates/oasis7/src/bin/oasis7_chain_runtime/status_server_support.rs
+++ b/crates/oasis7/src/bin/oasis7_chain_runtime/status_server_support.rs
@@ -259,6 +259,16 @@ fn handle_chain_status_connection(
         return Ok(());
     }
 
+    if main_token_submit_api::maybe_handle_main_token_submit_request(
+        &mut stream,
+        &buffer[..bytes],
+        &runtime,
+        method,
+        path,
+    )? {
+        return Ok(());
+    }
+
     if method.eq_ignore_ascii_case("POST") && path == "/v1/chain/feedback/submit" {
         let body = match extract_http_json_body(&buffer[..bytes]) {
             Ok(body) => body,

--- a/crates/oasis7/src/bin/oasis7_governance_registry_import.rs
+++ b/crates/oasis7/src/bin/oasis7_governance_registry_import.rs
@@ -5,11 +5,12 @@ use std::process;
 
 use oasis7::runtime::{
     GovernanceFinalitySignerRegistry, GovernanceMainTokenControllerRegistry,
-    GovernanceThresholdSignerPolicy, ReleaseSecurityPolicy, World,
+    GovernanceThresholdSignerPolicy, ReleaseSecurityPolicy, World, WorldState,
     MAIN_TOKEN_TREASURY_BUCKET_ECOSYSTEM_POOL, MAIN_TOKEN_TREASURY_BUCKET_SECURITY_RESERVE,
     MAIN_TOKEN_TREASURY_BUCKET_STAKING_REWARD,
 };
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 
 const DEFAULT_FINALITY_SLOT_ID: &str = "governance.finality.v1";
 const DEFAULT_GENESIS_CONTROLLER_ACCOUNT_ID: &str = "msig.genesis.v1";
@@ -43,6 +44,13 @@ struct ManifestSlotThresholds {
     thresholds: BTreeMap<String, u16>,
 }
 
+#[derive(Debug, Serialize)]
+struct StateRootProjection<'a> {
+    state: &'a WorldState,
+    manifest_hash: &'a str,
+    policy_hash: &'a str,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 struct ImportSummary {
     world_dir: String,
@@ -50,6 +58,8 @@ struct ImportSummary {
     imported_finality_slot_id: String,
     finality_signer_count: usize,
     controller_policy_count: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    reconciled_latest_tick: Option<u64>,
 }
 
 fn main() {
@@ -114,6 +124,7 @@ fn run_import(options: CliOptions) -> Result<ImportSummary, String> {
     world
         .set_governance_main_token_controller_registry(controller_registry.clone())
         .map_err(|err| format!("write controller registry failed: {err:?}"))?;
+    let (world, reconciled_latest_tick) = reconcile_latest_tick_consensus_state_root(world)?;
     world
         .save_to_dir(options.world_dir.as_path())
         .map_err(|err| format!("save world {} failed: {err:?}", options.world_dir.display()))?;
@@ -123,7 +134,40 @@ fn run_import(options: CliOptions) -> Result<ImportSummary, String> {
         imported_finality_slot_id: finality_registry.slot_id,
         finality_signer_count: finality_registry.signer_bindings.len(),
         controller_policy_count: controller_registry.controller_signer_policies.len(),
+        reconciled_latest_tick,
     })
+}
+
+fn reconcile_latest_tick_consensus_state_root(
+    world: World,
+) -> Result<(World, Option<u64>), String> {
+    let manifest_hash = world
+        .current_manifest_hash()
+        .map_err(|err| format!("compute current manifest hash failed: {err:?}"))?;
+    let policy_hash = hash_json(&world.policies())
+        .map_err(|err| format!("compute current policy hash failed: {err:?}"))?;
+    let state_root = hash_json(&StateRootProjection {
+        state: world.state(),
+        manifest_hash: manifest_hash.as_str(),
+        policy_hash: policy_hash.as_str(),
+    })
+    .map_err(|err| format!("compute current state root failed: {err:?}"))?;
+    let mut snapshot = world.snapshot();
+    let Some(record) = snapshot.tick_consensus_records.last_mut() else {
+        return Ok((world, None));
+    };
+    if record.block.header.state_root == state_root
+        && record.block.execution_digest.state_projection_hash == state_root
+    {
+        return Ok((world, None));
+    }
+    let reconciled_tick = record.block.header.tick;
+    record.block.header.state_root = state_root.clone();
+    record.block.execution_digest.state_projection_hash = state_root;
+    record.certificate.block_hash = record.block.block_hash();
+    let reconciled = World::from_snapshot(snapshot, world.journal().clone())
+        .map_err(|err| format!("rebuild world after state-root reconciliation failed: {err:?}"))?;
+    Ok((reconciled, Some(reconciled_tick)))
 }
 
 fn load_or_create_world(world_dir: &Path) -> Result<World, String> {
@@ -289,6 +333,13 @@ fn validate_manifest_entry(entry: &PublicManifestEntry) -> Result<(), String> {
         ));
     }
     Ok(())
+}
+
+fn hash_json<T: Serialize>(value: &T) -> Result<String, serde_json::Error> {
+    let bytes = serde_json::to_vec(value)?;
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    Ok(hex::encode(hasher.finalize()))
 }
 
 fn parse_options<'a>(args: impl Iterator<Item = &'a str>) -> Result<CliOptions, String> {
@@ -645,6 +696,105 @@ mod tests {
         })
         .expect_err("manifest threshold mismatch must fail");
         assert!(err.contains("manifest slot threshold mismatch"), "{err}");
+    }
+
+    #[test]
+    fn import_reconciles_latest_tick_consensus_state_root_for_existing_world() {
+        let temp_dir = temp_dir("reconcile-existing-world");
+        std::fs::create_dir_all(&temp_dir).expect("create temp dir");
+        let manifest_path = temp_dir.join("public_manifest.json");
+        std::fs::write(
+            manifest_path.as_path(),
+            serde_json::to_vec_pretty(&vec![
+                serde_json::json!({
+                    "slot_id": "governance.finality.v1",
+                    "signer_id": "signer01",
+                    "scheme": "ed25519",
+                    "public_key_hex": "54e7a02919fff2d49a9c325def8cb0211ea7f7a75a9011b9d0678b9e2a7af6bc"
+                }),
+                serde_json::json!({
+                    "slot_id": "governance.finality.v1",
+                    "signer_id": "signer02",
+                    "scheme": "ed25519",
+                    "public_key_hex": "38dac17ff403cc19de033e47be7cf7b5354635fbc5c1976d7c532e20494aace4"
+                }),
+                serde_json::json!({
+                    "slot_id": "governance.finality.v1",
+                    "signer_id": "signer03",
+                    "scheme": "ed25519",
+                    "public_key_hex": "e22bd5029176296712fb1a477f91c15775e5ab858181cb4172839ced526f12c8"
+                }),
+                serde_json::json!({
+                    "slot_id": "msig.genesis.v1",
+                    "signer_id": "signer01",
+                    "scheme": "ed25519",
+                    "public_key_hex": "6249e5a58278dbc4e629a16b5d33f6b84c39e3ceeb10e963bb9ef64ea4daac30"
+                }),
+                serde_json::json!({
+                    "slot_id": "msig.genesis.v1",
+                    "signer_id": "signer02",
+                    "scheme": "ed25519",
+                    "public_key_hex": "7014e88a6336ec91fc7e6ffb044b50232e4411ec403f90123fa8a202a3420a04"
+                }),
+                serde_json::json!({
+                    "slot_id": "msig.staking_governance.v1",
+                    "signer_id": "signer01",
+                    "scheme": "ed25519",
+                    "public_key_hex": "13c160fc0f516b9a5663aa00c2a5446be6467f68ce341fdd79cdb64224dffd20"
+                }),
+                serde_json::json!({
+                    "slot_id": "msig.staking_governance.v1",
+                    "signer_id": "signer02",
+                    "scheme": "ed25519",
+                    "public_key_hex": "10fa4d90abf753ec1aa54aee3ea53bab25f43e7078897e1fb6a3777af2255bcb"
+                }),
+                serde_json::json!({
+                    "slot_id": "msig.ecosystem_governance.v1",
+                    "signer_id": "signer01",
+                    "scheme": "ed25519",
+                    "public_key_hex": "0241f2e23305407676f2a5cec6d154da74944b2a366b2b2b6913cb746d402d0e"
+                }),
+                serde_json::json!({
+                    "slot_id": "msig.ecosystem_governance.v1",
+                    "signer_id": "signer02",
+                    "scheme": "ed25519",
+                    "public_key_hex": "960137cd5d675a517daed5f14ea6bea460e196fda4310a581ecd448f3bcd20b4"
+                }),
+                serde_json::json!({
+                    "slot_id": "msig.security_council.v1",
+                    "signer_id": "signer01",
+                    "scheme": "ed25519",
+                    "public_key_hex": "d09de9413371ae42f643e4f8f31e2139611d1617809375b1ad884df3fb089448"
+                }),
+                serde_json::json!({
+                    "slot_id": "msig.security_council.v1",
+                    "signer_id": "signer02",
+                    "scheme": "ed25519",
+                    "public_key_hex": "aa738a832b0d3bf371d231a0bd8502fd411f2a9723246e5d7d215e8fb0ecbb7c"
+                })
+            ])
+            .expect("encode manifest"),
+        )
+        .expect("write manifest");
+
+        let world_dir = temp_dir.join("world");
+        let mut world = World::new_production_hardened();
+        world.step().expect("step 1");
+        world.step().expect("step 2");
+        world.save_to_dir(world_dir.as_path()).expect("seed world");
+
+        let summary = run_import(super::CliOptions {
+            world_dir: world_dir.clone(),
+            public_manifest: manifest_path,
+            finality_slot_id: "governance.finality.v1".to_string(),
+            default_threshold: 2,
+        })
+        .expect("run import");
+        assert!(summary.reconciled_latest_tick.is_some());
+
+        let loaded = World::load_from_dir(world_dir).expect("load reconciled world");
+        assert!(loaded.governance_finality_signer_registry().is_some());
+        assert!(loaded.governance_main_token_controller_registry().is_some());
     }
 
     #[test]

--- a/crates/oasis7/src/bin/oasis7_testnet_faucet.rs
+++ b/crates/oasis7/src/bin/oasis7_testnet_faucet.rs
@@ -1,0 +1,988 @@
+use std::collections::HashMap;
+use std::env;
+use std::io::{Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::process;
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use oasis7::consensus_action_payload::{
+    sign_main_token_runtime_action_auth, sign_threshold_main_token_runtime_action_auth,
+};
+use oasis7::runtime::{
+    main_token_account_id_from_node_public_key, Action, MainTokenGenesisAllocationPlan,
+};
+use reqwest::blocking::Client;
+use serde::{Deserialize, Serialize};
+
+const DEFAULT_CLAIM_PATH: &str = "/claim";
+const DEFAULT_INFO_PATH: &str = "/";
+const DEFAULT_HEALTH_PATH: &str = "/healthz";
+const DEFAULT_REQUEST_TIMEOUT_SECS: u64 = 10;
+const DEFAULT_COOLDOWN_SECS: u64 = 24 * 60 * 60;
+
+#[derive(Debug, Clone)]
+enum Command {
+    Serve(ServeOptions),
+    SubmitGenesis(SubmitGenesisOptions),
+    ClaimVesting(ClaimVestingOptions),
+}
+
+#[derive(Debug, Clone)]
+struct ServeOptions {
+    listen: String,
+    upstream: String,
+    faucet_public_key: String,
+    faucet_private_key: String,
+    amount: u64,
+    cooldown_secs: u64,
+    request_timeout_secs: u64,
+}
+
+#[derive(Debug, Clone)]
+struct SubmitGenesisOptions {
+    upstream: String,
+    controller_account_id: String,
+    signers: Vec<SignerKeypair>,
+    threshold: u16,
+    bucket_id: String,
+    recipient: String,
+    ratio_bps: u32,
+    cliff_epochs: u64,
+    linear_unlock_epochs: u64,
+    start_epoch: u64,
+    request_timeout_secs: u64,
+}
+
+#[derive(Debug, Clone)]
+struct ClaimVestingOptions {
+    upstream: String,
+    bucket_id: String,
+    beneficiary: String,
+    nonce: u64,
+    public_key: String,
+    private_key: String,
+    request_timeout_secs: u64,
+}
+
+#[derive(Debug, Clone)]
+struct SignerKeypair {
+    public_key: String,
+    private_key: String,
+}
+
+#[derive(Debug, Clone)]
+struct FaucetService {
+    options: ServeOptions,
+    faucet_account_id: String,
+    client: Client,
+    state: Arc<Mutex<FaucetState>>,
+}
+
+#[derive(Debug, Default)]
+struct FaucetState {
+    next_nonce: Option<u64>,
+    last_account_claim_unix_ms: HashMap<String, i64>,
+    last_ip_claim_unix_ms: HashMap<String, i64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+struct ChainTransferSubmitRequest {
+    from_account_id: String,
+    to_account_id: String,
+    amount: u64,
+    nonce: u64,
+    public_key: String,
+    signature: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+struct ChainTransferSubmitResponse {
+    ok: bool,
+    #[serde(default)]
+    action_id: Option<u64>,
+    #[serde(default)]
+    submitted_at_unix_ms: Option<i64>,
+    #[serde(default)]
+    error_code: Option<String>,
+    #[serde(default)]
+    error: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+struct ChainMainTokenSubmitResponse {
+    ok: bool,
+    #[serde(default)]
+    action_id: Option<u64>,
+    #[serde(default)]
+    submitted_at_unix_ms: Option<i64>,
+    #[serde(default)]
+    error_code: Option<String>,
+    #[serde(default)]
+    error: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+struct ChainTransferAccountEntry {
+    account_id: String,
+    liquid_balance: u64,
+    vested_balance: u64,
+    restricted_starter_claim_balance: u64,
+    #[serde(default)]
+    last_transfer_nonce: Option<u64>,
+    next_nonce_hint: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+struct ChainTransferAccountsResponse {
+    ok: bool,
+    #[serde(default)]
+    accounts: Vec<ChainTransferAccountEntry>,
+    #[serde(default)]
+    error_code: Option<String>,
+    #[serde(default)]
+    error: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+struct FaucetClaimRequest {
+    account_id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct FaucetClaimResponse {
+    ok: bool,
+    faucet_account_id: String,
+    amount: u64,
+    cooldown_secs: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    action_id: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    submitted_at_unix_ms: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error_code: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct FaucetInfoResponse {
+    ok: bool,
+    faucet_account_id: String,
+    amount: u64,
+    cooldown_secs: u64,
+    claim_path: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct HealthResponse {
+    ok: bool,
+    observed_at_unix_ms: i64,
+}
+
+fn main() {
+    let command = match parse_args(env::args().skip(1).collect()) {
+        Ok(command) => command,
+        Err(err) => {
+            eprintln!("{err}");
+            print_help();
+            process::exit(1);
+        }
+    };
+
+    let result = match command {
+        Command::Serve(options) => run_serve(options),
+        Command::SubmitGenesis(options) => run_submit_genesis(options),
+        Command::ClaimVesting(options) => run_claim_vesting(options),
+    };
+    if let Err(err) = result {
+        eprintln!("oasis7_testnet_faucet failed: {err}");
+        process::exit(1);
+    }
+}
+
+fn parse_args(args: Vec<String>) -> Result<Command, String> {
+    let Some(subcommand) = args.first().map(String::as_str) else {
+        return Err("subcommand is required".to_string());
+    };
+    match subcommand {
+        "serve" => parse_serve_args(&args[1..]).map(Command::Serve),
+        "submit-genesis" => parse_submit_genesis_args(&args[1..]).map(Command::SubmitGenesis),
+        "claim-vesting" => parse_claim_vesting_args(&args[1..]).map(Command::ClaimVesting),
+        "--help" | "-h" | "help" => {
+            print_help();
+            process::exit(0);
+        }
+        other => Err(format!("unknown subcommand `{other}`")),
+    }
+}
+
+fn parse_serve_args(args: &[String]) -> Result<ServeOptions, String> {
+    let mut listen = None;
+    let mut upstream = None;
+    let mut faucet_public_key = None;
+    let mut faucet_private_key = None;
+    let mut amount = None;
+    let mut cooldown_secs = DEFAULT_COOLDOWN_SECS;
+    let mut request_timeout_secs = DEFAULT_REQUEST_TIMEOUT_SECS;
+    let mut index = 0_usize;
+    while index < args.len() {
+        match args[index].as_str() {
+            "--listen" => {
+                listen = Some(parse_required_value(args, &mut index, "--listen")?);
+            }
+            "--upstream" => {
+                upstream = Some(parse_required_value(args, &mut index, "--upstream")?);
+            }
+            "--faucet-public-key" => {
+                faucet_public_key = Some(parse_required_value(
+                    args,
+                    &mut index,
+                    "--faucet-public-key",
+                )?);
+            }
+            "--faucet-public-key-file" => {
+                let path = parse_required_value(args, &mut index, "--faucet-public-key-file")?;
+                faucet_public_key = Some(read_trimmed_file(path.as_str())?);
+            }
+            "--faucet-private-key" => {
+                faucet_private_key = Some(parse_required_value(
+                    args,
+                    &mut index,
+                    "--faucet-private-key",
+                )?);
+            }
+            "--faucet-private-key-file" => {
+                let path = parse_required_value(args, &mut index, "--faucet-private-key-file")?;
+                faucet_private_key = Some(read_trimmed_file(path.as_str())?);
+            }
+            "--amount" => {
+                amount = Some(parse_u64(
+                    parse_required_value(args, &mut index, "--amount")?.as_str(),
+                    "--amount",
+                )?);
+            }
+            "--cooldown-secs" => {
+                cooldown_secs = parse_u64(
+                    parse_required_value(args, &mut index, "--cooldown-secs")?.as_str(),
+                    "--cooldown-secs",
+                )?;
+            }
+            "--request-timeout-secs" => {
+                request_timeout_secs = parse_u64(
+                    parse_required_value(args, &mut index, "--request-timeout-secs")?.as_str(),
+                    "--request-timeout-secs",
+                )?;
+            }
+            other => return Err(format!("unknown serve argument `{other}`")),
+        }
+        index += 1;
+    }
+    Ok(ServeOptions {
+        listen: normalize_required(listen, "--listen")?,
+        upstream: normalize_required(upstream, "--upstream")?,
+        faucet_public_key: normalize_required(faucet_public_key, "--faucet-public-key")?,
+        faucet_private_key: normalize_required(faucet_private_key, "--faucet-private-key")?,
+        amount: amount.ok_or_else(|| "--amount is required".to_string())?,
+        cooldown_secs,
+        request_timeout_secs,
+    })
+}
+
+fn parse_submit_genesis_args(args: &[String]) -> Result<SubmitGenesisOptions, String> {
+    let mut upstream = None;
+    let mut controller_account_id = Some("msig.genesis.v1".to_string());
+    let mut signer_public_keys = Vec::new();
+    let mut signer_private_keys = Vec::new();
+    let mut threshold = None;
+    let mut bucket_id = None;
+    let mut recipient = None;
+    let mut ratio_bps = 10_000_u32;
+    let mut cliff_epochs = 0_u64;
+    let mut linear_unlock_epochs = 0_u64;
+    let mut start_epoch = 0_u64;
+    let mut request_timeout_secs = DEFAULT_REQUEST_TIMEOUT_SECS;
+    let mut index = 0_usize;
+    while index < args.len() {
+        match args[index].as_str() {
+            "--upstream" => upstream = Some(parse_required_value(args, &mut index, "--upstream")?),
+            "--controller-account-id" => {
+                controller_account_id = Some(parse_required_value(
+                    args,
+                    &mut index,
+                    "--controller-account-id",
+                )?);
+            }
+            "--signer-public-key" => {
+                signer_public_keys.push(parse_required_value(
+                    args,
+                    &mut index,
+                    "--signer-public-key",
+                )?);
+            }
+            "--signer-public-key-file" => {
+                let path = parse_required_value(args, &mut index, "--signer-public-key-file")?;
+                signer_public_keys.push(read_trimmed_file(path.as_str())?);
+            }
+            "--signer-private-key" => {
+                signer_private_keys.push(parse_required_value(
+                    args,
+                    &mut index,
+                    "--signer-private-key",
+                )?);
+            }
+            "--signer-private-key-file" => {
+                let path = parse_required_value(args, &mut index, "--signer-private-key-file")?;
+                signer_private_keys.push(read_trimmed_file(path.as_str())?);
+            }
+            "--threshold" => {
+                threshold = Some(parse_u16(
+                    parse_required_value(args, &mut index, "--threshold")?.as_str(),
+                    "--threshold",
+                )?);
+            }
+            "--bucket-id" => {
+                bucket_id = Some(parse_required_value(args, &mut index, "--bucket-id")?)
+            }
+            "--recipient" => {
+                recipient = Some(parse_required_value(args, &mut index, "--recipient")?)
+            }
+            "--ratio-bps" => {
+                ratio_bps = parse_u32(
+                    parse_required_value(args, &mut index, "--ratio-bps")?.as_str(),
+                    "--ratio-bps",
+                )?;
+            }
+            "--cliff-epochs" => {
+                cliff_epochs = parse_u64(
+                    parse_required_value(args, &mut index, "--cliff-epochs")?.as_str(),
+                    "--cliff-epochs",
+                )?;
+            }
+            "--linear-unlock-epochs" => {
+                linear_unlock_epochs = parse_u64(
+                    parse_required_value(args, &mut index, "--linear-unlock-epochs")?.as_str(),
+                    "--linear-unlock-epochs",
+                )?;
+            }
+            "--start-epoch" => {
+                start_epoch = parse_u64(
+                    parse_required_value(args, &mut index, "--start-epoch")?.as_str(),
+                    "--start-epoch",
+                )?;
+            }
+            "--request-timeout-secs" => {
+                request_timeout_secs = parse_u64(
+                    parse_required_value(args, &mut index, "--request-timeout-secs")?.as_str(),
+                    "--request-timeout-secs",
+                )?;
+            }
+            other => return Err(format!("unknown submit-genesis argument `{other}`")),
+        }
+        index += 1;
+    }
+    if signer_public_keys.len() != signer_private_keys.len() {
+        return Err("submit-genesis signer public/private key counts must match".to_string());
+    }
+    let signers = signer_public_keys
+        .into_iter()
+        .zip(signer_private_keys)
+        .map(|(public_key, private_key)| SignerKeypair {
+            public_key,
+            private_key,
+        })
+        .collect::<Vec<_>>();
+    if signers.is_empty() {
+        return Err("submit-genesis requires at least one signer".to_string());
+    }
+    Ok(SubmitGenesisOptions {
+        upstream: normalize_required(upstream, "--upstream")?,
+        controller_account_id: normalize_required(
+            controller_account_id,
+            "--controller-account-id",
+        )?,
+        threshold: threshold.ok_or_else(|| "--threshold is required".to_string())?,
+        signers,
+        bucket_id: normalize_required(bucket_id, "--bucket-id")?,
+        recipient: normalize_required(recipient, "--recipient")?,
+        ratio_bps,
+        cliff_epochs,
+        linear_unlock_epochs,
+        start_epoch,
+        request_timeout_secs,
+    })
+}
+
+fn parse_claim_vesting_args(args: &[String]) -> Result<ClaimVestingOptions, String> {
+    let mut upstream = None;
+    let mut bucket_id = None;
+    let mut beneficiary = None;
+    let mut nonce = None;
+    let mut public_key = None;
+    let mut private_key = None;
+    let mut request_timeout_secs = DEFAULT_REQUEST_TIMEOUT_SECS;
+    let mut index = 0_usize;
+    while index < args.len() {
+        match args[index].as_str() {
+            "--upstream" => upstream = Some(parse_required_value(args, &mut index, "--upstream")?),
+            "--bucket-id" => {
+                bucket_id = Some(parse_required_value(args, &mut index, "--bucket-id")?)
+            }
+            "--beneficiary" => {
+                beneficiary = Some(parse_required_value(args, &mut index, "--beneficiary")?)
+            }
+            "--nonce" => {
+                nonce = Some(parse_u64(
+                    parse_required_value(args, &mut index, "--nonce")?.as_str(),
+                    "--nonce",
+                )?)
+            }
+            "--public-key" => {
+                public_key = Some(parse_required_value(args, &mut index, "--public-key")?)
+            }
+            "--public-key-file" => {
+                let path = parse_required_value(args, &mut index, "--public-key-file")?;
+                public_key = Some(read_trimmed_file(path.as_str())?);
+            }
+            "--private-key" => {
+                private_key = Some(parse_required_value(args, &mut index, "--private-key")?)
+            }
+            "--private-key-file" => {
+                let path = parse_required_value(args, &mut index, "--private-key-file")?;
+                private_key = Some(read_trimmed_file(path.as_str())?);
+            }
+            "--request-timeout-secs" => {
+                request_timeout_secs = parse_u64(
+                    parse_required_value(args, &mut index, "--request-timeout-secs")?.as_str(),
+                    "--request-timeout-secs",
+                )?;
+            }
+            other => return Err(format!("unknown claim-vesting argument `{other}`")),
+        }
+        index += 1;
+    }
+    Ok(ClaimVestingOptions {
+        upstream: normalize_required(upstream, "--upstream")?,
+        bucket_id: normalize_required(bucket_id, "--bucket-id")?,
+        beneficiary: normalize_required(beneficiary, "--beneficiary")?,
+        nonce: nonce.ok_or_else(|| "--nonce is required".to_string())?,
+        public_key: normalize_required(public_key, "--public-key")?,
+        private_key: normalize_required(private_key, "--private-key")?,
+        request_timeout_secs,
+    })
+}
+
+fn run_serve(options: ServeOptions) -> Result<(), String> {
+    let faucet_account_id =
+        main_token_account_id_from_node_public_key(options.faucet_public_key.as_str());
+    let client = build_http_client(options.request_timeout_secs)?;
+    let service = FaucetService {
+        options,
+        faucet_account_id,
+        client,
+        state: Arc::new(Mutex::new(FaucetState::default())),
+    };
+    let listener = TcpListener::bind(service.options.listen.as_str())
+        .map_err(|err| format!("bind faucet listener failed: {err}"))?;
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&FaucetInfoResponse {
+            ok: true,
+            faucet_account_id: service.faucet_account_id.clone(),
+            amount: service.options.amount,
+            cooldown_secs: service.options.cooldown_secs,
+            claim_path: DEFAULT_CLAIM_PATH.to_string(),
+        })
+        .map_err(|err| format!("encode startup summary failed: {err}"))?
+    );
+    loop {
+        let (stream, addr) = listener
+            .accept()
+            .map_err(|err| format!("accept faucet connection failed: {err}"))?;
+        let service = service.clone();
+        thread::spawn(move || {
+            if let Err(err) = service.handle_connection(stream, addr.ip().to_string()) {
+                eprintln!("warning: faucet request failed: {err}");
+            }
+        });
+    }
+}
+
+fn run_submit_genesis(options: SubmitGenesisOptions) -> Result<(), String> {
+    let client = build_http_client(options.request_timeout_secs)?;
+    let action = Action::InitializeMainTokenGenesis {
+        allocations: vec![MainTokenGenesisAllocationPlan {
+            bucket_id: options.bucket_id.clone(),
+            ratio_bps: options.ratio_bps,
+            recipient: options.recipient.clone(),
+            cliff_epochs: options.cliff_epochs,
+            linear_unlock_epochs: options.linear_unlock_epochs,
+            start_epoch: options.start_epoch,
+        }],
+    };
+    let signer_refs = options
+        .signers
+        .iter()
+        .map(|item| (item.public_key.as_str(), item.private_key.as_str()))
+        .collect::<Vec<_>>();
+    let proof = sign_threshold_main_token_runtime_action_auth(
+        &action,
+        options.controller_account_id.as_str(),
+        options.threshold,
+        signer_refs.as_slice(),
+    )
+    .map_err(|err| format!("sign genesis request failed: {err}"))?;
+    let payload = serde_json::json!({
+        "action": "initialize_main_token_genesis",
+        "allocations": [{
+            "bucket_id": options.bucket_id,
+            "ratio_bps": options.ratio_bps,
+            "recipient": options.recipient,
+            "cliff_epochs": options.cliff_epochs,
+            "linear_unlock_epochs": options.linear_unlock_epochs,
+            "start_epoch": options.start_epoch,
+        }],
+        "auth": proof,
+    });
+    let response: ChainMainTokenSubmitResponse = post_json(
+        &client,
+        options.upstream.as_str(),
+        "/v1/chain/main-token/submit",
+        &payload,
+    )?;
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&response)
+            .map_err(|err| format!("encode genesis response failed: {err}"))?
+    );
+    if !response.ok {
+        return Err(format!(
+            "submit genesis rejected: {}",
+            response
+                .error
+                .unwrap_or_else(|| "unknown error".to_string())
+        ));
+    }
+    Ok(())
+}
+
+fn run_claim_vesting(options: ClaimVestingOptions) -> Result<(), String> {
+    let client = build_http_client(options.request_timeout_secs)?;
+    let action = Action::ClaimMainTokenVesting {
+        bucket_id: options.bucket_id.clone(),
+        beneficiary: options.beneficiary.clone(),
+        nonce: options.nonce,
+    };
+    let proof = sign_main_token_runtime_action_auth(
+        &action,
+        options.beneficiary.as_str(),
+        options.public_key.as_str(),
+        options.private_key.as_str(),
+    )
+    .map_err(|err| format!("sign claim request failed: {err}"))?;
+    let payload = serde_json::json!({
+        "action": "claim_main_token_vesting",
+        "bucket_id": options.bucket_id,
+        "beneficiary": options.beneficiary,
+        "nonce": options.nonce,
+        "auth": proof,
+    });
+    let response: ChainMainTokenSubmitResponse = post_json(
+        &client,
+        options.upstream.as_str(),
+        "/v1/chain/main-token/submit",
+        &payload,
+    )?;
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&response)
+            .map_err(|err| format!("encode claim response failed: {err}"))?
+    );
+    if !response.ok {
+        return Err(format!(
+            "claim vesting rejected: {}",
+            response
+                .error
+                .unwrap_or_else(|| "unknown error".to_string())
+        ));
+    }
+    Ok(())
+}
+
+impl FaucetService {
+    fn handle_connection(&self, mut stream: TcpStream, remote_ip: String) -> Result<(), String> {
+        stream
+            .set_read_timeout(Some(Duration::from_secs(2)))
+            .map_err(|err| format!("set faucet read timeout failed: {err}"))?;
+        let mut buffer = [0_u8; 65_536];
+        let bytes = stream
+            .read(&mut buffer)
+            .map_err(|err| format!("read faucet request failed: {err}"))?;
+        if bytes == 0 {
+            return Ok(());
+        }
+        let request = String::from_utf8_lossy(&buffer[..bytes]);
+        let Some(line) = request.lines().next() else {
+            write_json_response(
+                &mut stream,
+                400,
+                &serde_json::json!({"ok": false, "error_code": "bad_request", "error": "missing request line"}),
+            )?;
+            return Ok(());
+        };
+        let mut parts = line.split_whitespace();
+        let method = parts.next().unwrap_or_default();
+        let target = parts.next().unwrap_or_default();
+        let path = target.split('?').next().unwrap_or(target);
+        match (method, path) {
+            ("GET", DEFAULT_INFO_PATH) => {
+                let payload = FaucetInfoResponse {
+                    ok: true,
+                    faucet_account_id: self.faucet_account_id.clone(),
+                    amount: self.options.amount,
+                    cooldown_secs: self.options.cooldown_secs,
+                    claim_path: DEFAULT_CLAIM_PATH.to_string(),
+                };
+                write_json_response(&mut stream, 200, &payload)?;
+            }
+            ("GET", DEFAULT_HEALTH_PATH) => {
+                write_json_response(
+                    &mut stream,
+                    200,
+                    &HealthResponse {
+                        ok: true,
+                        observed_at_unix_ms: now_unix_ms(),
+                    },
+                )?;
+            }
+            ("POST", DEFAULT_CLAIM_PATH) => {
+                let body = extract_http_json_body(&buffer[..bytes])?;
+                let request: FaucetClaimRequest = serde_json::from_slice(body)
+                    .map_err(|err| format!("invalid faucet claim request: {err}"))?;
+                let response = self.process_claim(request, remote_ip.as_str())?;
+                write_json_response(&mut stream, if response.ok { 200 } else { 429 }, &response)?;
+            }
+            _ => {
+                write_json_response(
+                    &mut stream,
+                    404,
+                    &serde_json::json!({"ok": false, "error_code": "not_found", "error": "unsupported faucet path"}),
+                )?;
+            }
+        }
+        Ok(())
+    }
+
+    fn process_claim(
+        &self,
+        request: FaucetClaimRequest,
+        remote_ip: &str,
+    ) -> Result<FaucetClaimResponse, String> {
+        let target_account_id = validate_target_account_id(request.account_id.as_str())?;
+        let now_ms = now_unix_ms();
+        let mut state = self
+            .state
+            .lock()
+            .map_err(|_| "lock faucet state failed".to_string())?;
+        let cooldown_ms = i64::try_from(self.options.cooldown_secs)
+            .unwrap_or(i64::MAX)
+            .saturating_mul(1000);
+        if let Some(last_ms) = state
+            .last_account_claim_unix_ms
+            .get(target_account_id.as_str())
+        {
+            if now_ms.saturating_sub(*last_ms) < cooldown_ms {
+                return Ok(FaucetClaimResponse {
+                    ok: false,
+                    faucet_account_id: self.faucet_account_id.clone(),
+                    amount: self.options.amount,
+                    cooldown_secs: self.options.cooldown_secs,
+                    action_id: None,
+                    submitted_at_unix_ms: None,
+                    error_code: Some("cooldown_active".to_string()),
+                    error: Some(format!(
+                        "account is still in cooldown: account_id={target_account_id}"
+                    )),
+                });
+            }
+        }
+        if let Some(last_ms) = state.last_ip_claim_unix_ms.get(remote_ip) {
+            if now_ms.saturating_sub(*last_ms) < cooldown_ms {
+                return Ok(FaucetClaimResponse {
+                    ok: false,
+                    faucet_account_id: self.faucet_account_id.clone(),
+                    amount: self.options.amount,
+                    cooldown_secs: self.options.cooldown_secs,
+                    action_id: None,
+                    submitted_at_unix_ms: None,
+                    error_code: Some("ip_cooldown_active".to_string()),
+                    error: Some(format!("ip is still in cooldown: ip={remote_ip}")),
+                });
+            }
+        }
+        let snapshot = fetch_faucet_account_snapshot(
+            &self.client,
+            self.options.upstream.as_str(),
+            self.faucet_account_id.as_str(),
+        )?;
+        if snapshot.liquid_balance < self.options.amount {
+            return Ok(FaucetClaimResponse {
+                ok: false,
+                faucet_account_id: self.faucet_account_id.clone(),
+                amount: self.options.amount,
+                cooldown_secs: self.options.cooldown_secs,
+                action_id: None,
+                submitted_at_unix_ms: None,
+                error_code: Some("insufficient_balance".to_string()),
+                error: Some(format!(
+                    "faucet balance too low: liquid_balance={} amount={}",
+                    snapshot.liquid_balance, self.options.amount
+                )),
+            });
+        }
+        let nonce = state
+            .next_nonce
+            .unwrap_or(snapshot.next_nonce_hint)
+            .max(snapshot.next_nonce_hint);
+        let transfer_request = build_signed_transfer_request(
+            self.faucet_account_id.as_str(),
+            target_account_id.as_str(),
+            self.options.amount,
+            nonce,
+            self.options.faucet_public_key.as_str(),
+            self.options.faucet_private_key.as_str(),
+        )?;
+        let response: ChainTransferSubmitResponse = post_json(
+            &self.client,
+            self.options.upstream.as_str(),
+            "/v1/chain/transfer/submit",
+            &transfer_request,
+        )?;
+        if response.ok {
+            state.next_nonce = Some(nonce.saturating_add(1));
+            state
+                .last_account_claim_unix_ms
+                .insert(target_account_id.clone(), now_ms);
+            state
+                .last_ip_claim_unix_ms
+                .insert(remote_ip.to_string(), now_ms);
+        } else if response.error_code.as_deref() == Some("nonce_replay") {
+            state.next_nonce = None;
+        }
+        Ok(FaucetClaimResponse {
+            ok: response.ok,
+            faucet_account_id: self.faucet_account_id.clone(),
+            amount: self.options.amount,
+            cooldown_secs: self.options.cooldown_secs,
+            action_id: response.action_id,
+            submitted_at_unix_ms: response.submitted_at_unix_ms,
+            error_code: response.error_code,
+            error: response.error,
+        })
+    }
+}
+
+fn build_signed_transfer_request(
+    from_account_id: &str,
+    to_account_id: &str,
+    amount: u64,
+    nonce: u64,
+    public_key: &str,
+    private_key: &str,
+) -> Result<ChainTransferSubmitRequest, String> {
+    let action = Action::TransferMainToken {
+        from_account_id: from_account_id.to_string(),
+        to_account_id: to_account_id.to_string(),
+        amount,
+        nonce,
+    };
+    let proof =
+        sign_main_token_runtime_action_auth(&action, from_account_id, public_key, private_key)
+            .map_err(|err| format!("sign transfer request failed: {err}"))?;
+    Ok(ChainTransferSubmitRequest {
+        from_account_id: from_account_id.to_string(),
+        to_account_id: to_account_id.to_string(),
+        amount,
+        nonce,
+        public_key: proof
+            .public_key
+            .ok_or_else(|| "signed transfer proof missing public_key".to_string())?,
+        signature: proof
+            .signature
+            .ok_or_else(|| "signed transfer proof missing signature".to_string())?,
+    })
+}
+
+fn fetch_faucet_account_snapshot(
+    client: &Client,
+    upstream: &str,
+    faucet_account_id: &str,
+) -> Result<ChainTransferAccountEntry, String> {
+    let response: ChainTransferAccountsResponse =
+        get_json(client, upstream, "/v1/chain/transfer/accounts")?;
+    if !response.ok {
+        return Err(response
+            .error
+            .unwrap_or_else(|| "transfer accounts endpoint returned error".to_string()));
+    }
+    response
+        .accounts
+        .into_iter()
+        .find(|entry| entry.account_id == faucet_account_id)
+        .ok_or_else(|| format!("faucet account not found on upstream: {faucet_account_id}"))
+}
+
+fn post_json<T: Serialize, R: for<'de> Deserialize<'de>>(
+    client: &Client,
+    upstream: &str,
+    path: &str,
+    payload: &T,
+) -> Result<R, String> {
+    let url = format!("{}{}", normalize_upstream(upstream), path);
+    let response = client
+        .post(url)
+        .json(payload)
+        .send()
+        .map_err(|err| format!("POST {path} failed: {err}"))?;
+    decode_http_json::<R>(response)
+}
+
+fn get_json<R: for<'de> Deserialize<'de>>(
+    client: &Client,
+    upstream: &str,
+    path: &str,
+) -> Result<R, String> {
+    let url = format!("{}{}", normalize_upstream(upstream), path);
+    let response = client
+        .get(url)
+        .send()
+        .map_err(|err| format!("GET {path} failed: {err}"))?;
+    decode_http_json::<R>(response)
+}
+
+fn decode_http_json<R: for<'de> Deserialize<'de>>(
+    response: reqwest::blocking::Response,
+) -> Result<R, String> {
+    let status = response.status();
+    let text = response
+        .text()
+        .map_err(|err| format!("read http response body failed: {err}"))?;
+    let decoded = serde_json::from_str::<R>(text.as_str()).map_err(|err| {
+        format!("decode http response failed: status={status} error={err} body={text}")
+    })?;
+    Ok(decoded)
+}
+
+fn build_http_client(timeout_secs: u64) -> Result<Client, String> {
+    Client::builder()
+        .timeout(Duration::from_secs(timeout_secs))
+        .build()
+        .map_err(|err| format!("build http client failed: {err}"))
+}
+
+fn extract_http_json_body(request_bytes: &[u8]) -> Result<&[u8], String> {
+    let boundary = request_bytes
+        .windows(4)
+        .position(|window| window == b"\r\n\r\n")
+        .ok_or_else(|| "invalid HTTP request: missing body separator".to_string())?;
+    Ok(&request_bytes[(boundary + 4)..])
+}
+
+fn write_json_response<T: Serialize>(
+    stream: &mut TcpStream,
+    status_code: u16,
+    payload: &T,
+) -> Result<(), String> {
+    let body = serde_json::to_vec_pretty(payload)
+        .map_err(|err| format!("encode faucet response failed: {err}"))?;
+    let status_line = match status_code {
+        200 => "HTTP/1.1 200 OK",
+        400 => "HTTP/1.1 400 Bad Request",
+        404 => "HTTP/1.1 404 Not Found",
+        429 => "HTTP/1.1 429 Too Many Requests",
+        _ => "HTTP/1.1 500 Internal Server Error",
+    };
+    let headers = format!(
+        "{status_line}\r\nContent-Type: application/json\r\nAccess-Control-Allow-Origin: *\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+        body.len()
+    );
+    stream
+        .write_all(headers.as_bytes())
+        .and_then(|_| stream.write_all(body.as_slice()))
+        .map_err(|err| format!("write faucet response failed: {err}"))
+}
+
+fn validate_target_account_id(raw: &str) -> Result<String, String> {
+    let value = raw.trim().to_ascii_lowercase();
+    if !value.starts_with("oc:pk:") {
+        return Err("target account_id must start with oc:pk:".to_string());
+    }
+    let hex_part = &value["oc:pk:".len()..];
+    if hex_part.len() != 64 {
+        return Err("target account_id public key suffix must be 64 hex chars".to_string());
+    }
+    if !hex_part.chars().all(|ch| ch.is_ascii_hexdigit()) {
+        return Err("target account_id public key suffix must be hex".to_string());
+    }
+    Ok(value)
+}
+
+fn normalize_required(value: Option<String>, label: &str) -> Result<String, String> {
+    value
+        .map(|raw| raw.trim().to_string())
+        .filter(|raw| !raw.is_empty())
+        .ok_or_else(|| format!("{label} is required"))
+}
+
+fn parse_required_value(args: &[String], index: &mut usize, label: &str) -> Result<String, String> {
+    let next = index.saturating_add(1);
+    let value = args
+        .get(next)
+        .cloned()
+        .ok_or_else(|| format!("{label} requires a value"))?;
+    *index = next;
+    Ok(value)
+}
+
+fn parse_u64(raw: &str, label: &str) -> Result<u64, String> {
+    raw.parse::<u64>()
+        .map_err(|err| format!("parse {label} failed: {err}"))
+}
+
+fn parse_u32(raw: &str, label: &str) -> Result<u32, String> {
+    raw.parse::<u32>()
+        .map_err(|err| format!("parse {label} failed: {err}"))
+}
+
+fn parse_u16(raw: &str, label: &str) -> Result<u16, String> {
+    raw.parse::<u16>()
+        .map_err(|err| format!("parse {label} failed: {err}"))
+}
+
+fn read_trimmed_file(path: &str) -> Result<String, String> {
+    let content =
+        std::fs::read_to_string(path).map_err(|err| format!("read {path} failed: {err}"))?;
+    let trimmed = content.trim();
+    if trimmed.is_empty() {
+        return Err(format!("{path} is empty"));
+    }
+    Ok(trimmed.to_string())
+}
+
+fn normalize_upstream(raw: &str) -> String {
+    raw.trim_end_matches('/').to_string()
+}
+
+fn now_unix_ms() -> i64 {
+    let elapsed = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_else(|_| Duration::from_secs(0));
+    i64::try_from(elapsed.as_millis()).unwrap_or(i64::MAX)
+}
+
+fn print_help() {
+    eprintln!(
+        "Usage:\n  oasis7_testnet_faucet serve --listen <host:port> --upstream <base_url> --faucet-public-key[-file] <value> --faucet-private-key[-file] <value> --amount <u64> [--cooldown-secs <u64>] [--request-timeout-secs <u64>]\n  oasis7_testnet_faucet submit-genesis --upstream <base_url> --threshold <u16> --signer-public-key[-file] <value> --signer-private-key[-file] <value> --bucket-id <id> --recipient <account_id> [--controller-account-id <id>] [--ratio-bps <u32>] [--cliff-epochs <u64>] [--linear-unlock-epochs <u64>] [--start-epoch <u64>]\n  oasis7_testnet_faucet claim-vesting --upstream <base_url> --bucket-id <id> --beneficiary <account_id> --nonce <u64> --public-key[-file] <value> --private-key[-file] <value>"
+    );
+}

--- a/crates/oasis7_node/src/node_engine_core.rs
+++ b/crates/oasis7_node/src/node_engine_core.rs
@@ -444,9 +444,6 @@ impl PosNodeEngine {
     ) -> Result<PosDecision, NodeError> {
         let slot = self.next_slot;
         let epoch = self.slot_epoch(slot);
-        let committed_actions =
-            drain_ordered_consensus_actions(&mut self.pending_consensus_actions);
-        let action_root = compute_consensus_action_root(committed_actions.as_slice())?;
         let proposer_id = self
             .expected_proposer(slot)
             .ok_or_else(|| NodeError::Consensus {
@@ -455,6 +452,9 @@ impl PosNodeEngine {
         if proposer_id != node_id {
             return self.idle_pending_decision();
         }
+        let committed_actions =
+            drain_ordered_consensus_actions(&mut self.pending_consensus_actions);
+        let action_root = compute_consensus_action_root(committed_actions.as_slice())?;
         let parent_block_hash = self
             .last_committed_block_hash
             .as_deref()

--- a/crates/oasis7_node/src/node_runtime_core.rs
+++ b/crates/oasis7_node/src/node_runtime_core.rs
@@ -119,13 +119,13 @@ struct LocalMainTokenActionSigningEnvelope<'a> {
 enum LocalMainTokenActionSigningPayload<'a> {
     TransferMainToken(LocalTransferMainTokenSigningData<'a>),
     ClaimMainTokenVesting(LocalClaimMainTokenVestingSigningData<'a>),
-    InitializeMainTokenGenesis(LocalInitializeMainTokenGenesisSigningData<'a>),
-    DistributeMainTokenTreasury(LocalDistributeMainTokenTreasurySigningData<'a>),
+    InitializeMainTokenGenesis(LocalInitializeMainTokenGenesisSigningData),
+    DistributeMainTokenTreasury(LocalDistributeMainTokenTreasurySigningData),
     TopUpRestrictedStarterClaimLiveopsPool(
         LocalTopUpRestrictedStarterClaimLiveopsPoolSigningData<'a>,
     ),
     UpdateRestrictedStarterClaimAdminRegistry(
-        LocalUpdateRestrictedStarterClaimAdminRegistrySigningData<'a>,
+        LocalUpdateRestrictedStarterClaimAdminRegistrySigningData,
     ),
 }
 
@@ -145,16 +145,16 @@ struct LocalClaimMainTokenVestingSigningData<'a> {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-struct LocalInitializeMainTokenGenesisSigningData<'a> {
-    allocations: &'a [JsonValue],
+struct LocalInitializeMainTokenGenesisSigningData {
+    allocations: Vec<LocalMainTokenGenesisAllocationPlan>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-struct LocalDistributeMainTokenTreasurySigningData<'a> {
+struct LocalDistributeMainTokenTreasurySigningData {
     proposal_id: u64,
-    distribution_id: &'a str,
-    bucket_id: &'a str,
-    distributions: &'a [JsonValue],
+    distribution_id: String,
+    bucket_id: String,
+    distributions: Vec<LocalMainTokenTreasuryDistribution>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -165,9 +165,25 @@ struct LocalTopUpRestrictedStarterClaimLiveopsPoolSigningData<'a> {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-struct LocalUpdateRestrictedStarterClaimAdminRegistrySigningData<'a> {
-    controller_account_id: &'a str,
-    next_admin_account_ids: &'a [JsonValue],
+struct LocalUpdateRestrictedStarterClaimAdminRegistrySigningData {
+    controller_account_id: String,
+    next_admin_account_ids: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct LocalMainTokenGenesisAllocationPlan {
+    bucket_id: String,
+    ratio_bps: u32,
+    recipient: String,
+    cliff_epochs: u64,
+    linear_unlock_epochs: u64,
+    start_epoch: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct LocalMainTokenTreasuryDistribution {
+    account_id: String,
+    amount: u64,
 }
 
 impl fmt::Debug for NodeRuntime {
@@ -656,11 +672,12 @@ fn build_local_main_token_action_signing_action(
         "InitializeMainTokenGenesis" => Ok(
             LocalMainTokenActionSigningPayload::InitializeMainTokenGenesis(
                 LocalInitializeMainTokenGenesisSigningData {
-                    allocations: data
-                        .get("allocations")
-                        .and_then(JsonValue::as_array)
-                        .map(Vec::as_slice)
-                        .ok_or_else(|| "genesis action missing allocations".to_string())?,
+                    allocations: serde_json::from_value(
+                        data.get("allocations")
+                            .cloned()
+                            .ok_or_else(|| "genesis action missing allocations".to_string())?,
+                    )
+                    .map_err(|err| format!("genesis action allocations decode failed: {err}"))?,
                 },
             ),
         ),
@@ -674,16 +691,19 @@ fn build_local_main_token_action_signing_action(
                     distribution_id: data
                         .get("distribution_id")
                         .and_then(JsonValue::as_str)
-                        .ok_or_else(|| "treasury action missing distribution_id".to_string())?,
+                        .ok_or_else(|| "treasury action missing distribution_id".to_string())?
+                        .to_string(),
                     bucket_id: data
                         .get("bucket_id")
                         .and_then(JsonValue::as_str)
-                        .ok_or_else(|| "treasury action missing bucket_id".to_string())?,
-                    distributions: data
-                        .get("distributions")
-                        .and_then(JsonValue::as_array)
-                        .map(Vec::as_slice)
-                        .ok_or_else(|| "treasury action missing distributions".to_string())?,
+                        .ok_or_else(|| "treasury action missing bucket_id".to_string())?
+                        .to_string(),
+                    distributions: serde_json::from_value(
+                        data.get("distributions")
+                            .cloned()
+                            .ok_or_else(|| "treasury action missing distributions".to_string())?,
+                    )
+                    .map_err(|err| format!("treasury action distributions decode failed: {err}"))?,
                 },
             ),
         ),
@@ -723,15 +743,21 @@ fn build_local_main_token_action_signing_action(
                         .ok_or_else(|| {
                             "restricted claim admin registry action missing controller_account_id"
                                 .to_string()
-                        })?,
-                    next_admin_account_ids: data
-                        .get("next_admin_account_ids")
-                        .and_then(JsonValue::as_array)
-                        .map(Vec::as_slice)
-                        .ok_or_else(|| {
-                            "restricted claim admin registry action missing next_admin_account_ids"
-                                .to_string()
-                        })?,
+                        })?
+                        .to_string(),
+                    next_admin_account_ids: serde_json::from_value(
+                        data.get("next_admin_account_ids")
+                            .cloned()
+                            .ok_or_else(|| {
+                                "restricted claim admin registry action missing next_admin_account_ids"
+                                    .to_string()
+                            })?,
+                    )
+                    .map_err(|err| {
+                        format!(
+                            "restricted claim admin registry next_admin_account_ids decode failed: {err}"
+                        )
+                    })?,
                 },
             ),
         ),

--- a/crates/oasis7_node/src/tests_action_payload.rs
+++ b/crates/oasis7_node/src/tests_action_payload.rs
@@ -119,10 +119,10 @@ struct TestMainTokenActionSigningEnvelope<'a> {
 enum TestMainTokenActionSigningPayload<'a> {
     TransferMainToken(TestTransferMainTokenSigningData<'a>),
     ClaimMainTokenVesting(TestClaimMainTokenVestingSigningData<'a>),
-    InitializeMainTokenGenesis(TestInitializeMainTokenGenesisSigningData<'a>),
-    DistributeMainTokenTreasury(TestDistributeMainTokenTreasurySigningData<'a>),
+    InitializeMainTokenGenesis(TestInitializeMainTokenGenesisSigningData),
+    DistributeMainTokenTreasury(TestDistributeMainTokenTreasurySigningData),
     UpdateRestrictedStarterClaimAdminRegistry(
-        TestUpdateRestrictedStarterClaimAdminRegistrySigningData<'a>,
+        TestUpdateRestrictedStarterClaimAdminRegistrySigningData,
     ),
 }
 
@@ -142,22 +142,38 @@ struct TestClaimMainTokenVestingSigningData<'a> {
 }
 
 #[derive(Serialize)]
-struct TestInitializeMainTokenGenesisSigningData<'a> {
-    allocations: &'a [JsonValue],
+struct TestInitializeMainTokenGenesisSigningData {
+    allocations: Vec<TestMainTokenGenesisAllocationPlan>,
 }
 
 #[derive(Serialize)]
-struct TestDistributeMainTokenTreasurySigningData<'a> {
+struct TestDistributeMainTokenTreasurySigningData {
     proposal_id: u64,
-    distribution_id: &'a str,
-    bucket_id: &'a str,
-    distributions: &'a [JsonValue],
+    distribution_id: String,
+    bucket_id: String,
+    distributions: Vec<TestMainTokenTreasuryDistribution>,
 }
 
 #[derive(Serialize)]
-struct TestUpdateRestrictedStarterClaimAdminRegistrySigningData<'a> {
-    controller_account_id: &'a str,
-    next_admin_account_ids: &'a [JsonValue],
+struct TestUpdateRestrictedStarterClaimAdminRegistrySigningData {
+    controller_account_id: String,
+    next_admin_account_ids: Vec<String>,
+}
+
+#[derive(Serialize, Deserialize)]
+struct TestMainTokenGenesisAllocationPlan {
+    bucket_id: String,
+    ratio_bps: u32,
+    recipient: String,
+    cliff_epochs: u64,
+    linear_unlock_epochs: u64,
+    start_epoch: u64,
+}
+
+#[derive(Serialize, Deserialize)]
+struct TestMainTokenTreasuryDistribution {
+    account_id: String,
+    amount: u64,
 }
 
 fn test_main_token_action_signature_prefix(action_kind: &str) -> &'static str {
@@ -236,11 +252,12 @@ fn test_main_token_signing_action(action: &JsonValue) -> TestMainTokenActionSign
         "InitializeMainTokenGenesis" => {
             TestMainTokenActionSigningPayload::InitializeMainTokenGenesis(
                 TestInitializeMainTokenGenesisSigningData {
-                    allocations: data
-                        .get("allocations")
-                        .and_then(JsonValue::as_array)
-                        .map(Vec::as_slice)
-                        .expect("genesis allocations"),
+                    allocations: serde_json::from_value(
+                        data.get("allocations")
+                            .cloned()
+                            .expect("genesis allocations"),
+                    )
+                    .expect("decode genesis allocations"),
                 },
             )
         }
@@ -254,16 +271,19 @@ fn test_main_token_signing_action(action: &JsonValue) -> TestMainTokenActionSign
                     distribution_id: data
                         .get("distribution_id")
                         .and_then(JsonValue::as_str)
-                        .expect("treasury distribution_id"),
+                        .expect("treasury distribution_id")
+                        .to_string(),
                     bucket_id: data
                         .get("bucket_id")
                         .and_then(JsonValue::as_str)
-                        .expect("treasury bucket_id"),
-                    distributions: data
-                        .get("distributions")
-                        .and_then(JsonValue::as_array)
-                        .map(Vec::as_slice)
-                        .expect("treasury distributions"),
+                        .expect("treasury bucket_id")
+                        .to_string(),
+                    distributions: serde_json::from_value(
+                        data.get("distributions")
+                            .cloned()
+                            .expect("treasury distributions"),
+                    )
+                    .expect("decode treasury distributions"),
                 },
             )
         }
@@ -273,12 +293,14 @@ fn test_main_token_signing_action(action: &JsonValue) -> TestMainTokenActionSign
                     controller_account_id: data
                         .get("controller_account_id")
                         .and_then(JsonValue::as_str)
-                        .expect("restricted claim admin registry controller_account_id"),
-                    next_admin_account_ids: data
-                        .get("next_admin_account_ids")
-                        .and_then(JsonValue::as_array)
-                        .map(Vec::as_slice)
-                        .expect("restricted claim admin registry next_admin_account_ids"),
+                        .expect("restricted claim admin registry controller_account_id")
+                        .to_string(),
+                    next_admin_account_ids: serde_json::from_value(
+                        data.get("next_admin_account_ids")
+                            .cloned()
+                            .expect("restricted claim admin registry next_admin_account_ids"),
+                    )
+                    .expect("decode restricted claim admin registry next_admin_account_ids"),
                 },
             )
         }

--- a/crates/oasis7_node/src/tests_pos_engine_guardrails.rs
+++ b/crates/oasis7_node/src/tests_pos_engine_guardrails.rs
@@ -168,6 +168,57 @@ fn pos_engine_non_expected_proposer_does_not_open_local_proposal() {
 }
 
 #[test]
+fn pos_engine_non_expected_proposer_keeps_pending_consensus_actions_queued() {
+    let validators = multi_validators();
+    let probe_config = NodeConfig::new("node-a", "world-non-proposer-queue", NodeRole::Sequencer)
+        .expect("probe config")
+        .with_pos_validators(validators.clone())
+        .expect("probe validators");
+    let probe_engine = PosNodeEngine::new(&probe_config).expect("probe engine");
+    let expected = probe_engine
+        .expected_proposer(0)
+        .expect("expected proposer for slot 0");
+    let non_proposer = validators
+        .iter()
+        .map(|validator| validator.validator_id.as_str())
+        .find(|validator_id| *validator_id != expected)
+        .expect("non proposer");
+
+    let config = NodeConfig::new(
+        non_proposer,
+        "world-non-proposer-queue",
+        NodeRole::Sequencer,
+    )
+    .expect("config")
+    .with_pos_validators(validators)
+    .expect("validators")
+    .with_auto_attest_all_validators(true);
+    let mut engine = PosNodeEngine::new(&config).expect("engine");
+    let queued = NodeConsensusAction::from_payload(7, config.player_id.clone(), vec![7_u8])
+        .expect("queued action");
+    engine.pending_consensus_actions.insert(7, queued);
+
+    let snapshot = engine
+        .tick(
+            &config.node_id,
+            &config.world_id,
+            1_000,
+            None,
+            None,
+            None,
+            None,
+            Vec::new(),
+            None,
+        )
+        .expect("tick");
+
+    assert_eq!(snapshot.consensus_snapshot.latest_height, 0);
+    assert_eq!(snapshot.consensus_snapshot.committed_height, 0);
+    assert_eq!(engine.pending_consensus_actions.len(), 1);
+    assert!(engine.pending_consensus_actions.contains_key(&7));
+}
+
+#[test]
 fn pos_engine_apply_decision_rejects_height_overflow_without_state_mutation() {
     let config =
         NodeConfig::new("node-a", "world-overflow-apply", NodeRole::Observer).expect("config");

--- a/doc/p2p/project.md
+++ b/doc/p2p/project.md
@@ -793,7 +793,8 @@
 - `.agents/skills/prd/check.md`
 
 ## 状态
-- 更新日期: 2026-05-08
+- 更新日期: 2026-05-19
+- 最新完成: `public-testnet-faucet-service`（已在现有两台 ECS `public_testnet` 基础设施上完成真实 guarded faucet 部署：`faucet_ref` 现指向 `http://39.104.204.172:6681/`，两节点已用修过的 runtime 做协调冷重置并重新导入 `2-validator` governance manifest、重新注入 faucet genesis/claim；同时修复 `PosNodeEngine::propose_next_head()` 在非 proposer slot 提前 drain `pending_consensus_actions` 导致 transfer/faucet claim 静默丢失并最终 `timeout` 的共识 bug。当前外部 `POST /claim` 到 `oc:pk:2222...2222` 已实测 `confirmed`，但 `/v1/chain/balances` 仍不是 faucet 热钱包真值面，应继续以 `transfer/accounts`/`explorer/address`/world snapshot 为准。）
 - 最新完成: `newapi-auto-credit-closure`（已把 `oasis7_newapi_bridge_service` 收口为 LetAI OpenAPI 真链路：新增持久化 `bridge_ledger`、explorer poll watcher、block-height confirmation、exact-match `--pricing-rule` 折算、`platform_user_id/platform_project_id/token_key/external_order_id`、user upsert、project/token 创建、topup、query verification 与 retry/manual-review 状态机。）
 - 当前状态: active（ROUND-027）
 - 下一任务: 优先推进 `TASK-P2P-043` 对应的 `P2PARCH-1~3`，把 identity / transport / role policy 收成统一 substrate；在此之前，不再把“本机无公网 IP 连不上”归类为单点部署细节。

--- a/doc/testing/evidence/p2p-public-testnet-faucet-service-2026-05-19.md
+++ b/doc/testing/evidence/p2p-public-testnet-faucet-service-2026-05-19.md
@@ -1,0 +1,121 @@
+# p2p public testnet faucet service evidence (2026-05-19)
+
+## Summary
+- Verdict: `pass` for the task scope of replacing placeholder `faucet_ref` with a real guarded public-testnet faucet on existing ECS infrastructure.
+- Live faucet endpoint: `http://39.104.204.172:6681/`
+- Backing RPC endpoint: `http://39.104.204.172:6631/v1/chain/status`
+- Explorer endpoint used for verification: `http://39.104.205.67:6632/v1/chain/explorer/overview`
+- Faucet policy deployed on the live host:
+  - `amount = 1000000`
+  - `cooldown_secs = 3600`
+  - target account format must be `oc:pk:<64-hex>`
+
+## Topology
+- `39.104.204.172`
+  - `oasis7-testnet-sequencer.service`
+  - `oasis7-testnet-faucet.service`
+  - public status `:6631`
+  - public faucet `:6681`
+- `39.104.205.67`
+  - `oasis7-testnet-storage.service`
+  - public status `:6632`
+
+## Root Cause Closed
+- Chain liveness unblock:
+  - world finality registry signer bindings were imported as `<slot_id>.<signer_id>`, while local validator ids were plain node ids; `governance_registry.rs` now strips the slot prefix before mapping world finality bindings back to validator ids.
+- Faucet transfer unblock:
+  - `PosNodeEngine::propose_next_head()` was draining `pending_consensus_actions` before checking whether the local node was the proposer for that slot.
+  - Result before fix: a transfer submitted during a non-local proposer slot was silently dropped and later surfaced as faucet transfer `timeout`.
+  - Fix: only drain the queue after confirming the local node is the expected proposer.
+
+## Deployment Steps
+1. Built and deployed patched `oasis7_chain_runtime` and `oasis7_testnet_faucet`.
+2. Installed sequencer-side systemd unit `oasis7-testnet-faucet.service` on `39.104.204.172`.
+3. Performed a coordinated cold reset of both ECS nodes because the tier is explicitly `resettable public_testnet`.
+4. Re-imported `/opt/oasis7/p2p-testnet/config/governance-public-manifest-public-testnet-2validator.json` into both fresh `execution-world` directories with `oasis7_governance_registry_import`.
+5. Re-submitted main-token genesis bucket `public_testnet_faucet_genesis`.
+6. Claimed the faucet vesting bucket into the faucet hot wallet.
+7. Restarted faucet service and verified an external claim end-to-end.
+
+## External Verification
+### Faucet info
+`GET http://39.104.204.172:6681/`
+
+Observed payload:
+
+```json
+{
+  "ok": true,
+  "faucet_account_id": "oc:pk:14699ee340994e43103490585a96671ec66a3280bc0f90518f29cd1866f0fa7d",
+  "amount": 1000000,
+  "cooldown_secs": 3600,
+  "claim_path": "/claim"
+}
+```
+
+### Health check
+`GET http://39.104.204.172:6681/healthz`
+
+Observed payload:
+
+```json
+{
+  "ok": true
+}
+```
+
+### Real claim
+- Request:
+  - `POST http://39.104.204.172:6681/claim`
+  - body: `{"account_id":"oc:pk:2222222222222222222222222222222222222222222222222222222222222222"}`
+- Immediate faucet response:
+
+```json
+{
+  "ok": true,
+  "faucet_account_id": "oc:pk:14699ee340994e43103490585a96671ec66a3280bc0f90518f29cd1866f0fa7d",
+  "amount": 1000000,
+  "cooldown_secs": 3600,
+  "action_id": 1
+}
+```
+
+- Confirmed on-chain afterward:
+  - faucet account `oc:pk:14699e...fa7d` liquid balance: `9999000000`
+  - target account `oc:pk:2222...2222` liquid balance: `1000000`
+  - explorer address record status: `confirmed`
+
+Observed `transfer/accounts` snapshot:
+
+```json
+{
+  "accounts": [
+    {
+      "account_id": "oc:pk:14699ee340994e43103490585a96671ec66a3280bc0f90518f29cd1866f0fa7d",
+      "liquid_balance": 9999000000,
+      "last_transfer_nonce": 1,
+      "next_nonce_hint": 2
+    },
+    {
+      "account_id": "oc:pk:2222222222222222222222222222222222222222222222222222222222222222",
+      "liquid_balance": 1000000,
+      "next_nonce_hint": 1
+    }
+  ]
+}
+```
+
+## Operational Notes
+- `/v1/chain/balances` is not a faucet-wallet truth surface here because it only reports `node_main_token_account` bindings for the local node id; the faucet hot wallet is not exposed through that binding.
+- Use these surfaces for faucet truth:
+  - `/v1/chain/transfer/accounts`
+  - `/v1/chain/explorer/address`
+  - `data/execution-world/snapshot.json`
+- Backup directories created during this rollout include:
+  - sequencer: `/opt/oasis7/p2p-testnet/backups/coordinated-reset-20260519-172636`
+  - storage: `/opt/oasis7/p2p-testnet/backups/coordinated-reset-20260519-172637`
+
+## Acceptance Mapping
+- Real `faucet_ref` backed by working service: `pass`
+- Canonical liveops grant entrypoint reused with abuse-control boundary (`amount/cooldown/account-format`): `pass`
+- Runtime evidence and readiness verdict updated after external verification: `pass`


### PR DESCRIPTION
## Summary
- add signed main-token submit support and a dedicated `oasis7_testnet_faucet` binary for guarded public-testnet claims
- fix public-testnet validator/finality registry import and non-proposer consensus action queue loss that was causing faucet transfers to timeout
- record live public-testnet faucet deployment evidence for `http://39.104.204.172:6681/` including a confirmed external claim

## Verification
- `env -u RUSTC_WRAPPER cargo test -p oasis7_node pos_engine_non_expected_proposer_ -- --nocapture`
- `env -u RUSTC_WRAPPER cargo test -p oasis7 --bin oasis7_chain_runtime world_finality_registry_ -- --nocapture`
- `env -u RUSTC_WRAPPER cargo build -p oasis7 --bin oasis7_chain_runtime --release`
- `env -u RUSTC_WRAPPER cargo build -p oasis7 --bin oasis7_testnet_faucet --release`
- `./scripts/doc-governance-check.sh`
- `git diff --check`
- `OASIS7_CI_RUN_OASIS7_REQUIRED_TESTS=true OASIS7_CI_RUN_CONSENSUS_TESTS=false OASIS7_CI_RUN_DISTFS_TESTS=false OASIS7_CI_RUN_VIEWER_CONTRACT_TESTS=false OASIS7_CI_RUN_VIEWER_WASM_CHECK=false OASIS7_CI_RUN_LAUNCHER_WEB_BUILD=true ./scripts/ci-tests.sh required` (fails only at `trunk build --release` because `wasm-bindgen 0.2.121` download from GitHub timed out twice)
- external runtime verification on live testnet: `GET /`, `GET /healthz`, `POST /claim`, `transfer/accounts`, `explorer/address`, remote `snapshot.json`