### PR TITLE
Package hosted login deploy artifact

### DIFF
--- a/.github/workflows/hosted-login-linux-build.yml
+++ b/.github/workflows/hosted-login-linux-build.yml
@@ -5,12 +5,32 @@ on:
     branches: ["main"]
     paths:
       - ".github/workflows/hosted-login-linux-build.yml"
+      - "Cargo.lock"
+      - "Cargo.toml"
+      - "rust-toolchain.toml"
       - "crates/oasis7/**"
-      - "crates/oasis7_viewer/**"
-      - "scripts/build-viewer-software-safe.sh"
+      - "crates/oasis7_consensus/**"
+      - "crates/oasis7_distfs/**"
+      - "crates/oasis7_launcher_ui/**"
+      - "crates/oasis7_net/**"
+      - "crates/oasis7_node/**"
+      - "crates/oasis7_proto/**"
+      - "crates/oasis7_wasm_abi/**"
+      - "crates/oasis7_wasm_executor/**"
+      - "crates/oasis7_wasm_router/**"
+      - "crates/oasis7_wasm_sdk/**"
+      - "crates/oasis7_wasm_store/**"
+      - "crates/oasis7_viewer/favicon.ico"
+      - "crates/oasis7_viewer/package-lock.json"
+      - "crates/oasis7_viewer/package.json"
+      - "crates/oasis7_viewer/pixel-world-bridge/**"
+      - "crates/oasis7_viewer/software_safe.html"
+      - "crates/oasis7_viewer/software_safe.js"
+      - "crates/oasis7_viewer/software_safe_first_agent_claim_evidence.html"
+      - "crates/oasis7_viewer/viewer.js"
       - "scripts/copy-viewer-web-dist.sh"
-      - "package-lock.json"
-      - "package.json"
+      - "scripts/viewer-web-dist-contract.sh"
+      - "vendor-egui-winit-0.33.3/**"
   workflow_dispatch:
     inputs:
       build_profile:
@@ -35,13 +55,6 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
-
-      - uses: actions/setup-node@v6
-        with:
-          node-version: "22"
-
-      - name: Install viewer web dependencies
-        run: npm ci --prefix crates/oasis7_viewer
 
       - name: Install pinned Rust toolchain
         run: |

--- a/.github/workflows/hosted-login-linux-build.yml
+++ b/.github/workflows/hosted-login-linux-build.yml
@@ -97,9 +97,8 @@ jobs:
             --bin oasis7_game_launcher \
             --bin oasis7_viewer_live
 
-      - name: Build viewer web dist
+      - name: Stage viewer web dist
         run: |
-          ./scripts/build-viewer-software-safe.sh
           ./scripts/copy-viewer-web-dist.sh --dist-dir output/hosted-login/web
 
       - name: Stage deployable artifact

--- a/.github/workflows/hosted-login-linux-build.yml
+++ b/.github/workflows/hosted-login-linux-build.yml
@@ -1,6 +1,16 @@
 name: Hosted Login Linux Build
 
 on:
+  pull_request:
+    branches: ["main"]
+    paths:
+      - ".github/workflows/hosted-login-linux-build.yml"
+      - "crates/oasis7/**"
+      - "crates/oasis7_viewer/**"
+      - "scripts/build-viewer-software-safe.sh"
+      - "scripts/copy-viewer-web-dist.sh"
+      - "package-lock.json"
+      - "package.json"
   workflow_dispatch:
     inputs:
       build_profile:

--- a/.pm/tasks/task_a0282b0e2c51476590c5de733f0d45ef.execution.md
+++ b/.pm/tasks/task_a0282b0e2c51476590c5de733f0d45ef.execution.md
@@ -52,3 +52,21 @@ Example:
 - Expected Result: workflow YAML 仍可解析，diff 无 whitespace error。
 - Actual Result: 通过；输出 `yaml ok`，`git diff --check` 无输出且 rc=0。
 - Blocker / Next Action: 重新验证、amend/push，等待新 artifact。
