### PR TITLE
Remove trusted hosted login preview path

### DIFF
--- a/.github/workflows/hosted-login-linux-build.yml
+++ b/.github/workflows/hosted-login-linux-build.yml
@@ -1,0 +1,123 @@
+name: Hosted Login Linux Build
+
+on:
+  workflow_dispatch:
+    inputs:
+      build_profile:
+        description: "Cargo profile for the hosted login launcher binary"
+        required: true
+        default: release
+        type: choice
+        options:
+          - release
+          - dev
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+  CARGO_NET_RETRY: 10
+  CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
+  RUST_TOOLCHAIN: 1.92.0
+
+jobs:
+  build-linux-x86-64:
+    name: hosted-login-linux-x86-64
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+
+      - name: Install viewer web dependencies
+        run: npm ci --prefix crates/oasis7_viewer
+
+      - name: Install pinned Rust toolchain
+        run: |
+          rustup toolchain install "${RUST_TOOLCHAIN}" --profile default
+          rustup default "${RUST_TOOLCHAIN}"
+
+      - name: Install Linux system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            pkg-config \
+            libwayland-dev \
+            wayland-protocols \
+            libxkbcommon-dev \
+            libx11-dev \
+            libxi-dev \
+            libxcursor-dev \
+            libxrandr-dev \
+            libxinerama-dev \
+            libasound2-dev \
+            libudev-dev
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: hosted-login-linux-x86-64-v1
+          cache-on-failure: true
+
+      - name: Resolve build profile
+        id: profile
+        shell: bash
+        run: |
+          profile="${{ github.event.inputs.build_profile || 'release' }}"
+          case "${profile}" in
+            release)
+              echo "cargo_args=--release" >> "${GITHUB_OUTPUT}"
+              echo "binary_dir=release" >> "${GITHUB_OUTPUT}"
+              ;;
+            dev)
+              echo "cargo_args=" >> "${GITHUB_OUTPUT}"
+              echo "binary_dir=debug" >> "${GITHUB_OUTPUT}"
+              ;;
+            *)
+              echo "error: unsupported build_profile=${profile}" >&2
+              exit 1
+              ;;
+          esac
+
+      - name: Build hosted login launcher
+        run: |
+          env -u RUSTC_WRAPPER cargo build \
+            ${{ steps.profile.outputs.cargo_args }} \
+            -p oasis7 \
+            --bin oasis7_game_launcher \
+            --bin oasis7_viewer_live
+
+      - name: Build viewer web dist
+        run: |
+          ./scripts/build-viewer-software-safe.sh
+          ./scripts/copy-viewer-web-dist.sh --dist-dir output/hosted-login/web
+
+      - name: Stage deployable artifact
+        run: |
+          mkdir -p output/hosted-login/bin
+          cp "target/${{ steps.profile.outputs.binary_dir }}/oasis7_game_launcher" \
+            output/hosted-login/bin/oasis7_game_launcher_v3
+          cp "target/${{ steps.profile.outputs.binary_dir }}/oasis7_viewer_live" \
+            output/hosted-login/bin/oasis7_viewer_live
+          chmod +x output/hosted-login/bin/oasis7_game_launcher_v3
+          chmod +x output/hosted-login/bin/oasis7_viewer_live
+          {
+            echo "git_sha=${GITHUB_SHA}"
+            echo "profile=${{ github.event.inputs.build_profile || 'release' }}"
+            echo "target=x86_64-unknown-linux-gnu"
+            echo "binary=bin/oasis7_game_launcher_v3"
+            echo "viewer_live=bin/oasis7_viewer_live"
+            echo "web=web/"
+          } > output/hosted-login/BUILDINFO
+          (
+            cd output/hosted-login
+            sha256sum bin/oasis7_game_launcher_v3 bin/oasis7_viewer_live > SHA256SUMS
+            tar -czf ../hosted-login-linux-x86_64.tar.gz .
+          )
+
+      - name: Upload hosted login Linux artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: hosted-login-linux-x86_64-${{ github.sha }}
+          path: output/hosted-login-linux-x86_64.tar.gz
+          if-no-files-found: error

--- a/.pm/tasks/task_23af5676602c49c0ba233a217393f9d4.execution.md
+++ b/.pm/tasks/task_23af5676602c49c0ba233a217393f9d4.execution.md
@@ -1,0 +1,117 @@
+# task_23af5676602c49c0ba233a217393f9d4 Execution Log
+
+- task_uid: task_23af5676602c49c0ba233a217393f9d4
+- title: remove trusted local preview mode from user launcher flow
+- owner_role: producer_system_designer
+- worktree_hint: /Users/scc/ccwork/worktrees/oasis7-world-simulator-remove-trusted-local-preview
+
+<!-- Append entries using:
+Example:
+  ## YYYY-MM-DD HH:MM:SS CST / role_name
+  - 完成内容: ...
+  - 遗留事项: ...
+  - Action: ...
+  - Validation Command: ...
+  - Expected Result: ...
+  - Actual Result: ...
+  - Blocker / Next Action: ...
+-->
+
+## 2026-05-26 17:09:19 CST / producer_system_designer
+- 完成内容: 建立单一 task/worktree 后，开始移除用户启动器里的 trusted_local_only 本地可信预览入口；将 game/web/client launcher 默认入口收敛到 hosted_public_join，并让客户端旧配置 normalize 到 hosted join。
+- 遗留事项: 跑完目标 Rust 测试与 hosted account smoke，按结果修正遗漏断言。
+- Action: implementation
+- Validation Command: cargo fmt --check; env -u RUSTC_WRAPPER cargo test -p oasis7_client_launcher; env -u RUSTC_WRAPPER cargo test -p oasis7 --bin oasis7_web_launcher
+- Expected Result: 格式检查通过；客户端与 web launcher 测试确认默认 hosted_public_join、trusted_local_only 不再作为用户可选模式。
+- Actual Result: cargo fmt --check 已通过；Rust 测试仍在运行。
+- Blocker / Next Action: 等待编译与测试完成。
+
+## 2026-05-26 17:19:15 CST / producer_system_designer
+- 完成内容: 完成用户启动路径收敛：`hosted_public_join` 成为 game/web/client launcher 默认入口，用户可配置校验拒绝 `trusted_local_only`，客户端旧配置 normalize 到 hosted join；文档补充普通用户不再暴露本地可信预览，默认走邮箱 hosted account / player session 登录链路。
+- 遗留事项: 主 worktree 存在与本任务无关的本地运行产物/脚本改动，未触碰也未清理。
+- Action: verification
+- Validation Command: cargo fmt --check; env -u RUSTC_WRAPPER cargo test -p oasis7 --bin oasis7_web_launcher; env -u RUSTC_WRAPPER cargo test -p oasis7 --bin oasis7_game_launcher; env -u RUSTC_WRAPPER cargo test -p oasis7_client_launcher; ./scripts/hosted-account-staging-smoke.sh --mode local --out-dir .tmp/hosted-account-smoke-remove-trusted-local-preview --skip-build; ./scripts/pm/lint.sh; ./scripts/doc-governance-check.sh; git diff --check
+- Expected Result: 格式、目标单测、PM/doc gate、diff 空白检查通过；hosted account smoke 验证邮箱 hosted login 与重启后 account/player continuity。
+- Actual Result: 全部通过；hosted-account-smoke 输出 `hosted-account-smoke: OK`，summary 位于 `.tmp/hosted-account-smoke-remove-trusted-local-preview/hosted-account-smoke-20260526-171906/hosted-account-smoke-summary.json`。
+- Blocker / Next Action: 无。
+
+## 2026-05-26 17:36:58 CST / producer_system_designer
+- 完成内容: 本地用户入口运行验证时发现 `/viewer.js` 大静态资源会被 embedded static HTTP server 提前截断，导致根页面 200 但 UI 空白；修复 accept 后的连接阻塞模式，并用 dist 合约生成 `.tmp/local-user-viewer-dist` 作为本地用户静态目录重启 6611。
+- 遗留事项: 当前 6611/6612/6613 本地运行实例保持启动，供用户试玩；LLM 未配置时玩法推进仍显示 `llm_required` blocker。
+- Action: bugfix + local run
+- Validation Command: cargo fmt --check; env -u RUSTC_WRAPPER cargo test -p oasis7 --bin oasis7_game_launcher static_http_server_serves_large_static_asset_completely; env -u RUSTC_WRAPPER cargo build -p oasis7 --bin oasis7_game_launcher; curl -sS http://127.0.0.1:6611/viewer.js -o .tmp/local-user-run/viewer-js-download.js && wc -c .tmp/local-user-run/viewer-js-download.js .tmp/local-user-viewer-dist/viewer.js; Browser DOM verification
+- Expected Result: 格式与大静态文件传输回归测试通过；launcher 普通二进制重新编译；`viewer.js` 下载字节数等于本地文件；浏览器内 `#app` 挂载并显示 hosted public join 邮箱登录区域。
+- Actual Result: 通过；`viewer.js` 下载与本地文件均为 344312 bytes；Browser DOM 显示 `#app` children=4，并出现“邮箱 / 请求登录验证码”。
+- Blocker / Next Action: 若需要完整试玩推进，需要配置可达 LLM provider；当前登录链路已经可见。
+
+## 2026-05-26 17:43:45 CST / producer_system_designer
+- 完成内容: 用户反馈没有弹出邮箱登录入口后，将 hosted public join 的 `auth=missing` 状态改为首屏 modal gate，复用 HostedLoginForm，并同步输入框样式，避免登录入口藏在主路径中部或诊断面板里。
+- 遗留事项: 当前本地服务继续运行；登录后玩法推进仍取决于 LLM provider 配置。
+- Action: UI fix + local verification
+- Validation Command: npm --prefix crates/oasis7_viewer run test:ui -- main.test.jsx; ./scripts/build-viewer-software-safe.sh && rm -rf .tmp/local-user-viewer-dist && ./scripts/copy-viewer-web-dist.sh --dist-dir .tmp/local-user-viewer-dist; Browser DOM/geometry verification
+- Expected Result: 前端测试通过；viewer bundle 重建并同步到 6611 静态目录；浏览器首屏显示“登录邮箱后进入游戏”弹窗与邮箱输入、请求验证码按钮。
+- Actual Result: 通过；Vitest `main.test.jsx` 9 passed；Browser 验证 `.auth-gate` 可见，邮箱输入与“请求登录验证码”按钮 geometry 可见。
+- Blocker / Next Action: 无。
+
+## 2026-05-26 17:49:45 CST / producer_system_designer
+- 完成内容: 修复 HostedLoginForm 输入时每个字符触发 `core.requestRender()` 导致整页重挂载和输入框失焦的问题；邮箱和验证码输入现在只同步本地状态，提交按钮仍使用最新输入。
+- 遗留事项: 无。
+- Action: focus bugfix + local verification
+- Validation Command: npm --prefix crates/oasis7_viewer run test:ui -- main.test.jsx; ./scripts/build-viewer-software-safe.sh && rm -rf .tmp/local-user-viewer-dist && ./scripts/copy-viewer-web-dist.sh --dist-dir .tmp/local-user-viewer-dist; Browser focus verification
+- Expected Result: 前端测试通过；bundle 同步到当前 6611 静态目录；连续输入邮箱时 activeElement 仍是 gate email input。
+- Actual Result: 通过；Vitest `main.test.jsx` 9 passed；Browser 验证输入 `abc@example.com` 后 `activeId=gate-hosted-login-handle` 且 value 保持完整。
+- Blocker / Next Action: 无。
+
+## 2026-05-26 17:58:30 CST / producer_system_designer
+- 完成内容: 将 hosted account OTP 从确定性派生码改为每次 challenge 使用系统随机数生成的 6 位码，并避开 `000000` / `123456`；本地 `preview_inline` 继续显示 preview code 方便调试，但不再自动填入验证码输入框。
+- 遗留事项: 无。
+- Action: OTP hardening + local restart
+- Validation Command: cargo fmt --check; env -u RUSTC_WRAPPER cargo test -p oasis7 --bin oasis7_game_launcher hosted_account_login_start_uses_six_digit_preview_code_without_static_fixture; npm --prefix crates/oasis7_viewer run test:ui -- main.test.jsx; env -u RUSTC_WRAPPER cargo build -p oasis7 --bin oasis7_game_launcher; ./scripts/build-viewer-software-safe.sh && rm -rf .tmp/local-user-viewer-dist && ./scripts/copy-viewer-web-dist.sh --dist-dir .tmp/local-user-viewer-dist; curl POST /api/public/hosted-account/login/start
+- Expected Result: 格式、后端 OTP 测试和前端测试通过；launcher 重编译并重启；本地 API 返回 6 位随机 preview_code，不是 `123456`。
+- Actual Result: 通过；API 返回示例 preview_code=`039315`，delivery_mode=`preview_inline`。
+- Blocker / Next Action: 无。
+
+## 2026-05-26 18:08:40 CST / producer_system_designer
+- 完成内容: 删除 `preview_inline` / `preview_code` 用户链路：后端 delivery mode 只保留 `smtp` 与内部诊断 `server_log_only`，未知/默认 delivery 归一到 `smtp`；登录 start 响应不再返回 OTP；viewer 不再解析或展示 preview code；hosted account smoke 和文档改为 `smtp + otp-fetch-command` 云上投递口径。
+- 遗留事项: 当前本机没有 `OASIS7_HOSTED_LOGIN_SMTP_*` 凭据，因此 6611 本地实例用 `server_log_only` 保持页面可打开；正式/云上环境需要设置 `OASIS7_HOSTED_LOGIN_DELIVERY_MODE=smtp` 与 SMTP 凭据。
+- Action: remove local preview OTP mode + verification
+- Validation Command: cargo fmt --check; env -u RUSTC_WRAPPER cargo test -p oasis7 --bin oasis7_game_launcher; npm --prefix crates/oasis7_viewer run test:ui -- main.test.jsx; env -u RUSTC_WRAPPER cargo build -p oasis7 --bin oasis7_game_launcher; ./scripts/build-viewer-software-safe.sh && rm -rf .tmp/local-user-viewer-dist && ./scripts/copy-viewer-web-dist.sh --dist-dir .tmp/local-user-viewer-dist; bash -n scripts/hosted-account-staging-smoke.sh; ./scripts/doc-governance-check.sh; git diff --check; rg preview_inline/preview_code on code+docs touched
+- Expected Result: 所有目标测试/gate 通过；API `login/start` 不再含 `challenge.preview_code`；代码、脚本和相关文档不再出现 `preview_inline` / `preview_code`。
+- Actual Result: 通过；`login/start` 验证 `has_preview_code=false`，delivery_mode=`server_log_only`；`rg` 无匹配。
+- Blocker / Next Action: 若要本地也完整走云上 OTP，需要提供 SMTP env 或 staging OTP fetch command。
+
+## 2026-05-27 14:52:20 CST / producer_system_designer
+- 完成内容: 排查两台 ECS 上既有部署，确认 39.104.205.67 的 `/root/oasis7-hosted-smoke` 是此前 hosted public join smoke；上传当前 viewer web dist 到 `web-current`，重写并启动 `oasis7_hosted_smoke_start_public.sh`，开放 `0.0.0.0:4373/6511/6523` 供外部访问。
+- 遗留事项: ECS 未配置 `OASIS7_HOSTED_LOGIN_SMTP_FROM_EMAIL` / `OASIS7_HOSTED_LOGIN_SMTP_PASSWORD`，`smtp` 模式会拒绝启动；因此临时以 `server_log_only` 拉起云上服务，验证码不会返回页面，但也不会真正发邮件。ECS 上无 Rust/Node，远端安装 toolchain 速度过慢，当前运行 binary 仍是此前 Linux smoke binary，前端资源是本任务最新 dist。
+- Action: cloud redeploy smoke
+- Validation Command: curl -I http://39.104.205.67:4373/; curl -sS http://39.104.205.67:4373/viewer.js | rg "登录邮箱后进入游戏|preview_code"; remote curl POST /api/public/hosted-account/login/start
+- Expected Result: 外网 viewer 返回 200；前端包含邮箱登录 gate 且不包含 preview code UI；登录 start challenge 不返回 `preview_code`。
+- Actual Result: 外网 `http://39.104.205.67:4373/` 返回 200；`viewer.js` 包含“登录邮箱后进入游戏”和 `.auth-gate`，未匹配 `preview_code`；`login/start` 返回 `ok=true`、`delivery_mode=server_log_only`、无 `preview_code`。
+- Blocker / Next Action: 补齐 SMTP 发信凭据后，将 `OASIS7_HOSTED_LOGIN_DELIVERY_MODE` 切回 `smtp` 并重启；若要让云上 binary 完全对应当前源码，需要在 ECS 完成 Rust 1.92 Linux 构建或提供 CI/Linux artifact。
+
+## 2026-05-27 15:03:30 CST / producer_system_designer
+- 完成内容: 在 39.104.205.67 将 hosted 登录从 `/root/oasis7-hosted-smoke` 手工 smoke 收敛为中心化测试版 systemd 服务：创建 `/opt/oasis7/hosted-login-test/releases/20260527-150146`、`/opt/oasis7/hosted-login-test/current`、`/etc/oasis7/hosted-login-test.env`、`/etc/systemd/system/oasis7-hosted-login-test.service`，并启用开机自启。
+- 遗留事项: 仍使用 `server_log_only` 测试投递模式，因为 SMTP 发信账号未配置；服务 binary 仍是此前 Linux smoke binary，web dist 为当前任务最新资源。
+- Action: deploy centralized test login service
+- Validation Command: systemctl status oasis7-hosted-login-test.service; ss -ltnp | grep -E ':(4373|6511|6523)'; curl -I http://127.0.0.1:4373/; curl POST /api/public/hosted-account/login/start
+- Expected Result: systemd 服务 active/running；4373/6511/6523 端口监听；HTTP root 返回 200；login/start 返回 hosted_public_join challenge 且无 preview_code。
+- Actual Result: 通过；`oasis7-hosted-login-test.service` active/running/enabled，主进程为 `/opt/oasis7/hosted-login-test/current/bin/oasis7_game_launcher_v3`，端口 `0.0.0.0:4373/6511/6523` 监听；root 返回 200；login/start 返回 `ok=true`、`delivery_mode=server_log_only`。
+- Blocker / Next Action: 提供 `OASIS7_HOSTED_LOGIN_SMTP_FROM_EMAIL` 与 `OASIS7_HOSTED_LOGIN_SMTP_PASSWORD` 后，编辑 `/etc/oasis7/hosted-login-test.env` 将 delivery mode 切为 `smtp` 并 `systemctl restart oasis7-hosted-login-test.service`。
+
+## 2026-05-27 17:45:00 CST / producer_system_designer
+- 完成内容: 按“不要 `OASIS7_HOSTED_LOGIN_DELIVERY_MODE`，测试库 + 云上链路闭环”的要求，移除 hosted login delivery mode env 开关与 `server_log_only`/`preview_inline` 用户路径；后端 `from_env()` 现在只接受 SMTP 配置，challenge 固定报告 `delivery_mode=smtp`，缺 SMTP 时 fail closed；staging smoke 去掉 `--delivery-mode`；文档同步为无部署时 delivery mode 开关。
+- 遗留事项: 39.104.205.67 上旧 Linux binary 在删除 delivery env 后实测仍会回退 `preview_inline` 并返回 `preview_code`，因此已停止 `oasis7-hosted-login-test.service`，公网 `4373` 端口拒绝连接；新 Linux binary 尚未成功部署启动。
+- Action: smtp-only implementation + cloud deployment attempt
+- Validation Command: cargo fmt --check; bash -n scripts/hosted-account-staging-smoke.sh; env -u RUSTC_WRAPPER cargo test -p oasis7 --bin oasis7_game_launcher; rg "OASIS7_HOSTED_LOGIN_DELIVERY_MODE|server_log_only|preview_inline|preview_code|delivery-mode" crates/oasis7/src/bin/oasis7_game_launcher scripts/hosted-account-staging-smoke.sh doc/p2p; nc -vz -w 5 39.104.205.67 4373
+- Expected Result: 本地格式/语法/后端测试通过；目标代码、脚本与文档中不再出现 delivery mode env、本地预览或 server-log 投递模式；205 未部署新 binary 前不暴露旧预览服务。
+- Actual Result: 本地验证通过：`cargo fmt --check`、`bash -n`、`cargo test -p oasis7 --bin oasis7_game_launcher` 通过，目标 `rg` 无匹配；205 上 `/etc/oasis7/hosted-login-test.env` 已改为测试表 `oasis7_hosted_account_identity_test` 且无 `OASIS7_HOSTED_LOGIN_DELIVERY_MODE`；旧服务已停止，`39.104.205.67:4373` 连接拒绝。
+- Blocker / Next Action: 205 ECS 冷编当前源码时 SSH 长时间 banner/auth 超时，204 备用 Linux build 也因 1.6GiB 内存进入高负载；恢复 SSH 后优先用 `CARGO_BUILD_JOBS=1` 完成 `oasis7_game_launcher` Linux 构建，复制到 205 的 `/opt/oasis7/hosted-login-test/current/bin/oasis7_game_launcher_v3`，再用测试库 + 必填 SMTP env 启动并验证 `login/start` 不含 `preview_code`。
+
+## 2026-05-27 17:52:00 CST / producer_system_designer
+- 完成内容: 新增 `.github/workflows/hosted-login-linux-build.yml`，提供手工触发的 Ubuntu 24.04 Linux x86_64 构建流程：安装固定 Rust 1.92.0 与 Node 22，构建 `oasis7_game_launcher`，构建 viewer web dist，并上传 `hosted-login-linux-x86_64-<sha>` artifact。
+- 遗留事项: 需要推到 GitHub 后由 Actions 实际运行；artifact 下载后仍需复制到 205 并配置测试库 + SMTP env 才算云上登录闭环完成。
+- Action: ci artifact workflow
+- Validation Command: ruby -e 'require "yaml"; YAML.load_file(ARGV.fetch(0)); puts "yaml ok"' .github/workflows/hosted-login-linux-build.yml
+- Expected Result: workflow YAML 可解析。
+- Actual Result: 通过，输出 `yaml ok`。
+- Blocker / Next Action: 推送分支后手工触发 `Hosted Login Linux Build`，下载 artifact 并部署到 205。

--- a/.pm/tasks/task_23af5676602c49c0ba233a217393f9d4.yaml
+++ b/.pm/tasks/task_23af5676602c49c0ba233a217393f9d4.yaml
@@ -1,0 +1,24 @@
+task_uid: task_23af5676602c49c0ba233a217393f9d4
+title: "remove trusted local preview mode from user launcher flow"
+owner_role: producer_system_designer
+worktree_hint: /Users/scc/ccwork/worktrees/oasis7-world-simulator-remove-trusted-local-preview
+execution_log_path: .pm/tasks/task_23af5676602c49c0ba233a217393f9d4.execution.md
+status: committed
+priority: P1
+source_signal: null
+source_refs:
+  - doc/world-simulator/prd.md
+  - doc/p2p/prd.md
+  - crates/oasis7_client_launcher/src/main.rs
+  - crates/oasis7/src/bin/oasis7_web_launcher/control_plane.rs
+doc_refs:
+  - doc/world-simulator/viewer/viewer-manual.manual.md
+related_prd:
+  - PRD-WORLD_SIMULATOR
+acceptance:
+  - "Default user launcher deployment mode is hosted_public_join and local trusted preview is no longer exposed as a user-selectable mode."
+  - "CLI/config validation rejects trusted_local_only for user launcher surfaces or maps legacy configs to hosted_public_join with explicit tests."
+  - "Hosted/email login path is the default user-facing join path, and tests/docs no longer present trusted local preview as the normal user flow."
+handoff_to: []
+updated_at: 2026-05-26T17:02:01+08:00
+last_started_at: 2026-05-26T17:02:01+08:00

