### PR TITLE
[codex] Fix bootstrap anchor port pairing

### DIFF
--- a/crates/oasis7/src/bin/oasis7_web_launcher/control_plane.rs
+++ b/crates/oasis7/src/bin/oasis7_web_launcher/control_plane.rs
@@ -905,7 +905,7 @@ pub(super) fn validate_chain_config(config: &LauncherConfig) -> Vec<String> {
         .is_err()
     {
         issues.push(
-            "chain replication bootstrap peers must use multiaddr values like /dns4/bootstrap1.oasis7.tech/tcp/5611 or /ip4/203.0.113.10/tcp/4100/p2p/<peer-id>".to_string(),
+            "chain replication bootstrap peers must use multiaddr values like /dns4/bootstrap1.oasis7.tech/tcp/5612 or /ip4/203.0.113.10/tcp/4100/p2p/<peer-id>".to_string(),
         );
     }
 

--- a/crates/oasis7/src/launcher_bootstrap_peers.rs
+++ b/crates/oasis7/src/launcher_bootstrap_peers.rs
@@ -1,9 +1,9 @@
 use multiaddr::Multiaddr;
 
-const MULTIADDR_EXAMPLE: &str = "/dns4/bootstrap1.oasis7.tech/tcp/5611";
+const MULTIADDR_EXAMPLE: &str = "/dns4/bootstrap1.oasis7.tech/tcp/5612";
 pub const DEFAULT_CHAIN_REPLICATION_BOOTSTRAP_PEERS: &[&str] = &[
-    "/dns4/bootstrap1.oasis7.tech/tcp/5611",
-    "/dns4/bootstrap2.oasis7.tech/tcp/5612",
+    "/dns4/bootstrap1.oasis7.tech/tcp/5612",
+    "/dns4/bootstrap2.oasis7.tech/tcp/5611",
 ];
 
 pub fn default_chain_replication_bootstrap_peers_csv() -> String {
@@ -55,20 +55,20 @@ mod tests {
         assert_eq!(
             DEFAULT_CHAIN_REPLICATION_BOOTSTRAP_PEERS,
             [
-                "/dns4/bootstrap1.oasis7.tech/tcp/5611",
-                "/dns4/bootstrap2.oasis7.tech/tcp/5612",
+                "/dns4/bootstrap1.oasis7.tech/tcp/5612",
+                "/dns4/bootstrap2.oasis7.tech/tcp/5611",
             ]
         );
         assert_eq!(
             default_chain_replication_bootstrap_peers_csv(),
-            "/dns4/bootstrap1.oasis7.tech/tcp/5611,/dns4/bootstrap2.oasis7.tech/tcp/5612"
+            "/dns4/bootstrap1.oasis7.tech/tcp/5612,/dns4/bootstrap2.oasis7.tech/tcp/5611"
                 .to_string()
         );
         assert_eq!(
             default_chain_replication_bootstrap_peers_vec(),
             vec![
-                "/dns4/bootstrap1.oasis7.tech/tcp/5611".to_string(),
-                "/dns4/bootstrap2.oasis7.tech/tcp/5612".to_string(),
+                "/dns4/bootstrap1.oasis7.tech/tcp/5612".to_string(),
+                "/dns4/bootstrap2.oasis7.tech/tcp/5611".to_string(),
             ]
         );
     }

--- a/crates/oasis7_client_launcher/src/config_ui.rs
+++ b/crates/oasis7_client_launcher/src/config_ui.rs
@@ -152,8 +152,8 @@ impl ClientLauncherApp {
                     }
                     if field.id == "chain_replication_bootstrap_peers" {
                         ui.small(self.tr(
-                            "多个 bootstrap peer 可用逗号、分号或空白分隔，例如 /dns4/bootstrap1.oasis7.tech/tcp/5611 或 /ip4/127.0.0.1/tcp/4100/p2p/<peer-id>",
-                            "Separate multiple bootstrap peers with commas, semicolons, or whitespace, for example /dns4/bootstrap1.oasis7.tech/tcp/5611 or /ip4/127.0.0.1/tcp/4100/p2p/<peer-id>",
+                            "多个 bootstrap peer 可用逗号、分号或空白分隔，例如 /dns4/bootstrap1.oasis7.tech/tcp/5612 或 /ip4/127.0.0.1/tcp/4100/p2p/<peer-id>",
+                            "Separate multiple bootstrap peers with commas, semicolons, or whitespace, for example /dns4/bootstrap1.oasis7.tech/tcp/5612 or /ip4/127.0.0.1/tcp/4100/p2p/<peer-id>",
                         ));
                     }
                 }

--- a/crates/oasis7_client_launcher/src/main.rs
+++ b/crates/oasis7_client_launcher/src/main.rs
@@ -786,10 +786,10 @@ impl ConfigIssue {
                 "Public entry requires explicit confirmation of public-entry responsibility"
             }
             (Self::ChainReplicationBootstrapPeersInvalid, UiLanguage::ZhCn) => {
-                "链复制 bootstrap peers 必须是 /dns4/bootstrap1.oasis7.tech/tcp/5611 或 /ip4/.../tcp/.../p2p/<peer-id> 这类 multiaddr，多个地址可用逗号、分号或空白分隔"
+                "链复制 bootstrap peers 必须是 /dns4/bootstrap1.oasis7.tech/tcp/5612 或 /ip4/.../tcp/.../p2p/<peer-id> 这类 multiaddr，多个地址可用逗号、分号或空白分隔"
             }
             (Self::ChainReplicationBootstrapPeersInvalid, UiLanguage::EnUs) => {
-                "Chain replication bootstrap peers must use multiaddr values like /dns4/bootstrap1.oasis7.tech/tcp/5611 or /ip4/.../tcp/.../p2p/<peer-id>; separate multiple entries with commas, semicolons, or whitespace"
+                "Chain replication bootstrap peers must use multiaddr values like /dns4/bootstrap1.oasis7.tech/tcp/5612 or /ip4/.../tcp/.../p2p/<peer-id>; separate multiple entries with commas, semicolons, or whitespace"
             }
             (Self::ChainTickMsInvalid, UiLanguage::ZhCn) => {
                 "链节点轮询间隔毫秒（chain node poll interval ms）必须是正整数"

--- a/doc/world-simulator/launcher/game-client-launcher-native-web-control-plane-unification-2026-03-04.prd.md
+++ b/doc/world-simulator/launcher/game-client-launcher-native-web-control-plane-unification-2026-03-04.prd.md
@@ -48,7 +48,7 @@
   - AC-2: `/api/state` 返回游戏与区块链独立状态字段，客户端不再用 `snapshot.running` 推断链状态。
   - AC-2a: `/api/state` 在链就绪时同步返回 `chain_replication_status.local_peer_id/connected_peers/peer_healths`，供 native/web 启动器在 `节点观测` 摘要卡与可单独打开的 peer 明细窗口里直接展示已连接 peer 信息，而不新增第二套客户端探针。
   - AC-2b: 启动器配置增加 `chain_replication_bootstrap_peers` 入口，支持通过持久化配置文件与 launcher 界面填写 bootstrap peer multiaddr，并在 native/web 控制面启动链时统一透传为 `oasis7_chain_runtime --replication-network-peer <multiaddr>`。
-  - AC-2c: 启动器默认配置内置官方 bootstrap anchors：`/dns4/bootstrap1.oasis7.tech/tcp/5611` 与 `/dns4/bootstrap2.oasis7.tech/tcp/5612`，保证普通新用户在不手动填写 bootstrap peers 的情况下也能获得默认入网锚点；高级用户仍可覆盖该列表。
+  - AC-2c: 启动器默认配置内置官方 bootstrap anchors：`/dns4/bootstrap1.oasis7.tech/tcp/5612` 与 `/dns4/bootstrap2.oasis7.tech/tcp/5611`，保证普通新用户在不手动填写 bootstrap peers 的情况下也能获得默认入网锚点；高级用户仍可覆盖该列表。
   - AC-3: `oasis7_client_launcher` native 不再直接拉起 `oasis7_game_launcher` / `oasis7_chain_runtime`，改为通过 `oasis7_web_launcher` API 控制。
   - AC-4: wasm/web 启动器的“启动区块链/停止区块链”按钮恢复可操作，并与 native 同状态语义。
   - AC-5: native 与 web 在“自动拉起链 + 游戏/链独立启停 + 状态展示”行为上保持一致。

--- a/doc/world-simulator/launcher/game-client-launcher-native-web-control-plane-unification-2026-03-04.project.md
+++ b/doc/world-simulator/launcher/game-client-launcher-native-web-control-plane-unification-2026-03-04.project.md
@@ -12,7 +12,7 @@
 - [x] T3 (PRD-WORLD_SIMULATOR-015) [test_tier_required]: 执行 `cargo test/check` + `agent-browser --headed` 闭环（含链/游戏独立启停），归档证据并收口文档。
 - [x] launcher-p2p-peer-list-ui (PRD-WORLD_SIMULATOR-015) [test_tier_required]: 透传 `/api/state` 的 `chain_replication_status`，并在启动器 `节点观测` 摘要卡展示 peer 健康概览，同时提供可单独打开的 peer 明细窗口展示本地 peer id 与已连接 peer 明细。 Trace: .pm/tasks/task_ee3cc0c5d2d741658b404100843f93d8.yaml
 - [x] launcher-bootstrap-peers-config-entry (PRD-WORLD_SIMULATOR-015) [test_tier_required]: 为 launcher 增加链复制 bootstrap peers 配置入口，支持配置文件与界面持久化，并在 web/native 控制面与 `oasis7_game_launcher` 启动链时统一透传 `--replication-network-peer`。 Trace: .pm/tasks/task_9ce8515c10764278ac214b8b69efb2de.yaml
-- [x] launcher-default-bootstrap-anchors (PRD-WORLD_SIMULATOR-015) [test_tier_required]: 将官方 bootstrap anchors `/dns4/bootstrap1.oasis7.tech/tcp/5611` 与 `/dns4/bootstrap2.oasis7.tech/tcp/5612` 收敛到共享默认值，并让 `oasis7_game_launcher`、`oasis7_web_launcher`、`oasis7_client_launcher` 默认配置统一携带该列表，保证新用户零手填也有默认入网锚点。 Trace: .pm/tasks/task_e81e085cf2614cfd82e6c7bb411144d6.yaml
+- [x] launcher-default-bootstrap-anchors (PRD-WORLD_SIMULATOR-015) [test_tier_required]: 将官方 bootstrap anchors `/dns4/bootstrap1.oasis7.tech/tcp/5612` 与 `/dns4/bootstrap2.oasis7.tech/tcp/5611` 收敛到共享默认值，并让 `oasis7_game_launcher`、`oasis7_web_launcher`、`oasis7_client_launcher` 默认配置统一携带该列表，保证新用户零手填也有默认入网锚点。 Trace: .pm/tasks/task_e81e085cf2614cfd82e6c7bb411144d6.yaml
 
 ## 依赖
 - `doc/world-simulator/launcher/game-client-launcher-native-web-control-plane-unification-2026-03-04.design.md`


### PR DESCRIPTION
## Summary
- Update the default chain replication bootstrap anchors to match the current DNS-to-ECS port pairing.
- Refresh launcher validation/helper text and the launcher PRD/project references to the corrected anchors.

## Root Cause
`bootstrap1.oasis7.tech` currently resolves to `39.104.205.67`, whose reachable replication port is `5612`, while `bootstrap2.oasis7.tech` resolves to `39.104.204.172`, whose reachable replication port is `5611`. The previous defaults used the opposite port pairing, so both default `/dns4/.../tcp/...` addresses were refused.

## Validation
- `env -u RUSTC_WRAPPER cargo test -p oasis7 launcher_bootstrap_peers --lib`
- `env -u RUSTC_WRAPPER cargo test -p oasis7_client_launcher launch_config_defaults_enable_llm`
- `env -u RUSTC_WRAPPER cargo test -p oasis7_client_launcher build_chain_runtime_args_contains_chain_overrides_when_enabled`
- `git diff --check`
- `./scripts/doc-governance-check.sh`
- Live probe: `bootstrap1.oasis7.tech:5612` and `bootstrap2.oasis7.tech:5611` both accept TCP connections.