+
+## 2026-05-29 12:31:00 CST / producer_system_designer
+- 完成内容: `Hosted Login Linux Build` run `26617587116` 通过，job `hosted-login-linux-x86-64` 全部 step success，artifact `hosted-login-linux-x86_64-fa3089f375a37b912d5c84064a3773b703511d15` 已下载并展开校验。zip sha256 为 `606747add5bb3ef64ab3541a02a4fac9bd43392bea410c50774f8dfd2ab29db0`，内含 `hosted-login-linux-x86_64.tar.gz`，tar sha256 为 `a57f237fd98990be69a749e8e294baadceae8e6719e35e4aa1a84ab8a00618bd`，包内包含 `bin/oasis7_game_launcher_v3`、`bin/oasis7_viewer_live` 与 `web/` dist。
+- 遗留事项: 205 测试机可以先上传/落 release 目录；但当前 `/etc/oasis7/hosted-login-test.env` 未启用 SMTP 发件邮箱与 SMTP 密码，不能安全切 `current` 并重启到 smtp-only 版本。
+- Action: artifact verified
+- Validation Command: `mcp GitHub fetch_workflow_run_jobs run_id=26617587116 && shasum -a 256 /tmp/oasis7-hosted-login-artifacts/hosted-login-linux-x86_64.zip /tmp/oasis7-hosted-login-artifacts/hosted-login-linux-x86_64.tar.gz && tar -tzf /tmp/oasis7-hosted-login-artifacts/hosted-login-linux-x86_64.tar.gz`
+- Expected Result: GitHub Actions 成功，artifact digest 与下载 zip digest 一致，包内包含部署所需 binary 和 web dist。
+- Actual Result: 通过；artifact 可部署。
+- Blocker / Next Action: 上传 release 到 39.104.205.67；收到 SMTP credentials 后再更新 env、切 symlink、restart 并验证 `delivery_mode=smtp` 且无 `preview_code`。
+
+## 2026-05-29 12:36:00 CST / producer_system_designer
+- 完成内容: 已将 artifact 上传到 39.104.205.67，并展开为 staged release `/opt/oasis7/hosted-login-test/releases/20260529-1232-e054ccd6`。远端 tar sha256 仍为 `a57f237fd98990be69a749e8e294baadceae8e6719e35e4aa1a84ab8a00618bd`，release 内包含 `BUILDINFO`、`SHA256SUMS`、`bin/oasis7_game_launcher_v3`、`bin/oasis7_viewer_live` 与 `web/` dist。当前 `/opt/oasis7/hosted-login-test/current` 仍指向旧 release `/opt/oasis7/hosted-login-test/releases/20260527-150146`，未重启服务。
+- 遗留事项: 远端 `/etc/oasis7/hosted-login-test.env` 中 `OASIS7_HOSTED_LOGIN_SMTP_HOST`、`OASIS7_HOSTED_LOGIN_SMTP_FROM_EMAIL`、`OASIS7_HOSTED_LOGIN_SMTP_PASSWORD` 均未启用；缺少这三项时切到当前 smtp-only binary 会导致 hosted-login 服务不可用或无法发送验证码。
+- Action: staged release deployed, cutover blocked
+- Validation Command: `scp /tmp/oasis7-hosted-login-artifacts/hosted-login-linux-x86_64.tar.gz root@39.104.205.67:/tmp/hosted-login-linux-x86_64-e054ccd6.tar.gz && ssh root@39.104.205.67 'tar -xzf ... -C /opt/oasis7/hosted-login-test/releases/20260529-1232-e054ccd6 && sha256sum ... && readlink -f /opt/oasis7/hosted-login-test/current && grep -Eq ... /etc/oasis7/hosted-login-test.env'`
+- Expected Result: 新包在测试机可用 release 目录落盘，current 不变；SMTP 缺口明确。
+- Actual Result: 通过；release 已 staged，current 未切换，SMTP env 缺失已确认。
+- Blocker / Next Action: 需要补齐 SMTP 发件配置后执行 cutover：更新 `/etc/oasis7/hosted-login-test.env`，`ln -sfn /opt/oasis7/hosted-login-test/releases/20260529-1232-e054ccd6 /opt/oasis7/hosted-login-test/current`，`systemctl restart oasis7-hosted-login-test.service`，再用 `POST /api/public/hosted-account/login/start` 验证 `preview_code` 不再出现。

--- a/.pm/tasks/task_a0282b0e2c51476590c5de733f0d45ef.execution.md
+++ b/.pm/tasks/task_a0282b0e2c51476590c5de733f0d45ef.execution.md
@@ -97,3 +97,12 @@ Example:
 - Expected Result: 新增环境文档与入口引用满足文档治理、PM lint 和 whitespace 检查。
 - Actual Result: 通过；输出 `doc-governance-check: OK`、`pm-lint: OK`，`git diff --check` 无输出且 rc=0。
 - Blocker / Next Action: 将文档提交并推送到 PR #315。
+
+## 2026-05-29 15:35:09 CST / producer_system_designer
+- 完成内容: 处理 PR #315 review comments。`hosted-login-linux-build` 的 `pull_request.paths` 已扩大到 root Cargo/Rust toolchain、`oasis7` 二进制的 path dependencies、workspace patch vendor 目录和已提交 viewer dist 输入；同时移除 `crates/oasis7_viewer/**` 源码宽泛触发和无后续消费者的 Node setup / `npm ci`，避免 copy checked-in dist 的部署 job 在 viewer source-only PR 上生成 stale UI artifact。`.pm` task title 与 acceptance 已补齐 204 production deployment 和环境矩阵文档范围。
+- 遗留事项: 未自动 resolve GitHub review threads；需要 push 后再由 reviewer/owner 关闭或显式 resolve。
+- Action: review feedback addressed
+- Validation Command: `ruby -e 'require "yaml"; YAML.load_file(ARGV.fetch(0)); puts "workflow yaml ok"' .github/workflows/hosted-login-linux-build.yml && ruby -e 'require "yaml"; YAML.load_file(ARGV.fetch(0)); puts "task yaml ok"' .pm/tasks/task_a0282b0e2c51476590c5de733f0d45ef.yaml && ./scripts/pm/lint.sh && git diff --check`
+- Expected Result: workflow/task YAML 可解析，PM lint 通过，diff 无 whitespace error。
+- Actual Result: 通过；输出 `workflow yaml ok`、`task yaml ok`、`pm-lint: OK`，`git diff --check` 无输出且 rc=0。
+- Blocker / Next Action: 提交并推送 review follow-up，等待 PR checks 与 thread 复核。

--- a/.pm/tasks/task_a0282b0e2c51476590c5de733f0d45ef.execution.md
+++ b/.pm/tasks/task_a0282b0e2c51476590c5de733f0d45ef.execution.md
@@ -79,3 +79,12 @@ Example:
 - Expected Result: service active，current 指向最新 release，4373/6511/6523 正常监听，根路径 200，login/start 返回 `ok=true`、`challenge.delivery_mode=smtp`，且不包含 `preview_code`。
 - Actual Result: 通过；service active，current 为 `/opt/oasis7/hosted-login-test/releases/20260529-1245-b3d684ab`，端口 4373/6511/6523 监听，根路径 200，login/start 返回 `ok=true`、`challenge.delivery_mode=smtp`、`has_preview_code=false`。
 - Blocker / Next Action: 若需要端到端完成登录，需要从测试邮箱取得 OTP 后调用 `/api/public/hosted-account/login/complete`。
