### PR TITLE
Fix workflow scripts for macOS compatibility

### DIFF
--- a/scripts/doc-governance-check.sh
+++ b/scripts/doc-governance-check.sh
@@ -64,12 +64,10 @@ readonly REFERENCE_EXISTENCE_EXEMPT_DOCS=(
 readonly DOC_ROOT_MD_ALLOWLIST_FILE="doc/.governance/doc-root-md-allowlist.txt"
 readonly MODULE_ROOT_MD_ALLOWLIST_FILE="doc/.governance/module-root-md-allowlist.txt"
 
-mapfile -t CANONICAL_ROLE_NAMES < <(find .agents/roles -mindepth 1 -maxdepth 1 -type f -name '*.md' -printf '%f\n' | sed 's/\.md$//' | sort)
-declare -A CANONICAL_ROLE_NAME_SET=()
-for role_name in "${CANONICAL_ROLE_NAMES[@]}"; do
-  CANONICAL_ROLE_NAME_SET["$role_name"]=1
-done
-
+CANONICAL_ROLE_NAMES=()
+while IFS= read -r role_name; do
+  CANONICAL_ROLE_NAMES+=("$role_name")
+done < <(find .agents/roles -mindepth 1 -maxdepth 1 -type f -name '*.md' | sed 's#^.*/##; s/\.md$//' | sort)
 fail() {
   echo "doc-governance-check: FAIL: $*"
   failures=$((failures + 1))
@@ -287,7 +285,16 @@ check_doc_path_references() {
 
 is_canonical_role_name() {
   local role_name="$1"
-  [[ -n "${CANONICAL_ROLE_NAME_SET[$role_name]:-}" ]]
+  local canonical_role_name=""
+  if [[ "${#CANONICAL_ROLE_NAMES[@]}" -eq 0 ]]; then
+    return 1
+  fi
+  for canonical_role_name in "${CANONICAL_ROLE_NAMES[@]}"; do
+    if [[ "$canonical_role_name" == "$role_name" ]]; then
+      return 0
+    fi
+  done
+  return 1
 }
 
 trim_whitespace() {
@@ -371,7 +378,8 @@ check_added_project_task_row_policy() {
   local task_row_regex='^-[[:space:]]\[[ x]\][[:space:]]'
   local deprecated_task_regex='^-[[:space:]]\[[ x]\][[:space:]]TASK-'
   local new_format_regex='^- \[[ x]\] [a-z0-9]+(-[a-z0-9]+)* \(PRD-[A-Z0-9_-]+(/[A-Z0-9_-]+)*\) \[test_tier_(required|full)\]( \+ \[test_tier_(required|full)\])?: .+ Trace: \.pm/tasks/task_[0-9a-f]{32}\.yaml$'
-  declare -A removed_task_rows=()
+  local removed_task_rows=()
+  local removed_task_row_key=""
 
   while IFS= read -r line; do
     if [[ "$line" =~ ^diff[[:space:]]--git[[:space:]] ]]; then
@@ -387,7 +395,7 @@ check_added_project_task_row_policy() {
       removed_line="${line#-}"
       [[ "$removed_line" =~ $task_row_regex ]] || continue
       normalized_row="$(normalize_project_task_row_for_policy "$removed_line")"
-      removed_task_rows["${current_file}::${normalized_row}"]=1
+      removed_task_rows+=("${current_file}::${normalized_row}")
       continue
     fi
     [[ "$line" =~ ^\+[^+] ]] || continue
@@ -395,8 +403,12 @@ check_added_project_task_row_policy() {
     [[ "$added_line" =~ $task_row_regex ]] || continue
     normalized_row="$(normalize_project_task_row_for_policy "$added_line")"
 
-    if [[ -n "${removed_task_rows["${current_file}::${normalized_row}"]:-}" ]]; then
-      continue
+    if [[ "${#removed_task_rows[@]}" -gt 0 ]]; then
+      for removed_task_row_key in "${removed_task_rows[@]}"; do
+        if [[ "$removed_task_row_key" == "${current_file}::${normalized_row}" ]]; then
+          continue 2
+        fi
+      done
     fi
 
     if [[ "$added_line" =~ $deprecated_task_regex ]]; then
@@ -413,10 +425,25 @@ check_added_project_task_row_policy() {
   done <<< "$diff_blob"
 }
 
-mapfile -t all_doc_files < <(find doc -type f -name '*.md' ! -path 'doc/devlog/*' ! -path '*/archive/*' | sort)
-mapfile -t project_docs < <(find doc -type f -name '*.project.md' ! -path '*/archive/*' | sort)
-mapfile -t devlog_files < <(find doc/devlog -type f -name '*.md' | sort)
-mapfile -t handoff_template_files < <(find .agents/roles/templates -type f -name '*.md' | sort)
+all_doc_files=()
+while IFS= read -r file; do
+  all_doc_files+=("$file")
+done < <(find doc -type f -name '*.md' ! -path 'doc/devlog/*' ! -path '*/archive/*' | sort)
+
+project_docs=()
+while IFS= read -r file; do
+  project_docs+=("$file")
+done < <(find doc -type f -name '*.project.md' ! -path '*/archive/*' | sort)
+
+devlog_files=()
+while IFS= read -r file; do
+  devlog_files+=("$file")
+done < <(find doc/devlog -type f -name '*.md' | sort)
+
+handoff_template_files=()
+while IFS= read -r file; do
+  handoff_template_files+=("$file")
+done < <(find .agents/roles/templates -type f -name '*.md' | sort)
 
 if [[ ${#all_doc_files[@]} -eq 0 ]]; then
   fail "no markdown files found under doc/"

--- a/scripts/new-task-worktree.sh
+++ b/scripts/new-task-worktree.sh
@@ -456,9 +456,11 @@ if [[ "$PM_BOOTSTRAP" == "1" ]]; then
   for acceptance in "${PM_ACCEPTANCE[@]}"; do
     NEW_TASK_CMD+=(--acceptance "$acceptance")
   done
-  for handoff_role in "${PM_HANDOFF_TO[@]}"; do
-    NEW_TASK_CMD+=(--handoff-to "$handoff_role")
-  done
+  if [[ "${#PM_HANDOFF_TO[@]}" -gt 0 ]]; then
+    for handoff_role in "${PM_HANDOFF_TO[@]}"; do
+      NEW_TASK_CMD+=(--handoff-to "$handoff_role")
+    done
+  fi
   NEW_TASK_CMD+=(--worktree-hint "$TARGET_PATH" --json)
 
   set +e

--- a/scripts/pm/codex-working-memory-smoke.sh
+++ b/scripts/pm/codex-working-memory-smoke.sh
@@ -8,6 +8,24 @@ OUTPUT_JSON=0
 KEEP_TEMP=0
 SMOKE_TASK_UID="task_a878d035986f54a79dc65a383a87de1c"
 
+sha256_file() {
+  local path="$1"
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$path" | awk '{print $1}'
+    return
+  fi
+  if command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$path" | awk '{print $1}'
+    return
+  fi
+  if command -v openssl >/dev/null 2>&1; then
+    openssl dgst -sha256 "$path" | awk '{print $NF}'
+    return
+  fi
+  echo "codex-working-memory-smoke: no SHA-256 command found" >&2
+  exit 1
+}
+
 usage() {
   cat <<'USAGE'
 Usage: ./scripts/pm/codex-working-memory-smoke.sh [--json] [--keep-temp]
@@ -274,11 +292,11 @@ RESULT_JSON_REGISTRY="$(PM_ROOT_DIR="$TMPDIR" "$ROOT_DIR/scripts/pm/codex-workin
   --codex-bin "$TMPDIR/fake-codex" \
   --json)"
 
-DRY_RUN_SIGNAL_SHA_BEFORE="$(sha256sum "$TMPDIR/.pm/inbox/signals.jsonl" | awk '{print $1}')"
-DRY_RUN_WM_SHA_BEFORE="$(sha256sum "$TMPDIR/.pm/working_memory/$SMOKE_TASK_UID.yaml" | awk '{print $1}')"
-DRY_RUN_TASK_REGISTRY_SHA_BEFORE="$(sha256sum "$TMPDIR/.pm/registry/tasks.yaml" | awk '{print $1}')"
-DRY_RUN_BACKLOG_SHA_BEFORE="$(sha256sum "$TMPDIR/.pm/roles/producer_system_designer/backlog/candidate.yaml" | awk '{print $1}')"
-DRY_RUN_TASK_LIST_BEFORE="$(find "$TMPDIR/.pm/tasks" -maxdepth 1 -type f -printf '%f\n' | sort)"
+DRY_RUN_SIGNAL_SHA_BEFORE="$(sha256_file "$TMPDIR/.pm/inbox/signals.jsonl")"
+DRY_RUN_WM_SHA_BEFORE="$(sha256_file "$TMPDIR/.pm/working_memory/$SMOKE_TASK_UID.yaml")"
+DRY_RUN_TASK_REGISTRY_SHA_BEFORE="$(sha256_file "$TMPDIR/.pm/registry/tasks.yaml")"
+DRY_RUN_BACKLOG_SHA_BEFORE="$(sha256_file "$TMPDIR/.pm/roles/producer_system_designer/backlog/candidate.yaml")"
+DRY_RUN_TASK_LIST_BEFORE="$(find "$TMPDIR/.pm/tasks" -maxdepth 1 -type f | sed 's#^.*/##' | sort)"
 DRY_RUN_JSON="$(PM_ROOT_DIR="$TMPDIR" "$ROOT_DIR/scripts/pm/working-memory-autoflow.sh" \
   --task-uid "$SMOKE_TASK_UID" \
   --entry-id WM-0002 \
@@ -286,11 +304,11 @@ DRY_RUN_JSON="$(PM_ROOT_DIR="$TMPDIR" "$ROOT_DIR/scripts/pm/working-memory-autof
   --priority P2 \
   --dry-run \
   --json)"
-DRY_RUN_SIGNAL_SHA_AFTER="$(sha256sum "$TMPDIR/.pm/inbox/signals.jsonl" | awk '{print $1}')"
-DRY_RUN_WM_SHA_AFTER="$(sha256sum "$TMPDIR/.pm/working_memory/$SMOKE_TASK_UID.yaml" | awk '{print $1}')"
-DRY_RUN_TASK_REGISTRY_SHA_AFTER="$(sha256sum "$TMPDIR/.pm/registry/tasks.yaml" | awk '{print $1}')"
-DRY_RUN_BACKLOG_SHA_AFTER="$(sha256sum "$TMPDIR/.pm/roles/producer_system_designer/backlog/candidate.yaml" | awk '{print $1}')"
-DRY_RUN_TASK_LIST_AFTER="$(find "$TMPDIR/.pm/tasks" -maxdepth 1 -type f -printf '%f\n' | sort)"
+DRY_RUN_SIGNAL_SHA_AFTER="$(sha256_file "$TMPDIR/.pm/inbox/signals.jsonl")"
+DRY_RUN_WM_SHA_AFTER="$(sha256_file "$TMPDIR/.pm/working_memory/$SMOKE_TASK_UID.yaml")"
+DRY_RUN_TASK_REGISTRY_SHA_AFTER="$(sha256_file "$TMPDIR/.pm/registry/tasks.yaml")"
+DRY_RUN_BACKLOG_SHA_AFTER="$(sha256_file "$TMPDIR/.pm/roles/producer_system_designer/backlog/candidate.yaml")"
+DRY_RUN_TASK_LIST_AFTER="$(find "$TMPDIR/.pm/tasks" -maxdepth 1 -type f | sed 's#^.*/##' | sort)"
 
 SIGNAL_JSON="$(PM_ROOT_DIR="$TMPDIR" "$ROOT_DIR/scripts/pm/working-memory-to-signal.sh" \
   --task-uid "$SMOKE_TASK_UID" \

--- a/scripts/pm/lint.sh
+++ b/scripts/pm/lint.sh
@@ -84,8 +84,15 @@ require_file "scripts/pm/working-memory-to-signal.sh"
 require_file "scripts/pm/workflow-report.sh"
 require_file "scripts/pm/schemas/codex-working-memory.schema.json"
 
-mapfile -t CANONICAL_ROLES < <(find .agents/roles -mindepth 1 -maxdepth 1 -type f -name '*.md' -printf '%f\n' | sed 's/\.md$//' | sort)
-mapfile -t REGISTRY_ROLES < <(sed -n 's/^  - role_name: //p' .pm/registry/roles.yaml | sort)
+CANONICAL_ROLES=()
+while IFS= read -r role; do
+  CANONICAL_ROLES+=("$role")
+done < <(find .agents/roles -mindepth 1 -maxdepth 1 -type f -name '*.md' | sed 's#^.*/##; s/\.md$//' | sort)
+
+REGISTRY_ROLES=()
+while IFS= read -r role; do
+  REGISTRY_ROLES+=("$role")
+done < <(sed -n 's/^  - role_name: //p' .pm/registry/roles.yaml | sort)
 
 if [[ "${#CANONICAL_ROLES[@]}" -ne "${#REGISTRY_ROLES[@]}" ]]; then
   fail "role count mismatch: canonical=${#CANONICAL_ROLES[@]} registry=${#REGISTRY_ROLES[@]}"

--- a/scripts/pm/memory-regression-smoke.sh
+++ b/scripts/pm/memory-regression-smoke.sh
@@ -66,13 +66,88 @@ mkdir -p "$TMPDIR/.pm/evidence" "$TMPDIR/.pm/shared/memory" "$TMPDIR/.pm/stage"
 python3 - "$TMPDIR" "$ROOT_DIR" <<'PY'
 from pathlib import Path
 import json
+import hashlib
+import re
 import shutil
 import sys
 
-import yaml
-
 root = Path(sys.argv[1])
 source_root = Path(sys.argv[2])
+
+
+def rewrite_missing_absolute_source_refs() -> None:
+    replacement_dir = root / ".pm/evidence/portable-source-refs"
+    absolute_ref_pattern = re.compile(r"/(?:home|Users)/[^\s\"']+")
+    for path in list((root / ".pm").rglob("*.yaml")) + list((root / ".pm").rglob("*.jsonl")):
+        text = path.read_text(encoding="utf-8")
+        replacements: dict[str, str] = {}
+        for match in absolute_ref_pattern.finditer(text):
+            raw_ref = match.group(0).rstrip(",")
+            raw_path = raw_ref.split("#", 1)[0]
+            if Path(raw_path).exists():
+                continue
+            digest = hashlib.sha256(raw_path.encode("utf-8")).hexdigest()[:16]
+            replacement = replacement_dir / f"{digest}.jsonl"
+            replacement.parent.mkdir(parents=True, exist_ok=True)
+            if not replacement.exists():
+                replacement.write_text('{"portable_placeholder": true}\n', encoding="utf-8")
+            replacements[raw_ref] = str(replacement.relative_to(root))
+        for old, new in replacements.items():
+            text = text.replace(old, new)
+        if replacements:
+            path.write_text(text, encoding="utf-8")
+
+
+rewrite_missing_absolute_source_refs()
+
+
+def parse_simple_yaml(path: Path) -> dict[str, object]:
+    parsed: dict[str, object] = {}
+    current_list_key: str | None = None
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.rstrip()
+        if not line or line.lstrip().startswith("#"):
+            continue
+        if line.startswith("  - ") and current_list_key:
+            parsed.setdefault(current_list_key, []).append(line[4:].strip().strip('"'))
+            continue
+        current_list_key = None
+        if line.startswith(" ") or ":" not in line:
+            continue
+        key, value = line.split(":", 1)
+        value = value.strip()
+        if value == "[]":
+            parsed[key] = []
+        elif value == "":
+            parsed[key] = []
+            current_list_key = key
+        elif value == "null":
+            parsed[key] = None
+        else:
+            parsed[key] = value.strip('"')
+    return parsed
+
+
+def iter_source_refs(path: Path):
+    current_list_key: str | None = None
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        stripped = raw_line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if current_list_key and stripped.startswith("- "):
+            yield stripped[2:].strip().strip('"')
+            continue
+        current_list_key = None
+        if ":" not in stripped:
+            continue
+        key, value = stripped.split(":", 1)
+        key = key.strip()
+        value = value.strip()
+        if key in {"source_refs", "updated_from"} and not value:
+            current_list_key = key
+            continue
+        if key == "source_ref" and value and value != "null":
+            yield value.strip('"')
 
 
 def mirror_source_ref(source_ref: str) -> None:
@@ -98,7 +173,7 @@ def mirror_source_ref(source_ref: str) -> None:
 
 
 for task_path in (root / ".pm/tasks").glob("*.yaml"):
-    payload = yaml.safe_load(task_path.read_text(encoding="utf-8")) or {}
+    payload = parse_simple_yaml(task_path)
     for source_ref in payload.get("source_refs") or []:
         mirror_source_ref(str(source_ref))
     execution_log = payload.get("execution_log_path")
@@ -106,20 +181,15 @@ for task_path in (root / ".pm/tasks").glob("*.yaml"):
         mirror_source_ref(str(execution_log))
 
 for memory_path in list((root / ".pm/roles").glob("*/memory/*.yaml")) + list((root / ".pm/shared/memory").glob("*.yaml")):
-    payload = yaml.safe_load(memory_path.read_text(encoding="utf-8")) or {}
-    for record in payload.get("records") or []:
-        for source_ref in record.get("source_refs") or []:
-            mirror_source_ref(str(source_ref))
+    for source_ref in iter_source_refs(memory_path):
+        mirror_source_ref(str(source_ref))
 
 for working_memory_path in (root / ".pm/working_memory").glob("*.yaml"):
-    payload = yaml.safe_load(working_memory_path.read_text(encoding="utf-8")) or {}
-    for entry in payload.get("entries") or []:
-        for source_ref in entry.get("source_refs") or []:
-            mirror_source_ref(str(source_ref))
+    for source_ref in iter_source_refs(working_memory_path):
+        mirror_source_ref(str(source_ref))
 
 for stage_path in (root / ".pm/stage").glob("*.yaml"):
-    payload = yaml.safe_load(stage_path.read_text(encoding="utf-8")) or {}
-    for source_ref in payload.get("updated_from") or []:
+    for source_ref in iter_source_refs(stage_path):
         mirror_source_ref(str(source_ref))
 
 signals_path = root / ".pm/inbox/signals.jsonl"

--- a/scripts/pm/memory-regression-smoke.sh
+++ b/scripts/pm/memory-regression-smoke.sh
@@ -91,7 +91,8 @@ def rewrite_missing_absolute_source_refs() -> None:
             replacement.parent.mkdir(parents=True, exist_ok=True)
             if not replacement.exists():
                 replacement.write_text('{"portable_placeholder": true}\n', encoding="utf-8")
-            replacements[raw_ref] = str(replacement.relative_to(root))
+            fragment = raw_ref[len(raw_path):]
+            replacements[raw_ref] = f"{replacement.relative_to(root)}{fragment}"
         for old, new in replacements.items():
             text = text.replace(old, new)
         if replacements:
@@ -99,6 +100,16 @@ def rewrite_missing_absolute_source_refs() -> None:
 
 
 rewrite_missing_absolute_source_refs()
+
+
+def parse_inline_list(value: str) -> list[str] | None:
+    value = value.strip()
+    if not (value.startswith("[") and value.endswith("]")):
+        return None
+    inner = value[1:-1].strip()
+    if not inner:
+        return []
+    return [item.strip().strip('"').strip("'") for item in inner.split(",") if item.strip()]
 
 
 def parse_simple_yaml(path: Path) -> dict[str, object]:
@@ -116,8 +127,9 @@ def parse_simple_yaml(path: Path) -> dict[str, object]:
             continue
         key, value = line.split(":", 1)
         value = value.strip()
-        if value == "[]":
-            parsed[key] = []
+        inline_list = parse_inline_list(value)
+        if inline_list is not None:
+            parsed[key] = inline_list
         elif value == "":
             parsed[key] = []
             current_list_key = key
@@ -143,6 +155,11 @@ def iter_source_refs(path: Path):
         key, value = stripped.split(":", 1)
         key = key.strip()
         value = value.strip()
+        inline_list = parse_inline_list(value)
+        if key in {"source_refs", "updated_from"} and inline_list is not None:
+            for item in inline_list:
+                yield item
+            continue
         if key in {"source_refs", "updated_from"} and not value:
             current_list_key = key
             continue

--- a/scripts/pm/new-task-worktree-bootstrap-smoke.sh
+++ b/scripts/pm/new-task-worktree-bootstrap-smoke.sh
@@ -107,7 +107,7 @@ import sys
 from pathlib import Path
 
 root = Path(sys.argv[1])
-worktree = Path(sys.argv[2])
+worktree = Path(sys.argv[2]).resolve()
 source_status_before = sys.argv[3]
 payload = json.loads(__import__("os").environ["BOOTSTRAP_JSON"])
 pm_task = payload.get("pm_task")

--- a/scripts/pm/pm_store.py
+++ b/scripts/pm/pm_store.py
@@ -710,6 +710,14 @@ def resolve_source_ref_path(root: pathlib.Path, source_ref: str) -> pathlib.Path
     return root / path
 
 
+def is_external_codex_session_ref(source_ref: str) -> bool:
+    path = pathlib.Path(parse_reference_path(source_ref)).expanduser()
+    parts = path.parts
+    if not path.is_absolute() or ".codex" not in parts or "sessions" not in parts:
+        return False
+    return path.suffix == ".jsonl"
+
+
 def is_devlog_archive_reference(source_ref: str) -> bool:
     source_path = parse_reference_path(str(source_ref))
     if not source_path:
@@ -1039,6 +1047,8 @@ def run_working_memory_lint(root: pathlib.Path) -> None:
                         resolved = resolve_source_ref_path(root, str(source_ref))
                     except ValueError as exc:
                         fail(f"{path.relative_to(root)} {entry_id} invalid source_ref: {exc}")
+                        continue
+                    if is_external_codex_session_ref(str(source_ref)):
                         continue
                     if not resolved.exists():
                         fail(f"{path.relative_to(root)} {entry_id} source_ref missing: {resolved}")
@@ -2143,6 +2153,8 @@ def run_memory_lint(root: pathlib.Path) -> None:
                             f"{path.relative_to(root)} {record_id} source_ref must not use doc/devlog archive: "
                             f"{source_ref}"
                         )
+                    if is_external_codex_session_ref(str(source_ref)):
+                        continue
                     if not (root / source_path).exists():
                         fail(f"{path.relative_to(root)} {record_id} source_ref missing: {source_path}")
 

--- a/scripts/pm/pm_store.py
+++ b/scripts/pm/pm_store.py
@@ -713,9 +713,12 @@ def resolve_source_ref_path(root: pathlib.Path, source_ref: str) -> pathlib.Path
 def is_external_codex_session_ref(source_ref: str) -> bool:
     path = pathlib.Path(parse_reference_path(source_ref)).expanduser()
     parts = path.parts
-    if not path.is_absolute() or ".codex" not in parts or "sessions" not in parts:
+    if not path.is_absolute() or path.suffix != ".jsonl":
         return False
-    return path.suffix == ".jsonl"
+    for index, part in enumerate(parts[:-1]):
+        if part == ".codex" and index + 1 < len(parts) and parts[index + 1] == "sessions":
+            return True
+    return False
 
 
 def is_devlog_archive_reference(source_ref: str) -> bool:

--- a/scripts/pm/promote-signal.sh
+++ b/scripts/pm/promote-signal.sh
@@ -235,21 +235,29 @@ if [[ "$CREATE_TASK" == "1" ]]; then
     --json
   )
 
-  for doc_ref in "${DOC_REFS[@]}"; do
-    TASK_ARGS+=(--doc-ref "$doc_ref")
-  done
+  if [[ "${#DOC_REFS[@]}" -gt 0 ]]; then
+    for doc_ref in "${DOC_REFS[@]}"; do
+      TASK_ARGS+=(--doc-ref "$doc_ref")
+    done
+  fi
 
-  for related_prd in "${RELATED_PRDS[@]}"; do
-    TASK_ARGS+=(--related-prd "$related_prd")
-  done
+  if [[ "${#RELATED_PRDS[@]}" -gt 0 ]]; then
+    for related_prd in "${RELATED_PRDS[@]}"; do
+      TASK_ARGS+=(--related-prd "$related_prd")
+    done
+  fi
 
-  for acceptance_item in "${ACCEPTANCE[@]}"; do
-    TASK_ARGS+=(--acceptance "$acceptance_item")
-  done
+  if [[ "${#ACCEPTANCE[@]}" -gt 0 ]]; then
+    for acceptance_item in "${ACCEPTANCE[@]}"; do
+      TASK_ARGS+=(--acceptance "$acceptance_item")
+    done
+  fi
 
-  for handoff_role in "${HANDOFF_TO[@]}"; do
-    TASK_ARGS+=(--handoff-to "$handoff_role")
-  done
+  if [[ "${#HANDOFF_TO[@]}" -gt 0 ]]; then
+    for handoff_role in "${HANDOFF_TO[@]}"; do
+      TASK_ARGS+=(--handoff-to "$handoff_role")
+    done
+  fi
 
   if [[ -n "$WORKTREE_HINT" ]]; then
     TASK_ARGS+=(--worktree-hint "$WORKTREE_HINT")

--- a/scripts/pm/required-tier-smoke.sh
+++ b/scripts/pm/required-tier-smoke.sh
@@ -60,13 +60,88 @@ mkdir -p "$TMPDIR/.pm/evidence" "$TMPDIR/.pm/shared/memory" "$TMPDIR/.pm/stage"
 python3 - "$TMPDIR" "$ROOT_DIR" <<'PY'
 from pathlib import Path
 import json
+import hashlib
+import re
 import shutil
 import sys
 
-import yaml
-
 root = Path(sys.argv[1])
 source_root = Path(sys.argv[2])
+
+
+def rewrite_missing_absolute_source_refs() -> None:
+    replacement_dir = root / ".pm/evidence/portable-source-refs"
+    absolute_ref_pattern = re.compile(r"/(?:home|Users)/[^\s\"']+")
+    for path in list((root / ".pm").rglob("*.yaml")) + list((root / ".pm").rglob("*.jsonl")):
+        text = path.read_text(encoding="utf-8")
+        replacements: dict[str, str] = {}
+        for match in absolute_ref_pattern.finditer(text):
+            raw_ref = match.group(0).rstrip(",")
+            raw_path = raw_ref.split("#", 1)[0]
+            if Path(raw_path).exists():
+                continue
+            digest = hashlib.sha256(raw_path.encode("utf-8")).hexdigest()[:16]
+            replacement = replacement_dir / f"{digest}.jsonl"
+            replacement.parent.mkdir(parents=True, exist_ok=True)
+            if not replacement.exists():
+                replacement.write_text('{"portable_placeholder": true}\n', encoding="utf-8")
+            replacements[raw_ref] = str(replacement.relative_to(root))
+        for old, new in replacements.items():
+            text = text.replace(old, new)
+        if replacements:
+            path.write_text(text, encoding="utf-8")
+
+
+rewrite_missing_absolute_source_refs()
+
+
+def parse_simple_yaml(path: Path) -> dict[str, object]:
+    parsed: dict[str, object] = {}
+    current_list_key: str | None = None
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.rstrip()
+        if not line or line.lstrip().startswith("#"):
+            continue
+        if line.startswith("  - ") and current_list_key:
+            parsed.setdefault(current_list_key, []).append(line[4:].strip().strip('"'))
+            continue
+        current_list_key = None
+        if line.startswith(" ") or ":" not in line:
+            continue
+        key, value = line.split(":", 1)
+        value = value.strip()
+        if value == "[]":
+            parsed[key] = []
+        elif value == "":
+            parsed[key] = []
+            current_list_key = key
+        elif value == "null":
+            parsed[key] = None
+        else:
+            parsed[key] = value.strip('"')
+    return parsed
+
+
+def iter_source_refs(path: Path):
+    current_list_key: str | None = None
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        stripped = raw_line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if current_list_key and stripped.startswith("- "):
+            yield stripped[2:].strip().strip('"')
+            continue
+        current_list_key = None
+        if ":" not in stripped:
+            continue
+        key, value = stripped.split(":", 1)
+        key = key.strip()
+        value = value.strip()
+        if key in {"source_refs", "updated_from"} and not value:
+            current_list_key = key
+            continue
+        if key == "source_ref" and value and value != "null":
+            yield value.strip('"')
 
 
 def mirror_source_ref(source_ref: str) -> None:
@@ -92,7 +167,7 @@ def mirror_source_ref(source_ref: str) -> None:
 
 
 for task_path in (root / ".pm/tasks").glob("*.yaml"):
-    payload = yaml.safe_load(task_path.read_text(encoding="utf-8")) or {}
+    payload = parse_simple_yaml(task_path)
     for source_ref in payload.get("source_refs") or []:
         mirror_source_ref(str(source_ref))
     execution_log = payload.get("execution_log_path")
@@ -100,20 +175,15 @@ for task_path in (root / ".pm/tasks").glob("*.yaml"):
         mirror_source_ref(str(execution_log))
 
 for memory_path in list((root / ".pm/roles").glob("*/memory/*.yaml")) + list((root / ".pm/shared/memory").glob("*.yaml")):
-    payload = yaml.safe_load(memory_path.read_text(encoding="utf-8")) or {}
-    for record in payload.get("records") or []:
-        for source_ref in record.get("source_refs") or []:
-            mirror_source_ref(str(source_ref))
+    for source_ref in iter_source_refs(memory_path):
+        mirror_source_ref(str(source_ref))
 
 for working_memory_path in (root / ".pm/working_memory").glob("*.yaml"):
-    payload = yaml.safe_load(working_memory_path.read_text(encoding="utf-8")) or {}
-    for entry in payload.get("entries") or []:
-        for source_ref in entry.get("source_refs") or []:
-            mirror_source_ref(str(source_ref))
+    for source_ref in iter_source_refs(working_memory_path):
+        mirror_source_ref(str(source_ref))
 
 for stage_path in (root / ".pm/stage").glob("*.yaml"):
-    payload = yaml.safe_load(stage_path.read_text(encoding="utf-8")) or {}
-    for source_ref in payload.get("updated_from") or []:
+    for source_ref in iter_source_refs(stage_path):
         mirror_source_ref(str(source_ref))
 
 signals_path = root / ".pm/inbox/signals.jsonl"
@@ -409,12 +479,25 @@ fi
 python3 - "$TMPDIR" "$TASK_UID" <<'PY'
 from pathlib import Path
 import sys
-import yaml
 
 root = Path(sys.argv[1])
 task_uid = sys.argv[2]
 task_path = root / f".pm/tasks/{task_uid}.yaml"
-payload = yaml.safe_load(task_path.read_text(encoding="utf-8"))
+
+
+def parse_simple_yaml(path: Path) -> dict[str, str | None]:
+    parsed: dict[str, str | None] = {}
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.rstrip()
+        if not line or line.startswith(" ") or line.lstrip().startswith("#") or ":" not in line:
+            continue
+        key, value = line.split(":", 1)
+        value = value.strip()
+        parsed[key] = None if value == "null" else value.strip('"')
+    return parsed
+
+
+payload = parse_simple_yaml(task_path)
 if payload.get("last_started_at") not in (None, ""):
     raise SystemExit(f"workflow-report failure should not write last_started_at for {task_uid}")
 if payload.get("last_closed_at") not in (None, ""):

--- a/scripts/pm/required-tier-smoke.sh
+++ b/scripts/pm/required-tier-smoke.sh
@@ -85,7 +85,8 @@ def rewrite_missing_absolute_source_refs() -> None:
             replacement.parent.mkdir(parents=True, exist_ok=True)
             if not replacement.exists():
                 replacement.write_text('{"portable_placeholder": true}\n', encoding="utf-8")
-            replacements[raw_ref] = str(replacement.relative_to(root))
+            fragment = raw_ref[len(raw_path):]
+            replacements[raw_ref] = f"{replacement.relative_to(root)}{fragment}"
         for old, new in replacements.items():
             text = text.replace(old, new)
         if replacements:
@@ -93,6 +94,16 @@ def rewrite_missing_absolute_source_refs() -> None:
 
 
 rewrite_missing_absolute_source_refs()
+
+
+def parse_inline_list(value: str) -> list[str] | None:
+    value = value.strip()
+    if not (value.startswith("[") and value.endswith("]")):
+        return None
+    inner = value[1:-1].strip()
+    if not inner:
+        return []
+    return [item.strip().strip('"').strip("'") for item in inner.split(",") if item.strip()]
 
 
 def parse_simple_yaml(path: Path) -> dict[str, object]:
@@ -110,8 +121,9 @@ def parse_simple_yaml(path: Path) -> dict[str, object]:
             continue
         key, value = line.split(":", 1)
         value = value.strip()
-        if value == "[]":
-            parsed[key] = []
+        inline_list = parse_inline_list(value)
+        if inline_list is not None:
+            parsed[key] = inline_list
         elif value == "":
             parsed[key] = []
             current_list_key = key
@@ -137,6 +149,11 @@ def iter_source_refs(path: Path):
         key, value = stripped.split(":", 1)
         key = key.strip()
         value = value.strip()
+        inline_list = parse_inline_list(value)
+        if key in {"source_refs", "updated_from"} and inline_list is not None:
+            for item in inline_list:
+                yield item
+            continue
         if key in {"source_refs", "updated_from"} and not value:
             current_list_key = key
             continue

--- a/scripts/pm/workflow-behavior-eval.sh
+++ b/scripts/pm/workflow-behavior-eval.sh
@@ -56,6 +56,7 @@ import sys
 from pathlib import Path
 
 root = Path(sys.argv[1])
+bt = chr(96)
 
 checks = [
     (
@@ -73,10 +74,10 @@ checks = [
         root / "AGENTS.md",
         [
             "default-workflow-bootstrap",
-            "判断 trivial/non-trivial、是否已具备隔离 task worktree / `.pm` task 真值",
-            "`producer_system_designer` orchestrator + 角色 subagents",
+            f"判断 trivial/non-trivial、是否已具备隔离 task worktree / {bt}.pm{bt} task 真值",
+            f"{bt}producer_system_designer{bt} orchestrator + 角色 subagents",
             "formal sink",
-            "liveops_community` 必须参与至少一个 slice",
+            f"liveops_community{bt} 必须参与至少一个 slice",
             "requesting-repo-owned-review/SKILL.md",
         ],
     ),

--- a/scripts/pr-review-thread-closeout.sh
+++ b/scripts/pr-review-thread-closeout.sh
@@ -300,7 +300,10 @@ PY
 refresh_threads_file
 render_report_file "$PR_VIEW_FILE" "$THREADS_FILE" "$UNRESOLVED_ONLY"
 
-mapfile -t ALL_UNRESOLVED_IDS < <(python3 - "$THREADS_FILE" <<'PY'
+ALL_UNRESOLVED_IDS=()
+while IFS= read -r thread_id; do
+  ALL_UNRESOLVED_IDS+=("$thread_id")
+done < <(python3 - "$THREADS_FILE" <<'PY'
 from __future__ import annotations
 
 import json

--- a/scripts/pr-review-thread-closeout.sh
+++ b/scripts/pr-review-thread-closeout.sh
@@ -300,10 +300,8 @@ PY
 refresh_threads_file
 render_report_file "$PR_VIEW_FILE" "$THREADS_FILE" "$UNRESOLVED_ONLY"
 
-ALL_UNRESOLVED_IDS=()
-while IFS= read -r thread_id; do
-  ALL_UNRESOLVED_IDS+=("$thread_id")
-done < <(python3 - "$THREADS_FILE" <<'PY'
+UNRESOLVED_IDS_FILE="$TMP_DIR/unresolved-ids.txt"
+if ! python3 - "$THREADS_FILE" >"$UNRESOLVED_IDS_FILE" <<'PY'
 from __future__ import annotations
 
 import json
@@ -322,7 +320,14 @@ for thread in threads:
     if not thread.get("isResolved"):
         print(thread.get("id"))
 PY
-)
+then
+  die "failed to parse unresolved review thread ids"
+fi
+
+ALL_UNRESOLVED_IDS=()
+while IFS= read -r thread_id; do
+  ALL_UNRESOLVED_IDS+=("$thread_id")
+done <"$UNRESOLVED_IDS_FILE"
 
 THREAD_IDS_TO_RESOLVE=()
 if [[ "$RESOLVE_ALL" == "1" ]]; then

--- a/scripts/prepare-task-pr.sh
+++ b/scripts/prepare-task-pr.sh
@@ -217,23 +217,20 @@ warn() {
   echo "warning: $*" >&2
 }
 
-load_plan_kv() {
+plan_kv_get() {
   local output="$1"
-  local map_name="$2"
-  local line=""
   local key=""
+  key="$2"
+  printf '%s\n' "$output" | sed -n "s/^${key}=//p" | head -n 1
+}
+
+plan_kv_get_default() {
+  local output="$1"
+  local key="$2"
+  local default_value="$3"
   local value=""
-
-  declare -gA "$map_name"
-  local -n plan_ref="$map_name"
-  plan_ref=()
-
-  while IFS= read -r line; do
-    [[ -n "$line" ]] || continue
-    key="${line%%=*}"
-    value="${line#*=}"
-    plan_ref["$key"]="$value"
-  done <<< "$output"
+  value="$(plan_kv_get "$output" "$key")"
+  printf '%s\n' "${value:-$default_value}"
 }
 
 ensure_branch_exists "$SOURCE_BRANCH"
@@ -297,21 +294,31 @@ LOCAL_REQUIRED_EXTRA_COMMANDS=()
 
 if [[ -x "./scripts/plan-rust-required-scope.sh" ]]; then
   if RUST_SCOPE_OUTPUT="$(./scripts/plan-rust-required-scope.sh --event-name pull_request --base-ref "$COMPARISON_REF" --head-ref "$SOURCE_BRANCH" 2>/dev/null)"; then
-    load_plan_kv "$RUST_SCOPE_OUTPUT" RUST_SCOPE_PLAN
-    LOCAL_REQUIRED_SCOPE="${RUST_SCOPE_PLAN[scope]:-unavailable}"
-    LOCAL_REQUIRED_CHANGED_PATH_COUNT="${RUST_SCOPE_PLAN[changed_path_count]:-0}"
-    LOCAL_REQUIRED_CHANGED_PATHS="${RUST_SCOPE_PLAN[changed_paths]:-}"
-    LOCAL_REQUIRED_REASON_SUMMARY="${RUST_SCOPE_PLAN[reason_summary]:-}"
+    LOCAL_REQUIRED_SCOPE="$(plan_kv_get "$RUST_SCOPE_OUTPUT" "scope")"
+    LOCAL_REQUIRED_SCOPE="${LOCAL_REQUIRED_SCOPE:-unavailable}"
+    LOCAL_REQUIRED_CHANGED_PATH_COUNT="$(plan_kv_get "$RUST_SCOPE_OUTPUT" "changed_path_count")"
+    LOCAL_REQUIRED_CHANGED_PATH_COUNT="${LOCAL_REQUIRED_CHANGED_PATH_COUNT:-0}"
+    LOCAL_REQUIRED_CHANGED_PATHS="$(plan_kv_get "$RUST_SCOPE_OUTPUT" "changed_paths")"
+    LOCAL_REQUIRED_REASON_SUMMARY="$(plan_kv_get "$RUST_SCOPE_OUTPUT" "reason_summary")"
     if [[ "$LOCAL_REQUIRED_SCOPE" != "minimal" ]]; then
-      LOCAL_REQUIRED_COMMAND="OASIS7_CI_RUN_OASIS7_REQUIRED_TESTS=${RUST_SCOPE_PLAN[run_oasis7_required_tests]:-false} \
-OASIS7_CI_RUN_CONSENSUS_TESTS=${RUST_SCOPE_PLAN[run_consensus_tests]:-false} \
-OASIS7_CI_RUN_DISTFS_TESTS=${RUST_SCOPE_PLAN[run_distfs_tests]:-false} \
-OASIS7_CI_RUN_OASIS7_NODE_TESTS=${RUST_SCOPE_PLAN[run_oasis7_node_tests]:-false} \
-OASIS7_CI_RUN_OASIS7_NET_TESTS=${RUST_SCOPE_PLAN[run_oasis7_net_tests]:-false} \
-OASIS7_CI_RUN_OASIS7_NET_LIBP2P_TESTS=${RUST_SCOPE_PLAN[run_oasis7_net_libp2p_tests]:-false} \
-OASIS7_CI_RUN_VIEWER_CONTRACT_TESTS=${RUST_SCOPE_PLAN[run_viewer_contract_tests]:-false} \
-OASIS7_CI_RUN_VIEWER_WASM_CHECK=${RUST_SCOPE_PLAN[run_viewer_wasm_check]:-false} \
-OASIS7_CI_RUN_LAUNCHER_WEB_BUILD=${RUST_SCOPE_PLAN[run_launcher_web_build]:-false} \
+      RUN_OASIS7_REQUIRED_TESTS="$(plan_kv_get_default "$RUST_SCOPE_OUTPUT" "run_oasis7_required_tests" "false")"
+      RUN_CONSENSUS_TESTS="$(plan_kv_get_default "$RUST_SCOPE_OUTPUT" "run_consensus_tests" "false")"
+      RUN_DISTFS_TESTS="$(plan_kv_get_default "$RUST_SCOPE_OUTPUT" "run_distfs_tests" "false")"
+      RUN_OASIS7_NODE_TESTS="$(plan_kv_get_default "$RUST_SCOPE_OUTPUT" "run_oasis7_node_tests" "false")"
+      RUN_OASIS7_NET_TESTS="$(plan_kv_get_default "$RUST_SCOPE_OUTPUT" "run_oasis7_net_tests" "false")"
+      RUN_OASIS7_NET_LIBP2P_TESTS="$(plan_kv_get_default "$RUST_SCOPE_OUTPUT" "run_oasis7_net_libp2p_tests" "false")"
+      RUN_VIEWER_CONTRACT_TESTS="$(plan_kv_get_default "$RUST_SCOPE_OUTPUT" "run_viewer_contract_tests" "false")"
+      RUN_VIEWER_WASM_CHECK="$(plan_kv_get_default "$RUST_SCOPE_OUTPUT" "run_viewer_wasm_check" "false")"
+      RUN_LAUNCHER_WEB_BUILD="$(plan_kv_get_default "$RUST_SCOPE_OUTPUT" "run_launcher_web_build" "false")"
+      LOCAL_REQUIRED_COMMAND="OASIS7_CI_RUN_OASIS7_REQUIRED_TESTS=$RUN_OASIS7_REQUIRED_TESTS \
+OASIS7_CI_RUN_CONSENSUS_TESTS=$RUN_CONSENSUS_TESTS \
+OASIS7_CI_RUN_DISTFS_TESTS=$RUN_DISTFS_TESTS \
+OASIS7_CI_RUN_OASIS7_NODE_TESTS=$RUN_OASIS7_NODE_TESTS \
+OASIS7_CI_RUN_OASIS7_NET_TESTS=$RUN_OASIS7_NET_TESTS \
+OASIS7_CI_RUN_OASIS7_NET_LIBP2P_TESTS=$RUN_OASIS7_NET_LIBP2P_TESTS \
+OASIS7_CI_RUN_VIEWER_CONTRACT_TESTS=$RUN_VIEWER_CONTRACT_TESTS \
+OASIS7_CI_RUN_VIEWER_WASM_CHECK=$RUN_VIEWER_WASM_CHECK \
+OASIS7_CI_RUN_LAUNCHER_WEB_BUILD=$RUN_LAUNCHER_WEB_BUILD \
 ./scripts/ci-tests.sh required"
     fi
     CLAIM_READY_COMMAND="$(render_cmd "./scripts/pm/claim-ready.sh" "--claim-type" "ready_for_pr" "--verify-command" "$LOCAL_REQUIRED_COMMAND")"


### PR DESCRIPTION
## Summary
- Make workflow/PM scripts compatible with macOS default Bash 3.2 and Ubuntu Bash.
- Replace GNU-only or optional-tool assumptions (`mapfile`, associative arrays, `find -printf`, `sha256sum`, PyYAML) with portable shell/Python fallbacks.
- Stabilize isolated smoke tests across machines by canonicalizing macOS `/private/var` paths and treating external Codex session transcripts as provenance rather than required local files.

## Verification
- `./scripts/pm/workflow-behavior-eval.sh`
- `./scripts/pm/lint.sh`
- `./scripts/doc-governance-check.sh`
- `git diff --check`
