### PR TITLE
Add Chinese long-form ‘epic-story-orchestrator-zh’ skill with templates and tests

### DIFF
--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -33,6 +33,7 @@
 
 ## Workflow Execution Entry Points
 
+- 中文长篇背景叙事与世界观资产编排：`.agents/skills/epic-story-orchestrator-zh/SKILL.md`
 - 启动新的 non-trivial task、需要先判断 trivial/non-trivial、检查是否必须创建 task worktree / `.pm` task，并把后续阶段接回 repo-owned 主链时：`.agents/skills/default-workflow-bootstrap/SKILL.md`
 - 启动非 trivial task、或不确定下一步该走哪条 repo-owned workflow surface 时：`.agents/skills/repo-owned-workflow-router/SKILL.md`
 - 需求仍偏模糊、需要 scope 拆分、方案对比或判断是否需要 visual companion 时：`.agents/skills/bounded-brainstorming/SKILL.md`

--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -31,9 +31,12 @@
 - 模板：`.agents/skills/templates/SKILL.template.md`
 - 自检清单：`.agents/skills/checklists/skill-authoring-checklist.md`
 
-## Workflow Execution Entry Points
+## Domain-Specific Entry Points
 
 - 中文长篇背景叙事与世界观资产编排：`.agents/skills/epic-story-orchestrator-zh/SKILL.md`
+
+## Workflow Execution Entry Points
+
 - 启动新的 non-trivial task、需要先判断 trivial/non-trivial、检查是否必须创建 task worktree / `.pm` task，并把后续阶段接回 repo-owned 主链时：`.agents/skills/default-workflow-bootstrap/SKILL.md`
 - 启动非 trivial task、或不确定下一步该走哪条 repo-owned workflow surface 时：`.agents/skills/repo-owned-workflow-router/SKILL.md`
 - 需求仍偏模糊、需要 scope 拆分、方案对比或判断是否需要 visual companion 时：`.agents/skills/bounded-brainstorming/SKILL.md`

--- a/.agents/skills/epic-story-orchestrator-zh/README.md
+++ b/.agents/skills/epic-story-orchestrator-zh/README.md
@@ -1,0 +1,33 @@
+# epic-story-orchestrator-zh
+
+中文史诗背景故事编排 skill（repo-owned）。
+
+## 目标
+
+将长篇叙事拆解为可审计、可回写、可持续维护的资产：
+
+- 世界观真值（world-bible）
+- 人物库（character-registry）
+- 时间线（timeline）
+- 情节分支（plot-branches）
+- 章节卡（chapter-cards）
+- 一致性报告（consistency-report）
+- 变更日志（canon-log）
+
+## 默认写回路径
+
+`doc/game/lore/<story-slug>/`
+
+## 本地验证
+
+```bash
+bash .agents/skills/epic-story-orchestrator-zh/tests/run_smoke.sh
+```
+
+
+## 严格校验
+
+```bash
+python3 .agents/skills/epic-story-orchestrator-zh/tests/validate_writeback.py
+RUN_PM_LINT=1 bash .agents/skills/epic-story-orchestrator-zh/tests/run_smoke.sh
+```

--- a/.agents/skills/epic-story-orchestrator-zh/README.md
+++ b/.agents/skills/epic-story-orchestrator-zh/README.md
@@ -10,9 +10,16 @@
 - 人物库（character-registry）
 - 时间线（timeline）
 - 情节分支（plot-branches）
+- 当前游戏玩法真值绑定（gameplay-canon-binding）
 - 章节卡（chapter-cards）
 - 一致性报告（consistency-report）
 - 变更日志（canon-log）
+
+## 当前游戏流水线边界
+
+这个 skill 可以作为 oasis7 当前游戏背景故事生产流水线的 authoring surface，但不能单独决定游戏 canon。
+
+当前游戏 lore 必须绑定 `PRD-GAME-012/013/014/015` 中的 trust/capability、物理尺度、间接控制 control-feeling 与 mature-world 小玩家成长线真值。章节卡和草稿必须明确 `player_leverage`、`world_change_due_to_player` 与 `release_claim_boundary`，不得把 ambient world activity 写成玩家成长，也不得借背景故事扩大 `limited playable technical preview` 的对外承诺。
 
 ## 默认写回路径
 

--- a/.agents/skills/epic-story-orchestrator-zh/SKILL.md
+++ b/.agents/skills/epic-story-orchestrator-zh/SKILL.md
@@ -5,6 +5,12 @@ allowed-tools:
   - Read
   - Write
   - Edit
+  - Bash(git diff --check)
+  - Bash(./scripts/doc-governance-check.sh)
+  - Bash(./scripts/pm/lint.sh)
+  - Bash(python3 .agents/skills/epic-story-orchestrator-zh/tests/validate_writeback.py)
+  - Bash(bash .agents/skills/epic-story-orchestrator-zh/tests/run_smoke.sh)
+  - Bash(rg:*)
 license: MIT
 metadata:
   language: zh-CN