+
+## 2026-05-29 15:00:00 CST / producer_system_designer
+- 完成内容: 已在 39.104.204.172 部署正式邮箱登录环境，使用独立 prod 命名：`/opt/oasis7/hosted-login-prod`、`/etc/oasis7/hosted-login-prod.env`、`oasis7-hosted-login-prod.service`。prod release 为 `/opt/oasis7/hosted-login-prod/releases/20260529-1450-b3d684ab`，artifact tar sha256 为 `e15f021166ec02a82148bfa0bf9437d049e83dc9e430a8b7bf3941d287d91115`。正式服务已 `enable` 且 `active`，`current` 指向 prod release，临时传输文件已清理。
+- 遗留事项: 正式环境 `login/start` 已向测试邮箱发起 SMTP 投递；当前验证到 SMTP start 成功，但未读取收件箱 OTP 执行 `login/complete`。
+- Action: production deployment completed
+- Validation Command: `systemctl is-enabled oasis7-hosted-login-prod.service && systemctl is-active oasis7-hosted-login-prod.service && readlink -f /opt/oasis7/hosted-login-prod/current && ss -ltnp | grep -E '(:4373|:6511|:6523)' && curl -fsS http://39.104.204.172:4373/ && curl -fsS -X POST http://39.104.204.172:4373/api/public/hosted-account/login/start -H 'Content-Type: application/json' --data '{"channel":"email","handle":"cc@ncuhome.tech"}'`
+- Expected Result: service enabled/active，current 指向正式 release，4373/6511/6523 监听，根路径 200，login/start 返回 `ok=true`、`challenge.delivery_mode=smtp`，且不包含 `preview_code`。
+- Actual Result: 通过；service enabled/active，current 为 `/opt/oasis7/hosted-login-prod/releases/20260529-1450-b3d684ab`，端口 4373/6511/6523 监听，根路径 200，login/start 返回 `ok=true`、`challenge.delivery_mode=smtp`、`has_preview_code=false`。
+- Blocker / Next Action: 若需要端到端完成登录，需要从测试邮箱取得 OTP 后调用 `/api/public/hosted-account/login/complete`。

--- a/.pm/tasks/task_a0282b0e2c51476590c5de733f0d45ef.execution.md
+++ b/.pm/tasks/task_a0282b0e2c51476590c5de733f0d45ef.execution.md
@@ -70,3 +70,12 @@ Example:
 - Expected Result: 新包在测试机可用 release 目录落盘，current 不变；SMTP 缺口明确。
 - Actual Result: 通过；release 已 staged，current 未切换，SMTP env 缺失已确认。
 - Blocker / Next Action: 需要补齐 SMTP 发件配置后执行 cutover：更新 `/etc/oasis7/hosted-login-test.env`，`ln -sfn /opt/oasis7/hosted-login-test/releases/20260529-1232-e054ccd6 /opt/oasis7/hosted-login-test/current`，`systemctl restart oasis7-hosted-login-test.service`，再用 `POST /api/public/hosted-account/login/start` 验证 `preview_code` 不再出现。
+
+## 2026-05-29 14:32:00 CST / producer_system_designer
+- 完成内容: 收到 SMTP 与 Tablestore 配置后，已将最新 PR-head artifact `hosted-login-linux-x86_64-b3d684ab3cfe0dfc34db6050afab07120c8feab1` 上传并展开到 39.104.205.67 的 `/opt/oasis7/hosted-login-test/releases/20260529-1245-b3d684ab`。artifact zip sha256 为 `c7b06708df969d449e6eb3935c9f4eb3bccc33505bb57ce1d6b5c1e14fa3d054`，tar sha256 为 `e15f021166ec02a82148bfa0bf9437d049e83dc9e430a8b7bf3941d287d91115`。已备份旧 env 到 `/etc/oasis7/hosted-login-test.env.bak.20260529142730`，写入 SMTP/Tablestore env，切换 `/opt/oasis7/hosted-login-test/current` 到最新 release，并重启 `oasis7-hosted-login-test.service` 成功。
+- 遗留事项: `login/start` 已向测试邮箱发起 SMTP 投递；当前验证到 SMTP start 成功，但未读取收件箱 OTP 执行 `login/complete`。
+- Action: cutover completed
+- Validation Command: `systemctl is-active oasis7-hosted-login-test.service && readlink -f /opt/oasis7/hosted-login-test/current && ss -ltnp | grep -E ':(4373|6511|6523)\\b' && curl -fsS http://39.104.205.67:4373/ && curl -fsS -X POST http://39.104.205.67:4373/api/public/hosted-account/login/start -H 'Content-Type: application/json' --data '{"channel":"email","handle":"cc@ncuhome.tech"}'`
+- Expected Result: service active，current 指向最新 release，4373/6511/6523 正常监听，根路径 200，login/start 返回 `ok=true`、`challenge.delivery_mode=smtp`，且不包含 `preview_code`。
+- Actual Result: 通过；service active，current 为 `/opt/oasis7/hosted-login-test/releases/20260529-1245-b3d684ab`，端口 4373/6511/6523 监听，根路径 200，login/start 返回 `ok=true`、`challenge.delivery_mode=smtp`、`has_preview_code=false`。
+- Blocker / Next Action: 若需要端到端完成登录，需要从测试邮箱取得 OTP 后调用 `/api/public/hosted-account/login/complete`。

