### PR TITLE
Fix release gate launcher env and soak artifacts

### DIFF
--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -218,7 +218,10 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: release-gate-soak-summary
-          path: .tmp/release_gate_soak
+          path: |
+            .tmp/release_gate_soak
+            .tmp/release_gate_p2p
+            .tmp/release_gate_s10
           if-no-files-found: warn
 
   release_gate:

--- a/.pm/tasks/task_c3c2fa06ea7447639e29592e4ca2be7b.execution.md
+++ b/.pm/tasks/task_c3c2fa06ea7447639e29592e4ca2be7b.execution.md
@@ -1,0 +1,50 @@
+# task_c3c2fa06ea7447639e29592e4ca2be7b Execution Log
+
+- task_uid: task_c3c2fa06ea7447639e29592e4ca2be7b
+- title: fix v0.0.53 release gate blockers
+- owner_role: producer_system_designer
+- worktree_hint: /Users/scc/ccwork/worktrees/oasis7-release-v0053-gate-fixes
+
+<!-- Append entries using:
+Example:
+  ## YYYY-MM-DD HH:MM:SS CST / role_name
+  - 完成内容: ...
+  - 遗留事项: ...
+  - Action: ...
+  - Validation Command: ...
+  - Expected Result: ...
+  - Actual Result: ...
+  - Blocker / Next Action: ...
+-->
+
+## 2026-05-29 16:44:56 CST / producer_system_designer
+- 完成内容: release v0.0.53 gate failure triage；`release-gate-web` 的 launcher log 指向 hosted-login SMTP 必填环境缺失，`release-gate-soak` artifact 未上传 S10 外部 run dir，导致失败指标不可见。
+- 完成内容: 在 `scripts/hosted-login-gate-env-lib.sh` 增加 gate-only 默认环境生成；`scripts/viewer-primary-web-entry-regression.sh` 与 `scripts/run-game-test.sh` 启动 launcher 时继承这些默认值，只在调用方未设置真实 env 时补齐 SMTP sender/password 与 file-backed hosted account store。
+- 完成内容: 扩展 `.github/workflows/release-packages.yml` 的 soak artifact 上传范围，包含 `.tmp/release_gate_p2p` 与 `.tmp/release_gate_s10`。
+- 遗留事项: 需要补充本地启动验证、S10 侧验证或明确本地环境阻断。
+- Action: 保持生产/云上 hosted-login contract 不变；未改 Rust hosted login 配置要求，也未引入 preview/server-log/固定 OTP 路径。
+- Validation Command: `bash -n scripts/hosted-login-gate-env-lib.sh scripts/viewer-primary-web-entry-regression.sh scripts/run-game-test.sh`
+- Expected Result: shell syntax passes.
+- Actual Result: passed.
+- Blocker / Next Action: 等待本地 launcher startup probe 完成后继续做 S10/soak 侧验证。
+
+## 2026-05-29 16:48:51 CST / producer_system_designer
+- 完成内容: 将 task branch rebase 到最新 `origin/main` 后重新验证脚本语法与 diff。
+- 遗留事项: 本机缺少 `agent-browser`/npx fallback 与 `jq`，完整 browser regression 和 S10 短跑需交给 GitHub runner 或补齐本机工具后复验。
+- Action: 保留 task 为 done，因为 release web 根因已通过 launcher startup probe 验证，S10 失败证据链已改为上传完整 `.tmp/release_gate_s10` 目录；PR CI 将承担完整 gate 回归。
+- Validation Command: `bash -n scripts/hosted-login-gate-env-lib.sh scripts/viewer-primary-web-entry-regression.sh scripts/run-game-test.sh scripts/s10-five-node-game-soak.sh scripts/release-gate.sh`
+- Expected Result: shell syntax passes.
+- Actual Result: passed.
+- Validation Command: `git diff --check`
+- Expected Result: no whitespace errors.
+- Actual Result: passed.
+- Validation Command: local launcher startup probe using `oasis7_hosted_login_gate_env_defaults`, minimal static dir, and web bridge `127.0.0.1:6911`.
+- Expected Result: launcher reaches web bridge readiness without hosted-login SMTP env exported by the parent shell.
+- Actual Result: passed; output included `web bridge ready`.
+- Validation Command: `./scripts/viewer-primary-web-entry-regression.sh --out-dir .tmp/release-v0053-primary-web-entry --live-bind 127.0.0.1:6523 --web-bind 127.0.0.1:6511 --chain-status-bind 127.0.0.1:6621 --viewer-port 6673`
+- Expected Result: primary web entry regression passes.
+- Actual Result: blocked in this local environment: `agent-browser` or npx fallback is not installed.
+- Validation Command: `./scripts/s10-five-node-game-soak.sh --duration-secs 60 --base-port 8910 --no-prewarm --max-stall-secs 240 --max-lag-p95 50 --out-dir .tmp/release-v0053-s10-probe`
+- Expected Result: short S10 probe either passes or produces local metric artifacts.
+- Actual Result: blocked in this local environment: `jq is required for metrics aggregation but not found in PATH`.
+- Blocker / Next Action: Open PR; GitHub runner has `jq` installed and the soak artifact now uploads `.tmp/release_gate_s10` for direct diagnosis if S10 fails again.