--- a/crates/oasis7/src/bin/oasis7_game_launcher.rs
+++ b/crates/oasis7/src/bin/oasis7_game_launcher.rs
@@ -603,6 +603,9 @@ fn run_static_http_loop(
 
         match listener.accept() {
             Ok((stream, _addr)) => {
+                stream
+                    .set_nonblocking(false)
+                    .map_err(|err| format!("failed to set static HTTP stream blocking: {err}"))?;
                 let root_dir = Arc::clone(&root_dir);
                 let live_bind = Arc::clone(&live_bind);
                 let default_viewer_player_id = Arc::clone(&default_viewer_player_id);

--- a/crates/oasis7/src/bin/oasis7_game_launcher/cli.rs
+++ b/crates/oasis7/src/bin/oasis7_game_launcher/cli.rs
@@ -214,7 +214,7 @@ pub(super) fn parse_options<'a>(args: impl Iterator<Item = &'a str>) -> Result<C
     let _ = parse_host_port(options.live_bind.as_str(), "--live-bind")?;
     let _ = parse_host_port(options.web_bind.as_str(), "--web-bind")?;
     let deployment_mode =
-        DeploymentMode::parse(options.deployment_mode.as_str(), "--deployment-mode")?;
+        DeploymentMode::parse_user_facing(options.deployment_mode.as_str(), "--deployment-mode")?;
     if !deployment_mode.allows_local_chain_runtime() {
         options.chain_enabled = false;
     }
@@ -284,7 +284,7 @@ pub(super) fn parse_options<'a>(args: impl Iterator<Item = &'a str>) -> Result<C
 
 pub(super) fn deployment_mode_from_options(options: &CliOptions) -> DeploymentMode {
     DeploymentMode::parse(options.deployment_mode.as_str(), "deployment_mode")
-        .unwrap_or(DeploymentMode::TrustedLocalOnly)
+        .unwrap_or(DeploymentMode::HostedPublicJoin)
 }
 
 pub(super) fn uses_provider_http_transport(options: &CliOptions) -> bool {
@@ -396,7 +396,7 @@ Start player stack with one command:\n\
 - start built-in static web server\n\
 - print URL and optionally open browser\n\n\
 Options:\n\
-  --deployment-mode <mode>    trusted_local_only|hosted_public_join (default: {DEFAULT_DEPLOYMENT_MODE})\n\
+  --deployment-mode <mode>    hosted_public_join (default: {DEFAULT_DEPLOYMENT_MODE})\n\
   --scenario <name>            optional debug scenario; default uses formal release fixed world\n\
   --live-bind <host:port>      oasis7_viewer_live bind (default: {DEFAULT_LIVE_BIND})\n\
   --web-bind <host:port>       oasis7_viewer_live web bridge bind (default: {DEFAULT_WEB_BIND})\n\

--- a/crates/oasis7/src/bin/oasis7_game_launcher/hosted_account_identity.rs
+++ b/crates/oasis7/src/bin/oasis7_game_launcher/hosted_account_identity.rs
@@ -18,9 +18,6 @@ use std::time::{SystemTime, UNIX_EPOCH};
 pub(super) const HOSTED_ACCOUNT_LOGIN_START_ROUTE: &str = "/api/public/hosted-account/login/start";
 pub(super) const HOSTED_ACCOUNT_LOGIN_COMPLETE_ROUTE: &str =
     "/api/public/hosted-account/login/complete";
-const HOSTED_LOGIN_DELIVERY_MODE_ENV: &str = "OASIS7_HOSTED_LOGIN_DELIVERY_MODE";
-const HOSTED_LOGIN_DELIVERY_MODE_PREVIEW_INLINE: &str = "preview_inline";
-const HOSTED_LOGIN_DELIVERY_MODE_SERVER_LOG_ONLY: &str = "server_log_only";
 const HOSTED_LOGIN_DELIVERY_MODE_SMTP: &str = "smtp";
 const HOSTED_LOGIN_SMTP_HOST_ENV: &str = "OASIS7_HOSTED_LOGIN_SMTP_HOST";
 const HOSTED_LOGIN_SMTP_PORT_ENV: &str = "OASIS7_HOSTED_LOGIN_SMTP_PORT";
@@ -86,15 +83,14 @@ pub(super) struct HostedAccountLoginChallengeSnapshot {
     pub(super) masked_login_hint: String,
     pub(super) delivery_mode: String,
     pub(super) expires_at_unix_ms: u64,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub(super) preview_code: Option<String>,
 }
 
 #[derive(Debug)]
 pub(super) struct HostedAccountIdentityBroker {
     store_backend: HostedAccountStoreBackend,
-    delivery_mode: String,
     smtp_config: Option<HostedLoginSmtpConfig>,
+    #[cfg(test)]
+    test_log_delivery: bool,
     next_challenge_sequence: u64,
     otp_secret: [u8; 32],
     recent_start_timestamps_by_factor: BTreeMap<String, VecDeque<u64>>,
@@ -140,28 +136,19 @@ pub(super) struct ReservedHostedLoginStart {
 
 #[derive(Debug, Clone)]
 enum HostedLoginDeliveryPlan {
-    PreviewInline,
-    ServerLogOnly,
+    #[cfg(test)]
+    TestLogOnly,
     Smtp(HostedLoginSmtpConfig),
     SmtpUnavailable,
 }
 
 impl HostedAccountIdentityBroker {
     pub(super) fn from_env() -> Result<Self, String> {
-        let delivery_mode = normalize_delivery_mode(
-            std::env::var(HOSTED_LOGIN_DELIVERY_MODE_ENV)
-                .ok()
-                .as_deref(),
-        );
-        let smtp_config = if delivery_mode == HOSTED_LOGIN_DELIVERY_MODE_SMTP {
-            Some(HostedLoginSmtpConfig::from_env()?)
-        } else {
-            None
-        };
         Ok(Self {
             store_backend: HostedAccountStoreBackend::from_env()?,
-            delivery_mode,
-            smtp_config,
+            smtp_config: Some(HostedLoginSmtpConfig::from_env()?),
+            #[cfg(test)]
+            test_log_delivery: false,
             next_challenge_sequence: 0,
             otp_secret: random_otp_secret(),
             recent_start_timestamps_by_factor: BTreeMap::new(),
@@ -173,8 +160,8 @@ impl HostedAccountIdentityBroker {
     fn with_store_path(store_path: PathBuf) -> Result<Self, String> {
         Ok(Self {
             store_backend: HostedAccountStoreBackend::with_file_store_path(store_path)?,
-            delivery_mode: HOSTED_LOGIN_DELIVERY_MODE_PREVIEW_INLINE.to_string(),
             smtp_config: None,
+            test_log_delivery: true,
             next_challenge_sequence: 0,
             otp_secret: [0x5a; 32],
             recent_start_timestamps_by_factor: BTreeMap::new(),
@@ -185,8 +172,9 @@ impl HostedAccountIdentityBroker {
     pub(super) fn disabled() -> Self {
         Self {
             store_backend: HostedAccountStoreBackend::disabled(),
-            delivery_mode: HOSTED_LOGIN_DELIVERY_MODE_PREVIEW_INLINE.to_string(),
             smtp_config: None,
+            #[cfg(test)]
+            test_log_delivery: true,
             next_challenge_sequence: 0,
             otp_secret: [0u8; 32],
             recent_start_timestamps_by_factor: BTreeMap::new(),
@@ -274,13 +262,8 @@ impl HostedAccountIdentityBroker {
             challenge_id,
             login_channel: channel.to_string(),
             masked_login_hint,
-            delivery_mode: self.delivery_mode.clone(),
+            delivery_mode: HOSTED_LOGIN_DELIVERY_MODE_SMTP.to_string(),
             expires_at_unix_ms,
-            preview_code: if self.delivery_mode == HOSTED_LOGIN_DELIVERY_MODE_PREVIEW_INLINE {
-                Some(otp_code)
-            } else {
-                None
-            },
         };
         Ok(ReservedHostedLoginStart {
             factor_key,
@@ -559,23 +542,22 @@ impl HostedAccountIdentityBroker {
     }
 
     fn delivery_plan(&self) -> HostedLoginDeliveryPlan {
-        match self.delivery_mode.as_str() {
-            HOSTED_LOGIN_DELIVERY_MODE_SERVER_LOG_ONLY => HostedLoginDeliveryPlan::ServerLogOnly,
-            HOSTED_LOGIN_DELIVERY_MODE_SMTP => self
-                .smtp_config
-                .clone()
-                .map(HostedLoginDeliveryPlan::Smtp)
-                .unwrap_or(HostedLoginDeliveryPlan::SmtpUnavailable),
-            _ => HostedLoginDeliveryPlan::PreviewInline,
+        if let Some(config) = self.smtp_config.clone() {
+            return HostedLoginDeliveryPlan::Smtp(config);
         }
+        #[cfg(test)]
+        if self.test_log_delivery {
+            return HostedLoginDeliveryPlan::TestLogOnly;
+        }
+        HostedLoginDeliveryPlan::SmtpUnavailable
     }
 }
 
 impl ReservedHostedLoginStart {
     pub(super) fn deliver(&self) -> Result<(), String> {
         match &self.delivery_plan {
-            HostedLoginDeliveryPlan::PreviewInline => Ok(()),
-            HostedLoginDeliveryPlan::ServerLogOnly => {
+            #[cfg(test)]
+            HostedLoginDeliveryPlan::TestLogOnly => {
                 emit_delivery_notice(
                     self.challenge.login_channel.as_str(),
                     self.challenge.masked_login_hint.as_str(),
@@ -726,16 +708,7 @@ fn account_summary_from_record(record: &HostedAccountRecord) -> HostedAccountSum
     }
 }
 
-fn normalize_delivery_mode(raw: Option<&str>) -> String {
-    match raw.unwrap_or("").trim() {
-        HOSTED_LOGIN_DELIVERY_MODE_SERVER_LOG_ONLY => {
-            HOSTED_LOGIN_DELIVERY_MODE_SERVER_LOG_ONLY.to_string()
-        }
-        HOSTED_LOGIN_DELIVERY_MODE_SMTP => HOSTED_LOGIN_DELIVERY_MODE_SMTP.to_string(),
-        _ => HOSTED_LOGIN_DELIVERY_MODE_PREVIEW_INLINE.to_string(),
-    }
-}
-
+#[cfg(test)]
 fn emit_delivery_notice(channel: &str, masked_login_hint: &str, challenge_id: &str) {
     let message = format!(
         "hosted account login challenge issued: channel={channel} target={masked_login_hint} challenge_id={challenge_id}"
@@ -841,18 +814,18 @@ fn random_otp_secret() -> [u8; 32] {
 }
 
 fn build_login_otp_code(
-    otp_secret: &[u8; 32],
-    challenge_id: &str,
-    normalized_login_hint: &str,
+    _otp_secret: &[u8; 32],
+    _challenge_id: &str,
+    _normalized_login_hint: &str,
 ) -> String {
-    let mut input = Vec::with_capacity(challenge_id.len() + normalized_login_hint.len() + 1);
-    input.extend_from_slice(challenge_id.as_bytes());
-    input.push(0);
-    input.extend_from_slice(normalized_login_hint.as_bytes());
-    let digest = blake3::keyed_hash(otp_secret, input.as_slice());
-    let mut prefix = [0u8; 8];
-    prefix.copy_from_slice(&digest.as_bytes()[..8]);
-    format!("{:06}", u64::from_le_bytes(prefix) % 1_000_000)
+    loop {
+        let mut bytes = [0u8; 4];
+        OsRng.fill_bytes(&mut bytes);
+        let code = format!("{:06}", u32::from_le_bytes(bytes) % 1_000_000);
+        if code != "000000" && code != "123456" {
+            return code;
+        }
+    }
 }
 
 fn now_unix_ms() -> u64 {

--- a/crates/oasis7/src/bin/oasis7_game_launcher/hosted_account_identity_tests.rs
+++ b/crates/oasis7/src/bin/oasis7_game_launcher/hosted_account_identity_tests.rs
@@ -6,6 +6,15 @@ fn temp_store_path(name: &str) -> PathBuf {
     std::env::temp_dir().join(format!("oasis7-hosted-account-{name}-{unique}.json"))
 }
 
+fn pending_otp_code(broker: &HostedAccountIdentityBroker, challenge_id: &str) -> String {
+    broker
+        .pending_challenges
+        .get(challenge_id)
+        .expect("pending challenge")
+        .otp_code
+        .clone()
+}
+
 #[test]
 fn hosted_account_login_start_rejects_phone_channel() {
     let mut broker =
@@ -37,7 +46,7 @@ fn hosted_account_login_complete_reuses_stable_player_id() {
     let first = broker.complete_login(
         DeploymentMode::HostedPublicJoin,
         challenge.challenge_id.as_str(),
-        challenge.preview_code.as_deref().unwrap_or_default(),
+        pending_otp_code(&broker, challenge.challenge_id.as_str()).as_str(),
         &mut issuer,
     );
     assert!(first.ok);
@@ -56,7 +65,7 @@ fn hosted_account_login_complete_reuses_stable_player_id() {
     let second = broker.complete_login(
         DeploymentMode::HostedPublicJoin,
         challenge_second.challenge_id.as_str(),
-        challenge_second.preview_code.as_deref().unwrap_or_default(),
+        pending_otp_code(&broker, challenge_second.challenge_id.as_str()).as_str(),
         &mut issuer,
     );
     assert!(second.ok);
@@ -75,6 +84,24 @@ fn hosted_account_login_complete_reuses_stable_player_id() {
 }
 
 #[test]
+fn hosted_account_login_start_does_not_expose_otp_in_public_response() {
+    let mut broker = HostedAccountIdentityBroker::with_store_path(temp_store_path("otp-random"))
+        .expect("broker");
+    let start = broker.start_login(
+        DeploymentMode::HostedPublicJoin,
+        "email",
+        "player-random@example.com",
+    );
+    assert!(start.ok);
+    let challenge = start.challenge.expect("challenge");
+    let otp_code = pending_otp_code(&broker, challenge.challenge_id.as_str());
+
+    assert_eq!(otp_code.len(), 6);
+    assert!(otp_code.chars().all(|ch| ch.is_ascii_digit()));
+    assert_ne!(otp_code, "123456");
+}
+
+#[test]
 fn hosted_account_login_complete_rejects_wrong_otp() {
     let mut broker =
         HostedAccountIdentityBroker::with_store_path(temp_store_path("wrong-otp")).expect("broker");
@@ -85,7 +112,8 @@ fn hosted_account_login_complete_rejects_wrong_otp() {
         "player@example.com",
     );
     let challenge = start.challenge.expect("challenge");
-    let wrong_code = if challenge.preview_code.as_deref() == Some("000000") {
+    let otp_code = pending_otp_code(&broker, challenge.challenge_id.as_str());
+    let wrong_code = if otp_code == "000000" {
         "000001"
     } else {
         "000000"
@@ -111,7 +139,8 @@ fn hosted_account_login_complete_locks_after_repeated_invalid_otp() {
         "player@example.com",
     );
     let challenge = start.challenge.expect("challenge");
-    let wrong_code = if challenge.preview_code.as_deref() == Some("000000") {
+    let otp_code = pending_otp_code(&broker, challenge.challenge_id.as_str());
+    let wrong_code = if otp_code == "000000" {
         "000001"
     } else {
         "000000"
@@ -136,7 +165,7 @@ fn hosted_account_login_complete_locks_after_repeated_invalid_otp() {
     let missing = broker.complete_login(
         DeploymentMode::HostedPublicJoin,
         challenge.challenge_id.as_str(),
-        challenge.preview_code.as_deref().unwrap_or_default(),
+        otp_code.as_str(),
         &mut issuer,
     );
     assert_eq!(missing.error_code.as_deref(), Some("challenge_not_found"));
@@ -146,7 +175,7 @@ fn hosted_account_login_complete_locks_after_repeated_invalid_otp() {
 fn hosted_account_login_start_rolls_back_on_delivery_failure() {
     let mut broker =
         HostedAccountIdentityBroker::with_store_path(temp_store_path("smtp-fail")).expect("broker");
-    broker.delivery_mode = HOSTED_LOGIN_DELIVERY_MODE_SMTP.to_string();
+    broker.test_log_delivery = false;
     let response = broker.start_login(
         DeploymentMode::HostedPublicJoin,
         "email",
@@ -239,22 +268,6 @@ fn hosted_account_login_start_enforces_extended_rate_limit() {
         .as_deref()
         .unwrap_or_default()
         .contains("last 10 minutes"));
-}
-
-#[test]
-fn normalize_delivery_mode_accepts_smtp() {
-    assert_eq!(
-        normalize_delivery_mode(Some(" smtp ")),
-        HOSTED_LOGIN_DELIVERY_MODE_SMTP
-    );
-    assert_eq!(
-        normalize_delivery_mode(Some("server_log_only")),
-        HOSTED_LOGIN_DELIVERY_MODE_SERVER_LOG_ONLY
-    );
-    assert_eq!(
-        normalize_delivery_mode(Some("unexpected")),
-        HOSTED_LOGIN_DELIVERY_MODE_PREVIEW_INLINE
-    );
 }
 
 #[test]

--- a/crates/oasis7/src/bin/oasis7_game_launcher/oasis7_game_launcher_tests.rs
+++ b/crates/oasis7/src/bin/oasis7_game_launcher/oasis7_game_launcher_tests.rs
@@ -1,7 +1,7 @@
 use std::env;
 use std::fs;
-use std::io::{BufRead, BufReader, BufWriter, Write};
-use std::net::TcpListener;
+use std::io::{BufRead, BufReader, BufWriter, Read, Write};
+use std::net::{TcpListener, TcpStream};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::thread;
@@ -14,7 +14,8 @@ use super::{
     query_runtime_bound_players, resolve_static_asset_path,
     resolve_viewer_auth_bootstrap_for_embedded_server, resolve_viewer_auth_bootstrap_from_path,
     resolve_viewer_static_dir_with_override, sanitize_index_html_for_embedded_server,
-    sanitize_relative_request_path, viewer_dev_dist_candidates, CliOptions, ViewerAuthBootstrap,
+    sanitize_relative_request_path, start_static_http_server, stop_static_http_server,
+    viewer_dev_dist_candidates, CliOptions, DeploymentMode, ViewerAuthBootstrap,
     BUILTIN_LLM_DECISION_SOURCE, DEFAULT_AGENT_PROVIDER_CONNECT_TIMEOUT_MS,
     DEFAULT_AGENT_PROVIDER_PROFILE, DEFAULT_AGENT_PROVIDER_URL, DEFAULT_CHAIN_NODE_ID,
     DEFAULT_CHAIN_STATUS_BIND, DEFAULT_DEPLOYMENT_MODE, DEFAULT_INTERACTIVE_LLM_TIMEOUT_MS,
@@ -96,7 +97,7 @@ fn parse_options_defaults() {
     );
     assert!(options.open_browser);
     assert_eq!(options.viewer_static_dir, "web");
-    assert!(options.chain_enabled);
+    assert!(!options.chain_enabled);
     assert_eq!(options.chain_status_bind, DEFAULT_CHAIN_STATUS_BIND);
     assert!(options
         .chain_node_id
@@ -484,7 +485,7 @@ fn build_viewer_live_command_skips_default_llm_timeout_when_repo_config_exists()
 fn parse_options_rejects_unknown_deployment_mode() {
     let err = parse_options(["--deployment-mode", "invalid"].into_iter())
         .expect_err("invalid deployment mode should fail");
-    assert!(err.contains("trusted_local_only"));
+    assert!(err.contains("hosted_public_join"));
 }
 
 #[test]
@@ -508,8 +509,8 @@ fn parse_options_rejects_invalid_chain_replication_network_peer() {
 }
 
 #[test]
-fn parse_options_rejects_proposal_tick_phase_out_of_range() {
-    let err = parse_options(
+fn parse_options_ignores_chain_tuning_when_hosted_public_join_disables_chain() {
+    let options = parse_options(
         [
             "--chain-pos-ticks-per-slot",
             "4",
@@ -518,8 +519,11 @@ fn parse_options_rejects_proposal_tick_phase_out_of_range() {
         ]
         .into_iter(),
     )
-    .expect_err("should fail");
-    assert!(err.contains("--chain-pos-proposal-tick-phase"));
+    .expect("hosted public join disables local chain validation");
+    assert_eq!(options.deployment_mode, "hosted_public_join");
+    assert!(!options.chain_enabled);
+    assert_eq!(options.chain_pos_ticks_per_slot, 4);
+    assert_eq!(options.chain_pos_proposal_tick_phase, 4);
 }
 
 #[test]
@@ -713,7 +717,7 @@ fn build_game_url_brackets_ipv6_hosts() {
     assert!(url.starts_with(
         "http://[::1]:4173/?render_mode=viewer&ws=ws%3A%2F%2F%5B%3A%3A1%5D%3A5011&hosted_access="
     ));
-    assert!(url.contains("%22deployment_mode%22%3A%22trusted_local_only%22"));
+    assert!(url.contains("%22deployment_mode%22%3A%22hosted_public_join%22"));
 }
 
 #[test]
@@ -944,6 +948,50 @@ fn sanitize_index_html_for_embedded_server_injects_viewer_auth_bootstrap_into_no
     assert!(sanitized.contains("viewer-player"));
     assert!(sanitized.contains("pub-hex"));
     assert!(sanitized.contains("priv-hex"));
+}
+
+#[test]
+fn static_http_server_serves_large_static_asset_completely() {
+    let temp_dir = make_temp_dir("large_static_asset");
+    let large_body = vec![b'a'; 512 * 1024];
+    fs::write(temp_dir.join("viewer.js"), &large_body).expect("write large asset");
+
+    let probe = TcpListener::bind(("127.0.0.1", 0)).expect("bind port probe");
+    let port = probe.local_addr().expect("probe addr").port();
+    drop(probe);
+
+    let mut server = start_static_http_server(
+        DeploymentMode::TrustedLocalOnly,
+        "127.0.0.1:0",
+        "127.0.0.1",
+        port,
+        temp_dir.as_path(),
+        None,
+    )
+    .expect("start static HTTP server");
+
+    let mut response = Vec::new();
+    for _ in 0..50 {
+        match TcpStream::connect(("127.0.0.1", port)) {
+            Ok(mut stream) => {
+                stream
+                    .write_all(b"GET /viewer.js HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n")
+                    .expect("write request");
+                stream.read_to_end(&mut response).expect("read response");
+                break;
+            }
+            Err(_) => thread::sleep(std::time::Duration::from_millis(20)),
+        }
+    }
+    stop_static_http_server(&mut server);
+
+    let split_at = response
+        .windows(4)
+        .position(|window| window == b"\r\n\r\n")
+        .expect("response headers end")
+        + 4;
+    assert!(String::from_utf8_lossy(&response[..split_at]).starts_with("HTTP/1.1 200 OK"));
+    assert_eq!(&response[split_at..], large_body.as_slice());
 }
 
 #[test]

--- a/crates/oasis7/src/bin/oasis7_web_launcher.rs
+++ b/crates/oasis7/src/bin/oasis7_web_launcher.rs
@@ -577,7 +577,7 @@ fn print_help() {
         "Usage: oasis7_web_launcher [options]\n\n\
 Options:\n\
   --listen-bind <host:port>       web console listen bind (default: {DEFAULT_LISTEN_BIND})\n\
-  --deployment-mode <mode>        trusted_local_only|hosted_public_join\n\
+  --deployment-mode <mode>        hosted_public_join\n\
   --launcher-bin <path>           oasis7_game_launcher binary path\n\
   --chain-runtime-bin <path>      oasis7_chain_runtime binary path\n\
   --console-static-dir <path>     launcher web static directory (default: ../web-launcher)\n\
@@ -789,7 +789,7 @@ where
     normalize_chain_network_tier_config(&mut options.initial_config)?;
 
     parse_host_port(options.listen_bind.as_str(), "--listen-bind")?;
-    let deployment_mode = DeploymentMode::parse(
+    let deployment_mode = DeploymentMode::parse_user_facing(
         options.initial_config.deployment_mode.as_str(),
         "--deployment-mode",
     )?;

--- a/crates/oasis7/src/bin/oasis7_web_launcher/control_plane.rs
+++ b/crates/oasis7/src/bin/oasis7_web_launcher/control_plane.rs
@@ -750,9 +750,11 @@ pub(super) fn validate_game_config_with_launcher_bin(
     launcher_bin: &str,
 ) -> Vec<String> {
     let mut issues = Vec::new();
-    if DeploymentMode::parse(config.deployment_mode.as_str(), "deployment mode").is_err() {
+    if DeploymentMode::parse_user_facing(config.deployment_mode.as_str(), "deployment mode")
+        .is_err()
+    {
         issues.push(
-            "deployment mode must be one of: trusted_local_only|hosted_public_join".to_string(),
+            "deployment mode must be hosted_public_join; trusted_local_only has been removed from the user launcher flow".to_string(),
         );
     }
     if parse_host_port(config.live_bind.as_str(), "live bind").is_err() {
@@ -940,7 +942,9 @@ pub(super) fn build_launcher_args_with_launcher_bin(
 
     let mut args = vec![
         "--deployment-mode".to_string(),
-        config.deployment_mode.trim().to_string(),
+        DeploymentMode::parse_user_facing(config.deployment_mode.as_str(), "deployment_mode")?
+            .as_str()
+            .to_string(),
         "--live-bind".to_string(),
         config.live_bind.trim().to_string(),
         "--web-bind".to_string(),

--- a/crates/oasis7/src/bin/oasis7_web_launcher/oasis7_web_launcher_tests.rs
+++ b/crates/oasis7/src/bin/oasis7_web_launcher/oasis7_web_launcher_tests.rs
@@ -25,7 +25,7 @@ use oasis7_proto::storage_profile::StorageProfile;
 fn parse_options_defaults() {
     let options = parse_options(std::iter::empty()).expect("parse options");
     assert_eq!(options.listen_bind, DEFAULT_LISTEN_BIND);
-    assert_eq!(options.initial_config.deployment_mode, "trusted_local_only");
+    assert_eq!(options.initial_config.deployment_mode, "hosted_public_join");
     assert_eq!(options.initial_config.scenario, DEFAULT_SCENARIO);
     assert_eq!(
         options.initial_config.chain_status_bind,
@@ -57,7 +57,7 @@ fn parse_options_defaults() {
     );
     assert_eq!(options.initial_config.chain_pos_max_past_slot_lag, "256");
     assert!(options.initial_config.llm_enabled);
-    assert!(options.initial_config.chain_enabled);
+    assert!(!options.initial_config.chain_enabled);
     assert!(!options.initial_config.auto_open_browser);
     assert!(options
         .initial_config
@@ -227,12 +227,12 @@ fn parse_options_rejects_unknown_option() {
 fn parse_options_rejects_unknown_deployment_mode() {
     let err = parse_options(["--deployment-mode", "invalid"].into_iter())
         .expect_err("invalid deployment mode should fail");
-    assert!(err.contains("trusted_local_only"));
+    assert!(err.contains("hosted_public_join"));
 }
 
 #[test]
-fn parse_options_rejects_out_of_range_chain_pos_proposal_tick_phase() {
-    let err = parse_options(
+fn parse_options_ignores_chain_tuning_when_hosted_public_join_disables_chain() {
+    let options = parse_options(
         [
             "--chain-pos-ticks-per-slot",
             "4",
@@ -241,8 +241,11 @@ fn parse_options_rejects_out_of_range_chain_pos_proposal_tick_phase() {
         ]
         .into_iter(),
     )
-    .expect_err("out-of-range proposal tick phase should fail");
-    assert!(err.contains("--chain-pos-proposal-tick-phase"));
+    .expect("hosted public join disables local chain validation");
+    assert_eq!(options.initial_config.deployment_mode, "hosted_public_join");
+    assert!(!options.initial_config.chain_enabled);
+    assert_eq!(options.initial_config.chain_pos_ticks_per_slot, "4");
+    assert_eq!(options.initial_config.chain_pos_proposal_tick_phase, "4");
 }
 
 #[test]
@@ -296,6 +299,7 @@ fn build_launcher_args_includes_chain_disable_when_off() {
 #[test]
 fn build_launcher_args_keeps_chain_disabled_even_when_chain_config_is_on() {
     let config = LauncherConfig {
+        deployment_mode: "hosted_public_join".to_string(),
         viewer_static_dir: ".".to_string(),
         chain_enabled: true,
         chain_status_bind: "127.0.0.1:6121".to_string(),
@@ -325,6 +329,7 @@ fn build_launcher_args_keeps_chain_disabled_even_when_chain_config_is_on() {
 #[test]
 fn build_chain_runtime_args_includes_chain_overrides_when_on() {
     let config = LauncherConfig {
+        deployment_mode: "trusted_local_only".to_string(),
         viewer_static_dir: ".".to_string(),
         chain_enabled: true,
         chain_status_bind: "127.0.0.1:6121".to_string(),
@@ -387,6 +392,7 @@ fn build_chain_runtime_args_includes_chain_overrides_when_on() {
 #[test]
 fn build_chain_runtime_args_uses_network_tier_manifest_when_present() {
     let config = LauncherConfig {
+        deployment_mode: "trusted_local_only".to_string(),
         viewer_static_dir: ".".to_string(),
         chain_enabled: true,
         chain_status_bind: "127.0.0.1:6121".to_string(),
@@ -414,6 +420,7 @@ fn build_chain_runtime_args_uses_network_tier_manifest_when_present() {
 #[test]
 fn build_chain_runtime_args_resolves_public_testnet_tier_manifest() {
     let config = LauncherConfig {
+        deployment_mode: "trusted_local_only".to_string(),
         viewer_static_dir: ".".to_string(),
         chain_enabled: true,
         chain_status_bind: "127.0.0.1:6121".to_string(),
@@ -460,6 +467,7 @@ fn viewer_dev_dist_candidates_only_return_oasis7_path() {
 fn build_chain_runtime_args_supports_all_storage_profiles() {
     for expected in ["dev_local", "release_default", "soak_forensics"] {
         let config = LauncherConfig {
+            deployment_mode: "trusted_local_only".to_string(),
             viewer_static_dir: ".".to_string(),
             chain_enabled: true,
             chain_status_bind: "127.0.0.1:6121".to_string(),
@@ -477,6 +485,7 @@ fn build_chain_runtime_args_supports_all_storage_profiles() {
 #[test]
 fn build_chain_runtime_args_rejects_unknown_storage_profile() {
     let config = LauncherConfig {
+        deployment_mode: "trusted_local_only".to_string(),
         chain_enabled: true,
         chain_storage_profile: "unknown".to_string(),
         ..LauncherConfig::default()
@@ -490,6 +499,7 @@ fn build_chain_runtime_args_rejects_unknown_storage_profile() {
 #[test]
 fn build_chain_runtime_args_requires_public_entry_confirmation() {
     let err = build_chain_runtime_args(&LauncherConfig {
+        deployment_mode: "trusted_local_only".to_string(),
         chain_enabled: true,
         chain_status_bind: "127.0.0.1:6121".to_string(),
         chain_node_id: "chain-a".to_string(),

--- a/crates/oasis7/src/hosted_access.rs
+++ b/crates/oasis7/src/hosted_access.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 #[cfg(test)]
 use std::sync::{Mutex, OnceLock};
 
-pub(super) const DEFAULT_DEPLOYMENT_MODE: &str = "trusted_local_only";
+pub(super) const DEFAULT_DEPLOYMENT_MODE: &str = "hosted_public_join";
 #[allow(dead_code)]
 const DEFAULT_MAX_GUEST_SESSIONS: u64 = 32;
 #[allow(dead_code)]
@@ -37,6 +37,16 @@ impl DeploymentMode {
             _ => Err(format!(
                 "{label} must be one of: trusted_local_only|hosted_public_join"
             )),
+        }
+    }
+
+    pub(super) fn parse_user_facing(raw: &str, label: &str) -> Result<Self, String> {
+        match raw.trim() {
+            "hosted_public_join" => Ok(Self::HostedPublicJoin),
+            "trusted_local_only" => Err(format!(
+                "{label}=trusted_local_only has been removed from the user launcher flow; use hosted_public_join"
+            )),
+            _ => Err(format!("{label} must be hosted_public_join")),
         }
     }
 

--- a/crates/oasis7_client_launcher/src/launcher_core.rs
+++ b/crates/oasis7_client_launcher/src/launcher_core.rs
@@ -571,6 +571,9 @@ pub(super) fn chain_runtime_effectively_enabled(config: &LaunchConfig) -> bool {
 }
 
 pub(super) fn normalize_launch_config(config: &mut LaunchConfig) {
+    if config.deployment_mode.trim() == "trusted_local_only" {
+        config.deployment_mode = "hosted_public_join".to_string();
+    }
     if hosted_public_join_blocks_local_chain_runtime(config) {
         config.chain_enabled = false;
     }
@@ -584,11 +587,15 @@ fn hosted_public_join_local_chain_runtime_error() -> String {
 #[cfg(test)]
 pub(super) fn build_launcher_args(config: &LaunchConfig) -> Result<Vec<String>, String> {
     let deployment_mode = match config.deployment_mode.trim() {
-        "trusted_local_only" => "trusted_local_only",
         "hosted_public_join" => "hosted_public_join",
+        "trusted_local_only" => {
+            return Err(
+                "deployment mode trusted_local_only has been removed from the user launcher flow; use hosted_public_join".to_string(),
+            )
+        }
         _ => {
             return Err(format!(
-                "deployment mode must be one of trusted_local_only|hosted_public_join, got `{}`",
+                "deployment mode must be hosted_public_join, got `{}`",
                 config.deployment_mode.trim()
             ))
         }
@@ -803,7 +810,12 @@ pub(super) fn build_game_url(config: &LaunchConfig) -> String {
     let web_host = normalize_host_for_url(web_host.as_str());
     let web_host = host_for_url(web_host.as_str());
     let ws_url = format!("ws://{web_host}:{web_port}");
-    let is_hosted_public_join = hosted_public_join_blocks_local_chain_runtime(config);
+    let deployment_mode = match config.deployment_mode.trim() {
+        "trusted_local_only" => "hosted_public_join",
+        "hosted_public_join" => "hosted_public_join",
+        other => other,
+    };
+    let is_hosted_public_join = deployment_mode == "hosted_public_join";
     let hosted_strong_auth_backend_grant_enabled = hosted_strong_auth_backend_grant_enabled();
     let hosted_access_verdict = if is_hosted_public_join && hosted_strong_auth_backend_grant_enabled
     {
@@ -811,7 +823,7 @@ pub(super) fn build_game_url(config: &LaunchConfig) -> String {
     } else if is_hosted_public_join {
         "hosted_public_join_blocked_until_strong_auth"
     } else {
-        "trusted_local_only_preview"
+        "hosted_public_join_blocked_until_strong_auth"
     };
     let prompt_strong_auth_availability =
         if is_hosted_public_join && hosted_strong_auth_backend_grant_enabled {
@@ -819,7 +831,7 @@ pub(super) fn build_game_url(config: &LaunchConfig) -> String {
         } else if is_hosted_public_join {
             "blocked_until_strong_auth"
         } else {
-            "trusted_local_preview_only"
+            "blocked_until_strong_auth"
         };
     let prompt_strong_auth_reason = if is_hosted_public_join
         && hosted_strong_auth_backend_grant_enabled
@@ -828,25 +840,25 @@ pub(super) fn build_game_url(config: &LaunchConfig) -> String {
     } else if is_hosted_public_join {
         "hosted public join keeps this action behind strong_auth/private plane until the dedicated proof lane lands"
     } else {
-        "trusted local preview may still use preview bootstrap; hosted/public strong-auth lane remains pending"
+        "hosted public join keeps this action behind strong_auth/private plane until the dedicated proof lane lands"
     };
     let hosted_access_hint = serde_json::json!({
-        "deployment_mode": config.deployment_mode.trim(),
+        "deployment_mode": deployment_mode,
         "verdict": hosted_access_verdict,
         "browser_signer_bootstrap": if is_hosted_public_join {
             "disabled_for_public_player_plane"
         } else {
-            "trusted_local_bootstrap_allowed"
+            "disabled_for_public_player_plane"
         },
         "local_chain_runtime": if is_hosted_public_join {
             "blocked_for_public_player_plane"
         } else {
-            "launcher_managed_local_runtime_allowed"
+            "blocked_for_public_player_plane"
         },
         "node_admission": if is_hosted_public_join {
             "operator_managed_node_onboarding_only"
         } else {
-            "trusted_local_preview_only"
+            "operator_managed_node_onboarding_only"
         },
         "session_ladder": ["guest_session", "player_session", "strong_auth"],
         "action_matrix": [
@@ -886,12 +898,12 @@ pub(super) fn build_game_url(config: &LaunchConfig) -> String {
                 "availability": if is_hosted_public_join {
                     "blocked_until_strong_auth"
                 } else {
-                    "trusted_local_preview_only"
+                    "blocked_until_strong_auth"
                 },
                 "reason": if is_hosted_public_join {
                     "hosted public join keeps this action behind strong_auth/private plane until the dedicated proof lane lands"
                 } else {
-                    "trusted local preview may still use preview bootstrap; hosted/public strong-auth lane remains pending"
+                    "hosted public join keeps this action behind strong_auth/private plane until the dedicated proof lane lands"
                 },
             },
         ],

--- a/crates/oasis7_client_launcher/src/main.rs
+++ b/crates/oasis7_client_launcher/src/main.rs
@@ -118,7 +118,7 @@ const DEFAULT_CHAIN_POS_TICKS_PER_SLOT: &str = "10";
 const DEFAULT_CHAIN_POS_PROPOSAL_TICK_PHASE: &str = "9";
 const DEFAULT_CHAIN_POS_SLOT_CLOCK_GENESIS_UNIX_MS: &str = "";
 const DEFAULT_CHAIN_POS_MAX_PAST_SLOT_LAG: &str = "256";
-const DEFAULT_DEPLOYMENT_MODE: &str = "trusted_local_only";
+const DEFAULT_DEPLOYMENT_MODE: &str = "hosted_public_join";
 const MAX_LOG_LINES: usize = 2000;
 const OASIS7_CJK_FONT_NAME: &str = "oasis7-cjk";
 const EGUI_CJK_FONT_BYTES: &[u8] = include_bytes!("../../../third_party/ms-yahei.ttf");
@@ -460,7 +460,7 @@ impl Default for LaunchConfig {
             agent_provider_profile: DEFAULT_AGENT_PROVIDER_PROFILE.to_string(),
             llm_enabled: true,
             provider_auto_discover: true,
-            chain_enabled: true,
+            chain_enabled: false,
             chain_status_bind: DEFAULT_CHAIN_STATUS_BIND.to_string(),
             chain_node_id: default_chain_node_id(),
             chain_network_tier: DEFAULT_CHAIN_NETWORK_TIER.to_string(),

--- a/crates/oasis7_client_launcher/src/main_tests.rs
+++ b/crates/oasis7_client_launcher/src/main_tests.rs
@@ -104,7 +104,7 @@ fn build_launcher_args_contains_llm_and_no_open_switches() {
     assert!(args.contains(&"--agent-decision-source".to_string()));
     assert!(args.contains(&"builtin_llm".to_string()));
     assert!(args.contains(&"--deployment-mode".to_string()));
-    assert!(args.contains(&"trusted_local_only".to_string()));
+    assert!(args.contains(&"hosted_public_join".to_string()));
     assert!(args.contains(&"--no-open-browser".to_string()));
     assert!(args.contains(&"--viewer-static-dir".to_string()));
     assert!(args.contains(&"--chain-disable".to_string()));
@@ -186,9 +186,7 @@ fn hosted_public_join_transfer_barrier_tracks_deployment_mode() {
         deployment_mode: "hosted_public_join".to_string(),
         ..LaunchConfig::default()
     }));
-    assert!(!hosted_public_join_transfer_blocked(
-        &LaunchConfig::default()
-    ));
+    assert!(hosted_public_join_transfer_blocked(&LaunchConfig::default()));
 }
 #[test]
 fn build_game_url_rewrites_zero_host() {
@@ -248,7 +246,7 @@ fn build_game_url_brackets_ipv6_hosts() {
     assert!(url.starts_with(
         "http://[::1]:4173/?render_mode=viewer&ws=ws%3A%2F%2F%5B%3A%3A1%5D%3A5011&hosted_access="
     ));
-    assert!(url.contains("%22deployment_mode%22%3A%22trusted_local_only%22"));
+    assert!(url.contains("%22deployment_mode%22%3A%22hosted_public_join%22"));
 }
 
 #[test]
@@ -272,7 +270,7 @@ fn normalize_host_for_url_maps_empty_and_any() {
 fn launch_config_defaults_enable_llm() {
     let config = LaunchConfig::default();
     assert!(config.llm_enabled);
-    assert!(config.chain_enabled);
+    assert!(!config.chain_enabled);
     assert_eq!(config.agent_decision_source, "builtin_llm");
     assert_eq!(config.agent_provider_backend, "provider_local_bridge");
     assert_eq!(config.agent_provider_contract, "worldsim_provider_v1");
@@ -335,6 +333,7 @@ fn build_launcher_args_keeps_chain_disabled_even_when_chain_config_is_set() {
 #[test]
 fn build_chain_runtime_args_contains_chain_overrides_when_enabled() {
     let config = LaunchConfig {
+        deployment_mode: "trusted_local_only".to_string(),
         chain_enabled: true,
         chain_status_bind: "127.0.0.1:6121".to_string(),
         chain_node_id: "chain-node-a".to_string(),
@@ -416,6 +415,7 @@ fn normalize_launch_config_disables_chain_for_hosted_public_join() {
     assert!(!config.chain_enabled);
     assert!(!chain_runtime_effectively_enabled(&config));
 }
+
 #[test]
 fn parse_chain_role_rejects_invalid_value() {
     let err = parse_chain_role("invalid").expect_err("should fail");
@@ -766,7 +766,7 @@ fn chain_runtime_status_from_web_maps_stale_execution_world() {
 }
 
 #[test]
-fn apply_web_snapshot_tracks_chain_recovery_payload() {
+fn apply_web_snapshot_preserves_chain_recovery_payload_but_disables_legacy_local_chain() {
     let mut app = ClientLauncherApp::default();
     let snapshot = WebStateSnapshot {
         status: "idle".to_string(),
@@ -787,20 +787,25 @@ fn apply_web_snapshot_tracks_chain_recovery_payload() {
             fresh_node_id: "viewer-live-node-fresh-1".to_string(),
             fresh_chain_status_bind: "127.0.0.1:5122".to_string(),
             suggested_config: LaunchConfig {
+                deployment_mode: "trusted_local_only".to_string(),
                 chain_node_id: "viewer-live-node-fresh-1".to_string(),
                 chain_status_bind: "127.0.0.1:5122".to_string(),
                 ..LaunchConfig::default()
             },
         }),
         game_url: "http://127.0.0.1:4173/".to_string(),
-        config: LaunchConfig::default(),
+        config: LaunchConfig {
+            deployment_mode: "trusted_local_only".to_string(),
+            chain_enabled: true,
+            ..LaunchConfig::default()
+        },
         logs: vec![],
     };
 
     app.apply_web_snapshot(snapshot);
     assert!(matches!(
         app.chain_runtime_status,
-        ChainRuntimeStatus::StaleExecutionWorld(_)
+        ChainRuntimeStatus::Disabled
     ));
     assert_eq!(
         app.chain_recovery
@@ -1023,6 +1028,7 @@ fn collect_required_config_issues_reports_missing_required_fields() {
 #[test]
 fn collect_chain_required_config_issues_reports_missing_required_fields() {
     let config = LaunchConfig {
+        deployment_mode: "trusted_local_only".to_string(),
         chain_enabled: true,
         chain_runtime_bin: "".to_string(),
         chain_status_bind: "127.0.0.1".to_string(),
@@ -1128,6 +1134,7 @@ fn collect_chain_required_config_issues_accepts_valid_required_fields() {
 #[test]
 fn collect_chain_required_config_issues_requires_public_entry_confirmation() {
     let issues = collect_chain_required_config_issues(&LaunchConfig {
+        deployment_mode: "trusted_local_only".to_string(),
         chain_enabled: true,
         chain_runtime_bin: std::env::current_exe()
             .expect("current exe")
@@ -1147,6 +1154,7 @@ fn collect_chain_required_config_issues_requires_public_entry_confirmation() {
 #[test]
 fn build_chain_runtime_args_requires_public_entry_confirmation() {
     let err = build_chain_runtime_args(&LaunchConfig {
+        deployment_mode: "trusted_local_only".to_string(),
         chain_enabled: true,
         chain_runtime_bin: "/tmp/oasis7_chain_runtime".to_string(),
         chain_status_bind: "127.0.0.1:6121".to_string(),

--- a/crates/oasis7_client_launcher/src/main_tests_chain_args.rs
+++ b/crates/oasis7_client_launcher/src/main_tests_chain_args.rs
@@ -2,7 +2,8 @@ use super::*;
 
 #[test]
 fn build_chain_runtime_args_resolves_public_testnet_manifest_from_tier() {
-    let mut config = LaunchConfig {
+    let config = LaunchConfig {
+        deployment_mode: "trusted_local_only".to_string(),
         chain_enabled: true,
         chain_status_bind: "127.0.0.1:6121".to_string(),
         chain_node_id: "chain-a".to_string(),
@@ -11,7 +12,6 @@ fn build_chain_runtime_args_resolves_public_testnet_manifest_from_tier() {
         chain_p2p_accept_public_entry: true,
         ..LaunchConfig::default()
     };
-    config.normalize();
 
     let args = build_chain_runtime_args(&config).expect("args should build");
 

--- a/crates/oasis7_client_launcher/src/main_tests_onboarding.rs
+++ b/crates/oasis7_client_launcher/src/main_tests_onboarding.rs
@@ -58,7 +58,7 @@ fn apply_safe_defaults_for_game_target_recovers_required_fields() {
 }
 
 #[test]
-fn apply_safe_defaults_for_chain_target_recovers_required_fields() {
+fn apply_safe_defaults_for_chain_target_keeps_user_flow_chain_disabled() {
     let mut app = ClientLauncherApp::default();
     app.config.chain_enabled = false;
     app.config.chain_runtime_bin.clear();
@@ -74,9 +74,9 @@ fn apply_safe_defaults_for_chain_target_recovers_required_fields() {
     app.apply_safe_defaults_for_startup_target(StartupGuideTarget::Chain);
 
     let chain_issues = collect_chain_required_config_issues(&app.config);
-    assert!(app.config.chain_enabled);
+    assert!(!app.config.chain_enabled);
     assert!(chain_issues.is_empty());
-    assert_eq!(app.chain_runtime_status, ChainRuntimeStatus::NotStarted);
+    assert_eq!(app.chain_runtime_status, ChainRuntimeStatus::Disabled);
 }
 
 #[test]
@@ -315,6 +315,18 @@ fn restore_last_successful_config_profile_normalizes_hosted_public_join() {
 }
 
 #[test]
+fn normalize_launch_config_maps_legacy_trusted_local_preview_to_hosted_join() {
+    let mut config = LaunchConfig::default();
+    config.deployment_mode = "trusted_local_only".to_string();
+    config.chain_enabled = true;
+
+    normalize_launch_config(&mut config);
+
+    assert_eq!(config.deployment_mode, "hosted_public_join");
+    assert!(!config.chain_enabled);
+}
+
+#[test]
 fn clear_last_successful_config_profile_clears_saved_snapshot() {
     let mut app = ClientLauncherApp::default();
     app.ux_state.last_successful_config = Some(app.config.clone());
@@ -334,8 +346,8 @@ fn start_demo_mode_one_click_applies_safe_defaults() {
 
     app.start_demo_mode_one_click();
 
-    assert_eq!(app.demo_mode_phase, DemoModePhase::StartChainRequested);
-    assert!(app.config.chain_enabled);
+    assert_eq!(app.demo_mode_phase, DemoModePhase::StartGameRequested);
+    assert!(!app.config.chain_enabled);
     assert_eq!(app.config.scenario, "");
 }
 
@@ -343,7 +355,6 @@ fn start_demo_mode_one_click_applies_safe_defaults() {
 fn advance_demo_mode_reaches_done_when_chain_and_game_are_ready() {
     let mut app = ClientLauncherApp::default();
     app.start_demo_mode_one_click();
-    app.advance_demo_mode(&[], &[], false, true);
     assert_eq!(app.demo_mode_phase, DemoModePhase::StartGameRequested);
 
     app.advance_demo_mode(&[], &[], true, true);
@@ -351,10 +362,10 @@ fn advance_demo_mode_reaches_done_when_chain_and_game_are_ready() {
 }
 
 #[test]
-fn advance_demo_mode_fails_when_chain_config_is_blocked() {
+fn advance_demo_mode_fails_when_game_config_is_blocked() {
     let mut app = ClientLauncherApp::default();
     app.start_demo_mode_one_click();
-    app.advance_demo_mode(&[], &[ConfigIssue::ChainNodeIdRequired], false, false);
+    app.advance_demo_mode(&[ConfigIssue::LiveBindInvalid], &[], false, false);
     assert_eq!(app.demo_mode_phase, DemoModePhase::Failed);
 }
 

--- a/crates/oasis7_client_launcher/src/self_guided.rs
+++ b/crates/oasis7_client_launcher/src/self_guided.rs
@@ -392,11 +392,15 @@ impl ClientLauncherApp {
 
     pub(super) fn start_demo_mode_one_click(&mut self) {
         self.apply_demo_mode_safe_defaults();
-        self.demo_mode_phase = DemoModePhase::StartChainRequested;
+        self.demo_mode_phase = if chain_runtime_effectively_enabled(&self.config) {
+            DemoModePhase::StartChainRequested
+        } else {
+            DemoModePhase::StartGameRequested
+        };
         self.increment_guidance_counter(GuidanceCounter::DemoRuns);
         self.append_log(self.tr(
-            "演示模式：已应用安全默认配置，准备串行启动区块链与游戏。",
-            "Demo mode: safe defaults applied, preparing serial chain/game startup.",
+            "演示模式：已应用安全默认配置，准备启动游戏。",
+            "Demo mode: safe defaults applied, preparing game startup.",
         ));
     }
 

--- a/crates/oasis7_viewer/software_safe.html
+++ b/crates/oasis7_viewer/software_safe.html
@@ -186,7 +186,7 @@
         transform: translateY(-1px);
       }
       button:disabled { opacity: 0.5; cursor: not-allowed; }
-      input[type="number"], input[type="search"], textarea {
+      input[type="email"], input[type="number"], input[type="search"], input[type="text"], textarea {
         width: 100%;
         border-radius: 12px;
         border: 1px solid var(--border);
@@ -315,6 +315,41 @@
         display: flex;
         flex-direction: column;
         gap: 10px;
+      }
+      .auth-gate {
+        position: fixed;
+        inset: 0;
+        z-index: 40;
+        display: grid;
+        place-items: center;
+        padding: 20px;
+        background: rgba(5, 8, 7, 0.72);
+        backdrop-filter: blur(8px);
+      }
+      .auth-gate__dialog {
+        width: min(560px, 100%);
+        max-height: calc(100vh - 40px);
+        overflow: auto;
+        border: 1px solid rgba(208, 168, 91, 0.38);
+        border-radius: 8px;
+        padding: 18px;
+        background:
+          linear-gradient(180deg, rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0)),
+          var(--panel-strong);
+        box-shadow: 0 26px 70px rgba(0, 0, 0, 0.48);
+      }
+      .auth-gate__header {
+        display: flex;
+        align-items: flex-start;
+        justify-content: space-between;
+        gap: 14px;
+        margin-bottom: 12px;
+      }
+      .auth-gate__title {
+        margin: 4px 0 0;
+        font-size: 24px;
+        line-height: 1.2;
+        letter-spacing: 0;
       }
       .pixel-world-host__summary {
         display: flex;

--- a/crates/oasis7_viewer/software_safe_src/legacy_core.js
+++ b/crates/oasis7_viewer/software_safe_src/legacy_core.js
@@ -1383,8 +1383,7 @@ async function startHostedAccountLogin() {
     state.hostedLogin.challengeId = String(payload.challenge.challenge_id || "").trim() || null;
     state.hostedLogin.maskedLoginHint = String(payload.challenge.masked_login_hint || "").trim() || null;
     state.hostedLogin.deliveryMode = String(payload.challenge.delivery_mode || "").trim() || null;
-    state.hostedLogin.previewCode = String(payload.challenge.preview_code || "").trim() || null;
-    state.hostedLogin.code = state.hostedLogin.previewCode || "";
+    state.hostedLogin.code = "";
     state.hostedLogin.expiresAtUnixMs = payload?.challenge?.expires_at_unix_ms == null ? null : Number(payload.challenge.expires_at_unix_ms);
     state.hostedLogin.retryAfterSeconds = null;
     state.hostedLogin.accountExists = false;

--- a/crates/oasis7_viewer/software_safe_src/main.jsx
+++ b/crates/oasis7_viewer/software_safe_src/main.jsx
@@ -1,4 +1,4 @@
-import { createSignal, For, Show } from "solid-js";
+import { createSignal, For, onCleanup, onMount, Show } from "solid-js";
 import { render as mount } from "solid-js/web";
 
 import * as core from "./legacy_core.js";
@@ -146,6 +146,13 @@ function CalloutCard(props) {
 
 function HostedLoginForm(props) {
   const locale = () => props.locale ?? uiLocale();
+  const clearHostedLoginError = () => {
+    if (core.state.hostedLogin.error != null || core.state.hostedLogin.retryAfterSeconds != null) {
+      core.state.hostedLogin.error = null;
+      core.state.hostedLogin.retryAfterSeconds = null;
+      core.requestRender();
+    }
+  };
   return (
     <div class="stack">
       <div class="control-grid">
@@ -160,9 +167,7 @@ function HostedLoginForm(props) {
             value={core.state.hostedLogin.handle}
             onInput={(event) => {
               core.state.hostedLogin.handle = String(event.currentTarget.value || "");
-              core.state.hostedLogin.error = null;
-              core.state.hostedLogin.retryAfterSeconds = null;
-              core.requestRender();
+              clearHostedLoginError();
             }}
           />
         </div>
@@ -185,11 +190,6 @@ function HostedLoginForm(props) {
           <Badge>{`delivery=${core.state.hostedLogin.deliveryMode || "-"}`}</Badge>
           <Badge>{core.state.hostedLogin.accountExists ? "account=existing" : "account=new"}</Badge>
         </div>
-        <Show when={core.state.hostedLogin.previewCode}>
-          <div class="badge-row">
-            <Badge class="badge badge--accent">{`previewCode=${core.state.hostedLogin.previewCode}`}</Badge>
-          </div>
-        </Show>
         <div class="field">
           <label for={props.codeId ?? "hosted-login-code"}>
             {tr(locale(), "验证码", "Verification Code")}
@@ -201,8 +201,7 @@ function HostedLoginForm(props) {
             value={core.state.hostedLogin.code}
             onInput={(event) => {
               core.state.hostedLogin.code = String(event.currentTarget.value || "");
-              core.state.hostedLogin.error = null;
-              core.requestRender();
+              clearHostedLoginError();
             }}
           />
         </div>
@@ -229,6 +228,106 @@ function HostedLoginForm(props) {
         </div>
       </Show>
     </div>
+  );
+}
+
+function shouldShowHostedLoginGate() {
+  return !core.state.auth.available
+    && String(core.state.hostedAccess?.deployment_mode || "").trim() === "hosted_public_join";
+}
+
+function focusableElements(root) {
+  return [...root.querySelectorAll(
+    [
+      "a[href]",
+      "button:not([disabled])",
+      "input:not([disabled])",
+      "select:not([disabled])",
+      "textarea:not([disabled])",
+      "[tabindex]:not([tabindex='-1'])",
+    ].join(","),
+  )].filter((element) => !element.hasAttribute("aria-hidden"));
+}
+
+function HostedLoginGate() {
+  const locale = () => uiLocale();
+  let dialogRef;
+  let previousFocus = null;
+
+  onMount(() => {
+    previousFocus = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+    queueMicrotask(() => {
+      const firstFocusable = dialogRef ? focusableElements(dialogRef)[0] : null;
+      (firstFocusable || dialogRef)?.focus();
+    });
+  });
+
+  onCleanup(() => {
+    if (previousFocus && document.contains(previousFocus)) {
+      previousFocus.focus();
+    }
+  });
+
+  const trapDialogFocus = (event) => {
+    if (event.key !== "Tab" || !dialogRef) {
+      return;
+    }
+    const focusables = focusableElements(dialogRef);
+    if (focusables.length === 0) {
+      event.preventDefault();
+      dialogRef.focus();
+      return;
+    }
+    const first = focusables[0];
+    const last = focusables[focusables.length - 1];
+    if (event.shiftKey && document.activeElement === first) {
+      event.preventDefault();
+      last.focus();
+    } else if (!event.shiftKey && document.activeElement === last) {
+      event.preventDefault();
+      first.focus();
+    }
+  };
+
+  return (
+    <Show when={shouldShowHostedLoginGate()}>
+      <div
+        class="auth-gate"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="hosted-login-gate-title"
+        tabIndex="-1"
+        ref={dialogRef}
+        onKeyDown={trapDialogFocus}
+      >
+        <div class="auth-gate__dialog">
+          <div class="auth-gate__header">
+            <div>
+              <div class="panel__eyebrow">{tr(locale(), "标准用户流程", "Standard User Flow")}</div>
+              <h1 id="hosted-login-gate-title" class="auth-gate__title">
+                {tr(locale(), "登录邮箱后进入游戏", "Sign In With Email")}
+              </h1>
+            </div>
+            <Badge class="badge badge--warn">auth=missing</Badge>
+          </div>
+          <div class="feedback-summary">
+            {tr(
+              locale(),
+              "当前是 hosted public join。先领取玩家会话，再进入聊天、玩法动作和后续授权。",
+              "This is hosted public join. Acquire a player session first, then continue to chat, gameplay actions, and later authorization.",
+            )}
+          </div>
+          <HostedLoginForm
+            locale={locale()}
+            handleId="gate-hosted-login-handle"
+            codeId="gate-hosted-login-code"
+          />
+          <Show when={core.state.auth.rebindNotice || core.state.auth.error}>
+            <EmptyState>{core.state.auth.rebindNotice || core.state.auth.error}</EmptyState>
+          </Show>
+        </div>
+      </div>
+    </Show>
   );
 }
 
@@ -1756,6 +1855,7 @@ function AppShell() {
   return (
     <>
       <MobileJumpRail />
+      <HostedLoginGate />
       <section class="panel panel--targets" id="viewer-targets-panel">
         <div class="panel__header panel__header--stack">
           <div class="panel__eyebrow">{tr(locale(), "导航", "Navigate")}</div>

--- a/crates/oasis7_viewer/software_safe_src/main.test.jsx
+++ b/crates/oasis7_viewer/software_safe_src/main.test.jsx
@@ -1,4 +1,4 @@
-import { screen, waitFor, within } from "@solidjs/testing-library";
+import { fireEvent, screen, waitFor, within } from "@solidjs/testing-library";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("./pixel_world_host.jsx", () => ({
@@ -281,6 +281,7 @@ describe("viewer web ui automation baseline", () => {
     });
 
     screen.getByText("Runtime Diagnostics").click();
+    expect(screen.getByRole("dialog", { name: "Sign In With Email" })).toBeInTheDocument();
     expect(screen.getAllByRole("button", { name: "Request Login Code" }).length).toBeGreaterThan(0);
     expect(screen.getAllByLabelText("Email").length).toBeGreaterThan(0);
     expect(screen.getByText("upgrade_after_player_session")).toBeInTheDocument();
@@ -291,6 +292,27 @@ describe("viewer web ui automation baseline", () => {
     ).toBeGreaterThan(0);
     expect(screen.queryByText("not_implemented")).not.toBeInTheDocument();
     expect(screen.queryByText(/not implemented yet/i)).not.toBeInTheDocument();
+  });
+
+  it("does not show the hosted login gate after player session registration", async () => {
+    await renderViewerApp({
+      setupAfterMount(core) {
+        core.state.hostedAccess = sampleHostedPublicJoinAccess();
+        core.state.auth = {
+          ...core.state.auth,
+          available: true,
+          playerId: "hosted-player-1",
+          publicKey: "oc:pk:test-player",
+          privateKey: "ed25519-secret",
+          releaseToken: "hosted-release-1",
+          source: "hosted_browser_storage",
+          registrationStatus: "registered",
+          runtimeStatus: "registered",
+        };
+      },
+    });
+
+    expect(screen.queryByRole("dialog", { name: "Sign In With Email" })).not.toBeInTheDocument();
   });
 
   it("surfaces hosted login retry-after guidance when OTP resend is throttled", async () => {
@@ -308,6 +330,54 @@ describe("viewer web ui automation baseline", () => {
       screen.getAllByText("a login code was just sent for this email; retry in 21 seconds (retry in 21s)").length,
     ).toBeGreaterThan(0);
     expect(screen.getAllByText("retry_after=21s").length).toBeGreaterThan(0);
+  });
+
+  it("clears hosted login retry guidance immediately when the player edits the email", async () => {
+    await renderViewerApp({
+      setupAfterMount(core) {
+        core.state.hostedAccess = sampleHostedPublicJoinAccess();
+        core.state.hostedLogin.handle = "player@example.com";
+        core.state.hostedLogin.error = "a login code was just sent for this email; retry in 21 seconds (retry in 21s)";
+        core.state.hostedLogin.retryAfterSeconds = 21;
+      },
+    });
+
+    expect(screen.getAllByText("retry_after=21s").length).toBeGreaterThan(0);
+
+    fireEvent.input(document.getElementById("gate-hosted-login-handle"), {
+      target: { value: "next-player@example.com" },
+    });
+
+    expect(screen.queryByText("retry_after=21s")).not.toBeInTheDocument();
+    expect(screen.queryByText(/retry in 21 seconds/i)).not.toBeInTheDocument();
+  });
+
+  it("keeps keyboard focus inside the hosted login gate while it is modal", async () => {
+    await renderViewerApp({
+      setupAfterMount(core) {
+        core.state.hostedAccess = sampleHostedPublicJoinAccess();
+        core.state.hostedLogin.handle = "player@example.com";
+      },
+    });
+
+    const dialog = screen.getByRole("dialog", { name: "Sign In With Email" });
+    const emailInput = document.getElementById("gate-hosted-login-handle");
+    const requestButton = within(dialog).getByRole("button", { name: "Request Login Code" });
+
+    await waitFor(() => {
+      expect(document.activeElement).toBe(emailInput);
+    });
+
+    requestButton.focus();
+    const tabEvent = new KeyboardEvent("keydown", {
+      key: "Tab",
+      bubbles: true,
+      cancelable: true,
+    });
+    dialog.dispatchEvent(tabEvent);
+
+    expect(tabEvent.defaultPrevented).toBe(true);
+    expect(document.activeElement).toBe(emailInput);
   });
 
   it("marks hosted backend reauth as available once a browser player session is registered", async () => {

--- a/crates/oasis7_viewer/software_safe_src/viewer_hosted_login_state_module.js
+++ b/crates/oasis7_viewer/software_safe_src/viewer_hosted_login_state_module.js
@@ -5,7 +5,6 @@ export function createInitialHostedLoginState() {
     challengeId: null,
     maskedLoginHint: null,
     deliveryMode: null,
-    previewCode: null,
     code: "",
     expiresAtUnixMs: null,
     retryAfterSeconds: null,
@@ -24,7 +23,6 @@ export function resetHostedLoginChallenge(hostedLogin) {
   hostedLogin.challengeId = null;
   hostedLogin.maskedLoginHint = null;
   hostedLogin.deliveryMode = null;
-  hostedLogin.previewCode = null;
   hostedLogin.code = "";
   hostedLogin.expiresAtUnixMs = null;
   hostedLogin.accountExists = false;

--- a/crates/oasis7_viewer/viewer.js
+++ b/crates/oasis7_viewer/viewer.js
@@ -82,6 +82,9 @@ function untrack(fn) {
     Listener = listener;
   }
 }
+function onMount(fn) {
+  createEffect(() => untrack(fn));
+}
 function onCleanup(fn) {
   if (Owner === null) ;
   else if (Owner.cleanups === null) Owner.cleanups = [fn];
@@ -1962,7 +1965,6 @@ function createInitialHostedLoginState() {
     challengeId: null,
     maskedLoginHint: null,
     deliveryMode: null,
-    previewCode: null,
     code: "",
     expiresAtUnixMs: null,
     retryAfterSeconds: null,
@@ -1980,7 +1982,6 @@ function resetHostedLoginChallenge$1(hostedLogin) {
   hostedLogin.challengeId = null;
   hostedLogin.maskedLoginHint = null;
   hostedLogin.deliveryMode = null;
-  hostedLogin.previewCode = null;
   hostedLogin.code = "";
   hostedLogin.expiresAtUnixMs = null;
   hostedLogin.accountExists = false;
@@ -3508,8 +3509,7 @@ async function startHostedAccountLogin() {
     state.hostedLogin.challengeId = String(payload.challenge.challenge_id || "").trim() || null;
     state.hostedLogin.maskedLoginHint = String(payload.challenge.masked_login_hint || "").trim() || null;
     state.hostedLogin.deliveryMode = String(payload.challenge.delivery_mode || "").trim() || null;
-    state.hostedLogin.previewCode = String(payload.challenge.preview_code || "").trim() || null;
-    state.hostedLogin.code = state.hostedLogin.previewCode || "";
+    state.hostedLogin.code = "";
     state.hostedLogin.expiresAtUnixMs = payload?.challenge?.expires_at_unix_ms == null ? null : Number(payload.challenge.expires_at_unix_ms);
     state.hostedLogin.retryAfterSeconds = null;
     state.hostedLogin.accountExists = false;
@@ -5849,7 +5849,7 @@ function PixelWorldHost(props) {
   })();
 }
 delegateEvents(["click"]);
-var _tmpl$ = /* @__PURE__ */ template(`<span>`), _tmpl$2 = /* @__PURE__ */ template(`<div class=empty>`), _tmpl$3 = /* @__PURE__ */ template(`<pre class=json>`), _tmpl$4 = /* @__PURE__ */ template(`<div class=feedback-detail>`), _tmpl$5 = /* @__PURE__ */ template(`<details class=diagnostic><summary></summary><div class=stack style=margin-top:10px>`), _tmpl$6 = /* @__PURE__ */ template(`<div class=feedback-card><div class=badge-row></div><div class=feedback-summary>`), _tmpl$7 = /* @__PURE__ */ template(`<div class=feedback-detail style=margin-top:8px>`), _tmpl$8 = /* @__PURE__ */ template(`<div class=badge-row style=margin-top:8px>`), _tmpl$9 = /* @__PURE__ */ template(`<div class=metric><div class=metric__label></div><div class=metric__value>`), _tmpl$0 = /* @__PURE__ */ template(`<div class=event-card__meta>`), _tmpl$1 = /* @__PURE__ */ template(`<div><div class=event-card__title><span>`), _tmpl$10 = /* @__PURE__ */ template(`<div class=panel__eyebrow>`), _tmpl$11 = /* @__PURE__ */ template(`<div class=panel__meta-copy>`), _tmpl$12 = /* @__PURE__ */ template(`<div><div class=panel__header><div class=stack style=gap:4px><div class=panel__title></div></div></div><div class="panel__body stack">`), _tmpl$13 = /* @__PURE__ */ template(`<div><div class=callout__header><div class=callout__title></div></div><div class=callout__body>`), _tmpl$14 = /* @__PURE__ */ template(`<div class=badge-row>`), _tmpl$15 = /* @__PURE__ */ template(`<div class=field><label></label><input type=text autocomplete=off>`), _tmpl$16 = /* @__PURE__ */ template(`<div class=toolbar><button data-auth-action=complete-login>`), _tmpl$17 = /* @__PURE__ */ template(`<div class=stack>`), _tmpl$18 = /* @__PURE__ */ template(`<div class=stack><div class=control-grid><div class=field><label></label><input type=email autocomplete=email></div></div><div class=toolbar><button data-auth-action=start-login>`), _tmpl$19 = /* @__PURE__ */ template(`<div class=feedback-summary>`), _tmpl$20 = /* @__PURE__ */ template(`<details class=entry-menu><summary class=entry-menu__toggle></summary><div class="entry-menu__panel stack"><div><div class=panel__title style=margin-bottom:10px></div><div class=feedback-detail></div></div><div class=toolbar><button data-locale=zh>中文</button><button data-locale=en>English</button></div><div class=badge-row></div><div class=feedback-detail>`), _tmpl$21 = /* @__PURE__ */ template(`<div class=stage-hero><div class=stage-hero__topline><div class=stack style=gap:10px><div class=stage-hero__eyebrow></div><div class=stage-hero__title></div><div class=stage-hero__lede></div></div></div><div class=hero-focus-grid><div class=hero-focus-card><div class=hero-focus-card__label></div><div></div><div class=hero-focus-card__detail></div></div><div class=hero-focus-card><div class=hero-focus-card__label></div><div class="hero-focus-card__value hero-focus-card__value--body"></div><div class=hero-focus-card__detail></div></div><div class=hero-focus-card><div class=hero-focus-card__label></div><div class="hero-focus-card__value hero-focus-card__value--body">`), _tmpl$22 = /* @__PURE__ */ template(`<nav class=mobile-rail><a class=mobile-rail__link href=#viewer-stage-panel></a><a class=mobile-rail__link href=#viewer-targets-panel></a><a class=mobile-rail__link href=#viewer-details-panel>`), _tmpl$23 = /* @__PURE__ */ template(`<div class=stack><div class=field><label for=entity-search></label><input id=entity-search type=search></div><div><div class=panel__title style=margin-bottom:10px></div><div class=list></div></div><div><div class=panel__title style=margin-bottom:10px></div><div class=list>`), _tmpl$24 = /* @__PURE__ */ template(`<button class=list-item data-select-kind=agent><div class=list-item__title></div><div class=list-item__meta>`), _tmpl$25 = /* @__PURE__ */ template(`<button class=list-item data-select-kind=location><div class=list-item__title></div><div class=list-item__meta>`), _tmpl$26 = /* @__PURE__ */ template(`<div class=toolbar><button data-auth-action=logout>`), _tmpl$27 = /* @__PURE__ */ template(`<button data-auth-action=logout>`), _tmpl$28 = /* @__PURE__ */ template(`<div class=event-list>`), _tmpl$29 = /* @__PURE__ */ template(`<div class=stack><details class="panel diagnostic-surface"><summary class="panel__header diagnostic-surface__summary"><div class=diagnostic-surface__title><div class=panel__title></div><div class=diagnostic-surface__meta></div></div><div class=badge-row></div></summary><div class="panel__body stack"><div class=badge-row></div><div class=badge-row></div><div class=toolbar></div><div class=summary-grid></div><div><div class=panel__title style=margin-bottom:10px></div><div class=event-list>`), _tmpl$30 = /* @__PURE__ */ template(`<div class=badge-row style=margin-top:10px>`), _tmpl$31 = /* @__PURE__ */ template(`<div class=summary-grid>`), _tmpl$32 = /* @__PURE__ */ template(`<div><div class=panel__title style=margin-bottom:10px></div><div class=action-grid>`), _tmpl$33 = /* @__PURE__ */ template(`<div class=toolbar><button>`), _tmpl$34 = /* @__PURE__ */ template(`<div class=field><label for=agent-chat-message></label><textarea id=agent-chat-message rows=4>`), _tmpl$35 = /* @__PURE__ */ template(`<div class=toolbar><button data-chat-send=1>`), _tmpl$36 = /* @__PURE__ */ template(`<div><div class=panel__title style=margin-bottom:10px></div><div class=event-list>`), _tmpl$37 = /* @__PURE__ */ template(`<div class=toolbar><button data-prompt-visibility-toggle=1>`), _tmpl$38 = /* @__PURE__ */ template(`<div class=field><label for=strong-auth-approval-code></label><input id=strong-auth-approval-code type=password autocomplete=off>`), _tmpl$39 = /* @__PURE__ */ template(`<div class=field><label for=prompt-system></label><textarea id=prompt-system rows=4>`), _tmpl$40 = /* @__PURE__ */ template(`<div class=field><label for=prompt-short></label><textarea id=prompt-short rows=3>`), _tmpl$41 = /* @__PURE__ */ template(`<div class=field><label for=prompt-long></label><textarea id=prompt-long rows=3>`), _tmpl$42 = /* @__PURE__ */ template(`<div class=toolbar><button data-prompt-action=preview></button><button data-prompt-action=apply>`), _tmpl$43 = /* @__PURE__ */ template(`<div class=toolbar><div class=field style=margin:0;min-width:180px;flex:1><label for=prompt-rollback-version></label><input id=prompt-rollback-version type=number min=0 step=1></div><button data-prompt-action=rollback>`), _tmpl$44 = /* @__PURE__ */ template(`<div class=toolbar><button disabled>`), _tmpl$45 = /* @__PURE__ */ template(`<div class=stack><div class=badge-row></div><div class=badge-row>`), _tmpl$46 = /* @__PURE__ */ template(`<div><div class=panel__title style=margin-bottom:10px;color:var(--bad)></div><pre class=json>`), _tmpl$47 = /* @__PURE__ */ template(`<div class=stack><div class=badge-row></div><div><div class=panel__title style=margin-bottom:10px></div><div class=badge-row></div><div class=stack style=margin-top:10px><div class=feedback-detail></div><div class=feedback-detail></div><div><div class=panel__title style=margin-bottom:10px></div><div class=event-list>`), _tmpl$48 = /* @__PURE__ */ template(`<div class=feedback-detail>=`), _tmpl$49 = /* @__PURE__ */ template(`<section class="panel panel--targets"id=viewer-targets-panel><div class="panel__header panel__header--stack"><div class=panel__eyebrow></div><div class=panel__title></div><div class=panel__meta-copy></div></div><div class=panel__body>`), _tmpl$50 = /* @__PURE__ */ template(`<section class="panel panel--stage"id=viewer-stage-panel><div class="panel__body panel__body--stage"><div class=stack>`), _tmpl$51 = /* @__PURE__ */ template(`<section class="panel panel--details"id=viewer-details-panel><div class="panel__header panel__header--stack"><div class=panel__eyebrow></div><div class=panel__title></div><div class=panel__meta-copy></div></div><div class=panel__body>`);
+var _tmpl$ = /* @__PURE__ */ template(`<span>`), _tmpl$2 = /* @__PURE__ */ template(`<div class=empty>`), _tmpl$3 = /* @__PURE__ */ template(`<pre class=json>`), _tmpl$4 = /* @__PURE__ */ template(`<div class=feedback-detail>`), _tmpl$5 = /* @__PURE__ */ template(`<details class=diagnostic><summary></summary><div class=stack style=margin-top:10px>`), _tmpl$6 = /* @__PURE__ */ template(`<div class=feedback-card><div class=badge-row></div><div class=feedback-summary>`), _tmpl$7 = /* @__PURE__ */ template(`<div class=feedback-detail style=margin-top:8px>`), _tmpl$8 = /* @__PURE__ */ template(`<div class=badge-row style=margin-top:8px>`), _tmpl$9 = /* @__PURE__ */ template(`<div class=metric><div class=metric__label></div><div class=metric__value>`), _tmpl$0 = /* @__PURE__ */ template(`<div class=event-card__meta>`), _tmpl$1 = /* @__PURE__ */ template(`<div><div class=event-card__title><span>`), _tmpl$10 = /* @__PURE__ */ template(`<div class=panel__eyebrow>`), _tmpl$11 = /* @__PURE__ */ template(`<div class=panel__meta-copy>`), _tmpl$12 = /* @__PURE__ */ template(`<div><div class=panel__header><div class=stack style=gap:4px><div class=panel__title></div></div></div><div class="panel__body stack">`), _tmpl$13 = /* @__PURE__ */ template(`<div><div class=callout__header><div class=callout__title></div></div><div class=callout__body>`), _tmpl$14 = /* @__PURE__ */ template(`<div class=badge-row>`), _tmpl$15 = /* @__PURE__ */ template(`<div class=field><label></label><input type=text autocomplete=off>`), _tmpl$16 = /* @__PURE__ */ template(`<div class=toolbar><button data-auth-action=complete-login>`), _tmpl$17 = /* @__PURE__ */ template(`<div class=stack>`), _tmpl$18 = /* @__PURE__ */ template(`<div class=stack><div class=control-grid><div class=field><label></label><input type=email autocomplete=email></div></div><div class=toolbar><button data-auth-action=start-login>`), _tmpl$19 = /* @__PURE__ */ template(`<div class=auth-gate role=dialog aria-modal=true aria-labelledby=hosted-login-gate-title tabindex=-1><div class=auth-gate__dialog><div class=auth-gate__header><div><div class=panel__eyebrow></div><h1 id=hosted-login-gate-title class=auth-gate__title></h1></div></div><div class=feedback-summary>`), _tmpl$20 = /* @__PURE__ */ template(`<div class=feedback-summary>`), _tmpl$21 = /* @__PURE__ */ template(`<details class=entry-menu><summary class=entry-menu__toggle></summary><div class="entry-menu__panel stack"><div><div class=panel__title style=margin-bottom:10px></div><div class=feedback-detail></div></div><div class=toolbar><button data-locale=zh>中文</button><button data-locale=en>English</button></div><div class=badge-row></div><div class=feedback-detail>`), _tmpl$22 = /* @__PURE__ */ template(`<div class=stage-hero><div class=stage-hero__topline><div class=stack style=gap:10px><div class=stage-hero__eyebrow></div><div class=stage-hero__title></div><div class=stage-hero__lede></div></div></div><div class=hero-focus-grid><div class=hero-focus-card><div class=hero-focus-card__label></div><div></div><div class=hero-focus-card__detail></div></div><div class=hero-focus-card><div class=hero-focus-card__label></div><div class="hero-focus-card__value hero-focus-card__value--body"></div><div class=hero-focus-card__detail></div></div><div class=hero-focus-card><div class=hero-focus-card__label></div><div class="hero-focus-card__value hero-focus-card__value--body">`), _tmpl$23 = /* @__PURE__ */ template(`<nav class=mobile-rail><a class=mobile-rail__link href=#viewer-stage-panel></a><a class=mobile-rail__link href=#viewer-targets-panel></a><a class=mobile-rail__link href=#viewer-details-panel>`), _tmpl$24 = /* @__PURE__ */ template(`<div class=stack><div class=field><label for=entity-search></label><input id=entity-search type=search></div><div><div class=panel__title style=margin-bottom:10px></div><div class=list></div></div><div><div class=panel__title style=margin-bottom:10px></div><div class=list>`), _tmpl$25 = /* @__PURE__ */ template(`<button class=list-item data-select-kind=agent><div class=list-item__title></div><div class=list-item__meta>`), _tmpl$26 = /* @__PURE__ */ template(`<button class=list-item data-select-kind=location><div class=list-item__title></div><div class=list-item__meta>`), _tmpl$27 = /* @__PURE__ */ template(`<div class=toolbar><button data-auth-action=logout>`), _tmpl$28 = /* @__PURE__ */ template(`<button data-auth-action=logout>`), _tmpl$29 = /* @__PURE__ */ template(`<div class=event-list>`), _tmpl$30 = /* @__PURE__ */ template(`<div class=stack><details class="panel diagnostic-surface"><summary class="panel__header diagnostic-surface__summary"><div class=diagnostic-surface__title><div class=panel__title></div><div class=diagnostic-surface__meta></div></div><div class=badge-row></div></summary><div class="panel__body stack"><div class=badge-row></div><div class=badge-row></div><div class=toolbar></div><div class=summary-grid></div><div><div class=panel__title style=margin-bottom:10px></div><div class=event-list>`), _tmpl$31 = /* @__PURE__ */ template(`<div class=badge-row style=margin-top:10px>`), _tmpl$32 = /* @__PURE__ */ template(`<div class=summary-grid>`), _tmpl$33 = /* @__PURE__ */ template(`<div><div class=panel__title style=margin-bottom:10px></div><div class=action-grid>`), _tmpl$34 = /* @__PURE__ */ template(`<div class=toolbar><button>`), _tmpl$35 = /* @__PURE__ */ template(`<div class=field><label for=agent-chat-message></label><textarea id=agent-chat-message rows=4>`), _tmpl$36 = /* @__PURE__ */ template(`<div class=toolbar><button data-chat-send=1>`), _tmpl$37 = /* @__PURE__ */ template(`<div><div class=panel__title style=margin-bottom:10px></div><div class=event-list>`), _tmpl$38 = /* @__PURE__ */ template(`<div class=toolbar><button data-prompt-visibility-toggle=1>`), _tmpl$39 = /* @__PURE__ */ template(`<div class=field><label for=strong-auth-approval-code></label><input id=strong-auth-approval-code type=password autocomplete=off>`), _tmpl$40 = /* @__PURE__ */ template(`<div class=field><label for=prompt-system></label><textarea id=prompt-system rows=4>`), _tmpl$41 = /* @__PURE__ */ template(`<div class=field><label for=prompt-short></label><textarea id=prompt-short rows=3>`), _tmpl$42 = /* @__PURE__ */ template(`<div class=field><label for=prompt-long></label><textarea id=prompt-long rows=3>`), _tmpl$43 = /* @__PURE__ */ template(`<div class=toolbar><button data-prompt-action=preview></button><button data-prompt-action=apply>`), _tmpl$44 = /* @__PURE__ */ template(`<div class=toolbar><div class=field style=margin:0;min-width:180px;flex:1><label for=prompt-rollback-version></label><input id=prompt-rollback-version type=number min=0 step=1></div><button data-prompt-action=rollback>`), _tmpl$45 = /* @__PURE__ */ template(`<div class=toolbar><button disabled>`), _tmpl$46 = /* @__PURE__ */ template(`<div class=stack><div class=badge-row></div><div class=badge-row>`), _tmpl$47 = /* @__PURE__ */ template(`<div><div class=panel__title style=margin-bottom:10px;color:var(--bad)></div><pre class=json>`), _tmpl$48 = /* @__PURE__ */ template(`<div class=stack><div class=badge-row></div><div><div class=panel__title style=margin-bottom:10px></div><div class=badge-row></div><div class=stack style=margin-top:10px><div class=feedback-detail></div><div class=feedback-detail></div><div><div class=panel__title style=margin-bottom:10px></div><div class=event-list>`), _tmpl$49 = /* @__PURE__ */ template(`<div class=feedback-detail>=`), _tmpl$50 = /* @__PURE__ */ template(`<section class="panel panel--targets"id=viewer-targets-panel><div class="panel__header panel__header--stack"><div class=panel__eyebrow></div><div class=panel__title></div><div class=panel__meta-copy></div></div><div class=panel__body>`), _tmpl$51 = /* @__PURE__ */ template(`<section class="panel panel--stage"id=viewer-stage-panel><div class="panel__body panel__body--stage"><div class=stack>`), _tmpl$52 = /* @__PURE__ */ template(`<section class="panel panel--details"id=viewer-details-panel><div class="panel__header panel__header--stack"><div class=panel__eyebrow></div><div class=panel__title></div><div class=panel__meta-copy></div></div><div class=panel__body>`);
 function uiLocale() {
   return state.uiLocale;
 }
@@ -6085,14 +6085,19 @@ function CalloutCard(props) {
 }
 function HostedLoginForm(props) {
   const locale = () => props.locale ?? uiLocale();
+  const clearHostedLoginError = () => {
+    if (state.hostedLogin.error != null || state.hostedLogin.retryAfterSeconds != null) {
+      state.hostedLogin.error = null;
+      state.hostedLogin.retryAfterSeconds = null;
+      requestRender();
+    }
+  };
   return (() => {
     var _el$31 = _tmpl$18(), _el$32 = _el$31.firstChild, _el$33 = _el$32.firstChild, _el$34 = _el$33.firstChild, _el$35 = _el$34.nextSibling, _el$36 = _el$32.nextSibling, _el$37 = _el$36.firstChild;
     insert(_el$34, () => tr(locale(), "邮箱", "Email"));
     _el$35.$$input = (event) => {
       state.hostedLogin.handle = String(event.currentTarget.value || "");
-      state.hostedLogin.error = null;
-      state.hostedLogin.retryAfterSeconds = null;
-      requestRender();
+      clearHostedLoginError();
     };
     _el$37.$$click = () => {
       void startHostedAccountLogin();
@@ -6126,47 +6131,32 @@ function HostedLoginForm(props) {
             }
           }), null);
           return _el$38;
-        })(), createComponent(Show, {
-          get when() {
-            return state.hostedLogin.previewCode;
-          },
-          get children() {
-            var _el$39 = _tmpl$14();
-            insert(_el$39, createComponent(Badge, {
-              "class": "badge badge--accent",
-              get children() {
-                return `previewCode=${state.hostedLogin.previewCode}`;
-              }
-            }));
-            return _el$39;
-          }
-        }), (() => {
-          var _el$40 = _tmpl$15(), _el$41 = _el$40.firstChild, _el$42 = _el$41.nextSibling;
-          insert(_el$41, () => tr(locale(), "验证码", "Verification Code"));
-          _el$42.$$input = (event) => {
+        })(), (() => {
+          var _el$39 = _tmpl$15(), _el$40 = _el$39.firstChild, _el$41 = _el$40.nextSibling;
+          insert(_el$40, () => tr(locale(), "验证码", "Verification Code"));
+          _el$41.$$input = (event) => {
             state.hostedLogin.code = String(event.currentTarget.value || "");
-            state.hostedLogin.error = null;
-            requestRender();
+            clearHostedLoginError();
           };
           createRenderEffect((_p$) => {
             var _v$ = props.codeId ?? "hosted-login-code", _v$2 = props.codeId ?? "hosted-login-code";
-            _v$ !== _p$.e && setAttribute(_el$41, "for", _p$.e = _v$);
-            _v$2 !== _p$.t && setAttribute(_el$42, "id", _p$.t = _v$2);
+            _v$ !== _p$.e && setAttribute(_el$40, "for", _p$.e = _v$);
+            _v$2 !== _p$.t && setAttribute(_el$41, "id", _p$.t = _v$2);
             return _p$;
           }, {
             e: void 0,
             t: void 0
           });
-          createRenderEffect(() => _el$42.value = state.hostedLogin.code);
-          return _el$40;
+          createRenderEffect(() => _el$41.value = state.hostedLogin.code);
+          return _el$39;
         })(), (() => {
-          var _el$43 = _tmpl$16(), _el$44 = _el$43.firstChild;
-          _el$44.$$click = () => {
+          var _el$42 = _tmpl$16(), _el$43 = _el$42.firstChild;
+          _el$43.$$click = () => {
             void completeHostedAccountLogin();
           };
-          insert(_el$44, () => tr(locale(), "登录并领取玩家会话", "Sign In and Acquire Player Session"));
-          createRenderEffect(() => _el$44.disabled = state.hostedLogin.completeInFlight || state.auth.issueInFlight);
-          return _el$43;
+          insert(_el$43, () => tr(locale(), "登录并领取玩家会话", "Sign In and Acquire Player Session"));
+          createRenderEffect(() => _el$43.disabled = state.hostedLogin.completeInFlight || state.auth.issueInFlight);
+          return _el$42;
         })()];
       }
     }), null);
@@ -6175,27 +6165,27 @@ function HostedLoginForm(props) {
         return state.hostedLogin.error;
       },
       get children() {
-        var _el$45 = _tmpl$17();
-        insert(_el$45, createComponent(EmptyState, {
+        var _el$44 = _tmpl$17();
+        insert(_el$44, createComponent(EmptyState, {
           get children() {
             return state.hostedLogin.error;
           }
         }), null);
-        insert(_el$45, createComponent(Show, {
+        insert(_el$44, createComponent(Show, {
           get when() {
             return state.hostedLogin.retryAfterSeconds != null;
           },
           get children() {
-            var _el$46 = _tmpl$14();
-            insert(_el$46, createComponent(Badge, {
+            var _el$45 = _tmpl$14();
+            insert(_el$45, createComponent(Badge, {
               get children() {
                 return `retry_after=${state.hostedLogin.retryAfterSeconds}s`;
               }
             }));
-            return _el$46;
+            return _el$45;
           }
         }), null);
-        return _el$45;
+        return _el$44;
       }
     }), null);
     createRenderEffect((_p$) => {
@@ -6213,6 +6203,87 @@ function HostedLoginForm(props) {
     return _el$31;
   })();
 }
+function shouldShowHostedLoginGate() {
+  return !state.auth.available && String(state.hostedAccess?.deployment_mode || "").trim() === "hosted_public_join";
+}
+function focusableElements(root) {
+  return [...root.querySelectorAll(["a[href]", "button:not([disabled])", "input:not([disabled])", "select:not([disabled])", "textarea:not([disabled])", "[tabindex]:not([tabindex='-1'])"].join(","))].filter((element) => !element.hasAttribute("aria-hidden"));
+}
+function HostedLoginGate() {
+  const locale = () => uiLocale();
+  let dialogRef;
+  let previousFocus = null;
+  onMount(() => {
+    previousFocus = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+    queueMicrotask(() => {
+      const firstFocusable = dialogRef ? focusableElements(dialogRef)[0] : null;
+      (firstFocusable || dialogRef)?.focus();
+    });
+  });
+  onCleanup(() => {
+    if (previousFocus && document.contains(previousFocus)) {
+      previousFocus.focus();
+    }
+  });
+  const trapDialogFocus = (event) => {
+    if (event.key !== "Tab" || !dialogRef) {
+      return;
+    }
+    const focusables = focusableElements(dialogRef);
+    if (focusables.length === 0) {
+      event.preventDefault();
+      dialogRef.focus();
+      return;
+    }
+    const first = focusables[0];
+    const last = focusables[focusables.length - 1];
+    if (event.shiftKey && document.activeElement === first) {
+      event.preventDefault();
+      last.focus();
+    } else if (!event.shiftKey && document.activeElement === last) {
+      event.preventDefault();
+      first.focus();
+    }
+  };
+  return createComponent(Show, {
+    get when() {
+      return shouldShowHostedLoginGate();
+    },
+    get children() {
+      var _el$46 = _tmpl$19(), _el$47 = _el$46.firstChild, _el$48 = _el$47.firstChild, _el$49 = _el$48.firstChild, _el$50 = _el$49.firstChild, _el$51 = _el$50.nextSibling, _el$52 = _el$48.nextSibling;
+      _el$46.$$keydown = trapDialogFocus;
+      var _ref$ = dialogRef;
+      typeof _ref$ === "function" ? use(_ref$, _el$46) : dialogRef = _el$46;
+      insert(_el$50, () => tr(locale(), "标准用户流程", "Standard User Flow"));
+      insert(_el$51, () => tr(locale(), "登录邮箱后进入游戏", "Sign In With Email"));
+      insert(_el$48, createComponent(Badge, {
+        "class": "badge badge--warn",
+        children: "auth=missing"
+      }), null);
+      insert(_el$52, () => tr(locale(), "当前是 hosted public join。先领取玩家会话，再进入聊天、玩法动作和后续授权。", "This is hosted public join. Acquire a player session first, then continue to chat, gameplay actions, and later authorization."));
+      insert(_el$47, createComponent(HostedLoginForm, {
+        get locale() {
+          return locale();
+        },
+        handleId: "gate-hosted-login-handle",
+        codeId: "gate-hosted-login-code"
+      }), null);
+      insert(_el$47, createComponent(Show, {
+        get when() {
+          return state.auth.rebindNotice || state.auth.error;
+        },
+        get children() {
+          return createComponent(EmptyState, {
+            get children() {
+              return state.auth.rebindNotice || state.auth.error;
+            }
+          });
+        }
+      }), null);
+      return _el$46;
+    }
+  });
+}
 function EmptyEntityRecoveryCard(props) {
   const locale = () => props.locale ?? uiLocale();
   const gameplay = () => typeof props.gameplay === "function" ? props.gameplay() : props.gameplay;
@@ -6227,40 +6298,40 @@ function EmptyEntityRecoveryCard(props) {
     variant: "warn",
     get children() {
       return [(() => {
-        var _el$47 = _tmpl$19();
-        insert(_el$47, () => gameplay()?.blockerDetail || tr(locale(), "runtime 已发布玩法摘要，但当前快照还没有可选 Agent 或地点。", "Runtime published gameplay summary, but the current snapshot still has no selectable agents or locations."));
-        return _el$47;
+        var _el$53 = _tmpl$20();
+        insert(_el$53, () => gameplay()?.blockerDetail || tr(locale(), "runtime 已发布玩法摘要，但当前快照还没有可选 Agent 或地点。", "Runtime published gameplay summary, but the current snapshot still has no selectable agents or locations."));
+        return _el$53;
       })(), createComponent(Show, {
         get when() {
           return gameplay()?.nextStepHint;
         },
         get children() {
-          var _el$48 = _tmpl$4();
-          insert(_el$48, () => gameplay().nextStepHint);
-          return _el$48;
+          var _el$54 = _tmpl$4();
+          insert(_el$54, () => gameplay().nextStepHint);
+          return _el$54;
         }
       }), createComponent(Show, {
         get when() {
           return gameplay()?.entityCounts;
         },
         get children() {
-          var _el$49 = _tmpl$14();
-          insert(_el$49, createComponent(Badge, {
+          var _el$55 = _tmpl$14();
+          insert(_el$55, createComponent(Badge, {
             get children() {
               return `agents=${gameplay().entityCounts.agents}`;
             }
           }), null);
-          insert(_el$49, createComponent(Badge, {
+          insert(_el$55, createComponent(Badge, {
             get children() {
               return `locations=${gameplay().entityCounts.locations}`;
             }
           }), null);
-          return _el$49;
+          return _el$55;
         }
       }), (() => {
-        var _el$50 = _tmpl$4();
-        insert(_el$50, () => tr(locale(), "如果中间栏仍保留“刷新快照”动作，先从那里重拉一次；如果数量仍然是 0，就需要修复或重启 runtime world bootstrap。", "If the middle column still exposes a refresh action, pull a fresh snapshot there first. If the counts stay at 0, repair or restart the runtime world bootstrap."));
-        return _el$50;
+        var _el$56 = _tmpl$4();
+        insert(_el$56, () => tr(locale(), "如果中间栏仍保留“刷新快照”动作，先从那里重拉一次；如果数量仍然是 0，就需要修复或重启 runtime world bootstrap。", "If the middle column still exposes a refresh action, pull a fresh snapshot there first. If the counts stay at 0, repair or restart the runtime world bootstrap."));
+        return _el$56;
       })()];
     }
   });
@@ -6269,28 +6340,28 @@ function ViewerEntryMenu() {
   const locale = () => uiLocale();
   const viewerEntryUrls = () => buildViewerEntryUrls(locale());
   return (() => {
-    var _el$51 = _tmpl$20(), _el$52 = _el$51.firstChild, _el$53 = _el$52.nextSibling, _el$54 = _el$53.firstChild, _el$55 = _el$54.firstChild, _el$56 = _el$55.nextSibling, _el$57 = _el$54.nextSibling, _el$58 = _el$57.firstChild, _el$59 = _el$58.nextSibling, _el$60 = _el$57.nextSibling, _el$61 = _el$60.nextSibling;
-    insert(_el$52, () => tr(locale(), "入口", "Entry"));
-    insert(_el$55, () => tr(locale(), "语言与 Viewer 入口", "Language and Viewer Entry"));
-    insert(_el$56, () => tr(locale(), "主玩法继续留在当前页面；这里只保留语言切换。", "Primary gameplay stays on this page. This menu only keeps locale switching."));
-    _el$58.$$click = () => setViewerLocale("zh");
-    _el$59.$$click = () => setViewerLocale("en");
-    insert(_el$60, createComponent(Badge, {
+    var _el$57 = _tmpl$21(), _el$58 = _el$57.firstChild, _el$59 = _el$58.nextSibling, _el$60 = _el$59.firstChild, _el$61 = _el$60.firstChild, _el$62 = _el$61.nextSibling, _el$63 = _el$60.nextSibling, _el$64 = _el$63.firstChild, _el$65 = _el$64.nextSibling, _el$66 = _el$63.nextSibling, _el$67 = _el$66.nextSibling;
+    insert(_el$58, () => tr(locale(), "入口", "Entry"));
+    insert(_el$61, () => tr(locale(), "语言与 Viewer 入口", "Language and Viewer Entry"));
+    insert(_el$62, () => tr(locale(), "主玩法继续留在当前页面；这里只保留语言切换。", "Primary gameplay stays on this page. This menu only keeps locale switching."));
+    _el$64.$$click = () => setViewerLocale("zh");
+    _el$65.$$click = () => setViewerLocale("en");
+    insert(_el$66, createComponent(Badge, {
       get children() {
         return `locale=${localeCode(locale())}`;
       }
     }));
-    insert(_el$61, () => viewerEntryUrls().softwareSafeUrl);
+    insert(_el$67, () => viewerEntryUrls().softwareSafeUrl);
     createRenderEffect((_p$) => {
       var _v$6 = locale() === "zh", _v$7 = locale() === "en";
-      _v$6 !== _p$.e && (_el$58.disabled = _p$.e = _v$6);
-      _v$7 !== _p$.t && (_el$59.disabled = _p$.t = _v$7);
+      _v$6 !== _p$.e && (_el$64.disabled = _p$.e = _v$6);
+      _v$7 !== _p$.t && (_el$65.disabled = _p$.t = _v$7);
       return _p$;
     }, {
       e: void 0,
       t: void 0
     });
-    return _el$51;
+    return _el$57;
   })();
 }
 function gameplayStatusBadgeClass(status) {
@@ -6370,40 +6441,40 @@ function WorldStageHero() {
   const acceptedIntentTitle = () => gameplaySummary()?.acceptedIntentSummary || tr(locale(), "先提交一条明确意图", "Commit one clear intent first");
   const acceptedIntentDetail = () => gameplaySummary()?.acceptedIntentTarget ? tr(locale(), `当前意图正围绕 ${gameplaySummary().acceptedIntentTarget} 展开。`, `The current intent is centered on ${gameplaySummary().acceptedIntentTarget}.`) : selectionHint();
   return (() => {
-    var _el$62 = _tmpl$21(), _el$63 = _el$62.firstChild, _el$64 = _el$63.firstChild, _el$65 = _el$64.firstChild, _el$66 = _el$65.nextSibling, _el$67 = _el$66.nextSibling, _el$68 = _el$63.nextSibling, _el$69 = _el$68.firstChild, _el$70 = _el$69.firstChild, _el$71 = _el$70.nextSibling, _el$72 = _el$71.nextSibling, _el$73 = _el$69.nextSibling, _el$74 = _el$73.firstChild, _el$75 = _el$74.nextSibling, _el$76 = _el$75.nextSibling, _el$77 = _el$73.nextSibling, _el$78 = _el$77.firstChild, _el$79 = _el$78.nextSibling;
-    insert(_el$65, () => tr(locale(), "工业世界指挥桌", "Industrial World Command Desk"));
-    insert(_el$66, () => gameplaySummary()?.goalTitle || tr(locale(), "进入世界，先看局势，再做动作", "Read the world first, then act."));
-    insert(_el$67, () => gameplaySummary()?.nextStepHint || gameplaySummary()?.objective || tr(locale(), "这张入口页优先保留世界、目标和关键动作；高级诊断与治理能力按需展开。", "This entry keeps the world, objective, and primary actions in front. Advanced diagnostics and governance stay on demand."));
-    insert(_el$63, createComponent(ViewerEntryMenu, {}), null);
-    insert(_el$62, createComponent(Show, {
+    var _el$68 = _tmpl$22(), _el$69 = _el$68.firstChild, _el$70 = _el$69.firstChild, _el$71 = _el$70.firstChild, _el$72 = _el$71.nextSibling, _el$73 = _el$72.nextSibling, _el$74 = _el$69.nextSibling, _el$75 = _el$74.firstChild, _el$76 = _el$75.firstChild, _el$77 = _el$76.nextSibling, _el$78 = _el$77.nextSibling, _el$79 = _el$75.nextSibling, _el$80 = _el$79.firstChild, _el$81 = _el$80.nextSibling, _el$82 = _el$81.nextSibling, _el$83 = _el$79.nextSibling, _el$84 = _el$83.firstChild, _el$85 = _el$84.nextSibling;
+    insert(_el$71, () => tr(locale(), "工业世界指挥桌", "Industrial World Command Desk"));
+    insert(_el$72, () => gameplaySummary()?.goalTitle || tr(locale(), "进入世界，先看局势，再做动作", "Read the world first, then act."));
+    insert(_el$73, () => gameplaySummary()?.nextStepHint || gameplaySummary()?.objective || tr(locale(), "这张入口页优先保留世界、目标和关键动作；高级诊断与治理能力按需展开。", "This entry keeps the world, objective, and primary actions in front. Advanced diagnostics and governance stay on demand."));
+    insert(_el$69, createComponent(ViewerEntryMenu, {}), null);
+    insert(_el$68, createComponent(Show, {
       get when() {
         return selectedLabel();
       },
       children: (selected) => (() => {
-        var _el$81 = _tmpl$14();
-        insert(_el$81, createComponent(Badge, {
+        var _el$87 = _tmpl$14();
+        insert(_el$87, createComponent(Badge, {
           "class": "badge badge--accent",
           get children() {
             return tr(locale(), "当前选择", "Current Selection");
           }
         }), null);
-        insert(_el$81, createComponent(Badge, {
+        insert(_el$87, createComponent(Badge, {
           get children() {
             return selected();
           }
         }), null);
-        return _el$81;
+        return _el$87;
       })()
-    }), _el$68);
-    insert(_el$70, () => tr(locale(), "局势", "Situation"));
-    insert(_el$71, stageLabel);
-    insert(_el$72, () => gameplayProgressLabel(gameplaySummary()?.progressPercent, locale()));
-    insert(_el$74, () => tr(locale(), "已接受意图", "Accepted Intent"));
-    insert(_el$75, acceptedIntentTitle);
-    insert(_el$76, acceptedIntentDetail);
-    insert(_el$78, () => tr(locale(), "下一步", "Next Step"));
-    insert(_el$79, nextStepCopy);
-    insert(_el$62, createComponent(Show, {
+    }), _el$74);
+    insert(_el$76, () => tr(locale(), "局势", "Situation"));
+    insert(_el$77, stageLabel);
+    insert(_el$78, () => gameplayProgressLabel(gameplaySummary()?.progressPercent, locale()));
+    insert(_el$80, () => tr(locale(), "已接受意图", "Accepted Intent"));
+    insert(_el$81, acceptedIntentTitle);
+    insert(_el$82, acceptedIntentDetail);
+    insert(_el$84, () => tr(locale(), "下一步", "Next Step"));
+    insert(_el$85, nextStepCopy);
+    insert(_el$68, createComponent(Show, {
       get when() {
         return state.connectionStatus !== "connected";
       },
@@ -6420,26 +6491,26 @@ function WorldStageHero() {
           },
           variant: "warn",
           get children() {
-            var _el$80 = _tmpl$19();
-            insert(_el$80, () => tr(locale(), "首屏优先展示世界与目标；只有连接异常时，才把连接状态抬到这里提示你。", "This entry keeps the world and target first, and only elevates connection status when it needs attention."));
-            return _el$80;
+            var _el$86 = _tmpl$20();
+            insert(_el$86, () => tr(locale(), "首屏优先展示世界与目标；只有连接异常时，才把连接状态抬到这里提示你。", "This entry keeps the world and target first, and only elevates connection status when it needs attention."));
+            return _el$86;
           }
         });
       }
     }), null);
-    createRenderEffect(() => className(_el$71, gameplayStageToneClass(gameplaySummary()?.stageStatus)));
-    return _el$62;
+    createRenderEffect(() => className(_el$77, gameplayStageToneClass(gameplaySummary()?.stageStatus)));
+    return _el$68;
   })();
 }
 function MobileJumpRail() {
   const locale = () => uiLocale();
   return (() => {
-    var _el$82 = _tmpl$22(), _el$83 = _el$82.firstChild, _el$84 = _el$83.nextSibling, _el$85 = _el$84.nextSibling;
-    insert(_el$83, () => tr(locale(), "世界", "World"));
-    insert(_el$84, () => tr(locale(), "目标", "Targets"));
-    insert(_el$85, () => tr(locale(), "指挥", "Command"));
-    createRenderEffect(() => setAttribute(_el$82, "aria-label", tr(locale(), "主入口分区导航", "Primary entry section navigation")));
-    return _el$82;
+    var _el$88 = _tmpl$23(), _el$89 = _el$88.firstChild, _el$90 = _el$89.nextSibling, _el$91 = _el$90.nextSibling;
+    insert(_el$89, () => tr(locale(), "世界", "World"));
+    insert(_el$90, () => tr(locale(), "目标", "Targets"));
+    insert(_el$91, () => tr(locale(), "指挥", "Command"));
+    createRenderEffect(() => setAttribute(_el$88, "aria-label", tr(locale(), "主入口分区导航", "Primary entry section navigation")));
+    return _el$88;
   })();
 }
 function TargetsPanel() {
@@ -6447,36 +6518,36 @@ function TargetsPanel() {
   const locale = () => uiLocale();
   const selectedLabel = () => state.selectedKind && state.selectedId ? `${state.selectedKind}:${state.selectedId}` : null;
   return (() => {
-    var _el$86 = _tmpl$23(), _el$87 = _el$86.firstChild, _el$88 = _el$87.firstChild, _el$89 = _el$88.nextSibling, _el$90 = _el$87.nextSibling, _el$91 = _el$90.firstChild, _el$92 = _el$91.nextSibling, _el$93 = _el$90.nextSibling, _el$94 = _el$93.firstChild, _el$95 = _el$94.nextSibling;
-    insert(_el$86, createComponent(Show, {
+    var _el$92 = _tmpl$24(), _el$93 = _el$92.firstChild, _el$94 = _el$93.firstChild, _el$95 = _el$94.nextSibling, _el$96 = _el$93.nextSibling, _el$97 = _el$96.firstChild, _el$98 = _el$97.nextSibling, _el$99 = _el$96.nextSibling, _el$100 = _el$99.firstChild, _el$101 = _el$100.nextSibling;
+    insert(_el$92, createComponent(Show, {
       get when() {
         return selectedLabel();
       },
       children: (selected) => (() => {
-        var _el$96 = _tmpl$14();
-        insert(_el$96, createComponent(Badge, {
+        var _el$102 = _tmpl$14();
+        insert(_el$102, createComponent(Badge, {
           "class": "badge badge--accent",
           get children() {
             return tr(locale(), "已锁定目标", "Locked Target");
           }
         }), null);
-        insert(_el$96, createComponent(Badge, {
+        insert(_el$102, createComponent(Badge, {
           get children() {
             return selected();
           }
         }), null);
-        return _el$96;
+        return _el$102;
       })()
-    }), _el$87);
-    insert(_el$86, createComponent(EmptyState, {
+    }), _el$93);
+    insert(_el$92, createComponent(EmptyState, {
       get children() {
         return tr(locale(), "先从这里锁定一个 Agent 或地点。中间读局势，右侧只处理你当前选中的目标。", "Lock onto an agent or location here first. Read the world in the middle, then use the right column only for the selected target.");
       }
-    }), _el$87);
-    insert(_el$88, () => tr(locale(), "筛选目标", "Filter targets"));
-    _el$89.$$input = (event) => setSelectedSearch(event.currentTarget.value);
-    insert(_el$91, () => tr(locale(), "Agents", "Agents"));
-    insert(_el$92, createComponent(Show, {
+    }), _el$93);
+    insert(_el$94, () => tr(locale(), "筛选目标", "Filter targets"));
+    _el$95.$$input = (event) => setSelectedSearch(event.currentTarget.value);
+    insert(_el$97, () => tr(locale(), "Agents", "Agents"));
+    insert(_el$98, createComponent(Show, {
       get when() {
         return lists().agents.length > 0;
       },
@@ -6493,29 +6564,29 @@ function TargetsPanel() {
             return lists().agents;
           },
           children: (agent) => (() => {
-            var _el$97 = _tmpl$24(), _el$98 = _el$97.firstChild, _el$99 = _el$98.nextSibling;
-            _el$97.$$click = () => applySelection({
+            var _el$103 = _tmpl$25(), _el$104 = _el$103.firstChild, _el$105 = _el$104.nextSibling;
+            _el$103.$$click = () => applySelection({
               kind: "agent",
               id: agent.id
             });
-            insert(_el$98, () => agent.id);
-            insert(_el$99, () => `${tr(locale(), "地点", "location")}=${agent.location_id} · ${tr(locale(), "资源", "resources")}=${renderResourceSummary(agent.resources)}`);
+            insert(_el$104, () => agent.id);
+            insert(_el$105, () => `${tr(locale(), "地点", "location")}=${agent.location_id} · ${tr(locale(), "资源", "resources")}=${renderResourceSummary(agent.resources)}`);
             createRenderEffect((_p$) => {
               var _v$8 = agent.id, _v$9 = state.selectedKind === "agent" && state.selectedId === agent.id;
-              _v$8 !== _p$.e && setAttribute(_el$97, "data-select-id", _p$.e = _v$8);
-              _v$9 !== _p$.t && setAttribute(_el$97, "data-selected", _p$.t = _v$9);
+              _v$8 !== _p$.e && setAttribute(_el$103, "data-select-id", _p$.e = _v$8);
+              _v$9 !== _p$.t && setAttribute(_el$103, "data-selected", _p$.t = _v$9);
               return _p$;
             }, {
               e: void 0,
               t: void 0
             });
-            return _el$97;
+            return _el$103;
           })()
         });
       }
     }));
-    insert(_el$94, () => tr(locale(), "地点", "Locations"));
-    insert(_el$95, createComponent(Show, {
+    insert(_el$100, () => tr(locale(), "地点", "Locations"));
+    insert(_el$101, createComponent(Show, {
       get when() {
         return lists().locations.length > 0;
       },
@@ -6532,30 +6603,30 @@ function TargetsPanel() {
             return lists().locations;
           },
           children: (location) => (() => {
-            var _el$100 = _tmpl$25(), _el$101 = _el$100.firstChild, _el$102 = _el$101.nextSibling;
-            _el$100.$$click = () => applySelection({
+            var _el$106 = _tmpl$26(), _el$107 = _el$106.firstChild, _el$108 = _el$107.nextSibling;
+            _el$106.$$click = () => applySelection({
               kind: "location",
               id: location.id
             });
-            insert(_el$101, () => location.name || location.id);
-            insert(_el$102, () => `id=${location.id} · ${tr(locale(), "半径", "radius")}=${formatPhysicalDistanceCm(location.profile?.radius_cm, locale()) || "-"} · ${tr(locale(), "资源", "resources")}=${renderResourceSummary(location.resources)}`);
+            insert(_el$107, () => location.name || location.id);
+            insert(_el$108, () => `id=${location.id} · ${tr(locale(), "半径", "radius")}=${formatPhysicalDistanceCm(location.profile?.radius_cm, locale()) || "-"} · ${tr(locale(), "资源", "resources")}=${renderResourceSummary(location.resources)}`);
             createRenderEffect((_p$) => {
               var _v$0 = location.id, _v$1 = state.selectedKind === "location" && state.selectedId === location.id;
-              _v$0 !== _p$.e && setAttribute(_el$100, "data-select-id", _p$.e = _v$0);
-              _v$1 !== _p$.t && setAttribute(_el$100, "data-selected", _p$.t = _v$1);
+              _v$0 !== _p$.e && setAttribute(_el$106, "data-select-id", _p$.e = _v$0);
+              _v$1 !== _p$.t && setAttribute(_el$106, "data-selected", _p$.t = _v$1);
               return _p$;
             }, {
               e: void 0,
               t: void 0
             });
-            return _el$100;
+            return _el$106;
           })()
         });
       }
     }));
-    createRenderEffect(() => setAttribute(_el$89, "placeholder", tr(locale(), "搜索 Agent 或地点", "Search agents or locations")));
-    createRenderEffect(() => _el$89.value = getSelectedSearch());
-    return _el$86;
+    createRenderEffect(() => setAttribute(_el$95, "placeholder", tr(locale(), "搜索 Agent 或地点", "Search agents or locations")));
+    createRenderEffect(() => _el$95.value = getSelectedSearch());
+    return _el$92;
   })();
 }
 function WorldSummaryPanel() {
@@ -6577,8 +6648,8 @@ function WorldSummaryPanel() {
   const showPlayerSessionSurface = () => !!hostedRecoveryHint() || !state$1.auth.available && String(state$1.hostedAccess?.deployment_mode || "").trim() === "hosted_public_join" || showRebindNotice();
   const diagnosticsSummaryBadges = () => [`debugViewer=${state$1.debugViewerMode}:${state$1.debugViewerStatus}`, `auth=${state$1.auth.available ? state$1.auth.registrationStatus || "ready" : "missing"}`, `events=${state$1.recentEvents.length}`];
   return (() => {
-    var _el$103 = _tmpl$29(), _el$107 = _el$103.firstChild, _el$108 = _el$107.firstChild, _el$109 = _el$108.firstChild, _el$110 = _el$109.firstChild, _el$111 = _el$110.nextSibling, _el$112 = _el$109.nextSibling, _el$113 = _el$108.nextSibling, _el$114 = _el$113.firstChild, _el$116 = _el$114.nextSibling, _el$117 = _el$116.nextSibling, _el$125 = _el$117.nextSibling, _el$126 = _el$125.nextSibling, _el$127 = _el$126.firstChild, _el$128 = _el$127.nextSibling;
-    insert(_el$103, createComponent(PanelSection, {
+    var _el$109 = _tmpl$30(), _el$113 = _el$109.firstChild, _el$114 = _el$113.firstChild, _el$115 = _el$114.firstChild, _el$116 = _el$115.firstChild, _el$117 = _el$116.nextSibling, _el$118 = _el$115.nextSibling, _el$119 = _el$114.nextSibling, _el$120 = _el$119.firstChild, _el$122 = _el$120.nextSibling, _el$123 = _el$122.nextSibling, _el$131 = _el$123.nextSibling, _el$132 = _el$131.nextSibling, _el$133 = _el$132.firstChild, _el$134 = _el$133.nextSibling;
+    insert(_el$109, createComponent(PanelSection, {
       get title() {
         return tr(locale(), "正式玩法摘要", "Formal Gameplay Summary");
       },
@@ -6601,8 +6672,8 @@ function WorldSummaryPanel() {
             });
           },
           children: (gameplay) => [(() => {
-            var _el$129 = _tmpl$14();
-            insert(_el$129, createComponent(Badge, {
+            var _el$135 = _tmpl$14();
+            insert(_el$135, createComponent(Badge, {
               get ["class"]() {
                 return gameplayStatusBadgeClass(gameplay().stageStatus);
               },
@@ -6610,13 +6681,13 @@ function WorldSummaryPanel() {
                 return gameplayStageLabel(gameplay().stageStatus, locale());
               }
             }), null);
-            insert(_el$129, createComponent(Badge, {
+            insert(_el$135, createComponent(Badge, {
               "class": "badge badge--accent",
               get children() {
                 return gameplayProgressLabel(gameplay().progressPercent, locale());
               }
             }), null);
-            return _el$129;
+            return _el$135;
           })(), createComponent(EventCard, {
             get title() {
               return tr(locale(), "已接受意图", "Accepted Intent");
@@ -6632,30 +6703,30 @@ function WorldSummaryPanel() {
             },
             get children() {
               return [(() => {
-                var _el$130 = _tmpl$19();
-                insert(_el$130, () => gameplay().acceptedIntentSummary);
-                return _el$130;
+                var _el$136 = _tmpl$20();
+                insert(_el$136, () => gameplay().acceptedIntentSummary);
+                return _el$136;
               })(), (() => {
-                var _el$131 = _tmpl$4();
-                insert(_el$131, () => gameplay().acceptedIntentDetail);
-                return _el$131;
+                var _el$137 = _tmpl$4();
+                insert(_el$137, () => gameplay().acceptedIntentDetail);
+                return _el$137;
               })(), createComponent(Show, {
                 get when() {
                   return gameplay().resumeAnchor;
                 },
                 get children() {
                   return [(() => {
-                    var _el$132 = _tmpl$14();
-                    insert(_el$132, createComponent(Badge, {
+                    var _el$138 = _tmpl$14();
+                    insert(_el$138, createComponent(Badge, {
                       get children() {
                         return tr(locale(), "续玩锚点", "Resume Anchor");
                       }
                     }));
-                    return _el$132;
+                    return _el$138;
                   })(), (() => {
-                    var _el$133 = _tmpl$4();
-                    insert(_el$133, () => gameplay().resumeAnchor);
-                    return _el$133;
+                    var _el$139 = _tmpl$4();
+                    insert(_el$139, () => gameplay().resumeAnchor);
+                    return _el$139;
                   })()];
                 }
               })];
@@ -6675,8 +6746,8 @@ function WorldSummaryPanel() {
             },
             get children() {
               return [(() => {
-                var _el$134 = _tmpl$14();
-                insert(_el$134, createComponent(For, {
+                var _el$140 = _tmpl$14();
+                insert(_el$140, createComponent(For, {
                   get each() {
                     return gameplay().executionStateMachine || [];
                   },
@@ -6689,32 +6760,32 @@ function WorldSummaryPanel() {
                     }
                   })
                 }));
-                return _el$134;
+                return _el$140;
               })(), (() => {
-                var _el$135 = _tmpl$19();
-                insert(_el$135, () => gameplay().executionSummary || tr(locale(), "等待目标执行状态更新。", "Waiting for goal execution state updates."));
-                return _el$135;
+                var _el$141 = _tmpl$20();
+                insert(_el$141, () => gameplay().executionSummary || tr(locale(), "等待目标执行状态更新。", "Waiting for goal execution state updates."));
+                return _el$141;
               })(), createComponent(Show, {
                 get when() {
                   return gameplay().executionCauseLabel;
                 },
                 get children() {
-                  var _el$136 = _tmpl$14();
-                  insert(_el$136, createComponent(Badge, {
+                  var _el$142 = _tmpl$14();
+                  insert(_el$142, createComponent(Badge, {
                     get children() {
                       return gameplay().executionCauseLabel;
                     }
                   }));
-                  return _el$136;
+                  return _el$142;
                 }
               }), createComponent(Show, {
                 get when() {
                   return gameplay().executionCauseDetail;
                 },
                 get children() {
-                  var _el$137 = _tmpl$4();
-                  insert(_el$137, () => gameplay().executionCauseDetail);
-                  return _el$137;
+                  var _el$143 = _tmpl$4();
+                  insert(_el$143, () => gameplay().executionCauseDetail);
+                  return _el$143;
                 }
               })];
             }
@@ -6735,9 +6806,9 @@ function WorldSummaryPanel() {
                   return gameplay().progressDetail;
                 },
                 get children() {
-                  var _el$138 = _tmpl$4();
-                  insert(_el$138, () => gameplay().progressDetail);
-                  return _el$138;
+                  var _el$144 = _tmpl$4();
+                  insert(_el$144, () => gameplay().progressDetail);
+                  return _el$144;
                 }
               }), createComponent(Show, {
                 get when() {
@@ -6745,18 +6816,18 @@ function WorldSummaryPanel() {
                 },
                 get children() {
                   return [(() => {
-                    var _el$139 = _tmpl$30();
-                    insert(_el$139, createComponent(Badge, {
+                    var _el$145 = _tmpl$31();
+                    insert(_el$145, createComponent(Badge, {
                       "class": "badge badge--warn",
                       get children() {
                         return gameplay().blockerLabel || gameplay().blockerKind || tr(locale(), "当前阻塞", "Current Blocker");
                       }
                     }));
-                    return _el$139;
+                    return _el$145;
                   })(), (() => {
-                    var _el$140 = _tmpl$4();
-                    insert(_el$140, () => gameplay().narrativeBlockerDetail || tr(locale(), "当前玩法被阻塞，需要显式恢复。", "Gameplay is blocked and needs explicit recovery."));
-                    return _el$140;
+                    var _el$146 = _tmpl$4();
+                    insert(_el$146, () => gameplay().narrativeBlockerDetail || tr(locale(), "当前玩法被阻塞，需要显式恢复。", "Gameplay is blocked and needs explicit recovery."));
+                    return _el$146;
                   })()];
                 }
               }), createComponent(Show, {
@@ -6764,49 +6835,49 @@ function WorldSummaryPanel() {
                   return gameplay().blockerSupplementalDetail;
                 },
                 get children() {
-                  var _el$141 = _tmpl$4();
-                  insert(_el$141, () => gameplay().blockerSupplementalDetail);
-                  return _el$141;
+                  var _el$147 = _tmpl$4();
+                  insert(_el$147, () => gameplay().blockerSupplementalDetail);
+                  return _el$147;
                 }
               }), (() => {
-                var _el$142 = _tmpl$30();
-                insert(_el$142, createComponent(Badge, {
+                var _el$148 = _tmpl$31();
+                insert(_el$148, createComponent(Badge, {
                   "class": "badge badge--accent",
                   get children() {
                     return tr(locale(), "下一步", "Next Step");
                   }
                 }));
-                return _el$142;
+                return _el$148;
               })(), (() => {
-                var _el$143 = _tmpl$19();
-                insert(_el$143, () => gameplay().narrativeNextStep || tr(locale(), "等待下一次 runtime 指引更新。", "Wait for the next runtime guidance update."));
-                return _el$143;
+                var _el$149 = _tmpl$20();
+                insert(_el$149, () => gameplay().narrativeNextStep || tr(locale(), "等待下一次 runtime 指引更新。", "Wait for the next runtime guidance update."));
+                return _el$149;
               })(), createComponent(Show, {
                 get when() {
                   return gameplay().branchHint;
                 },
                 get children() {
-                  var _el$144 = _tmpl$4();
-                  insert(_el$144, () => gameplay().branchHint);
-                  return _el$144;
+                  var _el$150 = _tmpl$4();
+                  insert(_el$150, () => gameplay().branchHint);
+                  return _el$150;
                 }
               }), createComponent(Show, {
                 get when() {
                   return gameplay().entityCounts;
                 },
                 get children() {
-                  var _el$145 = _tmpl$14();
-                  insert(_el$145, createComponent(Badge, {
+                  var _el$151 = _tmpl$14();
+                  insert(_el$151, createComponent(Badge, {
                     get children() {
                       return `agents=${gameplay().entityCounts.agents}`;
                     }
                   }), null);
-                  insert(_el$145, createComponent(Badge, {
+                  insert(_el$151, createComponent(Badge, {
                     get children() {
                       return `locations=${gameplay().entityCounts.locations}`;
                     }
                   }), null);
-                  return _el$145;
+                  return _el$151;
                 }
               })];
             }
@@ -6821,8 +6892,8 @@ function WorldSummaryPanel() {
               return tr(locale(), "把当前玩法翻译成显式的投入 / 产出 / 新用途 / 修复动作 / 下一步价值，避免工业成长继续退化成只看库存与产量。", "Translate the current loop into explicit input / output / new use / repair move / next value so industrial growth does not collapse into stockpile and throughput alone.");
             },
             get children() {
-              var _el$146 = _tmpl$31();
-              insert(_el$146, createComponent(MetricCard, {
+              var _el$152 = _tmpl$32();
+              insert(_el$152, createComponent(MetricCard, {
                 get label() {
                   return tr(locale(), "投入", "Input");
                 },
@@ -6830,7 +6901,7 @@ function WorldSummaryPanel() {
                   return gameplay().economicSurface?.input || tr(locale(), "待发布", "not published");
                 }
               }), null);
-              insert(_el$146, createComponent(MetricCard, {
+              insert(_el$152, createComponent(MetricCard, {
                 get label() {
                   return tr(locale(), "产出", "Output");
                 },
@@ -6838,7 +6909,7 @@ function WorldSummaryPanel() {
                   return gameplay().economicSurface?.output || tr(locale(), "待发布", "not published");
                 }
               }), null);
-              insert(_el$146, createComponent(MetricCard, {
+              insert(_el$152, createComponent(MetricCard, {
                 get label() {
                   return tr(locale(), "新用途", "New Use");
                 },
@@ -6846,7 +6917,7 @@ function WorldSummaryPanel() {
                   return gameplay().economicSurface?.unlockedValue || tr(locale(), "待发布", "not published");
                 }
               }), null);
-              insert(_el$146, createComponent(MetricCard, {
+              insert(_el$152, createComponent(MetricCard, {
                 get label() {
                   return tr(locale(), "修复动作", "Repair Move");
                 },
@@ -6857,7 +6928,7 @@ function WorldSummaryPanel() {
                   return memo(() => !!gameplay().economicSurface?.blockerLabel)() ? tr(locale(), `当前阻塞归类: ${gameplay().economicSurface.blockerLabel}`, `Current blocker class: ${gameplay().economicSurface.blockerLabel}`) : null;
                 }
               }), null);
-              insert(_el$146, createComponent(MetricCard, {
+              insert(_el$152, createComponent(MetricCard, {
                 get label() {
                   return tr(locale(), "下一步价值", "Next Value");
                 },
@@ -6865,7 +6936,7 @@ function WorldSummaryPanel() {
                   return gameplay().economicSurface?.nextValue || tr(locale(), "待发布", "not published");
                 }
               }), null);
-              return _el$146;
+              return _el$152;
             }
           }), createComponent(Show, {
             get when() {
@@ -6886,26 +6957,26 @@ function WorldSummaryPanel() {
               },
               get children() {
                 return [(() => {
-                  var _el$152 = _tmpl$19();
-                  insert(_el$152, () => feedback().effect || feedback().reason || tr(locale(), "最新回执已更新，但还没有新的世界级后果。", "The latest feedback is in, but there is no new world-level consequence yet."));
-                  return _el$152;
+                  var _el$158 = _tmpl$20();
+                  insert(_el$158, () => feedback().effect || feedback().reason || tr(locale(), "最新回执已更新，但还没有新的世界级后果。", "The latest feedback is in, but there is no new world-level consequence yet."));
+                  return _el$158;
                 })(), createComponent(Show, {
                   get when() {
                     return feedback().reason;
                   },
                   get children() {
-                    var _el$153 = _tmpl$4();
-                    insert(_el$153, () => feedback().reason);
-                    return _el$153;
+                    var _el$159 = _tmpl$4();
+                    insert(_el$159, () => feedback().reason);
+                    return _el$159;
                   }
                 }), createComponent(Show, {
                   get when() {
                     return feedback().hint;
                   },
                   get children() {
-                    var _el$154 = _tmpl$4();
-                    insert(_el$154, () => feedback().hint);
-                    return _el$154;
+                    var _el$160 = _tmpl$4();
+                    insert(_el$160, () => feedback().hint);
+                    return _el$160;
                   }
                 })];
               }
@@ -6936,26 +7007,26 @@ function WorldSummaryPanel() {
               badgeClass: "badge badge--good",
               get children() {
                 return [(() => {
-                  var _el$155 = _tmpl$19();
-                  insert(_el$155, () => action().label || action().actionId || tr(locale(), "当前存在一条更合适的推进动作。", "One action is currently the best next move."));
-                  return _el$155;
+                  var _el$161 = _tmpl$20();
+                  insert(_el$161, () => action().label || action().actionId || tr(locale(), "当前存在一条更合适的推进动作。", "One action is currently the best next move."));
+                  return _el$161;
                 })(), (() => {
-                  var _el$156 = _tmpl$4();
-                  insert(_el$156, () => gameplay().narrativeNextStep || tr(locale(), "先执行这一步，再判断是否需要切到聊天、恢复或改道。", "Take this action first, then decide whether to chat, resume, or reprioritize."));
-                  return _el$156;
+                  var _el$162 = _tmpl$4();
+                  insert(_el$162, () => gameplay().narrativeNextStep || tr(locale(), "先执行这一步，再判断是否需要切到聊天、恢复或改道。", "Take this action first, then decide whether to chat, resume, or reprioritize."));
+                  return _el$162;
                 })(), (() => {
-                  var _el$157 = _tmpl$33(), _el$158 = _el$157.firstChild;
-                  _el$158.$$click = () => renderGameplayAction(action());
-                  insert(_el$158, () => gameplayActionButtonLabel(action(), locale()));
-                  createRenderEffect(() => _el$158.disabled = Boolean(action().disabledReason));
-                  return _el$157;
+                  var _el$163 = _tmpl$34(), _el$164 = _el$163.firstChild;
+                  _el$164.$$click = () => renderGameplayAction(action());
+                  insert(_el$164, () => gameplayActionButtonLabel(action(), locale()));
+                  createRenderEffect(() => _el$164.disabled = Boolean(action().disabledReason));
+                  return _el$163;
                 })()];
               }
             })
           }), (() => {
-            var _el$147 = _tmpl$32(), _el$148 = _el$147.firstChild, _el$149 = _el$148.nextSibling;
-            insert(_el$148, () => tr(locale(), "可用玩法动作", "Available Gameplay Actions"));
-            insert(_el$149, createComponent(Show, {
+            var _el$153 = _tmpl$33(), _el$154 = _el$153.firstChild, _el$155 = _el$154.nextSibling;
+            insert(_el$154, () => tr(locale(), "可用玩法动作", "Available Gameplay Actions"));
+            insert(_el$155, createComponent(Show, {
               get when() {
                 return gameplay().availableActions.length > 0;
               },
@@ -6987,30 +7058,30 @@ function WorldSummaryPanel() {
                     },
                     get children() {
                       return [(() => {
-                        var _el$159 = _tmpl$4();
-                        insert(_el$159, () => action.disabledReason || tr(locale(), "无需打开 visual QA viewer，也可以直接从正式 Web 入口执行。", "Playable from the formal Web entry without opening the visual QA viewer."));
-                        return _el$159;
+                        var _el$165 = _tmpl$4();
+                        insert(_el$165, () => action.disabledReason || tr(locale(), "无需打开 visual QA viewer，也可以直接从正式 Web 入口执行。", "Playable from the formal Web entry without opening the visual QA viewer."));
+                        return _el$165;
                       })(), createComponent(Show, {
                         get when() {
                           return action.executeKind === "request_snapshot" || action.executeKind === "step" || action.executeKind === "play" || action.executeKind === "gameplay_action";
                         },
                         get children() {
-                          var _el$160 = _tmpl$33(), _el$161 = _el$160.firstChild;
-                          _el$161.$$click = () => renderGameplayAction(action);
-                          insert(_el$161, () => gameplayActionButtonLabel(action, locale()));
-                          createRenderEffect(() => _el$161.disabled = Boolean(action.disabledReason));
-                          return _el$160;
+                          var _el$166 = _tmpl$34(), _el$167 = _el$166.firstChild;
+                          _el$167.$$click = () => renderGameplayAction(action);
+                          insert(_el$167, () => gameplayActionButtonLabel(action, locale()));
+                          createRenderEffect(() => _el$167.disabled = Boolean(action.disabledReason));
+                          return _el$166;
                         }
                       }), createComponent(Show, {
                         get when() {
                           return action.executeKind === "agent_chat";
                         },
                         get children() {
-                          var _el$162 = _tmpl$33(), _el$163 = _el$162.firstChild;
-                          _el$163.$$click = () => renderGameplayAction(action);
-                          insert(_el$163, () => gameplayActionButtonLabel(action, locale()));
-                          createRenderEffect(() => _el$163.disabled = Boolean(action.disabledReason));
-                          return _el$162;
+                          var _el$168 = _tmpl$34(), _el$169 = _el$168.firstChild;
+                          _el$169.$$click = () => renderGameplayAction(action);
+                          insert(_el$169, () => gameplayActionButtonLabel(action, locale()));
+                          createRenderEffect(() => _el$169.disabled = Boolean(action.disabledReason));
+                          return _el$168;
                         }
                       })];
                     }
@@ -7018,7 +7089,7 @@ function WorldSummaryPanel() {
                 });
               }
             }));
-            return _el$147;
+            return _el$153;
           })(), createComponent(CalloutCard, {
             get title() {
               return tr(locale(), "未在此页暴露的动作", "Actions Not Exposed On This Page");
@@ -7027,20 +7098,20 @@ function WorldSummaryPanel() {
             badgeClass: "badge badge--warn",
             get children() {
               return [(() => {
-                var _el$150 = _tmpl$19();
-                insert(_el$150, () => gameplay().assetGovernanceHandoff);
-                return _el$150;
+                var _el$156 = _tmpl$20();
+                insert(_el$156, () => gameplay().assetGovernanceHandoff);
+                return _el$156;
               })(), (() => {
-                var _el$151 = _tmpl$4();
-                insert(_el$151, () => tr(locale(), "资产 / 治理相关能力请走单独 lane；这张主入口页面只保留正式玩法所需的最小动作面。", "Asset and governance actions stay on their dedicated lane; this primary entry only keeps the minimum surface needed for formal gameplay."));
-                return _el$151;
+                var _el$157 = _tmpl$4();
+                insert(_el$157, () => tr(locale(), "资产 / 治理相关能力请走单独 lane；这张主入口页面只保留正式玩法所需的最小动作面。", "Asset and governance actions stay on their dedicated lane; this primary entry only keeps the minimum surface needed for formal gameplay."));
+                return _el$157;
               })()];
             }
           })]
         });
       }
-    }), _el$107);
-    insert(_el$103, createComponent(Show, {
+    }), _el$113);
+    insert(_el$109, createComponent(Show, {
       get when() {
         return showPlayerSessionSurface();
       },
@@ -7057,8 +7128,8 @@ function WorldSummaryPanel() {
           },
           get children() {
             return [(() => {
-              var _el$104 = _tmpl$14();
-              insert(_el$104, createComponent(Badge, {
+              var _el$110 = _tmpl$14();
+              insert(_el$110, createComponent(Badge, {
                 get ["class"]() {
                   return state$1.auth.available ? "badge badge--good" : "badge badge--warn";
                 },
@@ -7066,23 +7137,23 @@ function WorldSummaryPanel() {
                   return `auth=${state$1.auth.available ? state$1.auth.registrationStatus || "ready" : "missing"}`;
                 }
               }), null);
-              insert(_el$104, createComponent(Badge, {
+              insert(_el$110, createComponent(Badge, {
                 "class": "badge badge--accent",
                 get children() {
                   return `tier=${authSurface().currentTier}`;
                 }
               }), null);
-              insert(_el$104, createComponent(Badge, {
+              insert(_el$110, createComponent(Badge, {
                 get children() {
                   return `player=${state$1.auth.playerId || "-"}`;
                 }
               }), null);
-              insert(_el$104, createComponent(Badge, {
+              insert(_el$110, createComponent(Badge, {
                 get children() {
                   return `boundAgent=${state$1.auth.boundAgentId || "-"}`;
                 }
               }), null);
-              return _el$104;
+              return _el$110;
             })(), createComponent(EmptyState, {
               get children() {
                 return hostedRecoveryHint()?.detail || state$1.auth.rebindNotice || authSurface().currentTierReason;
@@ -7112,21 +7183,21 @@ function WorldSummaryPanel() {
                 return memo(() => !!state$1.auth.available)() && state$1.auth.source !== "legacy_viewer_auth_bootstrap";
               },
               get children() {
-                var _el$105 = _tmpl$26(), _el$106 = _el$105.firstChild;
-                _el$106.$$click = () => {
+                var _el$111 = _tmpl$27(), _el$112 = _el$111.firstChild;
+                _el$112.$$click = () => {
                   void logoutHostedPlayerSession();
                 };
-                insert(_el$106, () => tr(locale(), "释放玩家会话", "Release Player Session"));
-                return _el$105;
+                insert(_el$112, () => tr(locale(), "释放玩家会话", "Release Player Session"));
+                return _el$111;
               }
             })];
           }
         });
       }
-    }), _el$107);
-    insert(_el$110, () => tr(locale(), "运行诊断", "Runtime Diagnostics"));
-    insert(_el$111, () => tr(locale(), "执行 lane、auth/session、托管矩阵与最近事件都收在这里，避免它们继续抢占主玩法首屏。", "Execution lanes, auth/session truth, hosted matrix, and recent events live here so they no longer dominate the primary gameplay viewport."));
-    insert(_el$112, createComponent(For, {
+    }), _el$113);
+    insert(_el$116, () => tr(locale(), "运行诊断", "Runtime Diagnostics"));
+    insert(_el$117, () => tr(locale(), "执行 lane、auth/session、托管矩阵与最近事件都收在这里，避免它们继续抢占主玩法首屏。", "Execution lanes, auth/session truth, hosted matrix, and recent events live here so they no longer dominate the primary gameplay viewport."));
+    insert(_el$118, createComponent(For, {
       get each() {
         return diagnosticsSummaryBadges();
       },
@@ -7134,53 +7205,53 @@ function WorldSummaryPanel() {
         children: label
       })
     }));
-    insert(_el$114, createComponent(Badge, {
+    insert(_el$120, createComponent(Badge, {
       get children() {
         return `ws=${state$1.wsUrl || "-"}`;
       }
     }), null);
-    insert(_el$114, createComponent(Badge, {
+    insert(_el$120, createComponent(Badge, {
       get children() {
         return `entryReason=${state$1.viewerReason || "-"}`;
       }
     }), null);
-    insert(_el$114, createComponent(Badge, {
+    insert(_el$120, createComponent(Badge, {
       get children() {
         return `renderer=${state$1.renderer || "n/a"}`;
       }
     }), null);
-    insert(_el$114, createComponent(Badge, {
+    insert(_el$120, createComponent(Badge, {
       get children() {
         return `controlProfile=${state$1.controlProfile}`;
       }
     }), null);
-    insert(_el$113, createComponent(PanelSection, {
+    insert(_el$119, createComponent(PanelSection, {
       get title() {
         return tr(locale(), "执行 Lane", "Execution Lanes");
       },
       get children() {
         return [(() => {
-          var _el$115 = _tmpl$14();
-          insert(_el$115, createComponent(Badge, {
+          var _el$121 = _tmpl$14();
+          insert(_el$121, createComponent(Badge, {
             "class": "badge badge--accent",
             children: "debug_viewer"
           }), null);
-          insert(_el$115, createComponent(Badge, {
+          insert(_el$121, createComponent(Badge, {
             get children() {
               return `status=${state$1.debugViewerStatus}`;
             }
           }), null);
-          insert(_el$115, createComponent(Badge, {
+          insert(_el$121, createComponent(Badge, {
             get children() {
               return `renderMode=${state$1.renderMode}`;
             }
           }), null);
-          insert(_el$115, createComponent(Badge, {
+          insert(_el$121, createComponent(Badge, {
             get children() {
               return `entryReason=${state$1.viewerReason || "-"}`;
             }
           }), null);
-          return _el$115;
+          return _el$121;
         })(), createComponent(EmptyState, {
           style: "margin-top:-2px;",
           get children() {
@@ -7196,99 +7267,99 @@ function WorldSummaryPanel() {
             });
           },
           children: (debug) => [(() => {
-            var _el$164 = _tmpl$14();
-            insert(_el$164, createComponent(Badge, {
+            var _el$170 = _tmpl$14();
+            insert(_el$170, createComponent(Badge, {
               "class": "badge badge--accent",
               children: "selected agent lane"
             }), null);
-            insert(_el$164, createComponent(Badge, {
+            insert(_el$170, createComponent(Badge, {
               get children() {
                 return `provider=${debug().provider_mode || "-"}`;
               }
             }), null);
-            insert(_el$164, createComponent(Badge, {
+            insert(_el$170, createComponent(Badge, {
               get children() {
                 return `mode=${debug().execution_mode || "-"}`;
               }
             }), null);
-            insert(_el$164, createComponent(Badge, {
+            insert(_el$170, createComponent(Badge, {
               get children() {
                 return `env=${debug().environment_class || "-"}`;
               }
             }), null);
-            return _el$164;
+            return _el$170;
           })(), (() => {
-            var _el$165 = _tmpl$14();
-            insert(_el$165, createComponent(Badge, {
+            var _el$171 = _tmpl$14();
+            insert(_el$171, createComponent(Badge, {
               get children() {
                 return `obs=${debug().observation_schema_version || "-"}`;
               }
             }), null);
-            insert(_el$165, createComponent(Badge, {
+            insert(_el$171, createComponent(Badge, {
               get children() {
                 return `act=${debug().action_schema_version || "-"}`;
               }
             }), null);
-            insert(_el$165, createComponent(Badge, {
+            insert(_el$171, createComponent(Badge, {
               get children() {
                 return `agentProfile=${debug().agent_profile || "-"}`;
               }
             }), null);
-            insert(_el$165, createComponent(Badge, {
+            insert(_el$171, createComponent(Badge, {
               get children() {
                 return `providerFallback=${debug().fallback_reason || "-"}`;
               }
             }), null);
-            return _el$165;
+            return _el$171;
           })(), createComponent(EmptyState, {
             style: "margin-top:-2px;",
             get children() {
               return tr(locale(), "上面的 lane badge 表示 phase-1 期望执行 contract；下面的 provider check badge 表示 runtime_live 基于 /v1/provider/info 和 /v1/provider/health 的真实探测结果。", "Lane badges show the expected phase-1 execution contract. Provider check badges below show the actual runtime_live probe against /v1/provider/info and /v1/provider/health.");
             }
           }), (() => {
-            var _el$166 = _tmpl$14();
-            insert(_el$166, createComponent(Badge, {
+            var _el$172 = _tmpl$14();
+            insert(_el$172, createComponent(Badge, {
               "class": "badge badge--accent",
               children: "provider check"
             }), null);
-            insert(_el$166, createComponent(Badge, {
+            insert(_el$172, createComponent(Badge, {
               get children() {
                 return `status=${debug().provider_check_status || "-"}`;
               }
             }), null);
-            insert(_el$166, createComponent(Badge, {
+            insert(_el$172, createComponent(Badge, {
               get children() {
                 return `source=${debug().provider_check_source || "-"}`;
               }
             }), null);
-            insert(_el$166, createComponent(Badge, {
+            insert(_el$172, createComponent(Badge, {
               get children() {
                 return `fallback=${debug().provider_check_fallback_reason || "-"}`;
               }
             }), null);
-            return _el$166;
+            return _el$172;
           })(), createComponent(Show, {
             get when() {
               return debug().provider_check_error || debug().provider_reported_capabilities?.length || debug().provider_reported_supported_action_sets?.length;
             },
             get children() {
-              var _el$167 = _tmpl$14();
-              insert(_el$167, createComponent(Badge, {
+              var _el$173 = _tmpl$14();
+              insert(_el$173, createComponent(Badge, {
                 get children() {
                   return `actualCaps=${(debug().provider_reported_capabilities || []).join(",") || "-"}`;
                 }
               }), null);
-              insert(_el$167, createComponent(Badge, {
+              insert(_el$173, createComponent(Badge, {
                 get children() {
                   return `actualActions=${(debug().provider_reported_supported_action_sets || []).join(",") || "-"}`;
                 }
               }), null);
-              insert(_el$167, createComponent(Badge, {
+              insert(_el$173, createComponent(Badge, {
                 get children() {
                   return `checkError=${debug().provider_check_error || "-"}`;
                 }
               }), null);
-              return _el$167;
+              return _el$173;
             }
           }), createComponent(JsonBlock, {
             get value() {
@@ -7297,8 +7368,8 @@ function WorldSummaryPanel() {
           })]
         })];
       }
-    }), _el$116);
-    insert(_el$116, createComponent(Badge, {
+    }), _el$122);
+    insert(_el$122, createComponent(Badge, {
       get ["class"]() {
         return state$1.auth.available ? "badge badge--good" : "badge badge--warn";
       },
@@ -7306,71 +7377,71 @@ function WorldSummaryPanel() {
         return `auth=${state$1.auth.available ? state$1.auth.registrationStatus || "ready" : "missing"}`;
       }
     }), null);
-    insert(_el$116, createComponent(Badge, {
+    insert(_el$122, createComponent(Badge, {
       "class": "badge badge--accent",
       get children() {
         return `tier=${authSurface().currentTier}`;
       }
     }), null);
-    insert(_el$116, createComponent(Badge, {
+    insert(_el$122, createComponent(Badge, {
       get children() {
         return `source=${authSurface().source}`;
       }
     }), null);
-    insert(_el$116, createComponent(Badge, {
+    insert(_el$122, createComponent(Badge, {
       get children() {
         return `deploymentHint=${authSurface().deploymentHint}`;
       }
     }), null);
-    insert(_el$116, createComponent(Badge, {
+    insert(_el$122, createComponent(Badge, {
       get children() {
         return `player=${state$1.auth.playerId || "-"}`;
       }
     }), null);
-    insert(_el$116, createComponent(Badge, {
+    insert(_el$122, createComponent(Badge, {
       get children() {
         return `pubkey=${state$1.auth.publicKey ? `${state$1.auth.publicKey.slice(0, 10)}…` : "-"}`;
       }
     }), null);
-    insert(_el$116, createComponent(Badge, {
+    insert(_el$122, createComponent(Badge, {
       get children() {
         return `epoch=${state$1.auth.sessionEpoch == null ? "-" : state$1.auth.sessionEpoch}`;
       }
     }), null);
-    insert(_el$116, createComponent(Badge, {
+    insert(_el$122, createComponent(Badge, {
       get children() {
         return `runtime=${state$1.auth.runtimeStatus || "-"}`;
       }
     }), null);
-    insert(_el$116, createComponent(Badge, {
+    insert(_el$122, createComponent(Badge, {
       get children() {
         return `boundAgent=${state$1.auth.boundAgentId || "-"}`;
       }
     }), null);
-    insert(_el$116, createComponent(Badge, {
+    insert(_el$122, createComponent(Badge, {
       get children() {
         return `requestedAgent=${state$1.auth.pendingRequestedAgentId || "-"}`;
       }
     }), null);
-    insert(_el$116, createComponent(Badge, {
+    insert(_el$122, createComponent(Badge, {
       get children() {
         return state$1.auth.pendingForceRebind ? "rebind=forcing" : "rebind=idle";
       }
     }), null);
-    insert(_el$117, createComponent(Show, {
+    insert(_el$123, createComponent(Show, {
       get when() {
         return memo(() => !!state$1.auth.available)() && state$1.auth.source !== "legacy_viewer_auth_bootstrap";
       },
       get children() {
-        var _el$118 = _tmpl$27();
-        _el$118.$$click = () => {
+        var _el$124 = _tmpl$28();
+        _el$124.$$click = () => {
           void logoutHostedPlayerSession();
         };
-        insert(_el$118, () => tr(locale(), "释放玩家会话", "Release Player Session"));
-        return _el$118;
+        insert(_el$124, () => tr(locale(), "释放玩家会话", "Release Player Session"));
+        return _el$124;
       }
     }));
-    insert(_el$113, createComponent(Show, {
+    insert(_el$119, createComponent(Show, {
       get when() {
         return hostedRecoveryHint();
       },
@@ -7379,8 +7450,8 @@ function WorldSummaryPanel() {
           return hint().detail;
         }
       })
-    }), _el$125);
-    insert(_el$113, createComponent(Show, {
+    }), _el$131);
+    insert(_el$119, createComponent(Show, {
       get when() {
         return memo(() => !!!state$1.auth.available)() && String(state$1.hostedAccess?.deployment_mode || "").trim() === "hosted_public_join";
       },
@@ -7394,124 +7465,124 @@ function WorldSummaryPanel() {
           codeId: "diag-hosted-login-code"
         });
       }
-    }), _el$125);
-    insert(_el$113, createComponent(Show, {
+    }), _el$131);
+    insert(_el$119, createComponent(Show, {
       get when() {
         return state$1.auth.recoveryErrorCode || state$1.auth.recoveryErrorMessage;
       },
       get children() {
-        var _el$119 = _tmpl$14();
-        insert(_el$119, createComponent(Badge, {
+        var _el$125 = _tmpl$14();
+        insert(_el$125, createComponent(Badge, {
           "class": "badge badge--warn",
           get children() {
             return `recoveryError=${state$1.auth.recoveryErrorCode || "-"}`;
           }
         }), null);
-        insert(_el$119, createComponent(Badge, {
+        insert(_el$125, createComponent(Badge, {
           get children() {
             return state$1.auth.recoveryErrorMessage || "-";
           }
         }), null);
-        return _el$119;
+        return _el$125;
       }
-    }), _el$125);
-    insert(_el$113, createComponent(Show, {
+    }), _el$131);
+    insert(_el$119, createComponent(Show, {
       get when() {
         return showRebindNotice();
       },
       get children() {
         return [(() => {
-          var _el$120 = _tmpl$14();
-          insert(_el$120, createComponent(Badge, {
+          var _el$126 = _tmpl$14();
+          insert(_el$126, createComponent(Badge, {
             "class": "badge badge--accent",
             children: "rebind"
           }), null);
-          insert(_el$120, createComponent(Badge, {
+          insert(_el$126, createComponent(Badge, {
             get children() {
               return `target=${state$1.auth.pendingRequestedAgentId || "-"}`;
             }
           }), null);
-          insert(_el$120, createComponent(Badge, {
+          insert(_el$126, createComponent(Badge, {
             get children() {
               return state$1.auth.pendingForceRebind ? "mode=force_rebind" : "mode=awaiting_retry";
             }
           }), null);
-          return _el$120;
+          return _el$126;
         })(), createComponent(EmptyState, {
           children: "Player session is switching to the requested agent and the current action will continue after registration succeeds."
         })];
       }
-    }), _el$125);
-    insert(_el$113, createComponent(Show, {
+    }), _el$131);
+    insert(_el$119, createComponent(Show, {
       get when() {
         return state$1.hostedAdmission;
       },
       children: (admission) => (() => {
-        var _el$168 = _tmpl$14();
-        insert(_el$168, createComponent(Badge, {
+        var _el$174 = _tmpl$14();
+        insert(_el$174, createComponent(Badge, {
           get children() {
             return `activeSlots=${admission().active_player_sessions}/${admission().max_player_sessions}`;
           }
         }), null);
-        insert(_el$168, createComponent(Badge, {
+        insert(_el$174, createComponent(Badge, {
           get children() {
             return `effectiveSlots=${admission().effective_player_sessions == null ? "-" : `${admission().effective_player_sessions}/${admission().max_player_sessions}`}`;
           }
         }), null);
-        insert(_el$168, createComponent(Badge, {
+        insert(_el$174, createComponent(Badge, {
           get children() {
             return `runtimeBound=${admission().runtime_bound_player_sessions ?? "-"}`;
           }
         }), null);
-        insert(_el$168, createComponent(Badge, {
+        insert(_el$174, createComponent(Badge, {
           get children() {
             return `runtimeOnly=${admission().runtime_only_player_sessions ?? "-"}`;
           }
         }), null);
-        insert(_el$168, createComponent(Badge, {
+        insert(_el$174, createComponent(Badge, {
           get children() {
             return `runtimeProbe=${admission().runtime_probe_status || "-"}`;
           }
         }), null);
-        insert(_el$168, createComponent(Badge, {
+        insert(_el$174, createComponent(Badge, {
           get children() {
             return `issueBudget=${admission().remaining_issue_budget}`;
           }
         }), null);
-        insert(_el$168, createComponent(Badge, {
+        insert(_el$174, createComponent(Badge, {
           get children() {
             return `leaseTTL=${admission().slot_lease_ttl_ms}`;
           }
         }), null);
-        insert(_el$168, createComponent(Badge, {
+        insert(_el$174, createComponent(Badge, {
           get children() {
             return `issued=${admission().issued_players_total}`;
           }
         }), null);
-        insert(_el$168, createComponent(Badge, {
+        insert(_el$174, createComponent(Badge, {
           get children() {
             return `released=${admission().released_players_total}`;
           }
         }), null);
-        return _el$168;
+        return _el$174;
       })()
-    }), _el$125);
-    insert(_el$113, createComponent(Show, {
+    }), _el$131);
+    insert(_el$119, createComponent(Show, {
       get when() {
         return state$1.hostedAdmission?.runtime_probe_error;
       },
       get children() {
-        var _el$121 = _tmpl$14();
-        insert(_el$121, createComponent(Badge, {
+        var _el$127 = _tmpl$14();
+        insert(_el$127, createComponent(Badge, {
           "class": "badge badge--warn",
           get children() {
             return `runtimeProbeError=${state$1.hostedAdmission.runtime_probe_error}`;
           }
         }));
-        return _el$121;
+        return _el$127;
       }
-    }), _el$125);
-    insert(_el$113, createComponent(PanelSection, {
+    }), _el$131);
+    insert(_el$119, createComponent(PanelSection, {
       title: "Session Ladder",
       get children() {
         return [createComponent(EmptyState, {
@@ -7519,8 +7590,8 @@ function WorldSummaryPanel() {
             return authSurface().currentTierReason;
           }
         }), (() => {
-          var _el$122 = _tmpl$28();
-          insert(_el$122, createComponent(For, {
+          var _el$128 = _tmpl$29();
+          insert(_el$128, createComponent(For, {
             get each() {
               return authSurface().tiers;
             },
@@ -7539,10 +7610,10 @@ function WorldSummaryPanel() {
               }
             })
           }));
-          return _el$122;
+          return _el$128;
         })(), (() => {
-          var _el$123 = _tmpl$14();
-          insert(_el$123, createComponent(Badge, {
+          var _el$129 = _tmpl$14();
+          insert(_el$129, createComponent(Badge, {
             get ["class"]() {
               return authSurface().capabilities.prompt_control.enabled ? "badge badge--good" : "badge badge--warn";
             },
@@ -7550,7 +7621,7 @@ function WorldSummaryPanel() {
               return `prompt=${authSurface().capabilities.prompt_control.enabled ? "enabled" : authSurface().capabilities.prompt_control.code}`;
             }
           }), null);
-          insert(_el$123, createComponent(Badge, {
+          insert(_el$129, createComponent(Badge, {
             get ["class"]() {
               return authSurface().capabilities.agent_chat.enabled ? "badge badge--good" : "badge badge--warn";
             },
@@ -7558,21 +7629,21 @@ function WorldSummaryPanel() {
               return `chat=${authSurface().capabilities.agent_chat.enabled ? "enabled" : authSurface().capabilities.agent_chat.code}`;
             }
           }), null);
-          insert(_el$123, createComponent(Badge, {
+          insert(_el$129, createComponent(Badge, {
             "class": "badge badge--warn",
             get children() {
               return `mainToken=${authSurface().capabilities.main_token_transfer.code}`;
             }
           }), null);
-          return _el$123;
+          return _el$129;
         })(), createComponent(EmptyState, {
           get children() {
             return authSurface().reconnect;
           }
         })];
       }
-    }), _el$125);
-    insert(_el$113, createComponent(Show, {
+    }), _el$131);
+    insert(_el$119, createComponent(Show, {
       get when() {
         return hostedActionMatrixView().length > 0;
       },
@@ -7587,8 +7658,8 @@ function WorldSummaryPanel() {
                 return tr(locale(), "这里是 launcher 导出的 hosted public-join 真值面。QA 应该直接读取这些 action id，而不是只靠按钮状态推断。", "This is the hosted public-join truth surface exported by the launcher. QA should read these action ids directly instead of inferring from button state alone.");
               }
             }), (() => {
-              var _el$124 = _tmpl$28();
-              insert(_el$124, createComponent(For, {
+              var _el$130 = _tmpl$29();
+              insert(_el$130, createComponent(For, {
                 get each() {
                   return hostedActionMatrixView();
                 },
@@ -7625,13 +7696,13 @@ function WorldSummaryPanel() {
                   }
                 })
               }));
-              return _el$124;
+              return _el$130;
             })()];
           }
         });
       }
-    }), _el$125);
-    insert(_el$125, createComponent(MetricCard, {
+    }), _el$131);
+    insert(_el$131, createComponent(MetricCard, {
       get label() {
         return tr(locale(), "Prompt 反馈", "Prompt Feedback");
       },
@@ -7656,7 +7727,7 @@ function WorldSummaryPanel() {
         });
       }
     }), null);
-    insert(_el$125, createComponent(MetricCard, {
+    insert(_el$131, createComponent(MetricCard, {
       get label() {
         return tr(locale(), "聊天反馈", "Chat Feedback");
       },
@@ -7681,8 +7752,8 @@ function WorldSummaryPanel() {
         });
       }
     }), null);
-    insert(_el$127, () => tr(locale(), "最近事件", "Recent Events"));
-    insert(_el$128, createComponent(Show, {
+    insert(_el$133, () => tr(locale(), "最近事件", "Recent Events"));
+    insert(_el$134, createComponent(Show, {
       get when() {
         return state$1.recentEvents.length > 0;
       },
@@ -7719,7 +7790,7 @@ function WorldSummaryPanel() {
         });
       }
     }));
-    return _el$103;
+    return _el$109;
   })();
 }
 function InteractionPanel() {
@@ -7761,19 +7832,19 @@ function InteractionPanel() {
     });
   }
   return (() => {
-    var _el$169 = _tmpl$45(), _el$170 = _el$169.firstChild, _el$172 = _el$170.nextSibling;
-    insert(_el$170, createComponent(Badge, {
+    var _el$175 = _tmpl$46(), _el$176 = _el$175.firstChild, _el$178 = _el$176.nextSibling;
+    insert(_el$176, createComponent(Badge, {
       "class": "badge badge--accent",
       get children() {
         return tr(locale(), "当前交互目标", "Current Target");
       }
     }), null);
-    insert(_el$170, createComponent(Badge, {
+    insert(_el$176, createComponent(Badge, {
       get children() {
         return `agent=${agentId()}`;
       }
     }), null);
-    insert(_el$170, createComponent(Badge, {
+    insert(_el$176, createComponent(Badge, {
       get ["class"]() {
         return chatCapability().enabled ? "badge badge--good" : "badge badge--warn";
       },
@@ -7781,7 +7852,7 @@ function InteractionPanel() {
         return memo(() => !!chatCapability().enabled)() ? tr(locale(), "聊天可用", "Chat Ready") : tr(locale(), "聊天受限", "Chat Limited");
       }
     }), null);
-    insert(_el$169, createComponent(Show, {
+    insert(_el$175, createComponent(Show, {
       get when() {
         return debugContext()?.provider_mode === "provider_loopback_http";
       },
@@ -7792,8 +7863,8 @@ function InteractionPanel() {
           }
         });
       }
-    }), _el$172);
-    insert(_el$169, createComponent(Show, {
+    }), _el$178);
+    insert(_el$175, createComponent(Show, {
       get when() {
         return debugContext()?.provider_mode !== "provider_loopback_http";
       },
@@ -7811,24 +7882,24 @@ function InteractionPanel() {
           },
           get children() {
             return [(() => {
-              var _el$171 = _tmpl$14();
-              insert(_el$171, createComponent(Badge, {
+              var _el$177 = _tmpl$14();
+              insert(_el$177, createComponent(Badge, {
                 "class": "badge badge--good",
                 get children() {
                   return authSurface().currentTier;
                 }
               }), null);
-              insert(_el$171, createComponent(Badge, {
+              insert(_el$177, createComponent(Badge, {
                 get children() {
                   return `player=${state.auth.playerId}`;
                 }
               }), null);
-              insert(_el$171, createComponent(Badge, {
+              insert(_el$177, createComponent(Badge, {
                 get children() {
                   return `source=${authSurface().source}`;
                 }
               }), null);
-              return _el$171;
+              return _el$177;
             })(), createComponent(EmptyState, {
               get children() {
                 return promptCapability().reason;
@@ -7837,18 +7908,18 @@ function InteractionPanel() {
           }
         });
       }
-    }), _el$172);
-    insert(_el$172, createComponent(Badge, {
+    }), _el$178);
+    insert(_el$178, createComponent(Badge, {
       get children() {
         return `boundPlayer=${binding()?.playerId || "-"}`;
       }
     }), null);
-    insert(_el$172, createComponent(Badge, {
+    insert(_el$178, createComponent(Badge, {
       get children() {
         return `boundKey=${binding()?.publicKey ? `${binding().publicKey.slice(0, 10)}…` : "-"}`;
       }
     }), null);
-    insert(_el$172, createComponent(Badge, {
+    insert(_el$178, createComponent(Badge, {
       get ["class"]() {
         return promptCapability().enabled ? "badge badge--good" : "badge badge--warn";
       },
@@ -7856,7 +7927,7 @@ function InteractionPanel() {
         return `prompt=${promptCapability().enabled ? "enabled" : promptCapability().code}`;
       }
     }), null);
-    insert(_el$172, createComponent(Badge, {
+    insert(_el$178, createComponent(Badge, {
       get ["class"]() {
         return chatCapability().enabled ? "badge badge--good" : "badge badge--warn";
       },
@@ -7864,7 +7935,7 @@ function InteractionPanel() {
         return `chat=${chatCapability().enabled ? "enabled" : chatCapability().code}`;
       }
     }), null);
-    insert(_el$172, createComponent(Badge, {
+    insert(_el$178, createComponent(Badge, {
       get ["class"]() {
         return mainTokenTransferCapability().enabled ? "badge badge--good" : "badge badge--warn";
       },
@@ -7872,12 +7943,12 @@ function InteractionPanel() {
         return `mainToken=${assetLaneStatusText()}`;
       }
     }), null);
-    insert(_el$169, createComponent(EmptyState, {
+    insert(_el$175, createComponent(EmptyState, {
       get children() {
         return assetLaneDetail();
       }
     }), null);
-    insert(_el$169, createComponent(PanelSection, {
+    insert(_el$175, createComponent(PanelSection, {
       get title() {
         return tr(locale(), "Agent 聊天", "Agent Chat");
       },
@@ -7889,29 +7960,29 @@ function InteractionPanel() {
       },
       get children() {
         return [(() => {
-          var _el$173 = _tmpl$34(), _el$174 = _el$173.firstChild, _el$175 = _el$174.nextSibling;
-          insert(_el$174, () => tr(locale(), "消息", "Message"));
-          _el$175.$$input = (event) => {
+          var _el$179 = _tmpl$35(), _el$180 = _el$179.firstChild, _el$181 = _el$180.nextSibling;
+          insert(_el$180, () => tr(locale(), "消息", "Message"));
+          _el$181.$$input = (event) => {
             state.chatDraft.message = String(event.currentTarget.value || "");
             state.chatDraft.dirty = true;
           };
           createRenderEffect((_p$) => {
             var _v$10 = tr(locale(), "给当前选中的 Agent 发一条消息", "Send a message to the selected agent"), _v$11 = !chatCapability().enabled;
-            _v$10 !== _p$.e && setAttribute(_el$175, "placeholder", _p$.e = _v$10);
-            _v$11 !== _p$.t && (_el$175.disabled = _p$.t = _v$11);
+            _v$10 !== _p$.e && setAttribute(_el$181, "placeholder", _p$.e = _v$10);
+            _v$11 !== _p$.t && (_el$181.disabled = _p$.t = _v$11);
             return _p$;
           }, {
             e: void 0,
             t: void 0
           });
-          createRenderEffect(() => _el$175.value = state.chatDraft.message);
-          return _el$173;
+          createRenderEffect(() => _el$181.value = state.chatDraft.message);
+          return _el$179;
         })(), (() => {
-          var _el$176 = _tmpl$35(), _el$177 = _el$176.firstChild;
-          _el$177.$$click = () => sendAgentChat(agentId(), state.chatDraft.message);
-          insert(_el$177, () => tr(locale(), "发送聊天", "Send Chat"));
-          createRenderEffect(() => _el$177.disabled = !chatCapability().enabled);
-          return _el$176;
+          var _el$182 = _tmpl$36(), _el$183 = _el$182.firstChild;
+          _el$183.$$click = () => sendAgentChat(agentId(), state.chatDraft.message);
+          insert(_el$183, () => tr(locale(), "发送聊天", "Send Chat"));
+          createRenderEffect(() => _el$183.disabled = !chatCapability().enabled);
+          return _el$182;
         })(), createComponent(Show, {
           get when() {
             return chatFeedback();
@@ -7932,9 +8003,9 @@ function InteractionPanel() {
             }
           })
         }), (() => {
-          var _el$178 = _tmpl$36(), _el$179 = _el$178.firstChild, _el$180 = _el$179.nextSibling;
-          insert(_el$179, () => tr(locale(), "消息流", "Message Flow"));
-          insert(_el$180, createComponent(Show, {
+          var _el$184 = _tmpl$37(), _el$185 = _el$184.firstChild, _el$186 = _el$185.nextSibling;
+          insert(_el$185, () => tr(locale(), "消息流", "Message Flow"));
+          insert(_el$186, createComponent(Show, {
             get when() {
               return chatHistory().length > 0;
             },
@@ -7969,11 +8040,11 @@ function InteractionPanel() {
               });
             }
           }));
-          return _el$178;
+          return _el$184;
         })()];
       }
     }), null);
-    insert(_el$169, createComponent(PanelSection, {
+    insert(_el$175, createComponent(PanelSection, {
       get title() {
         return tr(locale(), "高级 Prompt 设置", "Advanced Prompt Settings");
       },
@@ -7985,18 +8056,18 @@ function InteractionPanel() {
       },
       get children() {
         return [(() => {
-          var _el$181 = _tmpl$14();
-          insert(_el$181, createComponent(Badge, {
+          var _el$187 = _tmpl$14();
+          insert(_el$187, createComponent(Badge, {
             get children() {
               return `activePrompt=v${promptVersionState().currentVersion}`;
             }
           }), null);
-          insert(_el$181, createComponent(Badge, {
+          insert(_el$187, createComponent(Badge, {
             get children() {
               return `nextRollback=v${promptVersionState().nextRollbackTargetVersion}`;
             }
           }), null);
-          insert(_el$181, createComponent(Show, {
+          insert(_el$187, createComponent(Show, {
             get when() {
               return promptVersionState().restoredFromVersion != null;
             },
@@ -8008,7 +8079,7 @@ function InteractionPanel() {
               });
             }
           }), null);
-          insert(_el$181, createComponent(Badge, {
+          insert(_el$187, createComponent(Badge, {
             get ["class"]() {
               return promptOverridesVisible() ? "badge badge--good" : "badge";
             },
@@ -8016,25 +8087,25 @@ function InteractionPanel() {
               return memo(() => !!promptOverridesVisible())() ? tr(locale(), "状态=已展开", "state=expanded") : tr(locale(), "状态=默认收起", "state=hidden_by_default");
             }
           }), null);
-          insert(_el$181, createComponent(Badge, {
+          insert(_el$187, createComponent(Badge, {
             get children() {
               return tr(locale(), "本地设置持久化", "locally persisted");
             }
           }), null);
-          return _el$181;
+          return _el$187;
         })(), createComponent(EmptyState, {
           get children() {
             return promptSettingsSummary();
           }
         }), (() => {
-          var _el$182 = _tmpl$37(), _el$183 = _el$182.firstChild;
-          _el$183.$$click = () => togglePromptOverridesVisible();
-          insert(_el$183, promptSettingsButtonLabel);
-          return _el$182;
+          var _el$188 = _tmpl$38(), _el$189 = _el$188.firstChild;
+          _el$189.$$click = () => togglePromptOverridesVisible();
+          insert(_el$189, promptSettingsButtonLabel);
+          return _el$188;
         })()];
       }
     }), null);
-    insert(_el$169, createComponent(Show, {
+    insert(_el$175, createComponent(Show, {
       get when() {
         return promptOverridesVisible();
       },
@@ -8043,97 +8114,97 @@ function InteractionPanel() {
           title: "Prompt Overrides",
           get children() {
             return [(() => {
-              var _el$184 = _tmpl$4();
-              insert(_el$184, () => promptVersionState().summary);
-              return _el$184;
+              var _el$190 = _tmpl$4();
+              insert(_el$190, () => promptVersionState().summary);
+              return _el$190;
             })(), (() => {
-              var _el$185 = _tmpl$4();
-              insert(_el$185, () => promptVersionState().detail);
-              return _el$185;
+              var _el$191 = _tmpl$4();
+              insert(_el$191, () => promptVersionState().detail);
+              return _el$191;
             })(), createComponent(Show, {
               get when() {
                 return memo(() => !!authSurface().capabilities.prompt_control.enabled)() && String(state.hostedAccess?.deployment_mode || "").trim() === "hosted_public_join";
               },
               get children() {
-                var _el$186 = _tmpl$38(), _el$187 = _el$186.firstChild, _el$188 = _el$187.nextSibling;
-                insert(_el$187, () => tr(locale(), "后端审批码", "Backend Approval Code"));
-                _el$188.$$input = (event) => {
+                var _el$192 = _tmpl$39(), _el$193 = _el$192.firstChild, _el$194 = _el$193.nextSibling;
+                insert(_el$193, () => tr(locale(), "后端审批码", "Backend Approval Code"));
+                _el$194.$$input = (event) => {
                   state.strongAuth.approvalCode = String(event.currentTarget.value || "");
                 };
-                createRenderEffect(() => _el$188.value = state.strongAuth.approvalCode || "");
-                return _el$186;
+                createRenderEffect(() => _el$194.value = state.strongAuth.approvalCode || "");
+                return _el$192;
               }
             }), (() => {
-              var _el$189 = _tmpl$39(), _el$190 = _el$189.firstChild, _el$191 = _el$190.nextSibling;
-              insert(_el$190, () => tr(locale(), "System Prompt 覆盖", "System Prompt Override"));
-              _el$191.$$input = (event) => {
+              var _el$195 = _tmpl$40(), _el$196 = _el$195.firstChild, _el$197 = _el$196.nextSibling;
+              insert(_el$196, () => tr(locale(), "System Prompt 覆盖", "System Prompt Override"));
+              _el$197.$$input = (event) => {
                 state.promptDraft.systemPrompt = String(event.currentTarget.value || "");
                 state.promptDraft.dirty = true;
               };
-              createRenderEffect(() => _el$191.disabled = !promptCapability().enabled);
-              createRenderEffect(() => _el$191.value = state.promptDraft.systemPrompt);
-              return _el$189;
+              createRenderEffect(() => _el$197.disabled = !promptCapability().enabled);
+              createRenderEffect(() => _el$197.value = state.promptDraft.systemPrompt);
+              return _el$195;
             })(), (() => {
-              var _el$192 = _tmpl$40(), _el$193 = _el$192.firstChild, _el$194 = _el$193.nextSibling;
-              insert(_el$193, () => tr(locale(), "短期目标覆盖", "Short-Term Goal Override"));
-              _el$194.$$input = (event) => {
+              var _el$198 = _tmpl$41(), _el$199 = _el$198.firstChild, _el$200 = _el$199.nextSibling;
+              insert(_el$199, () => tr(locale(), "短期目标覆盖", "Short-Term Goal Override"));
+              _el$200.$$input = (event) => {
                 state.promptDraft.shortTermGoal = String(event.currentTarget.value || "");
                 state.promptDraft.dirty = true;
               };
-              createRenderEffect(() => _el$194.disabled = !promptCapability().enabled);
-              createRenderEffect(() => _el$194.value = state.promptDraft.shortTermGoal);
-              return _el$192;
+              createRenderEffect(() => _el$200.disabled = !promptCapability().enabled);
+              createRenderEffect(() => _el$200.value = state.promptDraft.shortTermGoal);
+              return _el$198;
             })(), (() => {
-              var _el$195 = _tmpl$41(), _el$196 = _el$195.firstChild, _el$197 = _el$196.nextSibling;
-              insert(_el$196, () => tr(locale(), "长期目标覆盖", "Long-Term Goal Override"));
-              _el$197.$$input = (event) => {
+              var _el$201 = _tmpl$42(), _el$202 = _el$201.firstChild, _el$203 = _el$202.nextSibling;
+              insert(_el$202, () => tr(locale(), "长期目标覆盖", "Long-Term Goal Override"));
+              _el$203.$$input = (event) => {
                 state.promptDraft.longTermGoal = String(event.currentTarget.value || "");
                 state.promptDraft.dirty = true;
               };
-              createRenderEffect(() => _el$197.disabled = !promptCapability().enabled);
-              createRenderEffect(() => _el$197.value = state.promptDraft.longTermGoal);
-              return _el$195;
+              createRenderEffect(() => _el$203.disabled = !promptCapability().enabled);
+              createRenderEffect(() => _el$203.value = state.promptDraft.longTermGoal);
+              return _el$201;
             })(), (() => {
-              var _el$198 = _tmpl$42(), _el$199 = _el$198.firstChild, _el$200 = _el$199.nextSibling;
-              _el$199.$$click = () => sendPromptControl("preview", null);
-              insert(_el$199, () => tr(locale(), "预览 Prompt", "Preview Prompt"));
-              _el$200.$$click = () => sendPromptControl("apply", null);
-              insert(_el$200, () => tr(locale(), "应用 Prompt", "Apply Prompt"));
+              var _el$204 = _tmpl$43(), _el$205 = _el$204.firstChild, _el$206 = _el$205.nextSibling;
+              _el$205.$$click = () => sendPromptControl("preview", null);
+              insert(_el$205, () => tr(locale(), "预览 Prompt", "Preview Prompt"));
+              _el$206.$$click = () => sendPromptControl("apply", null);
+              insert(_el$206, () => tr(locale(), "应用 Prompt", "Apply Prompt"));
               createRenderEffect((_p$) => {
                 var _v$12 = !promptCapability().enabled, _v$13 = !promptCapability().enabled;
-                _v$12 !== _p$.e && (_el$199.disabled = _p$.e = _v$12);
-                _v$13 !== _p$.t && (_el$200.disabled = _p$.t = _v$13);
+                _v$12 !== _p$.e && (_el$205.disabled = _p$.e = _v$12);
+                _v$13 !== _p$.t && (_el$206.disabled = _p$.t = _v$13);
                 return _p$;
               }, {
                 e: void 0,
                 t: void 0
               });
-              return _el$198;
+              return _el$204;
             })(), (() => {
-              var _el$201 = _tmpl$43(), _el$202 = _el$201.firstChild, _el$203 = _el$202.firstChild, _el$204 = _el$203.nextSibling, _el$205 = _el$202.nextSibling;
-              insert(_el$203, () => tr(locale(), "下一次回滚目标版本", "Next Rollback Target Version"));
-              _el$204.$$input = (event) => {
+              var _el$207 = _tmpl$44(), _el$208 = _el$207.firstChild, _el$209 = _el$208.firstChild, _el$210 = _el$209.nextSibling, _el$211 = _el$208.nextSibling;
+              insert(_el$209, () => tr(locale(), "下一次回滚目标版本", "Next Rollback Target Version"));
+              _el$210.$$input = (event) => {
                 const nextValue = Number(event.currentTarget.value || 0);
                 state.promptDraft.rollbackTargetVersion = Math.max(0, Math.floor(nextValue || 0));
                 requestRender();
               };
-              _el$205.$$click = () => {
+              _el$211.$$click = () => {
                 sendPromptControl("rollback", {
                   toVersion: Number(state.promptDraft.rollbackTargetVersion || 0)
                 });
               };
-              insert(_el$205, () => tr(locale(), "回滚 Prompt", "Rollback Prompt"));
+              insert(_el$211, () => tr(locale(), "回滚 Prompt", "Rollback Prompt"));
               createRenderEffect((_p$) => {
                 var _v$14 = !promptCapability().enabled, _v$15 = !promptCapability().enabled;
-                _v$14 !== _p$.e && (_el$204.disabled = _p$.e = _v$14);
-                _v$15 !== _p$.t && (_el$205.disabled = _p$.t = _v$15);
+                _v$14 !== _p$.e && (_el$210.disabled = _p$.e = _v$14);
+                _v$15 !== _p$.t && (_el$211.disabled = _p$.t = _v$15);
                 return _p$;
               }, {
                 e: void 0,
                 t: void 0
               });
-              createRenderEffect(() => _el$204.value = Number(state.promptDraft.rollbackTargetVersion || 0));
-              return _el$201;
+              createRenderEffect(() => _el$210.value = Number(state.promptDraft.rollbackTargetVersion || 0));
+              return _el$207;
             })(), createComponent(Show, {
               get when() {
                 return promptFeedback();
@@ -8181,7 +8252,7 @@ function InteractionPanel() {
         });
       }
     }), null);
-    insert(_el$169, createComponent(PanelSection, {
+    insert(_el$175, createComponent(PanelSection, {
       get title() {
         return tr(locale(), "资产 / 治理 Lane", "Asset / Governance Lane");
       },
@@ -8193,8 +8264,8 @@ function InteractionPanel() {
       },
       get children() {
         return [(() => {
-          var _el$206 = _tmpl$14();
-          insert(_el$206, createComponent(Badge, {
+          var _el$212 = _tmpl$14();
+          insert(_el$212, createComponent(Badge, {
             get ["class"]() {
               return mainTokenTransferCapability().enabled ? "badge badge--good" : "badge badge--warn";
             },
@@ -8202,17 +8273,17 @@ function InteractionPanel() {
               return `main_token_transfer=${assetLaneStatusText()}`;
             }
           }), null);
-          insert(_el$206, createComponent(Badge, {
+          insert(_el$212, createComponent(Badge, {
             get children() {
               return `required_auth=${mainTokenTransferPolicy()?.required_auth || "-"}`;
             }
           }), null);
-          insert(_el$206, createComponent(Badge, {
+          insert(_el$212, createComponent(Badge, {
             get children() {
               return `availability=${mainTokenTransferPolicy()?.availability || "-"}`;
             }
           }), null);
-          return _el$206;
+          return _el$212;
         })(), createComponent(EmptyState, {
           get children() {
             return assetLaneDetail();
@@ -8222,13 +8293,13 @@ function InteractionPanel() {
             return mainTokenTransferPolicy()?.reason || tr(locale(), "当前 lane 没有 main_token_transfer 的 hosted action policy。", "No hosted action policy is available for main_token_transfer on this lane.");
           }
         }), (() => {
-          var _el$207 = _tmpl$44(), _el$208 = _el$207.firstChild;
-          insert(_el$208, () => tr(locale(), "主代币转账（这里暂未开放）", "Main Token Transfer (Not Exposed Here Yet)"));
-          return _el$207;
+          var _el$213 = _tmpl$45(), _el$214 = _el$213.firstChild;
+          insert(_el$214, () => tr(locale(), "主代币转账（这里暂未开放）", "Main Token Transfer (Not Exposed Here Yet)"));
+          return _el$213;
         })()];
       }
     }), null);
-    return _el$169;
+    return _el$175;
   })();
 }
 function DetailsPanel() {
@@ -8255,20 +8326,20 @@ function DetailsPanel() {
   });
   const hasSnapshotDiagnostics = () => !!state.snapshot || !!state.metrics || !!state.hostedAccess;
   return (() => {
-    var _el$209 = _tmpl$47(), _el$210 = _el$209.firstChild, _el$211 = _el$210.nextSibling, _el$212 = _el$211.firstChild, _el$213 = _el$212.nextSibling, _el$214 = _el$213.nextSibling, _el$215 = _el$214.firstChild, _el$216 = _el$215.nextSibling, _el$217 = _el$216.nextSibling, _el$218 = _el$217.firstChild, _el$219 = _el$218.nextSibling;
-    insert(_el$210, createComponent(Badge, {
+    var _el$215 = _tmpl$48(), _el$216 = _el$215.firstChild, _el$217 = _el$216.nextSibling, _el$218 = _el$217.firstChild, _el$219 = _el$218.nextSibling, _el$220 = _el$219.nextSibling, _el$221 = _el$220.firstChild, _el$222 = _el$221.nextSibling, _el$223 = _el$222.nextSibling, _el$224 = _el$223.firstChild, _el$225 = _el$224.nextSibling;
+    insert(_el$216, createComponent(Badge, {
       "class": "badge badge--accent",
       get children() {
         return tr(locale(), "当前命令目标", "Current Command Target");
       }
     }), null);
-    insert(_el$210, createComponent(Badge, {
+    insert(_el$216, createComponent(Badge, {
       get children() {
         return selectedLabel();
       }
     }), null);
-    insert(_el$209, createComponent(InteractionPanel, {}), _el$211);
-    insert(_el$209, createComponent(Show, {
+    insert(_el$215, createComponent(InteractionPanel, {}), _el$217);
+    insert(_el$215, createComponent(Show, {
       get when() {
         return state.selectedObject;
       },
@@ -8299,29 +8370,29 @@ function DetailsPanel() {
         },
         value: () => clone(selected())
       })
-    }), _el$211);
-    insert(_el$212, () => tr(locale(), "世界规模", "World Scale"));
-    insert(_el$213, createComponent(Badge, {
+    }), _el$217);
+    insert(_el$218, () => tr(locale(), "世界规模", "World Scale"));
+    insert(_el$219, createComponent(Badge, {
       get children() {
         return `agents=${snapshotCounts().agents}`;
       }
     }), null);
-    insert(_el$213, createComponent(Badge, {
+    insert(_el$219, createComponent(Badge, {
       get children() {
         return `locations=${snapshotCounts().locations}`;
       }
     }), null);
-    insert(_el$213, createComponent(Badge, {
+    insert(_el$219, createComponent(Badge, {
       get children() {
         return `promptProfiles=${snapshotCounts().promptProfiles}`;
       }
     }), null);
-    insert(_el$213, createComponent(Badge, {
+    insert(_el$219, createComponent(Badge, {
       get children() {
         return `debugContexts=${snapshotCounts().executionDebugContexts}`;
       }
     }), null);
-    insert(_el$214, createComponent(MetricCard, {
+    insert(_el$220, createComponent(MetricCard, {
       get label() {
         return tr(locale(), "物理真值单位", "Canonical Physical Unit");
       },
@@ -8335,9 +8406,9 @@ function DetailsPanel() {
           }
         });
       }
-    }), _el$215);
-    insert(_el$215, () => worldScaleSurface().physicalTruth.canonicalUnitDetail);
-    insert(_el$214, createComponent(MetricCard, {
+    }), _el$221);
+    insert(_el$221, () => worldScaleSurface().physicalTruth.canonicalUnitDetail);
+    insert(_el$220, createComponent(MetricCard, {
       get label() {
         return tr(locale(), "世界边界", "World Bounds");
       },
@@ -8351,9 +8422,9 @@ function DetailsPanel() {
           }
         });
       }
-    }), _el$216);
-    insert(_el$216, () => worldScaleSurface().physicalTruth.worldBoundsDetail);
-    insert(_el$214, createComponent(Show, {
+    }), _el$222);
+    insert(_el$222, () => worldScaleSurface().physicalTruth.worldBoundsDetail);
+    insert(_el$220, createComponent(Show, {
       get when() {
         return worldScaleSurface().physicalTruth.anchor;
       },
@@ -8370,25 +8441,25 @@ function DetailsPanel() {
         },
         get children() {
           return [(() => {
-            var _el$226 = _tmpl$19();
-            insert(_el$226, () => anchor().positionLabel || tr(locale(), "缺少可读坐标。", "Missing readable coordinates."));
-            return _el$226;
+            var _el$232 = _tmpl$20();
+            insert(_el$232, () => anchor().positionLabel || tr(locale(), "缺少可读坐标。", "Missing readable coordinates."));
+            return _el$232;
           })(), createComponent(Show, {
             get when() {
               return anchor().radiusLabel;
             },
             get children() {
-              var _el$227 = _tmpl$48(), _el$228 = _el$227.firstChild;
-              insert(_el$227, () => tr(locale(), "地点半径真值", "Location radius truth"), _el$228);
-              insert(_el$227, () => anchor().radiusLabel, null);
-              return _el$227;
+              var _el$233 = _tmpl$49(), _el$234 = _el$233.firstChild;
+              insert(_el$233, () => tr(locale(), "地点半径真值", "Location radius truth"), _el$234);
+              insert(_el$233, () => anchor().radiusLabel, null);
+              return _el$233;
             }
           })];
         }
       })
-    }), _el$217);
-    insert(_el$218, () => tr(locale(), "最近距离样本", "Nearest Distance Samples"));
-    insert(_el$219, createComponent(Show, {
+    }), _el$223);
+    insert(_el$224, () => tr(locale(), "最近距离样本", "Nearest Distance Samples"));
+    insert(_el$225, createComponent(Show, {
       get when() {
         return worldScaleSurface().physicalTruth.nearestLocations.length > 0;
       },
@@ -8417,19 +8488,19 @@ function DetailsPanel() {
             },
             get children() {
               return [(() => {
-                var _el$229 = _tmpl$48(), _el$230 = _el$229.firstChild;
-                insert(_el$229, () => tr(locale(), "真实距离", "Physical distance"), _el$230);
-                insert(_el$229, () => location.distanceLabel || "-", null);
-                return _el$229;
+                var _el$235 = _tmpl$49(), _el$236 = _el$235.firstChild;
+                insert(_el$235, () => tr(locale(), "真实距离", "Physical distance"), _el$236);
+                insert(_el$235, () => location.distanceLabel || "-", null);
+                return _el$235;
               })(), createComponent(Show, {
                 get when() {
                   return location.radiusLabel;
                 },
                 get children() {
-                  var _el$231 = _tmpl$48(), _el$232 = _el$231.firstChild;
-                  insert(_el$231, () => tr(locale(), "地点半径", "Location radius"), _el$232);
-                  insert(_el$231, () => location.radiusLabel, null);
-                  return _el$231;
+                  var _el$237 = _tmpl$49(), _el$238 = _el$237.firstChild;
+                  insert(_el$237, () => tr(locale(), "地点半径", "Location radius"), _el$238);
+                  insert(_el$237, () => location.radiusLabel, null);
+                  return _el$237;
                 }
               })];
             }
@@ -8437,7 +8508,7 @@ function DetailsPanel() {
         });
       }
     }));
-    insert(_el$214, createComponent(EventCard, {
+    insert(_el$220, createComponent(EventCard, {
       get title() {
         return tr(locale(), "表现层说明", "Presentation Notes");
       },
@@ -8447,26 +8518,26 @@ function DetailsPanel() {
       badgeClass: "badge badge--warn",
       get children() {
         return [(() => {
-          var _el$220 = _tmpl$19();
-          insert(_el$220, () => worldScaleSurface().presentationScale.markerTruthNote);
-          return _el$220;
+          var _el$226 = _tmpl$20();
+          insert(_el$226, () => worldScaleSurface().presentationScale.markerTruthNote);
+          return _el$226;
         })(), (() => {
-          var _el$221 = _tmpl$4();
-          insert(_el$221, () => worldScaleSurface().presentationScale.zoomTruthNote);
-          return _el$221;
+          var _el$227 = _tmpl$4();
+          insert(_el$227, () => worldScaleSurface().presentationScale.zoomTruthNote);
+          return _el$227;
         })(), (() => {
-          var _el$222 = _tmpl$4();
-          insert(_el$222, () => worldScaleSurface().presentationScale.softwareSafeNote);
-          return _el$222;
+          var _el$228 = _tmpl$4();
+          insert(_el$228, () => worldScaleSurface().presentationScale.softwareSafeNote);
+          return _el$228;
         })()];
       }
     }), null);
-    insert(_el$214, createComponent(EmptyState, {
+    insert(_el$220, createComponent(EmptyState, {
       get children() {
         return tr(locale(), "主状态已经在中间的“世界摘要”里展示；这里现在专门保留“厘米真值 vs 表现层夸张”的读图锚点，原始快照仍按需展开。", "The main runtime state already lives in World Summary; this section now reserves the reading anchors for centimeter truth vs presentation exaggeration, while raw snapshots stay collapsible.");
       }
     }), null);
-    insert(_el$211, createComponent(Show, {
+    insert(_el$217, createComponent(Show, {
       get when() {
         return hasSnapshotDiagnostics();
       },
@@ -8485,46 +8556,46 @@ function DetailsPanel() {
         });
       }
     }), null);
-    insert(_el$209, createComponent(Show, {
+    insert(_el$215, createComponent(Show, {
       get when() {
         return state.lastError;
       },
       get children() {
-        var _el$223 = _tmpl$46(), _el$224 = _el$223.firstChild, _el$225 = _el$224.nextSibling;
-        insert(_el$224, () => tr(locale(), "最近错误", "Last Error"));
-        insert(_el$225, () => state.lastError);
-        return _el$223;
+        var _el$229 = _tmpl$47(), _el$230 = _el$229.firstChild, _el$231 = _el$230.nextSibling;
+        insert(_el$230, () => tr(locale(), "最近错误", "Last Error"));
+        insert(_el$231, () => state.lastError);
+        return _el$229;
       }
     }), null);
-    return _el$209;
+    return _el$215;
   })();
 }
 function AppShell() {
   const locale = () => uiLocale();
-  return [createComponent(MobileJumpRail, {}), (() => {
-    var _el$233 = _tmpl$49(), _el$234 = _el$233.firstChild, _el$235 = _el$234.firstChild, _el$236 = _el$235.nextSibling, _el$237 = _el$236.nextSibling, _el$238 = _el$234.nextSibling;
-    insert(_el$235, () => tr(locale(), "导航", "Navigate"));
-    insert(_el$236, () => tr(locale(), "目标", "Targets"));
-    insert(_el$237, () => tr(locale(), "先锁定对象，再进入世界舞台或右侧命令面。", "Lock onto a target first, then move into the stage or command surface."));
-    insert(_el$238, createComponent(TargetsPanel, {}));
-    return _el$233;
+  return [createComponent(MobileJumpRail, {}), createComponent(HostedLoginGate, {}), (() => {
+    var _el$239 = _tmpl$50(), _el$240 = _el$239.firstChild, _el$241 = _el$240.firstChild, _el$242 = _el$241.nextSibling, _el$243 = _el$242.nextSibling, _el$244 = _el$240.nextSibling;
+    insert(_el$241, () => tr(locale(), "导航", "Navigate"));
+    insert(_el$242, () => tr(locale(), "目标", "Targets"));
+    insert(_el$243, () => tr(locale(), "先锁定对象，再进入世界舞台或右侧命令面。", "Lock onto a target first, then move into the stage or command surface."));
+    insert(_el$244, createComponent(TargetsPanel, {}));
+    return _el$239;
   })(), (() => {
-    var _el$239 = _tmpl$50(), _el$240 = _el$239.firstChild, _el$241 = _el$240.firstChild;
-    insert(_el$241, createComponent(WorldStageHero, {}), null);
-    insert(_el$241, createComponent(PixelWorldHost, {
+    var _el$245 = _tmpl$51(), _el$246 = _el$245.firstChild, _el$247 = _el$246.firstChild;
+    insert(_el$247, createComponent(WorldStageHero, {}), null);
+    insert(_el$247, createComponent(PixelWorldHost, {
       get locale() {
         return locale();
       }
     }), null);
-    insert(_el$241, createComponent(WorldSummaryPanel, {}), null);
-    return _el$239;
+    insert(_el$247, createComponent(WorldSummaryPanel, {}), null);
+    return _el$245;
   })(), (() => {
-    var _el$242 = _tmpl$51(), _el$243 = _el$242.firstChild, _el$244 = _el$243.firstChild, _el$245 = _el$244.nextSibling, _el$246 = _el$245.nextSibling, _el$247 = _el$243.nextSibling;
-    insert(_el$244, () => tr(locale(), "指挥与核查", "Command and Inspect"));
-    insert(_el$245, () => tr(locale(), "交互与明细", "Interact and Inspect"));
-    insert(_el$246, () => tr(locale(), "只有锁定目标后才进入这里。聊天优先，Prompt 与对象核查继续后置。", "Enter this column only after locking a target. Chat comes first; prompt controls and raw inspection stay behind it."));
-    insert(_el$247, createComponent(DetailsPanel, {}));
-    return _el$242;
+    var _el$248 = _tmpl$52(), _el$249 = _el$248.firstChild, _el$250 = _el$249.firstChild, _el$251 = _el$250.nextSibling, _el$252 = _el$251.nextSibling, _el$253 = _el$249.nextSibling;
+    insert(_el$250, () => tr(locale(), "指挥与核查", "Command and Inspect"));
+    insert(_el$251, () => tr(locale(), "交互与明细", "Interact and Inspect"));
+    insert(_el$252, () => tr(locale(), "只有锁定目标后才进入这里。聊天优先，Prompt 与对象核查继续后置。", "Enter this column only after locking a target. Chat comes first; prompt controls and raw inspection stay behind it."));
+    insert(_el$253, createComponent(DetailsPanel, {}));
+    return _el$248;
   })()];
 }
 function mountViewerApp(root = document.getElementById("app")) {
@@ -8554,7 +8625,7 @@ if (autoMountRoot) {
 } else if (!shouldBypassAutoMountForTestApi()) {
   throw new Error("viewer root #app is missing");
 }
-delegateEvents(["input", "click"]);
+delegateEvents(["input", "click", "keydown"]);
 export {
   AppShell,
   mountViewerApp

--- a/doc/p2p/blockchain/p2p-hosted-public-join-managed-identity-custody-2026-05-18.prd.md
+++ b/doc/p2p/blockchain/p2p-hosted-public-join-managed-identity-custody-2026-05-18.prd.md
@@ -120,7 +120,7 @@
 - Environment Tiering Contract:
   - `dev`:
     - 目标: 本地开发、结构验证、单机 smoke。
-    - 允许: `OASIS7_HOSTED_ACCOUNT_STORE_BACKEND=file` 或无 OTS 配置下的 `auto` fallback，`OASIS7_HOSTED_LOGIN_DELIVERY_MODE=preview_inline|server_log_only`，临时测试邮箱，最小手工 smoke。
+    - 允许: `OASIS7_HOSTED_ACCOUNT_STORE_BACKEND=file` 或无 OTS 配置下的 `auto` fallback，临时测试邮箱，最小手工 smoke。
     - 禁止: 对外宣称为真实玩家入口；复用 staging/production 的 SMTP、Tablestore、strong-auth signer 或 approval code。
   - `staging`:
     - 目标: 受控测试用户试用、回归、演练、上线前 smoke。
@@ -129,7 +129,7 @@
     - 禁止: 与 production 共用邮箱投递、账户表、signer、风控阈值或 incident channel。
   - `production`:
     - 目标: 面向真实外部玩家的正式 hosted account 服务面。
-    - 要求: 必须使用独立真实 SMTP、独立托管账户存储、独立强鉴权 signer/custody 后端、正式告警与审计；不得启用 `preview_inline` 或 `server_log_only`。
+    - 要求: 必须使用独立真实 SMTP、独立托管账户存储、独立强鉴权 signer/custody 后端、正式告警与审计。
     - 要求: 上线前必须先通过 staging fresh smoke、operator runbook 演练与 claims review；production 只能共享“已批准的发布工件”，不能共享 staging 数据面。
     - 禁止: 复用 staging/dev 的邮箱、OTP、account store、approval code、tablestore table 或对外 claims。
 - Edge Cases & Error Handling:
@@ -176,7 +176,7 @@
 | PRD-P2P-029-D | device-session-and-runtime-binding / step-up-auth-and-risk-policy | `test_tier_required` | viewer UX、设备会话存储、step-up 状态与错误反馈回归 | 前端登录/重连/敏感动作文案 |
 | PRD-P2P-029-E | qa-abuse-and-liveops-runbook | `test_tier_required` + `test_tier_full` | 盗号、设备丢失、重复绑定、风控冻结、撤销与恢复 runbook | 运营事故、QA 阻断 |
 | PRD-P2P-029-F | external-wallet-bind-and-transfer-out | `test_tier_required` + `test_tier_full` | self-custody 升级、wallet bind、transfer-out 冷却与审计回归 | 账户迁移、custody exit |
-| PRD-P2P-029-G | hosted-account-env-tiering | `test_tier_required` | 文档冻结 `dev/staging/production` 边界；`rg -n "preview_inline|staging|production|tablestore|smtp|claims"` 覆盖 PRD/project/runbook；`./scripts/doc-governance-check.sh` + `git diff --check` | 环境隔离、试用/正式口径、operator 上线清单 |
+| PRD-P2P-029-G | hosted-account-env-tiering | `test_tier_required` | 文档冻结 `dev/staging/production` 边界；`rg -n "staging|production|tablestore|smtp|claims"` 覆盖 PRD/project/runbook；`./scripts/doc-governance-check.sh` + `git diff --check` | 环境隔离、试用/正式口径、operator 上线清单 |
 - Decision Log:
 | 决策ID | 选定方案 | 备选方案（否决） | 依据 |
 | --- | --- | --- | --- |

--- a/doc/p2p/blockchain/p2p-hosted-public-join-managed-identity-custody-2026-05-18.project.md
+++ b/doc/p2p/blockchain/p2p-hosted-public-join-managed-identity-custody-2026-05-18.project.md
@@ -107,7 +107,7 @@
   - 原子步骤:
     1. 新增 hosted account smoke 脚本，自动完成 `login/start -> login/complete -> player-session/release -> launcher restart -> stable account continuity`。
        - 验证命令: `bash ./scripts/hosted-account-staging-smoke.sh --mode local`
-       - 预期结果: 本地 `preview_inline + file backend` smoke 通过，并生成 summary artifact。
+       - 预期结果: 本地 `smtp + file backend + otp-fetch-command` smoke 通过，并生成 summary artifact。
     2. 将本地 smoke 接入 repo-owned required 自动化，同时保留 staging `smtp + otp-fetch-command` 入口。
        - 验证命令: `bash -n scripts/hosted-account-staging-smoke.sh && rg -n "hosted account local smoke|OASIS7_CI_RUN_HOSTED_ACCOUNT_SMOKE" scripts/ci-tests.sh`
        - 预期结果: `./scripts/ci-tests.sh required` 拥有稳定的本地 hosted account e2e smoke，而 staging 继续复用同一脚本。
@@ -207,10 +207,10 @@
 - 结论-1: 对 `hosted_public_join` 而言，“邮箱登录 + 中心化托管密钥 + 可选自托管升级”是比“让普通玩家保存公私钥”更合适的正式产品路径。
 - 结论-2: 中心化 KMS 不是直接替代全部产品语义；更准确的落法是 `identity broker + custody service + sign API`，KMS/HSM 作为 custody backend 的实现选项，而不是前端/运行时直接耦合的唯一接口。
 - 结论-3: 当前代码已经完成两刀 hosted identity 基线：其一是 `device_session` 收口，viewer 不再把 hosted player `privateKey` 持久化到 `localStorage`；其二是中心化 hosted account 登录 server，`oasis7_game_launcher` 现已提供 email login challenge、稳定 `hosted_account_id -> player_id` 持久化和登录后换发 `device_session + player_session` 的 public route，viewer 也已改成 hosted account 登录表单。
-- 结论-4: 当前登录投递已具备真实邮件链路：server 现支持 `preview_inline`、`server_log_only` 与 `smtp` 三种 challenge delivery mode，其中 `smtp` 通过 `OASIS7_HOSTED_LOGIN_SMTP_*` 环境变量加载配置，默认可对接 Aliyun DirectMail `smtpdm.aliyun.com:465`；同时 OTP start 路径已补 resend cooldown、短窗/长窗配额与 `retry_after_seconds` 反馈，避免前端只能盲目重试。
+- 结论-4: 当前登录投递已具备真实邮件链路：server 面向用户固定使用 `smtp` challenge delivery lane，不再提供部署期 delivery mode 开关；`smtp` 通过 `OASIS7_HOSTED_LOGIN_SMTP_*` 环境变量加载配置，默认可对接 Aliyun DirectMail `smtpdm.aliyun.com:465`；同时 OTP start 路径已补 resend cooldown、短窗/长窗配额与 `retry_after_seconds` 反馈，避免前端只能盲目重试。
 - 结论-5: 当前 hosted account registry 已支持 Aliyun Tablestore 托管存储；服务端通过 `HostedAccountStoreBackend` 在 `file` 与 `tablestore` 之间切换，默认 `auto` 模式下会在检测到 `OASIS7_HOSTED_ACCOUNT_TABLESTORE_*` 或 `ALIYUN_OTS_*` 后自动启用 Tablestore。
 - 结论-5A: 2026-05-20 已在 ECS 上完成一次真实 VPC Tablestore smoke：`https://oasis7.cn-huhehaote.vpc.tablestore.aliyuncs.com` 可从部署机直连，`AUTO_CREATE=true` 时首次启动允许由 `OTSObjectNotExist` 进入自动建表；同一邮箱在 launcher 重启前后两次登录均返回同一个 `hosted_account_id` / `player_id`，证明 hosted identity MVP 的“邮箱登录 + 服务端持久化恢复”主链路已经跑通。
-- 结论-5B: 当前已补 repo-owned `scripts/hosted-account-staging-smoke.sh`。同一脚本在本地会默认跑 `preview_inline + file backend` 的 required smoke，并输出 summary artifact；切到 `--mode staging --delivery-mode smtp --otp-fetch-command <cmd>` 后，可直接验证 staging 环境里的真实 OTP 与跨重启 account continuity，不再需要临时拼散命令。
+- 结论-5B: 当前已补 repo-owned `scripts/hosted-account-staging-smoke.sh`。同一脚本默认使用 `smtp`，并要求 `--otp-fetch-command <cmd>` 读取云上投递的真实 OTP；本地可搭配 file backend 验证 account continuity，staging 可直接验证真实 OTP 与跨重启 account continuity，不再需要临时拼散命令。
 - 结论-6: 托管身份仅面向 player plane；node / validator / governance signer 继续沿用独立 custody/governance 专题。
 - 结论-7: hosted account 服务从现在起必须按 `dev/staging/production` 分层执行；环境分层的最小真值不是“不同 URL”，而是 SMTP、account store、strong-auth/custody secret、风控阈值和对外 claims 的独立隔离。
 

--- a/doc/p2p/blockchain/p2p-hosted-world-player-access-and-session-auth-2026-03-25.runbook.md
+++ b/doc/p2p/blockchain/p2p-hosted-world-player-access-and-session-auth-2026-03-25.runbook.md
@@ -102,8 +102,8 @@
    - 不能把“能解析 DNS”误当成“能访问实例”。
 3. 若未显式指定 `OASIS7_HOSTED_ACCOUNT_TABLESTORE_TABLE`，当前默认表名是 `oasis7_hosted_account_identity`。
 4. 首次启动若表还不存在，`OASIS7_HOSTED_ACCOUNT_TABLESTORE_AUTO_CREATE=true` 时允许先出现一次 `OTSObjectNotExist`，随后自动建表并继续启动。
-5. 面向真实玩家时，`OASIS7_HOSTED_LOGIN_DELIVERY_MODE` 应切到 `smtp`。
-   - `preview_inline` 只适合 smoke / staging，不适合公开玩家入口。
+5. hosted login 没有部署期 delivery mode 开关；服务端固定使用 SMTP 邮件投递。
+   - 登录 start 响应不得返回 inline OTP；验证码只走云上邮件投递链路。
 6. SMTP 与 Tablestore 要分开看待：
    - SMTP 负责把 OTP 送出去。
    - Tablestore 负责把 `hosted_account_id -> player_id` 稳定落盘。
@@ -146,7 +146,6 @@ MVP 最小 smoke：
   - 本地开发、结构验证、单机 smoke。
 - 允许:
   - `OASIS7_HOSTED_ACCOUNT_STORE_BACKEND=file`，或无 OTS 配置时的 `auto` 本地 fallback。
-  - `OASIS7_HOSTED_LOGIN_DELIVERY_MODE=preview_inline|server_log_only`。
   - 手工测试邮箱、一次性 OTP、无对外公告的局部验证。
 - 禁止:
   - 复用 staging/production 的 SMTP、Tablestore、strong-auth signer、approval code。
@@ -178,7 +177,7 @@ MVP 最小 smoke：
 - 目标:
   - 面向真实外部玩家的正式 hosted account 服务面。
 - 硬要求:
-  - `OASIS7_HOSTED_LOGIN_DELIVERY_MODE=smtp`；不得使用 `preview_inline` 或 `server_log_only`。
+  - hosted login 固定走 SMTP 邮件投递；不得使用 server log 或 inline OTP 作为用户链路。
   - 独立正式 SMTP、独立正式 account store/table、独立正式 strong-auth/custody secret。
   - 已有 staging fresh smoke、operator runbook 演练、claims review 和发布决策。
   - 审计、监控、告警、备份、恢复与 incident owner 已明确。

--- a/doc/p2p/prd.md
+++ b/doc/p2p/prd.md
@@ -51,6 +51,7 @@
   - SC-19: 当前本机 + 2 ECS real-env triad 必须具备一条可审计的“三节点等权 validator”落地路径，明确 validator set、signer binding、static bootstrap、same-window snapshot evidence 与 residual legacy service naming 的边界；当 execution world 已存在 `governance_finality_signer_registry` 时，节点启动/恢复必须优先从该 world-state registry 恢复 validator membership 与 signer binding，而不是继续把 role-separated `observer + sequencer + storage` 或 operator-local env 当成唯一真值拓扑。
   - SC-20: `oasis7` 可以通过独立部署的 bridge-service，把已确认的 `OC` 充值映射为 LetAI Run OpenAPI 的用户额度与动态项目 `token_key`，同时冻结“只支持 one-way service-credit bridge，不是公开兑换所、不是 AMM、也不支持自动提现回 OC”的对外口径。
   - SC-21: `hosted_public_join` 必须具备一条对普通玩家友好的正式身份路径：默认允许邮箱 hosted login、托管 player signer 与后续自托管升级；浏览器不再被要求作为长期玩家私钥保管面。
+  - SC-26: 面向普通用户的 game / web / client launcher 默认进入 `hosted_public_join`，并不再暴露 `trusted_local_only` 本地可信预览作为可选启动模式；历史本地配置迁移到 hosted join 后继续走邮箱 hosted account / player session 登录链路。
   - SC-22: validator / finality signer 必须具备一条正式的治理准入流程，至少覆盖 `apply -> approved_candidate -> probation_ready -> active -> rotate/revoke`，并明确 world-state registry 才是正式激活真值；`--node-validator*` 与 operator-local env 只能作为 bootstrap 或显式运维覆盖。
   - SC-23: p2p 模块必须具备一套正式的公共主链式网络分层机制，明确 `local_devnet -> shared_devnet -> public_testnet -> mainnet` 的 tier 边界、manifest 真值与 claims/promotion 规则，避免把 shared release-train 与正式 testnet/mainnet 继续混写。
   - SC-24: `public_testnet` 必须具备一条 repo-owned readiness review 路径，能把“只有 skeleton manifest”与“具备 live candidate evidence”明确区分，避免把 placeholder endpoint 或模板证据误报为可部署结论。

--- a/doc/p2p/project.md
+++ b/doc/p2p/project.md
@@ -646,7 +646,7 @@
     - `rg -n "SC-8|Environment Tiering Contract|NFR-P2P-029-7|PRD-P2P-029-G|hosted-account-env-tiering|5B\. 分环境执行清单|promotion gate" doc/p2p/blockchain/p2p-hosted-public-join-managed-identity-custody-2026-05-18.prd.md doc/p2p/blockchain/p2p-hosted-public-join-managed-identity-custody-2026-05-18.project.md doc/p2p/blockchain/p2p-hosted-world-player-access-and-session-auth-2026-03-25.runbook.md doc/p2p/project.md .pm/tasks/task_ad5cbac95aa54e26a9fa7d7558380750.execution.md`
     - `./scripts/doc-governance-check.sh`
     - `git diff --check`
-- [x] hosted-account-staging-automation (PRD-P2P-029-G) [test_tier_required]: 补齐 hosted account 的 repo-owned 自动化链路，新增 `scripts/hosted-account-staging-smoke.sh`，让本地 required `preview_inline` smoke 与 staging `smtp + continuity` live smoke 复用同一入口，并把该入口接入 `scripts/ci-tests.sh required`。 Trace: .pm/tasks/task_f445927d10234bada7bb7058a1d2f5d0.yaml
+- [x] hosted-account-staging-automation (PRD-P2P-029-G) [test_tier_required]: 补齐 hosted account 的 repo-owned 自动化链路，新增 `scripts/hosted-account-staging-smoke.sh`，让本地 file backend 与 staging continuity smoke 统一走 `smtp + otp-fetch-command` 入口；该入口作为 `scripts/ci-tests.sh required` 的显式 opt-in 组件接入，默认在无云端 OTP/SMTP 凭据的 PR 环境跳过。 Trace: .pm/tasks/task_f445927d10234bada7bb7058a1d2f5d0.yaml
   - 产物文件:
     - `scripts/hosted-account-staging-smoke.sh`
     - `scripts/ci-tests.sh`

--- a/doc/world-simulator/viewer/viewer-manual.manual.md
+++ b/doc/world-simulator/viewer/viewer-manual.manual.md
@@ -51,6 +51,7 @@ env -u NO_COLOR ./scripts/run-viewer-web.sh --address 127.0.0.1 --port 4173
 - 支持 `locale=zh|en` 初始化和页面内中英文切换。
 - 支持最小 prompt/chat 控制面；仅在 auth/bootstrap 可用时开放。
 - 在 `hosted_public_join` 路径下，页面支持获取/释放 hosted `player_session`、`reconnect_sync` 恢复，以及 `prompt_control` 的 preview-grade `strong_auth`（需 `Backend Approval Code`）。
+- 面向普通用户的启动入口现在默认且只暴露 `hosted_public_join`。旧的 `trusted_local_only` 本地可信预览不再作为可选用户流程；本地旧配置应迁移到 hosted join，并走邮箱 hosted account / player session 登录链路。
 - `main_token_transfer` 仍保持阻断，页面只显示 lane verdict，不提供资产转账表单。
 - 页面不再提供 `standard Viewer` 跳转，也不再承担材质/theme/3D 视觉 QA 职责。
 

--- a/scripts/ci-tests.sh
+++ b/scripts/ci-tests.sh
@@ -183,7 +183,7 @@ case "$tier" in
     run_required_component "oasis7_net libp2p tests" "${OASIS7_CI_RUN_OASIS7_NET_LIBP2P_TESTS:-false}" run_oasis7_net_libp2p_tests
     run_required_component "viewer software-safe contract" "${OASIS7_CI_RUN_VIEWER_CONTRACT_TESTS:-}" run_oasis7_viewer_software_safe_feedback_contract_tests
     run_required_component "viewer software-safe build" "${OASIS7_CI_RUN_VIEWER_WASM_CHECK:-}" run_oasis7_viewer_software_safe_build
-    run_required_component "hosted account local smoke" "${OASIS7_CI_RUN_HOSTED_ACCOUNT_SMOKE:-}" run_hosted_account_local_smoke
+    run_required_component "hosted account local smoke" "${OASIS7_CI_RUN_HOSTED_ACCOUNT_SMOKE:-false}" run_hosted_account_local_smoke
     run_required_component "launcher web build" "${OASIS7_CI_RUN_LAUNCHER_WEB_BUILD:-false}" run_oasis7_client_launcher_web_build
     ;;
   full)

--- a/scripts/hosted-account-staging-smoke.sh
+++ b/scripts/hosted-account-staging-smoke.sh
@@ -12,23 +12,22 @@ Usage: ./scripts/hosted-account-staging-smoke.sh [options]
 Run a repo-owned hosted account smoke against `oasis7_game_launcher`.
 
 Default (`--mode local`) behavior:
-1. start a local `hosted_public_join` launcher with
-   `OASIS7_HOSTED_LOGIN_DELIVERY_MODE=preview_inline`
+1. start a local `hosted_public_join` launcher with the standard SMTP
+   hosted-login delivery lane
 2. complete one email login and capture `hosted_account_id/player_id`
 3. release the issued player slot
 4. restart the launcher against the same hosted account store
 5. complete the same login again and assert the same account/player ids
 
-`--mode staging` reuses the same flow but expects a real OTP fetch command so
-the smoke can complete `/login/start -> /login/complete` with
-`OASIS7_HOSTED_LOGIN_DELIVERY_MODE=smtp` and the staging store backend.
+Both local and staging modes expect a real OTP fetch command so
+the smoke can complete `/login/start -> /login/complete`.
 
 Options:
   --mode <local|staging>         Smoke mode (default: local)
   --login-handle <email>         Login handle for both passes
                                  (default local: player@example.com)
   --otp-fetch-command <cmd>      Command that prints the latest OTP for the
-                                 current challenge when preview_code is absent
+                                 current challenge from the cloud delivery lane
   --otp-timeout <secs>           Wait timeout for OTP fetch command (default: 90)
   --startup-timeout <secs>       Wait timeout for launcher HTTP listener (default: 120)
   --out-dir <path>               Artifact root (default: output/playwright/hosted-account)
@@ -37,8 +36,6 @@ Options:
   --web-bind <host:port>         Viewer WS bind (default: 127.0.0.1:6412)
   --live-bind <host:port>        Runtime live bind (default: 127.0.0.1:6413)
   --viewer-static-dir <path>     Viewer static dir (default: crates/oasis7_viewer)
-  --delivery-mode <mode>         Override hosted login delivery mode.
-                                 Defaults: local=preview_inline, staging=smtp
   --store-backend <mode>         Override hosted account store backend.
                                  Defaults: local=file, staging=inherit
   --launcher-bin <path>          Reuse an existing launcher binary
@@ -123,7 +120,6 @@ viewer_port="6411"
 web_bind="127.0.0.1:6412"
 live_bind="127.0.0.1:6413"
 viewer_static_dir="crates/oasis7_viewer"
-delivery_mode=""
 store_backend=""
 launcher_bin=""
 viewer_live_bin=""
@@ -175,10 +171,6 @@ while [[ $# -gt 0 ]]; do
       viewer_static_dir="${2:-}"
       shift 2
       ;;
-    --delivery-mode)
-      delivery_mode="${2:-}"
-      shift 2
-      ;;
     --store-backend)
       store_backend="${2:-}"
       shift 2
@@ -227,14 +219,6 @@ done
   echo "error: --login-handle cannot be empty" >&2
   exit 2
 }
-
-if [[ -z "$delivery_mode" ]]; then
-  if [[ "$mode" == "local" ]]; then
-    delivery_mode="preview_inline"
-  else
-    delivery_mode="smtp"
-  fi
-fi
 
 if [[ -z "$store_backend" ]]; then
   if [[ "$mode" == "local" ]]; then
@@ -307,7 +291,6 @@ start_launcher() {
   }
 
   local -a env_cmd=(env)
-  env_cmd+=("OASIS7_HOSTED_LOGIN_DELIVERY_MODE=$delivery_mode")
   env_cmd+=("OASIS7_VIEWER_LIVE_BIN=$viewer_live_bin")
   if [[ "$store_backend" != "inherit" ]]; then
     env_cmd+=("OASIS7_HOSTED_ACCOUNT_STORE_BACKEND=$store_backend")
@@ -377,15 +360,8 @@ post_query() {
 resolve_otp_code() {
   local start_path=$1
   local attempt_label=$2
-  local preview_code=""
-  preview_code=$(json_field "$start_path" '.challenge.preview_code // empty')
-  if [[ -n "$preview_code" && "$preview_code" != "null" ]]; then
-    printf '%s\n' "$preview_code"
-    return 0
-  fi
-
   [[ -n "$otp_fetch_command" ]] || {
-    echo "error: login start response did not include preview_code and no --otp-fetch-command was provided" >&2
+    echo "error: --otp-fetch-command is required; hosted account login no longer exposes inline OTP codes" >&2
     return 1
   }
 
@@ -526,7 +502,6 @@ summary_json=$(
     --arg viewer_url "$http_base/" \
     --arg live_bind "$live_bind" \
     --arg web_bind "$web_bind" \
-    --arg delivery_mode "$delivery_mode" \
     --arg store_backend "$store_backend" \
     --arg first_delivery_mode "$first_delivery_mode" \
     --arg second_delivery_mode "$second_delivery_mode" \
@@ -547,7 +522,6 @@ summary_json=$(
       viewer_url: $viewer_url,
       live_bind: $live_bind,
       web_bind: $web_bind,
-      delivery_mode_request: $delivery_mode,
       store_backend_request: $store_backend,
       first_delivery_mode: $first_delivery_mode,
       second_delivery_mode: $second_delivery_mode,
@@ -573,7 +547,6 @@ cat >"$summary_md_path" <<EOF
 - run_id: \`$run_id\`
 - mode: \`$mode\`
 - login_handle: \`$login_handle\`
-- requested_delivery_mode: \`$delivery_mode\`
 - requested_store_backend: \`$store_backend\`
 - first_delivery_mode: \`$first_delivery_mode\`
 - second_delivery_mode: \`$second_delivery_mode\`


### PR DESCRIPTION
## Summary
- Remove the user-facing trusted/local hosted login preview path and the deployment-time `OASIS7_HOSTED_LOGIN_DELIVERY_MODE` switch.
- Make hosted account login require SMTP configuration from env in runtime deployments, with test-only log delivery kept behind `cfg(test)`.
- Update launcher/viewer defaults and tests so users enter through `hosted_public_join` and the email login gate.
- Add a manual GitHub Actions workflow that builds a deployable Linux x86_64 hosted login artifact for ECS instead of cold-building on the small server.

## Validation
- `cargo fmt --check`
- `bash -n scripts/hosted-account-staging-smoke.sh`
- `env -u RUSTC_WRAPPER cargo test -p oasis7 --bin oasis7_game_launcher`
- `ruby -e 'require "yaml"; YAML.load_file(ARGV.fetch(0)); puts "yaml ok"' .github/workflows/hosted-login-linux-build.yml`
- `rg "OASIS7_HOSTED_LOGIN_DELIVERY_MODE|server_log_only|preview_inline|preview_code|delivery-mode" crates/oasis7/src/bin/oasis7_game_launcher scripts/hosted-account-staging-smoke.sh doc/p2p`

## Deploy Note
205 is intentionally fail-closed right now: the old hosted-login service was stopped after the previous Linux binary proved it could fall back to `preview_inline`. The new GitHub Actions artifact should be used for the next 205 deploy with the test Tablestore table plus real SMTP env.