--- a/.pm/tasks/task_a0282b0e2c51476590c5de733f0d45ef.execution.md
+++ b/.pm/tasks/task_a0282b0e2c51476590c5de733f0d45ef.execution.md
@@ -1,0 +1,45 @@
+# task_a0282b0e2c51476590c5de733f0d45ef Execution Log
+
+- task_uid: task_a0282b0e2c51476590c5de733f0d45ef
+- title: deploy smtp-only hosted login test service
+- owner_role: producer_system_designer
+- worktree_hint: /Users/scc/ccwork/worktrees/oasis7-p2p-hosted-login-smtp-deploy
+
+<!-- Append entries using:
+Example:
+  ## YYYY-MM-DD HH:MM:SS CST / role_name
+  - 完成内容: ...
+  - 遗留事项: ...
+  - Action: ...
+  - Validation Command: ...
+  - Expected Result: ...
+  - Actual Result: ...
+  - Blocker / Next Action: ...
+-->
+
+## 2026-05-29 11:53:15 CST / producer_system_designer
+- 完成内容: WORKFLOW BOOTSTRAP DECIDED。该任务为 non-trivial 发布/部署工作，使用单一 owner role `producer_system_designer`、单一 `.pm` task `task_a0282b0e2c51476590c5de733f0d45ef`、单一 worktree `/Users/scc/ccwork/worktrees/oasis7-p2p-hosted-login-smtp-deploy`、单一 PR 主链。当前主工作区存在无关 `site/story` dirty state，因此本任务不复用主工作区。
+- 遗留事项: 39.104.205.67 上测试服务当前仍由旧 binary 提供 `preview_inline`/`preview_code` 行为；`/etc/oasis7/hosted-login-test.env` 使用测试 Tablestore 表 `oasis7_hosted_account_identity_test`，但 SMTP 发信变量仍为空注释。39.104.204.172 未运行 hosted-login 服务。
+- Action: bootstrap + route to execution
+- Validation Command: `./scripts/new-task-worktree.sh p2p hosted-login-smtp-deploy --base origin/main --branch codex/hosted-login-smtp-deploy --allow-dirty-source --pm-owner-role producer_system_designer ... --json`
+- Expected Result: 创建隔离 worktree 和 committed `.pm` task，用于 PR、打包、部署证据回写。
+- Actual Result: 通过；worktree 和 task 已创建。
+- Blocker / Next Action: 先让 hosted-login Linux build workflow 在 PR 上自动产出 Linux x86_64 artifact，再下载 artifact 部署到 205；如 205 仍缺 SMTP 凭据，则部署必须停在 fail-closed 状态而不能恢复 preview。
+
+## 2026-05-29 11:53:15 CST / producer_system_designer
+- 完成内容: WORKFLOW ROUTE DECIDED。当前方向清晰，无需 brainstorming；本轮仅改 CI packaging workflow 与任务证据，不改 hosted login 业务代码。选中 `executing-project-tasks` 执行 workflow/package/deploy slice，完成前使用 `verification-before-completion`，提交/PR 使用 GitHub publish flow。
+- 遗留事项: 本地没有 `gh`，PR 创建将使用 GitHub connector；本地 git 负责 commit/push。
+- Action: package workflow update
+- Validation Command: `rg -n "preview_inline|preview_code|server_log_only|OASIS7_HOSTED_LOGIN_DELIVERY_MODE" crates/oasis7/src/bin/oasis7_game_launcher scripts/hosted-account-staging-smoke.sh doc/p2p/blockchain/p2p-hosted-world-player-access-and-session-auth-2026-03-25.runbook.md doc/p2p/blockchain/p2p-hosted-public-join-managed-identity-custody-2026-05-18.project.md`
+- Expected Result: 当前代码合同仍是 smtp-only public path；PR 只需要补打包触发与执行证据。
+- Actual Result: 业务代码不再出现 preview/server-log delivery mode 开关；只剩 SMTP 合同和文档中的 staging/production 要求。
+- Blocker / Next Action: 提交并创建 PR 后等待 Actions artifact。
+
+## 2026-05-29 11:56:00 CST / producer_system_designer
+- 完成内容: 将 `.github/workflows/hosted-login-linux-build.yml` 扩展为 `pull_request` 触发，限定 main PR 与 hosted-login 相关代码/脚本/workflow 路径。该 PR 会在 GitHub Actions 中构建 `hosted-login-linux-x86_64-<sha>` artifact，供测试环境部署使用。
+- 遗留事项: 本地没有 `gh`；PR 创建和 artifact 查询使用 GitHub connector。
+- Action: workflow packaging trigger
+- Validation Command: `ruby -e 'require "yaml"; YAML.load_file(ARGV.fetch(0)); puts "yaml ok"' .github/workflows/hosted-login-linux-build.yml && ./scripts/pm/lint.sh && ./scripts/doc-governance-check.sh && git diff --check`
+- Expected Result: workflow YAML 可解析，PM/doc/diff 门禁通过。
+- Actual Result: 通过；输出 `yaml ok`、`pm-lint: OK`、`doc-governance-check: OK`，`git diff --check` 无输出且 rc=0。
+- Blocker / Next Action: commit + push + draft PR。

--- a/.pm/tasks/task_a0282b0e2c51476590c5de733f0d45ef.execution.md
+++ b/.pm/tasks/task_a0282b0e2c51476590c5de733f0d45ef.execution.md
@@ -43,3 +43,12 @@ Example:
 - Expected Result: workflow YAML 可解析，PM/doc/diff 门禁通过。
 - Actual Result: 通过；输出 `yaml ok`、`pm-lint: OK`、`doc-governance-check: OK`，`git diff --check` 无输出且 rc=0。
 - Blocker / Next Action: commit + push + draft PR。
+
+## 2026-05-29 12:14:47 CST / producer_system_designer
+- 完成内容: PR #315 已创建并触发 `Hosted Login Linux Build` run `26616985810`。该 run 的 Rust binary 编译通过，但 `Build viewer web dist` 长时间停留 in-progress。由于本 PR 不修改 viewer 源码，且 checked-in canonical viewer dist 已由 repo 管理，调整 packaging workflow 为直接 `copy-viewer-web-dist.sh` stage checked-in dist，避免在部署打包 job 里重新构建 web。
+- 遗留事项: 原 run `26616985810` 可忽略；新 commit 会触发新的 hosted-login Linux artifact run。205 仍缺活跃 SMTP credentials，部署切流前必须补齐 `OASIS7_HOSTED_LOGIN_SMTP_FROM_EMAIL` 与 `OASIS7_HOSTED_LOGIN_SMTP_PASSWORD`。
+- Action: unblock packaging artifact
+- Validation Command: `ruby -e 'require "yaml"; YAML.load_file(ARGV.fetch(0)); puts "yaml ok"' .github/workflows/hosted-login-linux-build.yml && git diff --check`
+- Expected Result: workflow YAML 仍可解析，diff 无 whitespace error。
+- Actual Result: 通过；输出 `yaml ok`，`git diff --check` 无输出且 rc=0。
+- Blocker / Next Action: 重新验证、amend/push，等待新 artifact。

