### PR TITLE
[codex] Add daily GitHub release workflow

### DIFF
--- a/.github/workflows/daily-github-release.yml
+++ b/.github/workflows/daily-github-release.yml
@@ -53,25 +53,35 @@ jobs:
           echo "tag=${tag}" >> "${GITHUB_OUTPUT}"
           echo "target_sha=${target_sha}" >> "${GITHUB_OUTPUT}"
 
-      - name: Refuse existing tag or release
+      - name: Check retry state
+        id: retry
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ steps.tag.outputs.tag }}
+          TARGET_SHA: ${{ steps.tag.outputs.target_sha }}
         shell: bash
         run: |
           set -euo pipefail
-
-          if git ls-remote --exit-code --tags origin "refs/tags/${TAG}" >/dev/null 2>&1; then
-            echo "error: tag already exists: ${TAG}" >&2
-            exit 1
-          fi
 
           if gh release view "${TAG}" >/dev/null 2>&1; then
             echo "error: release already exists: ${TAG}" >&2
             exit 1
           fi
 
+          if git ls-remote --exit-code --tags origin "refs/tags/${TAG}" >/dev/null 2>&1; then
+            git fetch --force origin "refs/tags/${TAG}:refs/tags/${TAG}"
+            existing_target_sha="$(git rev-list -n 1 "${TAG}")"
+            if [[ "${existing_target_sha}" != "${TARGET_SHA}" ]]; then
+              echo "error: existing tag ${TAG} points at ${existing_target_sha}, expected ${TARGET_SHA}" >&2
+              exit 1
+            fi
+            echo "tag_exists=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "tag_exists=false" >> "${GITHUB_OUTPUT}"
+          fi
+
       - name: Create and push tag
+        if: steps.retry.outputs.tag_exists != 'true'
         env:
           TAG: ${{ steps.tag.outputs.tag }}
           TARGET_SHA: ${{ steps.tag.outputs.target_sha }}