--- a/.agents/skills/epic-story-orchestrator-zh/SKILL.md
+++ b/.agents/skills/epic-story-orchestrator-zh/SKILL.md
@@ -38,6 +38,7 @@ metadata:
     - character-registry.md
     - timeline.md
     - plot-branches.md
+    - gameplay-canon-binding.md
     - chapter-cards/*.md
     - drafts/*.md
     - consistency-report.md
@@ -87,7 +88,8 @@ For each run, return all three blocks:
    - exact repo paths
    - operation (`create` / `update` / `append`)
 2. **Traceability map**
-   - chapter cards → `WR-*`, `CHAR-*`, `TL-*`, `PB-*`
+   - chapter cards -> `WR-*`, `CHAR-*`, `TL-*`, `PB-*`, `PRD-GAME-*`
+   - every current-game lore slice must answer `player_leverage`, `world_change_due_to_player`, and `control_feeling_guarantee`
 3. **Risk & next action**
    - blocker (`none` if absent)
    - next recommended step
@@ -114,6 +116,7 @@ Recommended artifact layout:
 - `character-registry.md`
 - `timeline.md`
 - `plot-branches.md`
+- `gameplay-canon-binding.md`
 - `chapter-cards/`
 - `drafts/`
 - `consistency-report.md`
@@ -129,6 +132,29 @@ Use stable IDs everywhere:
 - timeline events: `TL-*`
 - plot beats: `PB-*`
 - chapter cards: `CH-*`
+
+## Oasis7 Gameplay Canon Binding
+
+For oasis7 current-game background story work, this skill is a lore asset authoring layer, not a standalone fiction pipeline.
+
+Before creating or extending lore, bind the story space to current game truth:
+
+- `PRD-GAME-012`: 10-minute trust gate and first capability boundary
+- `PRD-GAME-013`: centimeter physical scale and indirect-control boundary
+- `PRD-GAME-014`: indirect-control control-feeling guarantees
+- `PRD-GAME-015`: mature-world small-player lane and `player leverage != world activity`
+- current claim envelope: `limited playable technical preview`, unless formal game docs say otherwise
+
+Required current-game lore fields:
+
+- `gameplay_prd_refs`: one or more `PRD-GAME-*`
+- `player_leverage`: what new leverage the player gains
+- `world_change_due_to_player`: what changed because of the player, not ambient world activity
+- `control_feeling_guarantee`: which accepted-intent / causality / fallback / reprioritize / resume guarantee the beat supports
+- `small_player_lane_stage`: `none`, `local_operator`, `regional_specialist`, or `limited_scope_regional_influence`
+- `release_claim_boundary`: must not upgrade stage or marketing claims by implication
+
+If a proposed lore beat cannot name the gameplay PRD refs and player leverage, keep it as brainstorm material and do not write it as canon.
 
 ## One-Pass Perfect Workflow
 
@@ -147,8 +173,10 @@ If any required field is missing, stop and request it.
 1. `world-bible.md`
 2. `character-registry.md`
 3. `timeline.md`
+4. `gameplay-canon-binding.md` for current-game lore
 
 Do not produce chapter cards or prose that rely on undefined canon.
+For current-game lore, do not produce chapter cards or prose that are not bound to `PRD-GAME-*` gameplay truth.
 
 ### 3) Plot Gate
 
@@ -157,6 +185,7 @@ Update `plot-branches.md` for major arc choices and append decision rationale to
 ### 4) Card Gate
 
 Create chapter cards before prose. Every card must cite at least one `TL-*` and one `CHAR-*`.
+For oasis7 current-game lore, every card must also cite at least one `PRD-GAME-*` and include `player_leverage`, `world_change_due_to_player`, and `release_claim_boundary`.
 
 ### 5) Draft Gate
 
@@ -201,6 +230,7 @@ This skill does **not** replace bootstrap/router/verification/closeout workflow 
 - `templates/character-registry.template.md`
 - `templates/timeline.template.md`
 - `templates/plot-branches.template.md`
+- `templates/gameplay-canon-binding.template.md`
 - `templates/chapter-card.template.md`
 - `templates/canon-log.template.md`
 - `templates/consistency-report.template.md`
@@ -212,6 +242,8 @@ This skill does **not** replace bootstrap/router/verification/closeout workflow 
 - Do not delete canon files.
 - Do not imitate a living author’s distinctive signature voice as a target.
 - Do not output giant prose dumps before card-level planning.
+- Do not write lore that contradicts current gameplay contracts or turns ambient world activity into player leverage.
+- Do not use lore to imply `closed beta`, `play now`, direct first-person control, global governance power, or broader launch readiness unless those claims already exist in current repo truth.
 - Keep default output language in Chinese unless explicitly requested otherwise.
 
 ## Verification
@@ -226,3 +258,7 @@ Run checks before claiming ready:
 For story assets, run reference scan:
 
 - `rg -n 'WR-|FAC-|LOC-|TEC-|CHAR-|TL-|PB-|CH-' doc/game/lore/<story-slug>/`
+
+For current-game lore, also scan gameplay binding:
+
+- `rg -n 'PRD-GAME-012|PRD-GAME-013|PRD-GAME-014|PRD-GAME-015|player_leverage|world_change_due_to_player|release_claim_boundary' doc/game/lore/<story-slug>/`

--- a/.agents/skills/epic-story-orchestrator-zh/SKILL.md
+++ b/.agents/skills/epic-story-orchestrator-zh/SKILL.md
@@ -1,0 +1,228 @@
+---
+name: epic-story-orchestrator-zh
+description: Use when planning, extending, or drafting a Chinese long-form, world-heavy story or lore bible that needs reusable world rules, character registries, timeline control, chapter cards, consistency checks, and repo-tracked writeback.
+allowed-tools:
+  - Read
+  - Write
+  - Edit
+license: MIT
+metadata:
+  language: zh-CN
+  domain:
+    - longform-fiction
+    - worldbuilding
+    - lore
+  task_modes:
+    - scaffold
+    - extend
+    - brainstorm
+    - chapter-card
+    - draft-scene
+    - polish
+    - audit
+  inputs:
+    required:
+      - story_slug
+      - task_mode
+      - premise
+      - canon_scope
+    optional:
+      - target_length
+      - pov_mode
+      - style_constraints
+      - taboo_list
+      - existing_refs
+      - chapter_targets
+  outputs:
+    - world-bible.md
+    - character-registry.md
+    - timeline.md
+    - plot-branches.md
+    - chapter-cards/*.md
+    - drafts/*.md
+    - consistency-report.md
+    - canon-log.md
+  writeback:
+    root: doc/game/lore/<story-slug>/
+    append_only:
+      - canon-log.md
+      - .pm/tasks/<TASK-UID>.execution.md
+  permissions:
+    no_delete: true
+    require_explicit_confirmation_for:
+      - overwrite human-authored canon paragraphs
+      - large-scale retcon
+      - moving or deleting canon files
+---
+
+# Epic Story Orchestrator ZH
+
+## Mission
+
+Build and maintain a **single canonical narrative truth** for Chinese long-form stories in oasis7.
+
+This skill orchestrates durable assets first, then prose slices. It never treats chat-only output as final truth.
+
+## When to Use
+
+Use this skill when:
+
+- the user wants to create or extend a Chinese long-form, world-heavy story, lore bible, or macro background narrative
+- the work needs reusable world rules, character registries, timeline control, chapter cards, or canon tracking
+- the task should produce repo-tracked story truth instead of chat-only prose
+- the story must stay consistent across many chapters, volumes, or parallel arcs
+
+Do not use this skill when:
+
+- the user only wants a short blurb, slogan, marketing copy, or one-paragraph synopsis
+- the request is really a product/design spec better owned by `prd.md`, `project.md`, or `game-architect`
+- the task is only polishing an existing Chinese paragraph and does not need story structure or writeback
+- the output should remain temporary and must not become repo truth
+
+## Output Contract (must always be explicit)
+
+For each run, return all three blocks:
+
+1. **Artifacts changed**
+   - exact repo paths
+   - operation (`create` / `update` / `append`)
+2. **Traceability map**
+   - chapter cards → `WR-*`, `CHAR-*`, `TL-*`, `PB-*`
+3. **Risk & next action**
+   - blocker (`none` if absent)
+   - next recommended step
+
+## Task Modes
+
+- `scaffold`: create a new story space from premise
+- `extend`: add or revise canon while preserving prior truth
+- `brainstorm`: produce 2–3 plot directions with one recommendation
+- `chapter-card`: create chapter/scene cards from existing canon
+- `draft-scene`: draft a scene or chapter slice from approved cards
+- `polish`: rewrite prose while preserving canon and tone
+- `audit`: inspect canon drift, retcon impact, and missing references
+
+## Canon Root
+
+Default canonical root:
+
+`doc/game/lore/<story-slug>/`
+
+Recommended artifact layout:
+
+- `world-bible.md`
+- `character-registry.md`
+- `timeline.md`
+- `plot-branches.md`
+- `chapter-cards/`
+- `drafts/`
+- `consistency-report.md`
+- `canon-log.md`
+
+Use stable IDs everywhere:
+
+- world rules: `WR-*`
+- factions: `FAC-*`
+- locations: `LOC-*`
+- technologies: `TEC-*`
+- characters: `CHAR-*`
+- timeline events: `TL-*`
+- plot beats: `PB-*`
+- chapter cards: `CH-*`
+
+## One-Pass Perfect Workflow
+
+### 0) Intake Gate
+
+Collect the minimal context: `story_slug`, `task_mode`, `premise`, `canon_scope`.
+If any required field is missing, stop and request it.
+
+### 1) Route Gate
+
+- If premise is ambiguous: run `brainstorm` first (2–3 options + 1 recommendation).
+- If premise is clear: continue.
+
+### 2) Canon Gate (strict order)
+
+1. `world-bible.md`
+2. `character-registry.md`
+3. `timeline.md`
+
+Do not produce chapter cards or prose that rely on undefined canon.
+
+### 3) Plot Gate
+
+Update `plot-branches.md` for major arc choices and append decision rationale to `canon-log.md`.
+
+### 4) Card Gate
+
+Create chapter cards before prose. Every card must cite at least one `TL-*` and one `CHAR-*`.
+
+### 5) Draft Gate
+
+Draft prose in slices:
+
+- scene slice: 800–2000 Chinese characters
+- chapter slice: 2000–6000 Chinese characters
+
+### 6) Polish Gate
+
+Optionally apply `humanizer-zh` for Chinese tone quality while preserving canon facts.
+
+### 7) Audit Gate
+
+Update `consistency-report.md` and `canon-log.md`.
+Verify timeline consistency, character-state consistency, and term drift.
+
+### 8) Formal Writeback Gate
+
+If bound to `.pm` task, append execution note to `.pm/tasks/<TASK-UID>.execution.md` with:
+
+- Action
+- Validation Command
+- Expected Result
+- Actual Result
+- Blocker
+- Next Action
+
+## Integration with Existing Local Surfaces
+
+- governance entrypoint: `.agents/skills/README.md`
+- skill authoring: `.agents/skills/writing-repo-owned-skills/SKILL.md`
+- world/system decomposition: `.agents/skills/game-architect/SKILL.md`
+- option comparison: `.agents/skills/bounded-brainstorming/SKILL.md`
+- prose polish: `.agents/skills/humanizer-zh/SKILL.md`
+
+This skill does **not** replace bootstrap/router/verification/closeout workflow surfaces.
+
+## Supporting Files
+
+- `templates/world-bible.template.md`
+- `templates/character-registry.template.md`
+- `templates/timeline.template.md`
+- `templates/plot-branches.template.md`
+- `templates/chapter-card.template.md`
+- `templates/canon-log.template.md`
+- `templates/consistency-report.template.md`
+
+## Guardrails
+
+- Do not create a second planning system outside repo truth.
+- Do not overwrite existing canon silently.
+- Do not delete canon files.
+- Do not imitate a living author’s distinctive signature voice as a target.
+- Do not output giant prose dumps before card-level planning.
+- Keep default output language in Chinese unless explicitly requested otherwise.
+
+## Verification
+
+Run checks before claiming ready:
+
+- `git diff --check`
+- `./scripts/doc-governance-check.sh`
+- `python3 .agents/skills/epic-story-orchestrator-zh/tests/validate_writeback.py`
+- `bash .agents/skills/epic-story-orchestrator-zh/tests/run_smoke.sh`
+
+For story assets, run reference scan:
+
+- `rg -n 'WR-|FAC-|LOC-|TEC-|CHAR-|TL-|PB-|CH-' doc/game/lore/<story-slug>/`

--- a/.agents/skills/epic-story-orchestrator-zh/templates/canon-log.template.md
+++ b/.agents/skills/epic-story-orchestrator-zh/templates/canon-log.template.md
@@ -1,0 +1,9 @@
+# Canon Log
+
+## YYYY-MM-DD HH:MM:SS / producer_system_designer
+- Action:
+- Validation Command:
+- Expected Result:
+- Actual Result:
+- Blocker: none
+- Next Action:

--- a/.agents/skills/epic-story-orchestrator-zh/templates/chapter-card.template.md
+++ b/.agents/skills/epic-story-orchestrator-zh/templates/chapter-card.template.md
@@ -1,0 +1,12 @@
+# Chapter Card (CH-*)
+
+- POV:
+- Timeline Anchor (TL-*):
+- Location (LOC-*):
+- Characters (CHAR-*):
+- Goal:
+- Conflict:
+- Reveal:
+- Emotional Shift:
+- Canon References (WR-*/FAC-*/PB-*):
+- Forbidden Contradictions:

--- a/.agents/skills/epic-story-orchestrator-zh/templates/chapter-card.template.md
+++ b/.agents/skills/epic-story-orchestrator-zh/templates/chapter-card.template.md
@@ -9,4 +9,10 @@
 - Reveal:
 - Emotional Shift:
 - Canon References (WR-*/FAC-*/PB-*):
+- Gameplay PRD Refs (PRD-GAME-*):
+- player_leverage:
+- world_change_due_to_player:
+- control_feeling_guarantee:
+- small_player_lane_stage:
+- release_claim_boundary:
 - Forbidden Contradictions:

--- a/.agents/skills/epic-story-orchestrator-zh/templates/character-registry.template.md
+++ b/.agents/skills/epic-story-orchestrator-zh/templates/character-registry.template.md
@@ -1,0 +1,9 @@
+# Character Registry
+
+## CHAR-*
+- Name:
+- Arc Role:
+- Goal / Fear / Wound:
+- Public Mask / Private Drive:
+- Voice Notes:
+- Relationships:

--- a/.agents/skills/epic-story-orchestrator-zh/templates/consistency-report.template.md
+++ b/.agents/skills/epic-story-orchestrator-zh/templates/consistency-report.template.md
@@ -21,6 +21,12 @@
 - Status:
 - Findings:
 