--- a/.pm/tasks/task_a0282b0e2c51476590c5de733f0d45ef.execution.md
+++ b/.pm/tasks/task_a0282b0e2c51476590c5de733f0d45ef.execution.md
@@ -88,3 +88,12 @@ Example:
 - Expected Result: service enabled/active，current 指向正式 release，4373/6511/6523 监听，根路径 200，login/start 返回 `ok=true`、`challenge.delivery_mode=smtp`，且不包含 `preview_code`。
 - Actual Result: 通过；service enabled/active，current 为 `/opt/oasis7/hosted-login-prod/releases/20260529-1450-b3d684ab`，端口 4373/6511/6523 监听，根路径 200，login/start 返回 `ok=true`、`challenge.delivery_mode=smtp`、`has_preview_code=false`。
 - Blocker / Next Action: 若需要端到端完成登录，需要从测试邮箱取得 OTP 后调用 `/api/public/hosted-account/login/complete`。
+
+## 2026-05-29 15:18:00 CST / producer_system_designer
+- 完成内容: 建立项目级环境矩阵文档 `doc/engineering/governance/environment-lanes-and-inventory-2026-05-29.md`，记录 test/prod 命名原则、204/205 云上清单、hosted-login test/prod 环境矩阵、network tier 与 `testnet/mainnet` claim boundary、全流程双环境要求和后续缺口。同步在 `doc/engineering/README.md`、`doc/p2p/prd.index.md`、`doc/testing/README.md` 与 hosted-world runbook 建立入口引用。
+- 遗留事项: hosted-login 仍需补自动读取测试邮箱 OTP 的完整 `login/start -> login/complete` 云上 smoke；public_testnet/mainnet 仍需各自的非 placeholder evidence 与 gate。
+- Action: environment documentation added
+- Validation Command: `./scripts/doc-governance-check.sh && ./scripts/pm/lint.sh && git diff --check`
+- Expected Result: 新增环境文档与入口引用满足文档治理、PM lint 和 whitespace 检查。
+- Actual Result: 通过；输出 `doc-governance-check: OK`、`pm-lint: OK`，`git diff --check` 无输出且 rc=0。
+- Blocker / Next Action: 将文档提交并推送到 PR #315。

--- a/.pm/tasks/task_a0282b0e2c51476590c5de733f0d45ef.yaml
+++ b/.pm/tasks/task_a0282b0e2c51476590c5de733f0d45ef.yaml
@@ -1,5 +1,5 @@
 task_uid: task_a0282b0e2c51476590c5de733f0d45ef
-title: "deploy smtp-only hosted login test service"
+title: "deploy smtp-only hosted login services"
 owner_role: producer_system_designer
 worktree_hint: /Users/scc/ccwork/worktrees/oasis7-p2p-hosted-login-smtp-deploy
 execution_log_path: .pm/tasks/task_a0282b0e2c51476590c5de733f0d45ef.execution.md
@@ -17,6 +17,8 @@ acceptance:
   - "Publish a PR for the smtp-only hosted login deployment slice."
   - "Build a Linux x86_64 package from the current branch."
   - "Deploy the package to 39.104.205.67 hosted-login-test with SMTP env and no preview_code in login/start."
+  - "Deploy the package to 39.104.204.172 hosted-login-prod with SMTP env and no preview_code in login/start."
+  - "Document the project-level test/prod environment lanes and hosted-login cloud inventory."
 handoff_to: []
-updated_at: 2026-05-29T11:49:32+08:00
+updated_at: 2026-05-29T15:35:09+08:00
 last_started_at: 2026-05-29T11:49:32+08:00

--- a/.pm/tasks/task_a0282b0e2c51476590c5de733f0d45ef.yaml
+++ b/.pm/tasks/task_a0282b0e2c51476590c5de733f0d45ef.yaml
@@ -1,0 +1,22 @@
+task_uid: task_a0282b0e2c51476590c5de733f0d45ef
+title: "deploy smtp-only hosted login test service"
+owner_role: producer_system_designer
+worktree_hint: /Users/scc/ccwork/worktrees/oasis7-p2p-hosted-login-smtp-deploy
+execution_log_path: .pm/tasks/task_a0282b0e2c51476590c5de733f0d45ef.execution.md
+status: committed
+priority: P1
+source_signal: null
+source_refs:
+  - doc/p2p/blockchain/p2p-hosted-world-player-access-and-session-auth-2026-03-25.runbook.md
+  - doc/p2p/blockchain/p2p-hosted-public-join-managed-identity-custody-2026-05-18.project.md
+doc_refs:
+  - doc/p2p/project.md
+related_prd:
+  - PRD-P2P-029-G
+acceptance:
+  - "Publish a PR for the smtp-only hosted login deployment slice."
+  - "Build a Linux x86_64 package from the current branch."
+  - "Deploy the package to 39.104.205.67 hosted-login-test with SMTP env and no preview_code in login/start."
+handoff_to: []
+updated_at: 2026-05-29T11:49:32+08:00
+last_started_at: 2026-05-29T11:49:32+08:00

--- a/doc/engineering/README.md
+++ b/doc/engineering/README.md
@@ -19,6 +19,7 @@
 ## 按主题进入
 - 文档治理与入口减重：先看 `doc/engineering/doc-governance/doc-corpus-maintenance-governance-2026-04-17.prd.md`
 - 目录职责与 redirect 规则：先看 `doc/engineering/doc-governance/doc-structure-standard.prd.md`