--- a/.github/workflows/daily-github-release.yml
+++ b/.github/workflows/daily-github-release.yml
@@ -1,0 +1,108 @@
+name: Daily GitHub Release
+
+on:
+  schedule:
+    # GitHub cron is UTC; 22:00 UTC is 06:00 Asia/Shanghai.
+    - cron: "0 22 * * *"
+  workflow_dispatch:
+    inputs:
+      release_date:
+        description: "Asia/Shanghai release date, YYYY-MM-DD. Empty uses today's date."
+        required: false
+        type: string
+
+permissions:
+  contents: write
+
+concurrency:
+  group: daily-github-release
+  cancel-in-progress: false
+
+jobs:
+  create-release:
+    name: create-date-release
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Resolve release tag
+        id: tag
+        env:
+          RELEASE_DATE_INPUT: ${{ github.event.inputs.release_date || '' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          release_date="${RELEASE_DATE_INPUT}"
+          if [[ -z "${release_date}" ]]; then
+            release_date="$(TZ=Asia/Shanghai date +%F)"
+          fi
+
+          if [[ ! "${release_date}" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
+            echo "error: release_date must use YYYY-MM-DD: ${release_date}" >&2
+            exit 1
+          fi
+
+          tag="${release_date}_v1"
+          target_sha="$(git rev-parse HEAD)"
+
+          echo "release_date=${release_date}" >> "${GITHUB_OUTPUT}"
+          echo "tag=${tag}" >> "${GITHUB_OUTPUT}"
+          echo "target_sha=${target_sha}" >> "${GITHUB_OUTPUT}"
+
+      - name: Refuse existing tag or release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.tag.outputs.tag }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if git ls-remote --exit-code --tags origin "refs/tags/${TAG}" >/dev/null 2>&1; then
+            echo "error: tag already exists: ${TAG}" >&2
+            exit 1
+          fi
+
+          if gh release view "${TAG}" >/dev/null 2>&1; then
+            echo "error: release already exists: ${TAG}" >&2
+            exit 1
+          fi
+
+      - name: Create and push tag
+        env:
+          TAG: ${{ steps.tag.outputs.tag }}
+          TARGET_SHA: ${{ steps.tag.outputs.target_sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "${TAG}" "${TARGET_SHA}" -m "Daily GitHub Release ${TAG}"
+          git push origin "refs/tags/${TAG}"
+
+      - name: Publish GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.tag.outputs.tag }}
+          TARGET_SHA: ${{ steps.tag.outputs.target_sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          gh release create "${TAG}" \
+            --target "${TARGET_SHA}" \
+            --title "oasis7 ${TAG}" \
+            --generate-notes
+
+      - name: Report release
+        env:
+          TAG: ${{ steps.tag.outputs.tag }}
+          REPOSITORY: ${{ github.repository }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "Created ${TAG}: https://github.com/${REPOSITORY}/releases/tag/${TAG}"

--- a/.github/workflows/daily-github-release.yml
+++ b/.github/workflows/daily-github-release.yml
@@ -106,7 +106,8 @@ jobs:
           gh release create "${TAG}" \
             --target "${TARGET_SHA}" \
             --title "oasis7 ${TAG}" \
-            --generate-notes
+            --generate-notes \
+            --prerelease
 
       - name: Report release
         env:

--- a/.pm/tasks/task_b62ea1b2fe584b23ae72a9776e7e1261.execution.md
+++ b/.pm/tasks/task_b62ea1b2fe584b23ae72a9776e7e1261.execution.md
@@ -1,0 +1,29 @@
+# task_b62ea1b2fe584b23ae72a9776e7e1261 Execution Log
+
+- task_uid: task_b62ea1b2fe584b23ae72a9776e7e1261
+- title: Daily GitHub Release via CI
+- owner_role: producer_system_designer
+- worktree_hint: /Users/scc/ccwork/worktrees/oasis7-engineering-daily-github-release-ci
+
+<!-- Append entries using:
+Example:
+  ## YYYY-MM-DD HH:MM:SS CST / role_name
+  - 完成内容: ...
+  - 遗留事项: ...
+  - Action: ...
+  - Validation Command: ...
+  - Expected Result: ...
+  - Actual Result: ...
+  - Blocker / Next Action: ...
+-->
+
+## 2026-05-29 11:42:55 CST / producer_system_designer
+- 完成内容: WORKFLOW BOOTSTRAP DECIDED. Classification: non-trivial, because the change creates an automated GitHub Release path with write permissions and externally visible tags/releases. Isolation: created dedicated worktree `/Users/scc/ccwork/worktrees/oasis7-engineering-daily-github-release-ci` from the dirty main source using branch `codex/daily-github-release-ci`, avoiding unrelated `site/story` edits. Task truth: `.pm/tasks/task_b62ea1b2fe584b23ae72a9776e7e1261.yaml` owns this task with `producer_system_designer`.
+- 完成内容: WORKFLOW ROUTE DECIDED. Selected `executing-project-tasks` for a narrow CI workflow implementation, then `verification-before-completion` before any done claim. Skipped bounded brainstorming because the user specified daily 06:00 and `<YYYY-MM-DD>_v1`; skipped TDD because this is YAML automation with parser/static validation rather than runtime product behavior.
+- 完成内容: Added `.github/workflows/daily-github-release.yml`, a GitHub-hosted scheduled workflow that runs at `0 22 * * *` UTC, resolves the Asia/Shanghai date, refuses existing tags/releases, creates an annotated `<YYYY-MM-DD>_v1` tag on `main`, pushes it, and publishes a GitHub Release. Deleted local Codex automation `daily-github-release` to avoid duplicate local/CI release attempts.
+- 遗留事项: None for implementation. `gh` is not installed in the local shell, so the GitHub CLI command was validated by workflow structure rather than a local `gh release create --help` probe; GitHub-hosted runners include `gh`.
+- Action: implement
+- Validation Command: `python3 -c "import pathlib, yaml; yaml.safe_load(pathlib.Path('.github/workflows/daily-github-release.yml').read_text()); print('yaml ok')"`; `git diff --check`; `rg -n "[[:blank:]]+$" .github/workflows/daily-github-release.yml .pm/tasks/task_b62ea1b2fe584b23ae72a9776e7e1261.yaml .pm/tasks/task_b62ea1b2fe584b23ae72a9776e7e1261.execution.md || true`; `./scripts/pm/lint.sh`; `./scripts/doc-governance-check.sh`; tag-format probe for `2026-05-30_v1`.
+- Expected Result: Workflow syntax parses, no whitespace errors, PM and doc governance checks pass, and date tag formatting yields `<YYYY-MM-DD>_v1`.
+- Actual Result: `yaml ok`; `git diff --check` no output; trailing-whitespace scan no output; `pm-lint: OK`; `doc-governance-check: OK`; tag-format probe output `2026-05-30_v1`.
+- Blocker / Next Action: Ready for user review or commit/PR flow.

--- a/.pm/tasks/task_b62ea1b2fe584b23ae72a9776e7e1261.execution.md
+++ b/.pm/tasks/task_b62ea1b2fe584b23ae72a9776e7e1261.execution.md
@@ -47,3 +47,13 @@ Example:
 - Expected Result: Daily date releases are prereleases and static checks pass.
 - Actual Result: `yaml ok`; `git diff --check` no output; `pm-lint: OK`; `doc-governance-check: OK`.
 - Blocker / Next Action: Commit, push, then re-check review threads.
+
+## 2026-05-29 14:52:10 CST / producer_system_designer
+- 完成内容: Investigated PR #314 CI failure in GitHub Actions run `26622001258` / job `78449891930`. The failing check was `Rust / required-gate`; `Wasm Determinism Gate` passed. Failure was `viewer_auth_bootstrap::tests::resolve_optional_viewer_auth_bootstrap_uses_config_file`, where `left: "env-public"` and `right: "public-key-hex"` showed a race with the sibling env-precedence test.
+- 完成内容: Fixed the flaky Rust unit test by adding a `OnceLock<Mutex<()>>` env guard plus RAII env restore in `crates/oasis7/src/bin/oasis7_web_launcher/viewer_auth_bootstrap.rs`; the config-file test now clears viewer auth env while holding the lock, and the env-precedence test restores previous env state after the assertion.
+- 遗留事项: Need commit and push CI fix, then re-check GitHub Actions.
+- Action: ci-fix
+- Validation Command: `./scripts/cargo-dev.sh test -p oasis7 --bin oasis7_web_launcher viewer_auth_bootstrap`; `python3 -c "import pathlib, yaml; yaml.safe_load(pathlib.Path('.github/workflows/daily-github-release.yml').read_text()); print('yaml ok')"`; `git diff --check`; `./scripts/pm/lint.sh`; `./scripts/doc-governance-check.sh`
+- Expected Result: The targeted viewer auth bootstrap tests pass under the normal Rust test runner, and repository static checks remain clean.
+- Actual Result: targeted test passed (`3 passed; 0 failed; 78 filtered out`); `yaml ok`; `git diff --check` no output; `pm-lint: OK`; `doc-governance-check: OK`.
+- Blocker / Next Action: Commit and push the CI fix, then monitor PR checks.

--- a/.pm/tasks/task_b62ea1b2fe584b23ae72a9776e7e1261.execution.md
+++ b/.pm/tasks/task_b62ea1b2fe584b23ae72a9776e7e1261.execution.md
@@ -37,3 +37,13 @@ Example:
 - Expected Result: Retry recovery path is represented in workflow outputs and static checks pass.
 - Actual Result: `yaml ok`; `git diff --check` no output; `pm-lint: OK`; `doc-governance-check: OK`.
 - Blocker / Next Action: Commit and push the review fix, then resolve the review thread.
+
+## 2026-05-29 14:29:04 CST / producer_system_designer
+- 完成内容: Addressed follow-up PR review thread `PRRT_kwDORHhWec6Fmdfm` / comment `PRRC_kwDORHhWec7GCdTD`. The review correctly identified that published daily releases without packaged assets would become GitHub `latest` and break documented site download URLs that expect installer assets on the latest release.
+- 完成内容: Updated the daily `gh release create` command to pass `--prerelease`, preserving the daily GitHub Release record while preventing it from replacing the official latest release used by the site download contract.
+- 遗留事项: Need rerun YAML/static checks and push the follow-up review-fix commit.
+- Action: review-fix
+- Validation Command: `python3 -c "import pathlib, yaml; yaml.safe_load(pathlib.Path('.github/workflows/daily-github-release.yml').read_text()); print('yaml ok')"`; `git diff --check`; `./scripts/pm/lint.sh`; `./scripts/doc-governance-check.sh`
+- Expected Result: Daily date releases are prereleases and static checks pass.
+- Actual Result: `yaml ok`; `git diff --check` no output; `pm-lint: OK`; `doc-governance-check: OK`.
+- Blocker / Next Action: Commit, push, then re-check review threads.

--- a/.pm/tasks/task_b62ea1b2fe584b23ae72a9776e7e1261.execution.md
+++ b/.pm/tasks/task_b62ea1b2fe584b23ae72a9776e7e1261.execution.md
@@ -27,3 +27,13 @@ Example:
 - Expected Result: Workflow syntax parses, no whitespace errors, PM and doc governance checks pass, and date tag formatting yields `<YYYY-MM-DD>_v1`.
 - Actual Result: `yaml ok`; `git diff --check` no output; trailing-whitespace scan no output; `pm-lint: OK`; `doc-governance-check: OK`; tag-format probe output `2026-05-30_v1`.
 - Blocker / Next Action: Ready for user review or commit/PR flow.
+
+## 2026-05-29 14:27:08 CST / producer_system_designer
+- 完成内容: Addressed PR review thread `PRRT_kwDORHhWec6Fmb8y` / comment `PRRC_kwDORHhWec7GCbKe`. The review correctly identified that a transient `gh release create` failure after tag push would leave the date tag present but no release, and the previous guard would block retry recovery.
+- 完成内容: Updated `.github/workflows/daily-github-release.yml` so the retry guard first refuses an existing release, then tolerates an existing tag only when it resolves to the intended `TARGET_SHA`; when that safe retry state is detected, the tag creation step is skipped and release creation can proceed.
+- 遗留事项: Need rerun workflow YAML/static checks and push the review-fix commit.
+- Action: review-fix
+- Validation Command: `python3 -c "import pathlib, yaml; yaml.safe_load(pathlib.Path('.github/workflows/daily-github-release.yml').read_text()); print('yaml ok')"`; `git diff --check`; `./scripts/pm/lint.sh`; `./scripts/doc-governance-check.sh`
+- Expected Result: Retry recovery path is represented in workflow outputs and static checks pass.
+- Actual Result: `yaml ok`; `git diff --check` no output; `pm-lint: OK`; `doc-governance-check: OK`.
+- Blocker / Next Action: Commit and push the review fix, then resolve the review thread.

--- a/.pm/tasks/task_b62ea1b2fe584b23ae72a9776e7e1261.yaml
+++ b/.pm/tasks/task_b62ea1b2fe584b23ae72a9776e7e1261.yaml
@@ -1,0 +1,27 @@
+task_uid: task_b62ea1b2fe584b23ae72a9776e7e1261
+title: "Daily GitHub Release via CI"
+owner_role: producer_system_designer
+worktree_hint: /Users/scc/ccwork/worktrees/oasis7-engineering-daily-github-release-ci
+execution_log_path: .pm/tasks/task_b62ea1b2fe584b23ae72a9776e7e1261.execution.md
+status: done
+priority: P2
+source_signal: null
+source_refs:
+  - AGENTS.md
+  - .github/workflows/release-packages.yml
+doc_refs:
+  - doc/engineering/workflow/source-of-truth.md
+related_prd: []
+acceptance:
+  - "A GitHub Actions workflow runs daily at 06:00 Asia/Shanghai and creates a date_v1 tag plus release without relying on a local machine."
+  - "The workflow is manually dispatchable for verification and refuses to overwrite existing tags/releases."
+  - "The prior local Codex automation is disabled or removed to avoid duplicate release attempts."
+handoff_to: []
+updated_at: 2026-05-29T11:48:02+08:00
+last_started_at: 2026-05-29T11:41:29+08:00
+last_claim_type: task_complete
+last_verify_command: "python3 -c \"import pathlib, yaml; yaml.safe_load(pathlib.Path('.github/workflows/daily-github-release.yml').read_text()); print('yaml ok')\" && git diff --check && ./scripts/pm/lint.sh && ./scripts/doc-governance-check.sh"
+last_verified_at: 2026-05-29T11:48:01+08:00
+last_verification_exit_code: 0
+last_verification_status: verified
+last_closed_at: 2026-05-29T11:48:02+08:00

--- a/crates/oasis7/src/bin/oasis7_web_launcher/viewer_auth_bootstrap.rs
+++ b/crates/oasis7/src/bin/oasis7_web_launcher/viewer_auth_bootstrap.rs
@@ -125,7 +125,44 @@ mod tests {
     };
     use std::fs;
     use std::path::PathBuf;
+    use std::sync::{Mutex, OnceLock};
     use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn viewer_auth_test_env_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    struct ViewerAuthEnvRestore {
+        public_key: Option<String>,
+        private_key: Option<String>,
+    }
+
+    impl ViewerAuthEnvRestore {
+        fn clear() -> Self {
+            let restore = Self {
+                public_key: std::env::var(VIEWER_AUTH_PUBLIC_KEY_ENV).ok(),
+                private_key: std::env::var(VIEWER_AUTH_PRIVATE_KEY_ENV).ok(),
+            };
+            std::env::remove_var(VIEWER_AUTH_PUBLIC_KEY_ENV);
+            std::env::remove_var(VIEWER_AUTH_PRIVATE_KEY_ENV);
+            restore
+        }
+    }
+
+    impl Drop for ViewerAuthEnvRestore {
+        fn drop(&mut self) {
+            restore_env_var(VIEWER_AUTH_PUBLIC_KEY_ENV, self.public_key.as_deref());
+            restore_env_var(VIEWER_AUTH_PRIVATE_KEY_ENV, self.private_key.as_deref());
+        }
+    }
+
+    fn restore_env_var(name: &str, value: Option<&str>) {
+        match value {
+            Some(value) => std::env::set_var(name, value),
+            None => std::env::remove_var(name),
+        }
+    }
 
     fn temp_config_path(label: &str) -> PathBuf {
         let mut path = std::env::temp_dir();
@@ -160,17 +197,19 @@ mod tests {
 
     #[test]
     fn resolve_optional_viewer_auth_bootstrap_prefers_env_keys() {
+        let _guard = viewer_auth_test_env_lock().lock().expect("env lock");
+        let _restore = ViewerAuthEnvRestore::clear();
         std::env::set_var(VIEWER_AUTH_PUBLIC_KEY_ENV, "env-public");
         std::env::set_var(VIEWER_AUTH_PRIVATE_KEY_ENV, "env-private");
         let auth = resolve_optional_viewer_auth_bootstrap().expect("auth");
         assert_eq!(auth.public_key, "env-public");
         assert_eq!(auth.private_key, "env-private");
-        std::env::remove_var(VIEWER_AUTH_PUBLIC_KEY_ENV);
-        std::env::remove_var(VIEWER_AUTH_PRIVATE_KEY_ENV);
     }
 
     #[test]
     fn resolve_optional_viewer_auth_bootstrap_uses_config_file() {
+        let _guard = viewer_auth_test_env_lock().lock().expect("env lock");
+        let _restore = ViewerAuthEnvRestore::clear();
         let temp_root = temp_config_path("config");
         fs::create_dir_all(&temp_root).expect("mkdir");
         let config_path = temp_root.join("config.toml");


### PR DESCRIPTION
## Summary

Adds a GitHub-hosted daily release workflow so the project can create a date-based GitHub Release without relying on a local machine being online.

## Changes

- Adds `.github/workflows/daily-github-release.yml`.
- Schedules the workflow for `0 22 * * *` UTC, which is 06:00 in `Asia/Shanghai`.
- Resolves the release tag as `<YYYY-MM-DD>_v1` using the current Asia/Shanghai date.
- Refuses to continue if the tag or release already exists.
- Creates and pushes an annotated tag on `main`, then creates a GitHub Release with generated notes.
- Keeps the existing `release-packages.yml` `v*` package release path unchanged.
- Records and closes the `.pm` task for this work.

## Validation

- `python3 -c "import pathlib, yaml; yaml.safe_load(pathlib.Path('.github/workflows/daily-github-release.yml').read_text()); print('yaml ok')"`
- `git diff --check`
- `./scripts/pm/lint.sh`
- `./scripts/doc-governance-check.sh`
- Tag-format probe produced `2026-05-30_v1`.

## Notes

The previous local Codex automation `daily-github-release` was deleted before this PR was opened to avoid duplicate local and CI release attempts.