+## Gameplay Canon Binding
+- PRD-GAME refs present:
+- player_leverage != world_activity_only:
+- control-feeling guarantee present:
+- release claim boundary preserved:
+
 ## Affected Cards/Drafts
 - CH-*:
 - Draft Paths:

--- a/.agents/skills/epic-story-orchestrator-zh/templates/consistency-report.template.md
+++ b/.agents/skills/epic-story-orchestrator-zh/templates/consistency-report.template.md
@@ -1,0 +1,31 @@
+# Consistency Report
+
+- Story Slug:
+- Scope:
+- Auditor Role:
+- Time:
+
+## Timeline Consistency
+- Status:
+- Findings:
+
+## Character State Consistency
+- Status:
+- Findings:
+
+## Immutable Rule Violations
+- Status:
+- Findings:
+
+## Terminology Drift
+- Status:
+- Findings:
+
+## Affected Cards/Drafts
+- CH-*:
+- Draft Paths:
+
+## Decision
+- pass/fail:
+- blocker:
+- next action:

--- a/.agents/skills/epic-story-orchestrator-zh/templates/gameplay-canon-binding.template.md
+++ b/.agents/skills/epic-story-orchestrator-zh/templates/gameplay-canon-binding.template.md
@@ -1,0 +1,21 @@
+# Gameplay Canon Binding
+
+- Story Slug:
+- Current Game Scope:
+- Gameplay PRD Refs (PRD-GAME-*):
+- Claim Envelope Boundary:
+- Physical / Interaction Boundary:
+
+## Player Leverage Contract
+- player_leverage:
+- world_change_due_to_player:
+- world_activity_only risk:
+
+## Control-Feeling Contract
+- accepted intent / causality / fallback / reprioritize / resume guarantee:
+- blocker signature if absent:
+
+## Small-Player Lane
+- small_player_lane_stage:
+- regional value:
+- recovery / pivot path:

--- a/.agents/skills/epic-story-orchestrator-zh/templates/plot-branches.template.md
+++ b/.agents/skills/epic-story-orchestrator-zh/templates/plot-branches.template.md
@@ -1,0 +1,17 @@
+# Plot Branches
+
+## Branch A
+- Summary:
+- Tradeoffs:
+
+## Branch B
+- Summary:
+- Tradeoffs:
+
+## Branch C
+- Summary:
+- Tradeoffs:
+
+## Recommendation
+- Chosen Branch:
+- Why:

--- a/.agents/skills/epic-story-orchestrator-zh/templates/timeline.template.md
+++ b/.agents/skills/epic-story-orchestrator-zh/templates/timeline.template.md
@@ -1,0 +1,9 @@
+# Timeline
+
+## TL-*
+- Sequence:
+- Date/Anchor:
+- Actors:
+- Cause:
+- Consequence:
+- Rollback Risk:

--- a/.agents/skills/epic-story-orchestrator-zh/templates/world-bible.template.md
+++ b/.agents/skills/epic-story-orchestrator-zh/templates/world-bible.template.md
@@ -13,3 +13,9 @@
 ## Technology Ceiling (TEC-*)
 
 ## Tone & Theme Boundaries
+
+## Oasis7 Current-Game Binding
+- Gameplay PRD Refs:
+- Claim Envelope Boundary:
+- Player Role Boundary:
+- Physical / Interaction Boundary:

--- a/.agents/skills/epic-story-orchestrator-zh/templates/world-bible.template.md
+++ b/.agents/skills/epic-story-orchestrator-zh/templates/world-bible.template.md
@@ -1,0 +1,15 @@
+# World Bible
+
+- Story Slug:
+- Logline:
+- Premise:
+
+## Immutable Rules (WR-*)
+
+## Factions (FAC-*)
+
+## Locations (LOC-*)
+
+## Technology Ceiling (TEC-*)
+
+## Tone & Theme Boundaries