+- 环境分层、测试/正式云上清单、testnet/mainnet 口径：先看 `doc/engineering/governance/environment-lanes-and-inventory-2026-05-29.md`
 - Rust 体量治理：先看 `doc/engineering/rust-governance/rust-1200-line-root-cause-governance-2026-03-29.prd.md`
 - `.pm` / self-evolution：先看 `doc/engineering/self-evolution/file-based-self-evolution-management-2026-03-30.prd.md`
 - 趋势 / 季度复核 / 迁移 / 审读：统一从 `doc/engineering/prd.index.md` 下钻对应专题

--- a/doc/engineering/governance/environment-lanes-and-inventory-2026-05-29.md
+++ b/doc/engineering/governance/environment-lanes-and-inventory-2026-05-29.md
@@ -1,0 +1,162 @@
+# oasis7 环境分层与云上服务清单
+
+审计轮次: 1
+
+## Meta
+- Owner Role: `producer_system_designer`
+- Review Roles:
+  - `qa_engineer`
+  - `runtime_engineer`
+  - `liveops_community`
+- Scope: 项目级 `test/prod` 环境分层、hosted-login 云上清单、testnet/mainnet 口径边界、上线与回归流程的双环境要求
+- Last Verified: 2026-05-29 Asia/Shanghai
+- Related Runtime Evidence:
+  - `.pm/tasks/task_a0282b0e2c51476590c5de733f0d45ef.execution.md`
+  - `doc/p2p/blockchain/p2p-hosted-world-player-access-and-session-auth-2026-03-25.runbook.md`
+  - `doc/p2p/blockchain/p2p-formal-network-tiers-testnet-mechanism-2026-05-14.runbook.md`
+
+## 1. 适用范围
+这份文档是项目级环境真值入口，用于回答三类问题：
+
+1. 当前云上哪些机器承担测试环境、正式环境或网络层职责。
+2. 新流程上线前是否具备一套可反复演练的 test lane 和一套受控 prod lane。
+3. `testnet/mainnet`、`staging/production`、`dev/local` 这些词在 oasis7 内部如何对应，避免把测试服务误说成正式服务。
+
+本文件不保存任何密钥值。所有 SMTP、Tablestore、signer、custody、API key、approval code 只允许存在于受控 secret store、部署机 env 文件或 operator 临时输入中。
+
+## 2. 命名原则
+项目默认采用三层表达，但所有对外或可变更流程至少必须具备 test/prod 两套：
+
+| 层级 | 用途 | 是否可给外部用户 | 数据是否可重置 | 典型命名 |
+| --- | --- | --- | --- | --- |
+| `dev/local` | 本地开发、单机 smoke、结构验证 | 不可 | 可随时重置 | `local`, `dev`, `file backend` |
+| `test/staging` | 上线前验证、受控测试用户、operator 演练 | 仅受控测试 | 可按 runbook 重置 | `test`, `staging`, `public_testnet`, `shared_devnet` |
+| `prod/mainnet` | 真实玩家或正式网络入口 | 可 | 不可随意重置 | `prod`, `production`, `mainnet` |
+
+强规则：
+1. 新增外部服务时，先定义 test lane，再定义 prod lane。
+2. test lane 不得复用 prod 的状态存储、secret、signer、approval code 或用户数据表。
+3. prod lane 不得使用 inline OTP、server log OTP、placeholder endpoint、example manifest 或本地 file backend 作为用户主链路。
+4. `public_testnet` 只能说明“公开可测试且可重置”；它不是 `mainnet`，也不承诺 mainnet 价值语义。
+5. `mainnet` 只有在 genesis、bootstrap、public RPC/explorer、claims boundary、custody/signing、rollback/incident runbook 全部过 gate 后才能声明。
+
+## 3. 当前云上清单
+以下是 2026-05-29 只读核查与部署后的当前清单。
+
+| 主机 | 当前职责 | Hosted Login | Network / Chain | 对外检查 |
+| --- | --- | --- | --- | --- |
+| `39.104.205.67` | 邮箱登录测试环境 | `oasis7-hosted-login-test.service`，active | 同机还有 testnet storage / triad storage / bridge 类服务 | `http://39.104.205.67:4373/` 返回 `200` |
+| `39.104.204.172` | 邮箱登录正式环境；同时承载若干测试网络节点服务 | `oasis7-hosted-login-prod.service`，enabled + active | 同机还有 testnet sequencer / triad sequencer / faucet 类服务；这些不等于 mainnet | `http://39.104.204.172:4373/` 返回 `200` |
+
+说明：
+1. 主机上存在 testnet/triad 服务，不自动意味着 `public_testnet` 已达到 live candidate，也不意味着 mainnet 已上线。
+2. `public_testnet` readiness 仍以 `doc/p2p/blockchain/p2p-formal-network-tiers-testnet-mechanism-2026-05-14.runbook.md` 的 seven-lane checklist 为准。
+3. hosted-login 的 test/prod 两套已经分开部署，但仍建议补完整 `login/complete` 自动 smoke，以便把 OTP 收件箱验证也纳入日常 gate。
+
+## 4. Hosted Login 环境矩阵
+| 项 | 测试环境 | 正式环境 |
+| --- | --- | --- |
+| Host | `39.104.205.67` | `39.104.204.172` |
+| Service | `oasis7-hosted-login-test.service` | `oasis7-hosted-login-prod.service` |
+| Root | `/opt/oasis7/hosted-login-test` | `/opt/oasis7/hosted-login-prod` |
+| Env file | `/etc/oasis7/hosted-login-test.env` | `/etc/oasis7/hosted-login-prod.env` |
+| Current release | `/opt/oasis7/hosted-login-test/releases/20260529-1245-b3d684ab` | `/opt/oasis7/hosted-login-prod/releases/20260529-1450-b3d684ab` |
+| Viewer port | `4373` | `4373` |
+| WebSocket port | `6511` | `6511` |
+| Live bind port | `6523` | `6523` |
+| Store backend | `tablestore` | `tablestore` |
+| Tablestore table | `oasis7_hosted_account_identity_test` | `oasis7_hosted_account_identity` |
+| OTP delivery | SMTP only | SMTP only |
+| Inline preview OTP | forbidden | forbidden |
+
+Hosted-login 最小验证：
+```bash
+curl -fsS http://<host>:4373/
+
+curl -fsS -X POST http://<host>:4373/api/public/hosted-account/login/start \
+  -H 'Content-Type: application/json' \
+  --data '{"channel":"email","handle":"<test-email>"}'
+```
+
+验收口径：
+1. 根路径返回 `200`。
+2. `login/start` 返回 `ok=true`。
+3. `challenge.delivery_mode=smtp`。
+4. 响应中没有 `preview_code`。
+5. 完整 smoke 还必须用真实邮箱 OTP 调 `/api/public/hosted-account/login/complete`，并确认同一邮箱跨重启后账号映射稳定。
+
+## 5. Network Tier 矩阵
+| Tier | 环境语义 | 当前可声明状态 | Gate 文档 |
+| --- | --- | --- | --- |
+| `local_dev` | 本地或单机开发验证 | 可用于开发反馈，不可对外声明 | `testing-manual.md` |
+| `shared_devnet` | 共享开发网络 / release train 前置环境 | 可作为 public testnet promotion 输入，不能替代 public testnet | `doc/p2p/blockchain/p2p-shared-network-release-train-minimum-2026-03-24.runbook.md` |
+| `public_testnet` | 面向外部测试者、可重置、有 faucet guard 的测试网络 | 只有 seven-lane 全 pass 后才可声明 live candidate | `doc/p2p/blockchain/p2p-formal-network-tiers-testnet-mechanism-2026-05-14.runbook.md` |
+| `mainnet` | 正式网络，非可随意重置的生产语义 | 未有 mainnet gate 前不得声明 | `doc/p2p/blockchain/p2p-mainnet-grade-readiness-hardening-2026-03-23.prd.md` |
+
+`testnet -> mainnet` promotion 必须至少证明：
+1. 候选版本、genesis、bootstrap peers 与 manifest 都不是 placeholder。
+2. public RPC、explorer、faucet 都有公开可达证据。
+3. reset policy 和 claims boundary 已由 `qa_engineer` / `liveops_community` 复核。
+4. signer/custody/mainnet key 与 testnet key 完全隔离。
+5. rollback、incident、communication runbook 可执行。
+
+## 6. 全流程双环境要求
+任何新增流程只要会被外部用户、operator、CI/CD、云服务或长期数据依赖，就必须补一行 test/prod 环境矩阵。
+
+| 流程类型 | Test lane 必须有 | Prod lane 必须有 |
+| --- | --- | --- |
+| 用户登录 / 账号 | 独立测试邮箱、独立表、受控测试收件箱 smoke | 独立正式表、SMTP-only、真实 OTP complete smoke |
+| 链 / 网络 | shared-devnet 或 public-testnet manifest + evidence | mainnet manifest + non-reset claims + signing/custody gate |
+| 数据存储 | 测试 bucket/table/path，可清理 | 正式 bucket/table/path，备份与迁移策略 |
+| Signer / Custody | 测试 key，允许演练 revoke/recovery | 正式 key，严格权限、审计与轮换 |
+| CI / 打包 | PR artifact、测试部署、回归 smoke | release artifact、prod deploy、回滚点 |
+| LiveOps / 对外公告 | 测试公告、preview wording、incident drill | 正式公告、claims review、支持与回滚窗口 |
+
+新增或修改流程时，PR 描述至少回答：
+1. test lane 在哪里。
+2. prod lane 在哪里。
+3. 哪些 secret / state / endpoint 被隔离。
+4. test lane 的 smoke 命令是什么。
+5. prod lane 的 smoke 命令是什么。
+6. 回滚点是什么。
+
+## 7. 变更记录要求
+每次新增、移动、下线或重命名云上环境，至少回写：
+
+1. 本文件的对应矩阵。
+2. 相关 runbook 或 module README 的入口链接。
+3. `.pm/tasks/<TASK-UID>.execution.md` 的部署与验证证据。
+4. PR body 的环境状态摘要。
+
+禁止项：
+1. 不得在本文件、PR body、PM execution log 或公开 issue/comment 中写入密钥值。
+2. 不得只部署 prod 而没有 test lane。
+3. 不得把 testnet 的 `200 OK` 或单点服务 active 直接当作 mainnet readiness。
+4. 不得把 `login/start` 成功误报成完整登录成功；完整登录必须包含 OTP complete。
+
+## 8. 快速状态检查
+Hosted login 测试环境：
+```bash
+curl -fsS -o /tmp/oasis7-hosted-login-test.html -w '%{http_code}\n' \
+  http://39.104.205.67:4373/
+```
+
+Hosted login 正式环境：
+```bash
+curl -fsS -o /tmp/oasis7-hosted-login-prod.html -w '%{http_code}\n' \
+  http://39.104.204.172:4373/
+```
+
+systemd 只读核查：
+```bash
+systemctl is-active oasis7-hosted-login-test.service
+systemctl is-active oasis7-hosted-login-prod.service
+```
+
+云上 operator 检查时只允许输出 env key 名，不允许输出 env value。
+
+## 9. 后续缺口
+1. 为 hosted-login 增加可自动读取测试邮箱 OTP 的 `login/start -> login/complete` 云上 smoke。
+2. 为 public_testnet 生成非 placeholder manifest、lanes TSV 与公开 endpoint evidence。
+3. 为 mainnet readiness 增加独立环境矩阵，明确 signer/custody/genesis/bootstrap/RPC/explorer/faucet 的 test/prod 隔离。
+4. 将 CI deploy job 拆成 `deploy-test` 与 `deploy-prod` 两条显式 lane，避免人工命令长期承担环境真值。