--- a/.pm/tasks/task_c3c2fa06ea7447639e29592e4ca2be7b.yaml
+++ b/.pm/tasks/task_c3c2fa06ea7447639e29592e4ca2be7b.yaml
@@ -1,0 +1,30 @@
+task_uid: task_c3c2fa06ea7447639e29592e4ca2be7b
+title: "fix v0.0.53 release gate blockers"
+owner_role: producer_system_designer
+worktree_hint: /Users/scc/ccwork/worktrees/oasis7-release-v0053-gate-fixes
+execution_log_path: .pm/tasks/task_c3c2fa06ea7447639e29592e4ca2be7b.execution.md
+status: done
+priority: P1
+source_signal: null
+source_refs:
+  - .github/workflows/release-packages.yml
+  - scripts/release-gate-web-strict.sh
+  - scripts/s10-five-node-game-soak.sh
+doc_refs:
+  - doc/testing/project.md
+related_prd: []
+acceptance:
+  - "release-gate-web no longer fails before web bridge startup due to missing hosted-login SMTP env in CI"
+  - "S10 release soak failure is reproduced or narrowed and the relevant gate script is fixed or made diagnosable"
+  - "targeted local verification passes and release re-trigger path is documented"
+handoff_to:
+  - qa_engineer
+  - runtime_engineer
+updated_at: 2026-05-29T16:49:13+08:00
+last_started_at: 2026-05-29T16:30:01+08:00
+last_claim_type: task_complete
+last_verify_command: "bash -n scripts/hosted-login-gate-env-lib.sh scripts/viewer-primary-web-entry-regression.sh scripts/run-game-test.sh scripts/s10-five-node-game-soak.sh scripts/release-gate.sh && git diff --check"
+last_verified_at: 2026-05-29T16:49:12+08:00
+last_verification_exit_code: 0
+last_verification_status: verified
+last_closed_at: 2026-05-29T16:49:13+08:00

--- a/scripts/hosted-login-gate-env-lib.sh
+++ b/scripts/hosted-login-gate-env-lib.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+oasis7_hosted_login_env_default_if_unset() {
+  local key="$1"
+  local value="$2"
+  local current=""
+
+  current=$(printenv "$key" 2>/dev/null || true)
+  case "$current" in
+    *[![:space:]]*) ;;
+    *) printf '%s=%s\n' "$key" "$value" ;;
+  esac
+}
+
+oasis7_hosted_login_gate_env_defaults() {
+  local store_path="$1"
+
+  oasis7_hosted_login_env_default_if_unset \
+    "OASIS7_HOSTED_LOGIN_SMTP_FROM_EMAIL" \
+    "oasis7-release-gate@example.invalid"
+  oasis7_hosted_login_env_default_if_unset \
+    "OASIS7_HOSTED_LOGIN_SMTP_PASSWORD" \
+    "oasis7-release-gate-placeholder"
+  oasis7_hosted_login_env_default_if_unset \
+    "OASIS7_HOSTED_ACCOUNT_STORE_BACKEND" \
+    "file"
+  oasis7_hosted_login_env_default_if_unset \
+    "OASIS7_HOSTED_ACCOUNT_STORE_PATH" \
+    "$store_path"
+}