--- a/.agents/skills/epic-story-orchestrator-zh/tests/fixtures/writeback.sample.json
+++ b/.agents/skills/epic-story-orchestrator-zh/tests/fixtures/writeback.sample.json
@@ -2,6 +2,14 @@
   "story_slug": "heliopause-exodus",
   "task_mode": "chapter-card",
   "canon_scope": "chapter",
+  "gameplay_canon_binding": {
+    "gameplay_prd_refs": ["PRD-GAME-012", "PRD-GAME-014", "PRD-GAME-015"],
+    "player_leverage": "玩家完成一次低爆炸半径的区域工业胜利，并获得新的修复/扩产选择。",
+    "world_change_due_to_player": "本地冶炼节点从停机恢复为稳定产出，区域供应链出现可见改善。",
+    "control_feeling_guarantee": "accepted intent + causality + fallback",
+    "small_player_lane_stage": "local_operator",
+    "release_claim_boundary": "limited playable technical preview; stage upgrade not implied"
+  },
   "writeback_targets": [
     {
       "path": "doc/game/lore/heliopause-exodus/chapter-cards/ch-003.md",
@@ -16,7 +24,8 @@
     "world_rules": ["WR-001", "WR-004"],
     "characters": ["CHAR-LIN-001", "CHAR-QIAO-002"],
     "timeline": ["TL-012"],
-    "plot_beats": ["PB-007"]
+    "plot_beats": ["PB-007"],
+    "gameplay_prds": ["PRD-GAME-012", "PRD-GAME-014", "PRD-GAME-015"]
   },
   "consistency": {
     "status": "pass",

--- a/.agents/skills/epic-story-orchestrator-zh/tests/fixtures/writeback.sample.json
+++ b/.agents/skills/epic-story-orchestrator-zh/tests/fixtures/writeback.sample.json
@@ -1,0 +1,25 @@
+{
+  "story_slug": "heliopause-exodus",
+  "task_mode": "chapter-card",
+  "canon_scope": "chapter",
+  "writeback_targets": [
+    {
+      "path": "doc/game/lore/heliopause-exodus/chapter-cards/ch-003.md",
+      "mode": "overwrite"
+    },
+    {
+      "path": "doc/game/lore/heliopause-exodus/canon-log.md",
+      "mode": "append"
+    }
+  ],
+  "artifact_refs": {
+    "world_rules": ["WR-001", "WR-004"],
+    "characters": ["CHAR-LIN-001", "CHAR-QIAO-002"],
+    "timeline": ["TL-012"],
+    "plot_beats": ["PB-007"]
+  },
+  "consistency": {
+    "status": "pass",
+    "issues": []
+  }
+}

--- a/.agents/skills/epic-story-orchestrator-zh/tests/run_smoke.sh
+++ b/.agents/skills/epic-story-orchestrator-zh/tests/run_smoke.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+skill_root=".agents/skills/epic-story-orchestrator-zh"
+
+for p in \
+  "$skill_root/SKILL.md" \
+  "$skill_root/README.md" \
+  "$skill_root/templates/world-bible.template.md" \
+  "$skill_root/templates/character-registry.template.md" \
+  "$skill_root/templates/timeline.template.md" \
+  "$skill_root/templates/plot-branches.template.md" \
+  "$skill_root/templates/chapter-card.template.md" \
+  "$skill_root/templates/canon-log.template.md" \
+  "$skill_root/templates/consistency-report.template.md" \
+  "$skill_root/tests/smoke-scaffold.md" \
+  "$skill_root/tests/smoke-chapter-draft.md" \
+  "$skill_root/tests/smoke-canon-audit.md" \
+  "$skill_root/tests/fixtures/writeback.sample.json" \
+  "$skill_root/tests/validate_writeback.py"
+do
+  test -f "$p"
+done
+
+python3 "$skill_root/tests/validate_writeback.py"
+git diff --check
+./scripts/doc-governance-check.sh
+
+if [[ "${RUN_PM_LINT:-0}" == "1" ]]; then
+  ./scripts/pm/lint.sh
+else
+  echo "skip pm lint (set RUN_PM_LINT=1 to enable)"
+fi
+
+echo "epic-story-orchestrator-zh smoke: OK"

--- a/.agents/skills/epic-story-orchestrator-zh/tests/run_smoke.sh
+++ b/.agents/skills/epic-story-orchestrator-zh/tests/run_smoke.sh
@@ -10,6 +10,7 @@ for p in \
   "$skill_root/templates/character-registry.template.md" \
   "$skill_root/templates/timeline.template.md" \
   "$skill_root/templates/plot-branches.template.md" \
+  "$skill_root/templates/gameplay-canon-binding.template.md" \
   "$skill_root/templates/chapter-card.template.md" \
   "$skill_root/templates/canon-log.template.md" \
   "$skill_root/templates/consistency-report.template.md" \

--- a/.agents/skills/epic-story-orchestrator-zh/tests/smoke-canon-audit.md
+++ b/.agents/skills/epic-story-orchestrator-zh/tests/smoke-canon-audit.md
@@ -1,0 +1,3 @@
+# Smoke: canon audit
+
+使用 `task_mode=audit` 生成 consistency-report 并 append canon-log。

--- a/.agents/skills/epic-story-orchestrator-zh/tests/smoke-chapter-draft.md
+++ b/.agents/skills/epic-story-orchestrator-zh/tests/smoke-chapter-draft.md
@@ -1,0 +1,3 @@
+# Smoke: chapter draft
+
+使用 `task_mode=chapter-card` 与 `task_mode=draft-scene`，验证章节卡引用 ID 完整。

--- a/.agents/skills/epic-story-orchestrator-zh/tests/smoke-scaffold.md
+++ b/.agents/skills/epic-story-orchestrator-zh/tests/smoke-scaffold.md
@@ -1,0 +1,3 @@
+# Smoke: scaffold
+
+使用 `task_mode=scaffold` 创建最小 world-bible、character-registry、timeline 与 canon-log。

--- a/.agents/skills/epic-story-orchestrator-zh/tests/validate_writeback.py
+++ b/.agents/skills/epic-story-orchestrator-zh/tests/validate_writeback.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+import json
+from pathlib import Path
+
+p = Path('.agents/skills/epic-story-orchestrator-zh/tests/fixtures/writeback.sample.json')
+data = json.loads(p.read_text(encoding='utf-8'))
+
+required = ['story_slug', 'task_mode', 'canon_scope', 'writeback_targets', 'artifact_refs', 'consistency']
+missing = [k for k in required if k not in data]
+if missing:
+    raise SystemExit(f'missing required keys: {missing}')
+
+if not isinstance(data['writeback_targets'], list) or not data['writeback_targets']:
+    raise SystemExit('writeback_targets must be a non-empty list')
+
+for i, target in enumerate(data['writeback_targets']):
+    if 'path' not in target or 'mode' not in target:
+        raise SystemExit(f'writeback_targets[{i}] missing path/mode')
+    if target['mode'] not in {'overwrite', 'append', 'create'}:
+        raise SystemExit(f'writeback_targets[{i}] invalid mode: {target["mode"]}')
+
+for key in ['world_rules', 'characters', 'timeline', 'plot_beats']:
+    if key not in data['artifact_refs'] or not isinstance(data['artifact_refs'][key], list):
+        raise SystemExit(f'artifact_refs.{key} must be list')
+
+if data.get('consistency', {}).get('status') not in {'pass', 'fail'}:
+    raise SystemExit('consistency.status must be pass/fail')
+
+print('validate_writeback: OK')

--- a/.agents/skills/epic-story-orchestrator-zh/tests/validate_writeback.py
+++ b/.agents/skills/epic-story-orchestrator-zh/tests/validate_writeback.py
@@ -5,7 +5,15 @@ from pathlib import Path
 p = Path('.agents/skills/epic-story-orchestrator-zh/tests/fixtures/writeback.sample.json')
 data = json.loads(p.read_text(encoding='utf-8'))
 
-required = ['story_slug', 'task_mode', 'canon_scope', 'writeback_targets', 'artifact_refs', 'consistency']
+required = [
+    'story_slug',
+    'task_mode',
+    'canon_scope',
+    'gameplay_canon_binding',
+    'writeback_targets',
+    'artifact_refs',
+    'consistency',
+]
 missing = [k for k in required if k not in data]
 if missing:
     raise SystemExit(f'missing required keys: {missing}')
@@ -19,9 +27,38 @@ for i, target in enumerate(data['writeback_targets']):
     if target['mode'] not in {'overwrite', 'append', 'create'}:
         raise SystemExit(f'writeback_targets[{i}] invalid mode: {target["mode"]}')
 
-for key in ['world_rules', 'characters', 'timeline', 'plot_beats']:
+for key in ['world_rules', 'characters', 'timeline', 'plot_beats', 'gameplay_prds']:
     if key not in data['artifact_refs'] or not isinstance(data['artifact_refs'][key], list):
         raise SystemExit(f'artifact_refs.{key} must be list')
+
+binding = data['gameplay_canon_binding']
+binding_required = [
+    'gameplay_prd_refs',
+    'player_leverage',
+    'world_change_due_to_player',
+    'control_feeling_guarantee',
+    'small_player_lane_stage',
+    'release_claim_boundary',
+]
+binding_missing = [k for k in binding_required if k not in binding]
+if binding_missing:
+    raise SystemExit(f'gameplay_canon_binding missing required keys: {binding_missing}')
+
+if not isinstance(binding['gameplay_prd_refs'], list) or not binding['gameplay_prd_refs']:
+    raise SystemExit('gameplay_canon_binding.gameplay_prd_refs must be a non-empty list')
+
+for ref in binding['gameplay_prd_refs']:
+    if not isinstance(ref, str) or not ref.startswith('PRD-GAME-'):
+        raise SystemExit(f'invalid gameplay PRD ref: {ref}')
+
+allowed_lane_stages = {'none', 'local_operator', 'regional_specialist', 'limited_scope_regional_influence'}
+if binding['small_player_lane_stage'] not in allowed_lane_stages:
+    raise SystemExit(f'invalid small_player_lane_stage: {binding["small_player_lane_stage"]}')
+
+boundary = binding['release_claim_boundary'].lower()
+blocked_claims = ['closed beta', 'play now', 'live now']
+if any(claim in boundary for claim in blocked_claims):
+    raise SystemExit(f'release_claim_boundary contains blocked claim: {binding["release_claim_boundary"]}')
 
 if data.get('consistency', {}).get('status') not in {'pass', 'fail'}:
     raise SystemExit('consistency.status must be pass/fail')

--- a/.agents/skills/epic-story-orchestrator-zh/tests/validate_writeback.py
+++ b/.agents/skills/epic-story-orchestrator-zh/tests/validate_writeback.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import json
 from pathlib import Path
+import re
 
 p = Path('.agents/skills/epic-story-orchestrator-zh/tests/fixtures/writeback.sample.json')
 data = json.loads(p.read_text(encoding='utf-8'))
@@ -46,6 +47,26 @@ if binding_missing:
 
 if not isinstance(binding['gameplay_prd_refs'], list) or not binding['gameplay_prd_refs']:
     raise SystemExit('gameplay_canon_binding.gameplay_prd_refs must be a non-empty list')
+
+story_slug = data['story_slug']
+if not isinstance(story_slug, str) or not re.fullmatch(r'[a-z0-9]+(?:-[a-z0-9]+)*', story_slug):
+    raise SystemExit(f'invalid story_slug: {story_slug}')
+
+canonical_root = f'doc/game/lore/{story_slug}/'
+append_only_paths = {f'{canonical_root}canon-log.md'}
+
+for i, target in enumerate(data['writeback_targets']):
+    path = target['path']
+    if not isinstance(path, str) or path.startswith('/') or '..' in Path(path).parts:
+        raise SystemExit(f'writeback_targets[{i}] invalid path: {path}')
+    if not path.startswith(canonical_root):
+        raise SystemExit(
+            f'writeback_targets[{i}] path must stay under {canonical_root}: {path}'
+        )
+    if target['mode'] == 'append' and path not in append_only_paths:
+        raise SystemExit(f'writeback_targets[{i}] append only allowed for canon-log.md: {path}')
+    if path in append_only_paths and target['mode'] != 'append':
+        raise SystemExit(f'writeback_targets[{i}] canon-log.md must use append mode: {path}')
 
 for ref in binding['gameplay_prd_refs']:
     if not isinstance(ref, str) or not ref.startswith('PRD-GAME-'):


### PR DESCRIPTION
### Motivation

- Introduce a repo-owned skill to plan, scaffold, and maintain canonical Chinese long-form story assets (world bible, character registry, timeline, chapter cards, consistency reports, and canon log).
- Provide structured writeback rules and guardrails so story truth is tracked in the repo instead of chat-only output.
- Surface the skill in the global skills index so it can be discovered and used by other workflows.

### Description

- Added a new skill under `.agents/skills/epic-story-orchestrator-zh/` including `SKILL.md` with metadata, task modes, gates, writeback rules, and guardrails.
- Added a skill `README.md` describing goals, default writeback root, verification commands, and artifact layout.
- Added templates for common artifacts: `world-bible`, `character-registry`, `timeline`, `plot-branches`, `chapter-card`, `canon-log`, and `consistency-report` under `templates/`.
- Added tests, fixtures, and smoke harness under `tests/`: `validate_writeback.py`, `run_smoke.sh`, smoke scenario docs, and a sample writeback fixture; and updated the main skills index `.agents/skills/README.md` to include the skill.

### Testing

- Added automated validation and smoke scripts: `python3 .agents/skills/epic-story-orchestrator-zh/tests/validate_writeback.py` and `bash .agents/skills/epic-story-orchestrator-zh/tests/run_smoke.sh` which check fixture structure, required files, `git diff --check`, and `./scripts/doc-governance-check.sh`.
- Included a sample fixture at `tests/fixtures/writeback.sample.json` used by the validator to verify writeback target and artifact reference shapes.
- No automated tests were executed by CI as part of this PR; the added smoke and validation scripts are intended to be run locally or in CI and should pass when the repository scripts referenced (`./scripts/doc-governance-check.sh`, optional `./scripts/pm/lint.sh`) are available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a141d0f33788331a5a71adc266e6bb7)