--- a/doc/p2p/blockchain/p2p-hosted-world-player-access-and-session-auth-2026-03-25.runbook.md
+++ b/doc/p2p/blockchain/p2p-hosted-world-player-access-and-session-auth-2026-03-25.runbook.md
@@ -139,6 +139,8 @@ MVP 最小 smoke：
    - 说明要么先建表，要么打开 `AUTO_CREATE`。
 
 ## 5B. 分环境执行清单
+项目级环境矩阵与当前云上服务清单以 `doc/engineering/governance/environment-lanes-and-inventory-2026-05-29.md` 为入口；本节只保留 hosted account operator 执行口径。
+
 如果你准备把这条 hosted account 中心化服务给测试用户或真实玩家用，不要只想“有没有一个服务器能跑起来”；最小真值应是 `dev/staging/production` 三层各自独立。
 
 ### dev 环境

--- a/doc/p2p/prd.index.md
+++ b/doc/p2p/prd.index.md
@@ -42,6 +42,7 @@
 | `consensus/` | 6 | 共识实现与内建 wasm 身份口径 |
 
 ## 活跃补充文档
+- `doc/engineering/governance/environment-lanes-and-inventory-2026-05-29.md`：项目级 test/prod 环境分层、hosted-login 云上清单与 `testnet/mainnet` claim boundary。
 - `doc/p2p/node/README.md`：`node/` 热点子域 landing page，按奖励、复制、PoS 时间、身份引导与 WASM 编译分流读者。
 - `doc/p2p/blockchain/p2p-formal-network-tiers-testnet-mechanism-2026-05-14.runbook.md`：formal `public_testnet` 从 `specified_skeleton_only` 进入 `ready_for_live_candidate` 前的 companion checklist/runbook。
 - `doc/p2p/blockchain/p2p-shared-network-release-train-minimum-2026-03-24.runbook.md`：共享网络最小发布列车的执行 companion runbook，不并入下方 PRD 三件套长表。