--- a/scripts/run-game-test.sh
+++ b/scripts/run-game-test.sh
@@ -5,6 +5,7 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 source "$ROOT_DIR/scripts/agent-browser-lib.sh"
 source "$ROOT_DIR/scripts/bundle-freshness-lib.sh"
 source "$ROOT_DIR/scripts/cargo-dev-lib.sh"
+source "$ROOT_DIR/scripts/hosted-login-gate-env-lib.sh"
 
 VIEWER_HOST="127.0.0.1"
 VIEWER_PORT="4173"
@@ -393,6 +394,11 @@ WORLD_LOG="$OUTPUT_DIR/oasis7_viewer_live.log"
 WEB_LOG="$OUTPUT_DIR/web_viewer.log"
 LLM_PROVIDER_PROBE_JSON="$OUTPUT_DIR/oasis7_llm_provider_probe.json"
 LLM_PROVIDER_PROBE_LOG="$OUTPUT_DIR/oasis7_llm_provider_probe.log"
+HOSTED_ACCOUNT_STORE_PATH="$OUTPUT_DIR/hosted-account-store.json"
+LAUNCHER_ENV_DEFAULTS=()
+while IFS= read -r env_default; do
+  LAUNCHER_ENV_DEFAULTS+=("$env_default")
+done < <(oasis7_hosted_login_gate_env_defaults "$HOSTED_ACCOUNT_STORE_PATH")
 if [[ -n "$META_FILE" ]]; then
   if [[ "$META_FILE" != /* ]]; then
     META_FILE="$ROOT_DIR/$META_FILE"
@@ -456,7 +462,7 @@ if [[ -n "$BUNDLE_DIR" ]]; then
   fi
   (
     cd "$BUNDLE_DIR"
-    "$BUNDLE_DIR/run-game.sh" "${WORLD_ARGS[@]}" >"$WORLD_LOG" 2>&1
+    env "${LAUNCHER_ENV_DEFAULTS[@]}" "$BUNDLE_DIR/run-game.sh" "${WORLD_ARGS[@]}" >"$WORLD_LOG" 2>&1
   ) &
 else
   LAUNCH_MODE="source"
@@ -500,6 +506,7 @@ else
   LAUNCH_CMD="$SOURCE_MODE_LAUNCHER_BIN"
   (
     cd "$ROOT_DIR"
+    env "${LAUNCHER_ENV_DEFAULTS[@]}" \
     OASIS7_VIEWER_LIVE_BIN="$SOURCE_MODE_VIEWER_LIVE_BIN" \
     OASIS7_CHAIN_RUNTIME_BIN="$SOURCE_MODE_CHAIN_RUNTIME_BIN" \
     "$SOURCE_MODE_LAUNCHER_BIN" "${WORLD_ARGS[@]}" >"$WORLD_LOG" 2>&1
@@ -530,6 +537,7 @@ INFO
   echo "LLM_PROVIDER_PREFLIGHT_SKIPPED=$SKIP_LLM_PROVIDER_PREFLIGHT"
   echo "LLM_PROVIDER_PROBE_JSON=$LLM_PROVIDER_PROBE_JSON"
   echo "LLM_PROVIDER_PROBE_LOG=$LLM_PROVIDER_PROBE_LOG"
+  echo "HOSTED_ACCOUNT_STORE_PATH=$HOSTED_ACCOUNT_STORE_PATH"
   echo "STACK_READY=0"
 } >"$META_FILE"
 
@@ -585,6 +593,7 @@ SOFTWARE_SAFE_VIEWER_URL_EN="http://${URL_VIEWER_HOST}:${VIEWER_PORT}/?render_mo
   echo "LLM_PROVIDER_PREFLIGHT_SKIPPED=$SKIP_LLM_PROVIDER_PREFLIGHT"
   echo "LLM_PROVIDER_PROBE_JSON=$LLM_PROVIDER_PROBE_JSON"
   echo "LLM_PROVIDER_PROBE_LOG=$LLM_PROVIDER_PROBE_LOG"
+  echo "HOSTED_ACCOUNT_STORE_PATH=$HOSTED_ACCOUNT_STORE_PATH"
   echo "STACK_READY=1"
   echo "GAME_URL=$GAME_URL"
   echo "SOFTWARE_SAFE_VIEWER_URL_ZH=$SOFTWARE_SAFE_VIEWER_URL_ZH"

--- a/scripts/viewer-primary-web-entry-regression.sh
+++ b/scripts/viewer-primary-web-entry-regression.sh
@@ -5,6 +5,7 @@ repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 cd "$repo_root"
 source "$repo_root/scripts/agent-browser-lib.sh"
 source "$repo_root/scripts/cargo-dev-lib.sh"
+source "$repo_root/scripts/hosted-login-gate-env-lib.sh"
 
 usage() {
   cat <<'USAGE'
@@ -306,6 +307,11 @@ default_body_path="$out_dir/default_body.txt"
 auto_body_path="$out_dir/auto_body.txt"
 summary_json_path="$out_dir/summary.json"
 summary_md_path="$out_dir/summary.md"
+hosted_account_store_path="$out_dir/hosted-account-store.json"
+launcher_env_defaults=()
+while IFS= read -r env_default; do
+  launcher_env_defaults+=("$env_default")
+done < <(oasis7_hosted_login_gate_env_defaults "$hosted_account_store_path")
 
 resolved_viewer_static_dir=$(resolve_viewer_static_dir_for_web_closure \
   "$repo_root" \
@@ -349,7 +355,7 @@ echo "+ oasis7_cargo_dev build -p oasis7 --bin oasis7_viewer_live --bin oasis7_c
 OASIS7_CARGO_DEV_REPO_ROOT="$repo_root" oasis7_cargo_dev build -p oasis7 --bin oasis7_viewer_live --bin oasis7_chain_runtime >>"$launcher_log" 2>&1
 
 echo "+ oasis7_cargo_dev run -p oasis7 --bin oasis7_game_launcher -- ${live_args[*]}"
-OASIS7_CARGO_DEV_REPO_ROOT="$repo_root" oasis7_cargo_dev run -p oasis7 --bin oasis7_game_launcher -- "${live_args[@]}" >"$launcher_log" 2>&1 &
+env "${launcher_env_defaults[@]}" OASIS7_CARGO_DEV_REPO_ROOT="$repo_root" oasis7_cargo_dev run -p oasis7 --bin oasis7_game_launcher -- "${live_args[@]}" >"$launcher_log" 2>&1 &
 launcher_pid=$!
 
 wait_for_port "$web_bind_host" "$web_bind_port" 240 || { echo "error: web bridge did not come up on $web_bind" >&2; exit 1; }


### PR DESCRIPTION
## Summary
- Add gate-only hosted-login env defaults for launcher-based web tests so missing SMTP env no longer stops the web bridge before the regression starts.
- Apply those defaults in `viewer-primary-web-entry-regression.sh` and `run-game-test.sh` without changing the production hosted-login SMTP contract.
- Upload `.tmp/release_gate_p2p` and `.tmp/release_gate_s10` with the release soak artifact so future S9/S10 failures include their metric artifacts.

## Verification
- `bash -n scripts/hosted-login-gate-env-lib.sh scripts/viewer-primary-web-entry-regression.sh scripts/run-game-test.sh scripts/s10-five-node-game-soak.sh scripts/release-gate.sh`
- `git diff --check`
- `./scripts/pm/lint.sh`
- Local launcher startup probe with `oasis7_hosted_login_gate_env_defaults` and a minimal static dir: web bridge reached readiness.

## Local blockers
- Full `viewer-primary-web-entry-regression.sh` is blocked locally because `agent-browser`/npx fallback is not installed.
- Short S10 probe is blocked locally because `jq` is not installed; GitHub release runner installs `jq`, and this PR makes S10 artifacts upload for diagnosis if the gate still fails.