--- a/doc/testing/README.md
+++ b/doc/testing/README.md
@@ -13,6 +13,7 @@
 - 想先判断要跑哪套测试或查操作步骤：`testing-manual.md`、`doc/testing/manual/web-ui-agent-browser-closure-manual.manual.md`
 - 想先进入 `evidence` 热点子域，并按 release gate / hosted-world / p2p-shared-network / governance drill / claim-audit 问题分流：`doc/testing/evidence/README.md`
 - 想先看当前 QA 阻断摘要：`doc/testing/provider-dual-mode-t4-blocker-2026-03-16.md`
+- 想先确认云上测试/正式环境、hosted-login 服务清单与 testnet/mainnet 口径边界：`doc/engineering/governance/environment-lanes-and-inventory-2026-05-29.md`
 - 想按子域或文件名继续下钻，而不是从长表里逐行找：`doc/testing/prd.index.md`
 
 ## 入口


### PR DESCRIPTION
## Summary
- Adds pull_request triggering for the hosted-login Linux build workflow so PRs can produce a deployable Linux x86_64 artifact.
- Uses checked-in viewer web dist for the deploy artifact to avoid hanging in an unnecessary web rebuild during this deploy slice.
- Broadens Rust build-input filters and narrows viewer triggers to checked-in dist inputs so the workflow does not package stale UI for source-only viewer changes.
- Creates a repo-owned PM task and records packaging/deployment evidence for both hosted-login test and production services.
- Adds the project-level environment matrix at `doc/engineering/governance/environment-lanes-and-inventory-2026-05-29.md`, covering test/prod lanes, hosted-login inventory, and testnet/mainnet claim boundaries.

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(ARGV.fetch(0)); puts "workflow yaml ok"' .github/workflows/hosted-login-linux-build.yml`
- `ruby -e 'require "yaml"; YAML.load_file(ARGV.fetch(0)); puts "task yaml ok"' .pm/tasks/task_a0282b0e2c51476590c5de733f0d45ef.yaml`
- `./scripts/pm/lint.sh`
- `./scripts/doc-governance-check.sh`
- `git diff --check`
- GitHub Actions `Hosted Login Linux Build` run `26618151949`: success for packaged code artifact
- Artifact zip sha256: `c7b06708df969d449e6eb3935c9f4eb3bccc33505bb57ce1d6b5c1e14fa3d054`
- Artifact tar sha256: `e15f021166ec02a82148bfa0bf9437d049e83dc9e430a8b7bf3941d287d91115`

## Test Deployment Status
- Deployed on `39.104.205.67` at `/opt/oasis7/hosted-login-test/releases/20260529-1245-b3d684ab`.
- Active `current` points to `/opt/oasis7/hosted-login-test/releases/20260529-1245-b3d684ab`.
- `oasis7-hosted-login-test.service` is active; ports `4373`, `6511`, and `6523` are listening.
- External root smoke returned HTTP `200`.
- `POST /api/public/hosted-account/login/start` with the test mailbox returned `ok=true`, `challenge.delivery_mode=smtp`, and no `preview_code`.

## Production Deployment Status
- Deployed on `39.104.204.172` at `/opt/oasis7/hosted-login-prod/releases/20260529-1450-b3d684ab`.
- Active `current` points to `/opt/oasis7/hosted-login-prod/releases/20260529-1450-b3d684ab`.
- `oasis7-hosted-login-prod.service` is enabled and active; ports `4373`, `6511`, and `6523` are listening.
- External root smoke returned HTTP `200`.
- `POST /api/public/hosted-account/login/start` with the test mailbox returned `ok=true`, `challenge.delivery_mode=smtp`, and no `preview_code`.

## Environment Contract
- Every externally used flow should define a test lane and a prod lane before public claims.
- Hosted-login test/prod now have separate service names, roots, env files, and Tablestore tables.
- `public_testnet` and `mainnet` remain separate network-tier claims with their own gates; testnet service liveness is not mainnet readiness.

## Review Follow-up
- Addressed comments about Rust path filters, stale viewer UI packaging, non-existent root package paths, unused Node setup, and prod deployment acceptance scope.
- No secret values are included in this PR body, environment document, or PM execution log.