### PR TITLE
Move pixel-world host derivation into Rust

### DIFF
--- a/.pm/tasks/task_1c7bd1a781d24f81b0c9611861599eff.execution.md
+++ b/.pm/tasks/task_1c7bd1a781d24f81b0c9611861599eff.execution.md
@@ -43,3 +43,12 @@ Example:
 - Expected Result: required gate 全绿，claim-ready 记录 `ready_for_pr` verified。
 - Actual Result: required gate 多次阻塞在 unrelated timing tests：`tests::runtime_gossip_tracks_peer_committed_heads` 曾报 peer heads timeout，随后 clean state 单独重跑通过；`tests::reconcile_provisions_letai_user_project_token_and_marks_reconciled` 曾报 mock LetAI request `Resource temporarily unavailable`，单独重跑通过；最后一轮 required gate 又在 `oasis7_newapi_bridge_service` mock chain/LetAI request EAGAIN 上失败，`last_verification_status` 记录为 `blocked`。
 - Blocker / Next Action: 以 draft PR 提交本 task，让 GitHub CI / reviewer 在干净 runner 上复核；不要宣称 ready-for-PR。
+
+## 2026-05-30 11:44:11 CST / viewer_engineer
+- 完成内容: 处理 PR #320 两条 Copilot review comments：`build_pixel_world_render_state` 序列化失败现在返回结构化 `fatal` payload，不再静默 `null`；static runtime stub 的 `derivePixelWorldRenderState` 现在直接返回 `null`，移除不存在的 `fallback_render_state` 合同暗示，并补 stub 行为测试。同步刷新 checked-in wasm binary。
+- 遗留事项: 无。
+- Action: 应用最小修复并跑 targeted validation。
+- Validation Command: `env -u RUSTC_WRAPPER cargo fmt --check -p pixel_world_bridge && env -u RUSTC_WRAPPER cargo test -p pixel_world_bridge --lib host_state -- --nocapture && env -u RUSTC_WRAPPER cargo check -p pixel_world_bridge --target wasm32-unknown-unknown`; `PATH="/Users/scc/.nvm/versions/node/v24.14.1/bin:$PATH" npm --prefix crates/oasis7_viewer run test:ui -- pixel_world_runtime_loader pixel_world_host`; `PATH="/Users/scc/.nvm/versions/node/v24.14.1/bin:$PATH" npm --prefix crates/oasis7_viewer run build:software-safe`
+- Expected Result: review comments 对应行为被覆盖；Rust host-state targeted tests、wasm check、UI targeted tests、software-safe build 通过。
+- Actual Result: Rust host-state targeted tests 2 passed；wasm check passed；targeted UI tests 11 passed；software-safe build finalized。
+- Blocker / Next Action: 运行 doc/PM/diff hygiene 后 commit/push，并 resolve 对应 review threads。

--- a/.pm/tasks/task_1c7bd1a781d24f81b0c9611861599eff.execution.md
+++ b/.pm/tasks/task_1c7bd1a781d24f81b0c9611861599eff.execution.md
@@ -1,0 +1,45 @@
+# task_1c7bd1a781d24f81b0c9611861599eff Execution Log
+
+- task_uid: task_1c7bd1a781d24f81b0c9611861599eff
+- title: Move pixel-world host derivation into Rust
+- owner_role: viewer_engineer
+- worktree_hint: /Users/scc/ccwork/worktrees/oasis7-viewer-rust-pixel-world-host-logic
+
+<!-- Append entries using:
+Example:
+  ## YYYY-MM-DD HH:MM:SS CST / role_name
+  - 完成内容: ...
+  - 遗留事项: ...
+  - Action: ...
+  - Validation Command: ...
+  - Expected Result: ...
+  - Actual Result: ...
+  - Blocker / Next Action: ...
+-->
+
+## 2026-05-29 20:50:49 CST / viewer_engineer
+- 完成内容: 按用户“尽量多的逻辑放到 Rust”的方向创建独立 task worktree，并完成第一片实现：新增 `pixel_world_bridge::host_state` Rust 派生层与 wasm 导出 `build_pixel_world_render_state`；runtime module 暴露 `derivePixelWorldRenderState`；`PixelWorldHost` 在 wasm runtime 可用时用 Rust DTO 驱动 renderer/HUD，导入失败或派生失败时保留现有 JS fallback 合同。同步刷新 checked-in `viewer.js` 与 `pixel-world-bridge/*` 生成产物。
+- 遗留事项: 尚未做 browser visual smoke；本地 JS 依赖通过临时链接主工作区 ignored `node_modules` 运行，已移除该链接，未进入 diff。
+- Action: 完成 Rust host-state 单测、JS runtime loader/host targeted tests、wasm check、software-safe build 和基础治理检查。
+- Validation Command: `env -u RUSTC_WRAPPER cargo test -p pixel_world_bridge --lib host_state -- --nocapture`; `env -u RUSTC_WRAPPER cargo fmt --check -p pixel_world_bridge && env -u RUSTC_WRAPPER cargo test -p pixel_world_bridge --lib && env -u RUSTC_WRAPPER cargo check -p pixel_world_bridge --target wasm32-unknown-unknown`; `PATH="/Users/scc/.nvm/versions/node/v24.14.1/bin:$PATH" npm --prefix crates/oasis7_viewer run test:ui -- pixel_world_runtime_loader pixel_world_host`; `PATH="/Users/scc/.nvm/versions/node/v24.14.1/bin:$PATH" npm --prefix crates/oasis7_viewer run build:software-safe`; `./scripts/doc-governance-check.sh && ./scripts/pm/lint.sh && git diff --check`
+- Expected Result: Rust 派生层与既有 Bevy render tests 全绿；targeted UI tests 证明 runtime 可传回 Rust DTO；wasm target check 与 generated software-safe artifacts 保持可构建；治理检查通过。
+- Actual Result: Rust host-state targeted tests 2 passed；`pixel_world_bridge --lib` 12 tests passed；wasm check passed；targeted UI tests 10 passed；software-safe build finalized；`doc-governance-check.sh` passed；首次 `pm-lint` 因本 execution log 缺少条目失败，已补本条后待重跑。
+- Blocker / Next Action: 重跑 `./scripts/doc-governance-check.sh && ./scripts/pm/lint.sh && git diff --check`，然后补 browser/visual smoke 或记录环境边界。
+
+## 2026-05-29 20:56:20 CST / viewer_engineer
+- 完成内容: 完成收尾验证；确认临时 `node_modules` 链接已移除且没有进入 git 状态。
+- 遗留事项: 本 slice 仍保留 JS fallback 派生作为 Rust runtime 失败时的降级路径；后续若继续迁移，可把更多 host fallback/fixture presentation 汇总也收敛到 Rust。
+- Action: 重跑治理 gate，并执行 pixel-world fragment visual smoke。
+- Validation Command: `./scripts/doc-governance-check.sh && ./scripts/pm/lint.sh && git diff --check`; `PATH="/Users/scc/.nvm/versions/node/v24.14.1/bin:$PATH" ./scripts/viewer-pixel-world-fragment-visual-smoke.sh`
+- Expected Result: doc/PM/diff gate 全部通过；本地 viewer visual smoke 打开 software-safe 页面，确认 wasm runtime ready、fragment terrain 背景层级、agent 可读性、action receipt 桌面/移动布局正常。
+- Actual Result: `doc-governance-check: OK`; `pm-lint: OK`; `git diff --check` exited 0；visual smoke passed，summary 写入 `output/playwright/pixel-world-fragment-visual/2026-05-29T12-54-06-031Z/summary.json`，截图写入同目录三张 PNG。
+- Blocker / Next Action: 无阻塞；本 task slice 可进入 review/commit 前检查。
+
+## 2026-05-29 21:21:00 CST / viewer_engineer
+- 完成内容: 创建 task commit 并执行 PR preflight；branch 已 rebase 到当时的 `refs/remotes/origin/main`，preflight 报告 ahead 1、behind 0、rebase required no，required scope 为 full。
+- 遗留事项: `ready_for_pr` required gate 未能绿，阻塞在本 task 无关的时序型测试上，因此 PR 只能作为 draft 创建。
+- Action: 运行 `./scripts/pm/claim-ready.sh --claim-type ready_for_pr` 包裹 preflight 推荐的 full required command；为 viewer npm 段临时链接 ignored `crates/oasis7_viewer/node_modules`，trap 中已移除。
+- Validation Command: `PATH="/Users/scc/.nvm/versions/node/v24.14.1/bin:/opt/homebrew/bin:$PATH" OASIS7_CI_RUN_OASIS7_REQUIRED_TESTS=true OASIS7_CI_RUN_CONSENSUS_TESTS=true OASIS7_CI_RUN_DISTFS_TESTS=true OASIS7_CI_RUN_OASIS7_NODE_TESTS=true OASIS7_CI_RUN_OASIS7_NET_TESTS=true OASIS7_CI_RUN_OASIS7_NET_LIBP2P_TESTS=true OASIS7_CI_RUN_VIEWER_CONTRACT_TESTS=true OASIS7_CI_RUN_VIEWER_WASM_CHECK=true OASIS7_CI_RUN_LAUNCHER_WEB_BUILD=true ./scripts/ci-tests.sh required`
+- Expected Result: required gate 全绿，claim-ready 记录 `ready_for_pr` verified。
+- Actual Result: required gate 多次阻塞在 unrelated timing tests：`tests::runtime_gossip_tracks_peer_committed_heads` 曾报 peer heads timeout，随后 clean state 单独重跑通过；`tests::reconcile_provisions_letai_user_project_token_and_marks_reconciled` 曾报 mock LetAI request `Resource temporarily unavailable`，单独重跑通过；最后一轮 required gate 又在 `oasis7_newapi_bridge_service` mock chain/LetAI request EAGAIN 上失败，`last_verification_status` 记录为 `blocked`。
+- Blocker / Next Action: 以 draft PR 提交本 task，让 GitHub CI / reviewer 在干净 runner 上复核；不要宣称 ready-for-PR。

--- a/.pm/tasks/task_1c7bd1a781d24f81b0c9611861599eff.yaml
+++ b/.pm/tasks/task_1c7bd1a781d24f81b0c9611861599eff.yaml
@@ -22,11 +22,11 @@ acceptance:
   - "Targeted JS UI tests, Rust tests, wasm check, software-safe build, doc governance, PM lint, and diff hygiene pass."
 handoff_to:
   - qa_engineer
-updated_at: 2026-05-29T21:20:38+08:00
+updated_at: 2026-05-30T11:46:50+08:00
 last_started_at: 2026-05-29T17:50:31+08:00
-last_claim_type: ready_for_pr
-last_verify_command: "set -euo pipefail\nln -s /Users/scc/ccwork/oasis7/crates/oasis7_viewer/node_modules crates/oasis7_viewer/node_modules\ncleanup() { rm -f crates/oasis7_viewer/node_modules; }\ntrap cleanup EXIT\nPATH=\"/Users/scc/.nvm/versions/node/v24.14.1/bin:/opt/homebrew/bin:$PATH\" OASIS7_CI_RUN_OASIS7_REQUIRED_TESTS=true OASIS7_CI_RUN_CONSENSUS_TESTS=true OASIS7_CI_RUN_DISTFS_TESTS=true OASIS7_CI_RUN_OASIS7_NODE_TESTS=true OASIS7_CI_RUN_OASIS7_NET_TESTS=true OASIS7_CI_RUN_OASIS7_NET_LIBP2P_TESTS=true OASIS7_CI_RUN_VIEWER_CONTRACT_TESTS=true OASIS7_CI_RUN_VIEWER_WASM_CHECK=true OASIS7_CI_RUN_LAUNCHER_WEB_BUILD=true ./scripts/ci-tests.sh required"
-last_verified_at: 2026-05-29T21:20:38+08:00
-last_verification_exit_code: 101
-last_verification_status: blocked
-last_closed_at: 2026-05-29T20:56:59+08:00
+last_claim_type: task_complete
+last_verify_command: "\nset -euo pipefail\nenv -u RUSTC_WRAPPER cargo fmt --check -p pixel_world_bridge\nenv -u RUSTC_WRAPPER cargo test -p pixel_world_bridge --lib host_state -- --nocapture\nenv -u RUSTC_WRAPPER cargo check -p pixel_world_bridge --target wasm32-unknown-unknown\nln -s /Users/scc/ccwork/oasis7/crates/oasis7_viewer/node_modules crates/oasis7_viewer/node_modules\ncleanup() { rm -f crates/oasis7_viewer/node_modules; }\ntrap cleanup EXIT\nPATH=\"/Users/scc/.nvm/versions/node/v24.14.1/bin:$PATH\" npm --prefix crates/oasis7_viewer run test:ui -- pixel_world_runtime_loader pixel_world_host\nPATH=\"/Users/scc/.nvm/versions/node/v24.14.1/bin:$PATH\" npm --prefix crates/oasis7_viewer run build:software-safe\n./scripts/doc-governance-check.sh\n./scripts/pm/lint.sh\ngit diff --check\n"
+last_verified_at: 2026-05-30T11:46:49+08:00
+last_verification_exit_code: 0
+last_verification_status: verified
+last_closed_at: 2026-05-30T11:46:50+08:00

--- a/.pm/tasks/task_1c7bd1a781d24f81b0c9611861599eff.yaml
+++ b/.pm/tasks/task_1c7bd1a781d24f81b0c9611861599eff.yaml
@@ -1,0 +1,32 @@
+task_uid: task_1c7bd1a781d24f81b0c9611861599eff
+title: "Move pixel-world host derivation into Rust"
+owner_role: viewer_engineer
+worktree_hint: /Users/scc/ccwork/worktrees/oasis7-viewer-rust-pixel-world-host-logic
+execution_log_path: .pm/tasks/task_1c7bd1a781d24f81b0c9611861599eff.execution.md
+status: done
+priority: P1
+source_signal: null
+source_refs:
+  - AGENTS.md
+  - doc/world-simulator/viewer/README.md
+doc_refs:
+  - doc/world-simulator/viewer/viewer-pixel-world-semantic-positioning-2026-05-26.prd.md
+  - doc/world-simulator/viewer/viewer-pixel-world-fragment-lod-2026-05-27.prd.md
+  - doc/world-simulator/viewer/viewer-pixel-world-commercial-rendering-loop-2026-05-28.prd.md
+related_prd:
+  - PRD-WORLD_SIMULATOR-046
+acceptance:
+  - "Pixel-world render state pure derivation logic for world bounds, fragment terrain, location marker role, agent derived positions, links, visual hotspots, and commercial surface has a Rust implementation with parity tests."
+  - "Solid host keeps renderer lifecycle, DOM fallback rendering, and UI state, but no longer owns duplicated pure domain derivation logic where Rust can provide it."
+  - "Existing wasm bridge mount/update/fallback/select/hover/camera contracts remain compatible, and software-safe generated artifacts are refreshed."
+  - "Targeted JS UI tests, Rust tests, wasm check, software-safe build, doc governance, PM lint, and diff hygiene pass."
+handoff_to:
+  - qa_engineer
+updated_at: 2026-05-29T21:20:38+08:00
+last_started_at: 2026-05-29T17:50:31+08:00
+last_claim_type: ready_for_pr
+last_verify_command: "set -euo pipefail\nln -s /Users/scc/ccwork/oasis7/crates/oasis7_viewer/node_modules crates/oasis7_viewer/node_modules\ncleanup() { rm -f crates/oasis7_viewer/node_modules; }\ntrap cleanup EXIT\nPATH=\"/Users/scc/.nvm/versions/node/v24.14.1/bin:/opt/homebrew/bin:$PATH\" OASIS7_CI_RUN_OASIS7_REQUIRED_TESTS=true OASIS7_CI_RUN_CONSENSUS_TESTS=true OASIS7_CI_RUN_DISTFS_TESTS=true OASIS7_CI_RUN_OASIS7_NODE_TESTS=true OASIS7_CI_RUN_OASIS7_NET_TESTS=true OASIS7_CI_RUN_OASIS7_NET_LIBP2P_TESTS=true OASIS7_CI_RUN_VIEWER_CONTRACT_TESTS=true OASIS7_CI_RUN_VIEWER_WASM_CHECK=true OASIS7_CI_RUN_LAUNCHER_WEB_BUILD=true ./scripts/ci-tests.sh required"
+last_verified_at: 2026-05-29T21:20:38+08:00
+last_verification_exit_code: 101
+last_verification_status: blocked
+last_closed_at: 2026-05-29T20:56:59+08:00

--- a/crates/oasis7_viewer/pixel-world-bridge/pixel_world_bridge.js
+++ b/crates/oasis7_viewer/pixel-world-bridge/pixel_world_bridge.js
@@ -1,4 +1,7 @@
-import initPixelWorldBridgeModule, { PixelWorldBridge } from "./pixel_world_bridge_bindgen.js";
+import initPixelWorldBridgeModule, {
+  PixelWorldBridge,
+  build_pixel_world_render_state,
+} from "./pixel_world_bridge_bindgen.js";
 
 export const PIXEL_WORLD_RUNTIME_SOURCE = "wasm_bindgen_runtime";
 
@@ -182,4 +185,11 @@ export async function createPixelWorldBridge({ onEvent, onFatal } = {}) {
       return result;
     },
   };
+}
+
+export function derivePixelWorldRenderState(input) {
+  if (!runtimeInitPromise) {
+    throw new Error("pixel world bridge module is not initialized");
+  }
+  return build_pixel_world_render_state(input);
 }

--- a/crates/oasis7_viewer/pixel-world-bridge/pixel_world_bridge_bindgen.d.ts
+++ b/crates/oasis7_viewer/pixel-world-bridge/pixel_world_bridge_bindgen.d.ts
@@ -16,11 +16,14 @@ export class PixelWorldBridge {
     wheel(delta_y: number): any;
 }
 
+export function build_pixel_world_render_state(raw_input: any): any;
+
 export type InitInput = RequestInfo | URL | Response | BufferSource | WebAssembly.Module;
 
 export interface InitOutput {
     readonly memory: WebAssembly.Memory;
     readonly __wbg_pixelworldbridge_free: (a: number, b: number) => void;
+    readonly build_pixel_world_render_state: (a: any) => any;
     readonly pixelworldbridge_click: (a: number, b: number, c: number) => any;
     readonly pixelworldbridge_mount: (a: number, b: any, c: any) => any;
     readonly pixelworldbridge_new: (a: any, b: any) => number;

--- a/crates/oasis7_viewer/pixel-world-bridge/pixel_world_bridge_bindgen.js
+++ b/crates/oasis7_viewer/pixel-world-bridge/pixel_world_bridge_bindgen.js
@@ -101,6 +101,15 @@ export class PixelWorldBridge {
     }
 }
 if (Symbol.dispose) PixelWorldBridge.prototype[Symbol.dispose] = PixelWorldBridge.prototype.free;
+
+/**
+ * @param {any} raw_input
+ * @returns {any}
+ */
+export function build_pixel_world_render_state(raw_input) {
+    const ret = wasm.build_pixel_world_render_state(raw_input);
+    return ret;
+}
 function __wbg_get_imports() {
     const import0 = {
         __proto__: null,
@@ -131,6 +140,12 @@ function __wbg_get_imports() {
             const ret = arg0.WorkerGlobalScope;
             return ret;
         },
+        __wbg___wbindgen_bigint_get_as_i64_410e28c7b761ad83: function(arg0, arg1) {
+            const v = arg1;
+            const ret = typeof(v) === 'bigint' ? v : undefined;
+            getDataViewMemory0().setBigInt64(arg0 + 8 * 1, isLikeNone(ret) ? BigInt(0) : ret, true);
+            getDataViewMemory0().setInt32(arg0 + 4 * 0, !isLikeNone(ret), true);
+        },
         __wbg___wbindgen_boolean_get_2304fb8c853028c8: function(arg0) {
             const v = arg0;
             const ret = typeof(v) === 'boolean' ? v : undefined;
@@ -145,6 +160,10 @@ function __wbg_get_imports() {
         },
         __wbg___wbindgen_in_07056af4f902c445: function(arg0, arg1) {
             const ret = arg0 in arg1;
+            return ret;
+        },
+        __wbg___wbindgen_is_bigint_aeae3893f30ed54e: function(arg0) {
+            const ret = typeof(arg0) === 'bigint';
             return ret;
         },
         __wbg___wbindgen_is_function_5cd60d5cf78b4eef: function(arg0) {
@@ -166,6 +185,10 @@ function __wbg_get_imports() {
         },
         __wbg___wbindgen_is_undefined_35bb9f4c7fd651d5: function(arg0) {
             const ret = arg0 === undefined;
+            return ret;
+        },
+        __wbg___wbindgen_jsval_eq_c0ed08b3e0f393b9: function(arg0, arg1) {
+            const ret = arg0 === arg1;
             return ret;
         },
         __wbg___wbindgen_jsval_loose_eq_0ad77b7717db155c: function(arg0, arg1) {
@@ -762,6 +785,10 @@ function __wbg_get_imports() {
         __wbg_endQuery_42d36ba1d568a37a: function(arg0, arg1) {
             arg0.endQuery(arg1 >>> 0);
         },
+        __wbg_entries_564a7e8b1e54ede5: function(arg0) {
+            const ret = Object.entries(arg0);
+            return ret;
+        },
         __wbg_error_19d45ba06d627441: function(arg0, arg1) {
             console.error(arg0, arg1);
         },
@@ -1050,6 +1077,16 @@ function __wbg_get_imports() {
             let result;
             try {
                 result = arg0 instanceof HTMLCanvasElement;
+            } catch (_) {
+                result = false;
+            }
+            const ret = result;
+            return ret;
+        },
+        __wbg_instanceof_Map_16f217b9a2a08d8c: function(arg0) {
+            let result;
+            try {
+                result = arg0 instanceof Map;
             } catch (_) {
                 result = false;
             }
@@ -1955,67 +1992,67 @@ function __wbg_get_imports() {
             return ret;
         },
         __wbindgen_cast_0000000000000001: function(arg0, arg1) {
-            // Cast intrinsic for `Closure(Closure { owned: true, function: Function { arguments: [Externref], shim_idx: 134495, ret: Result(Unit), inner_ret: Some(Result(Unit)) }, mutable: true }) -> Externref`.
+            // Cast intrinsic for `Closure(Closure { owned: true, function: Function { arguments: [Externref], shim_idx: 134505, ret: Result(Unit), inner_ret: Some(Result(Unit)) }, mutable: true }) -> Externref`.
             const ret = makeMutClosure(arg0, arg1, wasm_bindgen__convert__closures_____invoke__h656285ab01c66ca0);
             return ret;
         },
         __wbindgen_cast_0000000000000002: function(arg0, arg1) {
-            // Cast intrinsic for `Closure(Closure { owned: true, function: Function { arguments: [Externref], shim_idx: 1494, ret: Unit, inner_ret: Some(Unit) }, mutable: true }) -> Externref`.
+            // Cast intrinsic for `Closure(Closure { owned: true, function: Function { arguments: [Externref], shim_idx: 1506, ret: Unit, inner_ret: Some(Unit) }, mutable: true }) -> Externref`.
             const ret = makeMutClosure(arg0, arg1, wasm_bindgen__convert__closures_____invoke__h1089e505c78a14e4);
             return ret;
         },
         __wbindgen_cast_0000000000000003: function(arg0, arg1) {
-            // Cast intrinsic for `Closure(Closure { owned: true, function: Function { arguments: [NamedExternref("Array<any>"), NamedExternref("ResizeObserver")], shim_idx: 1505, ret: Unit, inner_ret: Some(Unit) }, mutable: true }) -> Externref`.
+            // Cast intrinsic for `Closure(Closure { owned: true, function: Function { arguments: [NamedExternref("Array<any>"), NamedExternref("ResizeObserver")], shim_idx: 1517, ret: Unit, inner_ret: Some(Unit) }, mutable: true }) -> Externref`.
             const ret = makeMutClosure(arg0, arg1, wasm_bindgen__convert__closures_____invoke__h5b8e399d53c6236b);
             return ret;
         },
         __wbindgen_cast_0000000000000004: function(arg0, arg1) {
-            // Cast intrinsic for `Closure(Closure { owned: true, function: Function { arguments: [NamedExternref("Array<any>")], shim_idx: 1494, ret: Unit, inner_ret: Some(Unit) }, mutable: true }) -> Externref`.
+            // Cast intrinsic for `Closure(Closure { owned: true, function: Function { arguments: [NamedExternref("Array<any>")], shim_idx: 1506, ret: Unit, inner_ret: Some(Unit) }, mutable: true }) -> Externref`.
             const ret = makeMutClosure(arg0, arg1, wasm_bindgen__convert__closures_____invoke__h1089e505c78a14e4_3);
             return ret;
         },
         __wbindgen_cast_0000000000000005: function(arg0, arg1) {
-            // Cast intrinsic for `Closure(Closure { owned: true, function: Function { arguments: [NamedExternref("Event")], shim_idx: 1494, ret: Unit, inner_ret: Some(Unit) }, mutable: true }) -> Externref`.
+            // Cast intrinsic for `Closure(Closure { owned: true, function: Function { arguments: [NamedExternref("Event")], shim_idx: 1506, ret: Unit, inner_ret: Some(Unit) }, mutable: true }) -> Externref`.
             const ret = makeMutClosure(arg0, arg1, wasm_bindgen__convert__closures_____invoke__h1089e505c78a14e4_4);
             return ret;
         },
         __wbindgen_cast_0000000000000006: function(arg0, arg1) {
-            // Cast intrinsic for `Closure(Closure { owned: true, function: Function { arguments: [NamedExternref("FocusEvent")], shim_idx: 1494, ret: Unit, inner_ret: Some(Unit) }, mutable: true }) -> Externref`.
+            // Cast intrinsic for `Closure(Closure { owned: true, function: Function { arguments: [NamedExternref("FocusEvent")], shim_idx: 1506, ret: Unit, inner_ret: Some(Unit) }, mutable: true }) -> Externref`.
             const ret = makeMutClosure(arg0, arg1, wasm_bindgen__convert__closures_____invoke__h1089e505c78a14e4_5);
             return ret;
         },
         __wbindgen_cast_0000000000000007: function(arg0, arg1) {
-            // Cast intrinsic for `Closure(Closure { owned: true, function: Function { arguments: [NamedExternref("KeyboardEvent")], shim_idx: 1494, ret: Unit, inner_ret: Some(Unit) }, mutable: true }) -> Externref`.
+            // Cast intrinsic for `Closure(Closure { owned: true, function: Function { arguments: [NamedExternref("KeyboardEvent")], shim_idx: 1506, ret: Unit, inner_ret: Some(Unit) }, mutable: true }) -> Externref`.
             const ret = makeMutClosure(arg0, arg1, wasm_bindgen__convert__closures_____invoke__h1089e505c78a14e4_6);
             return ret;
         },
         __wbindgen_cast_0000000000000008: function(arg0, arg1) {
-            // Cast intrinsic for `Closure(Closure { owned: true, function: Function { arguments: [NamedExternref("PageTransitionEvent")], shim_idx: 1494, ret: Unit, inner_ret: Some(Unit) }, mutable: true }) -> Externref`.
+            // Cast intrinsic for `Closure(Closure { owned: true, function: Function { arguments: [NamedExternref("PageTransitionEvent")], shim_idx: 1506, ret: Unit, inner_ret: Some(Unit) }, mutable: true }) -> Externref`.
             const ret = makeMutClosure(arg0, arg1, wasm_bindgen__convert__closures_____invoke__h1089e505c78a14e4_7);
             return ret;
         },
         __wbindgen_cast_0000000000000009: function(arg0, arg1) {
-            // Cast intrinsic for `Closure(Closure { owned: true, function: Function { arguments: [NamedExternref("PointerEvent")], shim_idx: 1494, ret: Unit, inner_ret: Some(Unit) }, mutable: true }) -> Externref`.
+            // Cast intrinsic for `Closure(Closure { owned: true, function: Function { arguments: [NamedExternref("PointerEvent")], shim_idx: 1506, ret: Unit, inner_ret: Some(Unit) }, mutable: true }) -> Externref`.
             const ret = makeMutClosure(arg0, arg1, wasm_bindgen__convert__closures_____invoke__h1089e505c78a14e4_8);
             return ret;
         },
         __wbindgen_cast_000000000000000a: function(arg0, arg1) {
-            // Cast intrinsic for `Closure(Closure { owned: true, function: Function { arguments: [NamedExternref("WheelEvent")], shim_idx: 1494, ret: Unit, inner_ret: Some(Unit) }, mutable: true }) -> Externref`.
+            // Cast intrinsic for `Closure(Closure { owned: true, function: Function { arguments: [NamedExternref("WheelEvent")], shim_idx: 1506, ret: Unit, inner_ret: Some(Unit) }, mutable: true }) -> Externref`.
             const ret = makeMutClosure(arg0, arg1, wasm_bindgen__convert__closures_____invoke__h1089e505c78a14e4_9);
             return ret;
         },
         __wbindgen_cast_000000000000000b: function(arg0, arg1) {
-            // Cast intrinsic for `Closure(Closure { owned: true, function: Function { arguments: [Option(NamedExternref("Blob"))], shim_idx: 1500, ret: Unit, inner_ret: Some(Unit) }, mutable: true }) -> Externref`.
+            // Cast intrinsic for `Closure(Closure { owned: true, function: Function { arguments: [Option(NamedExternref("Blob"))], shim_idx: 1512, ret: Unit, inner_ret: Some(Unit) }, mutable: true }) -> Externref`.
             const ret = makeMutClosure(arg0, arg1, wasm_bindgen__convert__closures_____invoke__h2c6d6c1dfa024e53);
             return ret;
         },
         __wbindgen_cast_000000000000000c: function(arg0, arg1) {
-            // Cast intrinsic for `Closure(Closure { owned: true, function: Function { arguments: [], shim_idx: 100524, ret: Unit, inner_ret: Some(Unit) }, mutable: true }) -> Externref`.
+            // Cast intrinsic for `Closure(Closure { owned: true, function: Function { arguments: [], shim_idx: 100536, ret: Unit, inner_ret: Some(Unit) }, mutable: true }) -> Externref`.
             const ret = makeMutClosure(arg0, arg1, wasm_bindgen__convert__closures_____invoke__h953c336461e674c0);
             return ret;
         },
         __wbindgen_cast_000000000000000d: function(arg0, arg1) {
-            // Cast intrinsic for `Closure(Closure { owned: true, function: Function { arguments: [], shim_idx: 1497, ret: Unit, inner_ret: Some(Unit) }, mutable: true }) -> Externref`.
+            // Cast intrinsic for `Closure(Closure { owned: true, function: Function { arguments: [], shim_idx: 1509, ret: Unit, inner_ret: Some(Unit) }, mutable: true }) -> Externref`.
             const ret = makeMutClosure(arg0, arg1, wasm_bindgen__convert__closures_____invoke__ha544621b2880cc31);
             return ret;
         },

--- a/crates/oasis7_viewer/pixel-world-bridge/pixel_world_bridge_bindgen_bg.wasm.d.ts
+++ b/crates/oasis7_viewer/pixel-world-bridge/pixel_world_bridge_bindgen_bg.wasm.d.ts
@@ -2,6 +2,7 @@
 /* eslint-disable */
 export const memory: WebAssembly.Memory;
 export const __wbg_pixelworldbridge_free: (a: number, b: number) => void;
+export const build_pixel_world_render_state: (a: any) => any;
 export const pixelworldbridge_click: (a: number, b: number, c: number) => any;
 export const pixelworldbridge_mount: (a: number, b: any, c: any) => any;
 export const pixelworldbridge_new: (a: any, b: any) => number;

--- a/crates/oasis7_viewer/software_safe_src/pixel_world_host.jsx
+++ b/crates/oasis7_viewer/software_safe_src/pixel_world_host.jsx
@@ -551,8 +551,30 @@ function createPixelWorldHostAdapter({ onSelectEntity, onHoverEntity, onFatal })
   let bridge = null;
   let runtimeSource = "detached";
   let runtimeModuleUrl = null;
+  let deriveRenderState = null;
+
+  function deriveRenderStateOrFallback(renderInput, fallbackRenderState) {
+    if (!deriveRenderState || !renderInput) {
+      return fallbackRenderState;
+    }
+    try {
+      const nextRenderState = deriveRenderState(renderInput);
+      if (nextRenderState?.fatal) {
+        onFatal?.(nextRenderState.fatal);
+        return fallbackRenderState;
+      }
+      return nextRenderState || fallbackRenderState;
+    } catch (error) {
+      onFatal?.({
+        code: "pixel_world_rust_render_state_failed",
+        message: error instanceof Error ? error.message : String(error || "Rust render state derivation failed"),
+      });
+      return fallbackRenderState;
+    }
+  }
+
   return {
-    async mount(canvas, renderState) {
+    async mount(canvas, renderState, renderInput) {
       const runtime = await createPixelWorldRuntimeBridge({
         onEvent(event) {
           if (event?.type === "canvas_ready") {
@@ -573,23 +595,28 @@ function createPixelWorldHostAdapter({ onSelectEntity, onHoverEntity, onFatal })
         onFatal,
       });
       bridge = runtime.bridge;
+      deriveRenderState = runtime.deriveRenderState || null;
       runtimeSource = runtime.source;
       runtimeModuleUrl = runtime.moduleUrl || null;
-      const result = bridge.mount(canvas, renderState);
+      const mountedRenderState = deriveRenderStateOrFallback(renderInput, renderState);
+      const result = bridge.mount(canvas, mountedRenderState);
       return {
         status: result?.status || "ready",
-        selection: renderState.selection,
+        selection: mountedRenderState.selection,
         fatal: result?.fatal || null,
+        renderState: mountedRenderState,
         runtimeSource,
         runtimeModuleUrl,
       };
     },
-    update(renderState) {
-      const result = bridge?.update(renderState) || { status: "detached" };
+    update(renderState, renderInput) {
+      const nextRenderState = deriveRenderStateOrFallback(renderInput, renderState);
+      const result = bridge?.update(nextRenderState) || { status: "detached" };
       return {
         status: result?.status || "ready",
-        selection: renderState.selection,
+        selection: nextRenderState.selection,
         fatal: result?.fatal || null,
+        renderState: nextRenderState,
         runtimeSource,
         runtimeModuleUrl,
       };
@@ -597,6 +624,7 @@ function createPixelWorldHostAdapter({ onSelectEntity, onHoverEntity, onFatal })
     unmount() {
       const result = bridge?.unmount() || { status: "detached" };
       bridge = null;
+      deriveRenderState = null;
       runtimeSource = "detached";
       runtimeModuleUrl = null;
       return result;
@@ -622,15 +650,37 @@ function createPixelWorldHostAdapter({ onSelectEntity, onHoverEntity, onFatal })
     runtimeModuleUrl() {
       return runtimeModuleUrl;
     },
+    deriveRenderState(renderInput) {
+      return deriveRenderStateOrFallback(renderInput, null);
+    },
   };
 }
 
-export function buildPixelWorldRenderState(locale = core.state.uiLocale) {
-  const lists = core.modelLists();
-  const gameplay = core.buildGameplaySummary(locale);
+export function buildPixelWorldRenderInput(locale = core.state.uiLocale) {
   const worldScaleSurface = core.buildWorldScaleSurface(locale);
-  const snapshot = core.state.snapshot;
-  const selected = core.clone(core.state.selectedObject);
+  return {
+    locale,
+    snapshot: core.state.snapshot,
+    lists: core.modelLists(),
+    gameplay: core.buildGameplaySummary(locale),
+    selected: core.clone(core.state.selectedObject),
+    selectedKind: core.state.selectedKind,
+    selectedId: core.state.selectedId,
+    recentEvents: core.clone(core.state.recentEvents),
+    presentation: {
+      world_bounds_label: worldScaleSurface.physicalTruth.worldBoundsLabel,
+      marker_truth_note: worldScaleSurface.presentationScale.markerTruthNote,
+    },
+  };
+}
+
+export function buildPixelWorldRenderStateFromInput(input) {
+  const locale = input.locale || core.state.uiLocale;
+  const lists = input.lists || { agents: [], locations: [] };
+  const gameplay = input.gameplay;
+  const worldScaleSurface = core.buildWorldScaleSurface(locale);
+  const snapshot = input.snapshot;
+  const selected = input.selected;
   const space = snapshot?.config?.space || null;
 
   const worldBounds = space
@@ -699,10 +749,10 @@ export function buildPixelWorldRenderState(locale = core.state.uiLocale) {
     };
   });
 
-  const selection = core.state.selectedKind && core.state.selectedId
+  const selection = input.selectedKind && input.selectedId
     ? {
-        kind: core.state.selectedKind,
-        id: core.state.selectedId,
+        kind: input.selectedKind,
+        id: input.selectedId,
       }
     : null;
   const links = buildPixelWorldLinks(agents, locationById);
@@ -718,11 +768,11 @@ export function buildPixelWorldRenderState(locale = core.state.uiLocale) {
     : null;
   const blockerHighlight = gameplay?.blockerKind || gameplay?.blockerDetail
     ? {
-        kind: gameplay.blockerKind || "blocked",
-        detail: gameplay.blockerDetail || null,
+        kind: gameplay?.blockerKind || "blocked",
+        detail: gameplay?.blockerDetail || null,
       }
     : null;
-  const recentEventHotspots = buildRecentEventHotspots(core.state.recentEvents);
+  const recentEventHotspots = buildRecentEventHotspots(input.recentEvents);
   const visualHotspots = buildVisualHotspots({
     worldBounds,
     anchor,
@@ -760,6 +810,10 @@ export function buildPixelWorldRenderState(locale = core.state.uiLocale) {
   };
 }
 
+export function buildPixelWorldRenderState(locale = core.state.uiLocale) {
+  return buildPixelWorldRenderStateFromInput(buildPixelWorldRenderInput(locale));
+}
+
 function PixelWorldCanvasRenderer(props) {
   let canvasRef;
 
@@ -771,7 +825,7 @@ function PixelWorldCanvasRenderer(props) {
   });
 
   createEffect(() => {
-    props.renderState();
+    props.renderInput?.();
     if (!canvasRef) {
       return;
     }
@@ -973,7 +1027,10 @@ function PixelWorldCanvasPlaceholder(props) {
 
 export function PixelWorldHost(props) {
   const locale = () => props.locale ?? core.state.uiLocale;
-  const renderState = createMemo(() => buildPixelWorldRenderState(locale()));
+  const renderInput = createMemo(() => buildPixelWorldRenderInput(locale()));
+  const fallbackRenderState = createMemo(() => buildPixelWorldRenderStateFromInput(renderInput()));
+  const [rustRenderState, setRustRenderState] = createSignal(null);
+  const renderState = () => rustRenderState() || fallbackRenderState();
   const [rendererStatus, setRendererStatus] = createSignal("booting");
   const [rendererFatal, setRendererFatal] = createSignal(null);
   const [hoverSelection, setHoverSelection] = createSignal(null);
@@ -1015,10 +1072,11 @@ export function PixelWorldHost(props) {
   let mountedCanvas = null;
 
   function applyRendererUpdate() {
-    const result = adapter().update(renderState());
+    const result = adapter().update(fallbackRenderState(), renderInput());
     if (result?.fatal) {
       setRendererFatal(result.fatal);
     }
+    setRustRenderState(result?.renderState || null);
     setRendererStatus(result?.status || "ready");
     setRuntimeSource(result?.runtimeSource || adapter().runtimeSource());
     core.updatePixelWorldRuntimeMeta({
@@ -1069,10 +1127,11 @@ export function PixelWorldHost(props) {
       });
       return;
     }
-    const result = await adapter().mount(mountedCanvas, renderState());
+    const result = await adapter().mount(mountedCanvas, fallbackRenderState(), renderInput());
     if (result?.fatal) {
       setRendererFatal(result.fatal);
     }
+    setRustRenderState(result?.renderState || null);
     setRendererStatus(result?.status || "ready");
     setRuntimeSource(result?.runtimeSource || adapter().runtimeSource());
     core.updatePixelWorldRuntimeMeta({
@@ -1086,6 +1145,7 @@ export function PixelWorldHost(props) {
 
   function setFallbackMode() {
     adapter().unmount();
+    setRustRenderState(null);
     setRendererStatus("fallback");
     setRuntimeSource("detached");
     setCameraState(null);
@@ -1127,6 +1187,7 @@ export function PixelWorldHost(props) {
       <Show when={rendererStatus() !== "fallback"}>
         <PixelWorldCanvasRenderer
           locale={locale}
+          renderInput={renderInput}
           renderState={renderState}
           onFatal={(message) => adapter().simulateFatal(message)}
           onCanvasMount={(canvas) => {

--- a/crates/oasis7_viewer/software_safe_src/pixel_world_host.test.jsx
+++ b/crates/oasis7_viewer/software_safe_src/pixel_world_host.test.jsx
@@ -1,10 +1,15 @@
 import { render, screen, waitFor } from "@solidjs/testing-library";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+const runtimeMock = vi.hoisted(() => ({
+  deriveRenderState: null,
+}));
+
 vi.mock("./pixel_world_runtime_loader.js", () => ({
   createPixelWorldRuntimeBridge: async ({ onFatal }) => ({
-    source: "wasm_import_failed",
+    source: runtimeMock.deriveRenderState ? "test_rust_runtime" : "wasm_import_failed",
     moduleUrl: "http://127.0.0.1:4173/pixel-world-bridge/pixel_world_bridge.js",
+    deriveRenderState: runtimeMock.deriveRenderState,
     bridge: {
       mount() {
         const fatal = {
@@ -211,6 +216,7 @@ async function renderPixelWorldHost(snapshot = sampleSnapshot()) {
 }
 
 beforeEach(() => {
+  runtimeMock.deriveRenderState = null;
   window.history.replaceState({}, "", "/software_safe.html?test_api=1&connect=0&locale=en");
   window.localStorage.clear();
   document.body.innerHTML = "";
@@ -429,6 +435,80 @@ describe("pixel world host", () => {
     expect(document.querySelectorAll(".pixel-world-fragment-terrain")).toHaveLength(2);
     expect(document.querySelector(".pixel-world-entity--location")).toHaveAttribute("data-marker-role", "logic_anchor");
     expect(core.state.lastError).toContain("pixel world wasm runtime is unavailable");
+  });
+
+  it("uses Rust-derived render state from the runtime module when available", async () => {
+    runtimeMock.deriveRenderState = vi.fn((input) => ({
+      locale: input.locale,
+      world_bounds: { width_cm: 1, depth_cm: 1, height_cm: 1 },
+      locations: [],
+      fragment_terrain: [],
+      agents: [],
+      links: [],
+      selection: null,
+      goal_highlight: {
+        title: "Rust derived goal",
+        objective: "Rust objective detail",
+      },
+      blocker_highlight: null,
+      recent_event_hotspots: [],
+      visual_hotspots: [],
+      commercial_surface: {
+        objective: {
+          title: "Rust derived goal",
+          detail: "Rust objective detail",
+          progress_percent: null,
+        },
+        next_action: {
+          label: "Rust next move",
+          detail: null,
+          target_agent_id: null,
+          execute_kind: null,
+        },
+        active_agent_id: null,
+        player_leverage: {
+          state: "waiting_for_intent",
+          label: "Waiting for Intent",
+          summary: "Rust leverage summary",
+          detail: null,
+        },
+        action_receipt: {
+          present: false,
+          state: "waiting_for_intent",
+          confidence: "none",
+          title: "No action receipt yet",
+          summary: "Rust receipt summary",
+          detail: null,
+          target_agent_id: null,
+          effect_kind: null,
+          delta_logical_time: null,
+          delta_event_seq: null,
+        },
+        blocker: {
+          label: null,
+          detail: null,
+        },
+        world_read: {
+          agents: 0,
+          routes: 0,
+          fragments: 0,
+          hotspots: 0,
+        },
+      },
+      presentation: {
+        world_bounds_label: "rust bounds",
+        marker_truth_note: "rust truth",
+      },
+    }));
+
+    await renderPixelWorldHost();
+
+    await waitFor(() => {
+      expect(screen.getByText("Rust derived goal")).toBeInTheDocument();
+    });
+    expect(screen.getByText("Rust next move")).toBeInTheDocument();
+    expect(screen.getByText("Rust leverage summary")).toBeInTheDocument();
+    expect(runtimeMock.deriveRenderState).toHaveBeenCalled();
   });
 
   it("renders the no-receipt fallback without implying an active agent caused progress", async () => {

--- a/crates/oasis7_viewer/software_safe_src/pixel_world_runtime_loader.js
+++ b/crates/oasis7_viewer/software_safe_src/pixel_world_runtime_loader.js
@@ -93,6 +93,7 @@ export async function createPixelWorldRuntimeBridge({
   if (runtimeModule.module?.createPixelWorldBridge) {
     return {
       bridge: await runtimeModule.module.createPixelWorldBridge({ onEvent, onFatal }),
+      deriveRenderState: runtimeModule.module.derivePixelWorldRenderState || null,
       source: runtimeModule.module.PIXEL_WORLD_RUNTIME_SOURCE || "runtime_module",
       moduleUrl: runtimeModule.moduleUrl,
     };
@@ -101,6 +102,7 @@ export async function createPixelWorldRuntimeBridge({
   const fatal = buildRuntimeUnavailableFatal(runtimeModule.moduleUrl, runtimeModule.error);
   return {
     bridge: createUnavailableBridge({ fatal, onFatal }),
+    deriveRenderState: null,
     source: "wasm_import_failed",
     moduleUrl: runtimeModule.moduleUrl,
     fatal,

--- a/crates/oasis7_viewer/software_safe_src/pixel_world_runtime_loader.test.js
+++ b/crates/oasis7_viewer/software_safe_src/pixel_world_runtime_loader.test.js
@@ -4,6 +4,7 @@ import {
   PIXEL_WORLD_RUNTIME_UNAVAILABLE_CODE,
   createPixelWorldRuntimeBridge,
 } from "./pixel_world_runtime_loader.js";
+import { derivePixelWorldRenderState as deriveStubRenderState } from "./pixel_world_runtime_module_stub.js";
 
 describe("pixel world runtime loader", () => {
   it("uses the wasm runtime module when it loads successfully", async () => {
@@ -51,5 +52,11 @@ describe("pixel world runtime loader", () => {
       code: PIXEL_WORLD_RUNTIME_UNAVAILABLE_CODE,
       message: expect.stringContaining("missing wasm bridge"),
     }));
+  });
+
+  it("keeps the static runtime stub derivation explicitly unavailable", () => {
+    expect(deriveStubRenderState({
+      fallback_render_state: { locale: "en" },
+    })).toBeNull();
   });
 });

--- a/crates/oasis7_viewer/software_safe_src/pixel_world_runtime_loader.test.js
+++ b/crates/oasis7_viewer/software_safe_src/pixel_world_runtime_loader.test.js
@@ -12,17 +12,20 @@ describe("pixel world runtime loader", () => {
       update: vi.fn(() => ({ status: "ready" })),
       unmount: vi.fn(() => ({ status: "detached" })),
     }));
+    const derivePixelWorldRenderState = vi.fn(() => ({ locale: "en" }));
 
     const runtime = await createPixelWorldRuntimeBridge({
       loadRuntimeModule: async () => ({
         PIXEL_WORLD_RUNTIME_SOURCE: "test_runtime",
         createPixelWorldBridge,
+        derivePixelWorldRenderState,
       }),
     });
 
     expect(runtime.source).toBe("test_runtime");
     expect(runtime.moduleUrl).toContain("pixel-world-bridge/pixel_world_bridge.js");
     expect(createPixelWorldBridge).toHaveBeenCalledTimes(1);
+    expect(runtime.deriveRenderState({ locale: "en" })).toEqual({ locale: "en" });
   });
 
   it("surfaces a structured fatal path when the wasm runtime import fails", async () => {

--- a/crates/oasis7_viewer/software_safe_src/pixel_world_runtime_module_stub.js
+++ b/crates/oasis7_viewer/software_safe_src/pixel_world_runtime_module_stub.js
@@ -5,3 +5,7 @@ export const PIXEL_WORLD_RUNTIME_SOURCE = "static_runtime_module_stub";
 export async function createPixelWorldBridge({ onEvent, onFatal } = {}) {
   return createPixelWorldBevyBridge({ onEvent, onFatal });
 }
+
+export function derivePixelWorldRenderState(input) {
+  return input?.fallback_render_state || null;
+}

--- a/crates/oasis7_viewer/software_safe_src/pixel_world_runtime_module_stub.js
+++ b/crates/oasis7_viewer/software_safe_src/pixel_world_runtime_module_stub.js
@@ -6,6 +6,6 @@ export async function createPixelWorldBridge({ onEvent, onFatal } = {}) {
   return createPixelWorldBevyBridge({ onEvent, onFatal });
 }
 
-export function derivePixelWorldRenderState(input) {
-  return input?.fallback_render_state || null;
+export function derivePixelWorldRenderState() {
+  return null;
 }

--- a/crates/oasis7_viewer/software_safe_src/pixel_world_runtime_module_wasm.js
+++ b/crates/oasis7_viewer/software_safe_src/pixel_world_runtime_module_wasm.js
@@ -1,4 +1,7 @@
-import initPixelWorldBridgeModule, { PixelWorldBridge } from "./pixel_world_bridge_bindgen.js";
+import initPixelWorldBridgeModule, {
+  PixelWorldBridge,
+  build_pixel_world_render_state,
+} from "./pixel_world_bridge_bindgen.js";
 
 export const PIXEL_WORLD_RUNTIME_SOURCE = "wasm_bindgen_runtime";
 
@@ -182,4 +185,11 @@ export async function createPixelWorldBridge({ onEvent, onFatal } = {}) {
       return result;
     },
   };
+}
+
+export function derivePixelWorldRenderState(input) {
+  if (!runtimeInitPromise) {
+    throw new Error("pixel world bridge module is not initialized");
+  }
+  return build_pixel_world_render_state(input);
 }

--- a/crates/oasis7_viewer/viewer.js
+++ b/crates/oasis7_viewer/viewer.js
@@ -4935,6 +4935,7 @@ async function createPixelWorldRuntimeBridge({
   if (runtimeModule.module?.createPixelWorldBridge) {
     return {
       bridge: await runtimeModule.module.createPixelWorldBridge({ onEvent, onFatal }),
+      deriveRenderState: runtimeModule.module.derivePixelWorldRenderState || null,
       source: runtimeModule.module.PIXEL_WORLD_RUNTIME_SOURCE || "runtime_module",
       moduleUrl: runtimeModule.moduleUrl
     };
@@ -4942,6 +4943,7 @@ async function createPixelWorldRuntimeBridge({
   const fatal = buildRuntimeUnavailableFatal(runtimeModule.moduleUrl, runtimeModule.error);
   return {
     bridge: createUnavailableBridge({ fatal, onFatal }),
+    deriveRenderState: null,
     source: "wasm_import_failed",
     moduleUrl: runtimeModule.moduleUrl,
     fatal
@@ -5390,8 +5392,28 @@ function createPixelWorldHostAdapter({
   let bridge = null;
   let runtimeSource = "detached";
   let runtimeModuleUrl = null;
+  let deriveRenderState = null;
+  function deriveRenderStateOrFallback(renderInput, fallbackRenderState) {
+    if (!deriveRenderState || !renderInput) {
+      return fallbackRenderState;
+    }
+    try {
+      const nextRenderState = deriveRenderState(renderInput);
+      if (nextRenderState?.fatal) {
+        onFatal?.(nextRenderState.fatal);
+        return fallbackRenderState;
+      }
+      return nextRenderState || fallbackRenderState;
+    } catch (error) {
+      onFatal?.({
+        code: "pixel_world_rust_render_state_failed",
+        message: error instanceof Error ? error.message : String(error || "Rust render state derivation failed")
+      });
+      return fallbackRenderState;
+    }
+  }
   return {
-    async mount(canvas, renderState) {
+    async mount(canvas, renderState, renderInput) {
       const runtime = await createPixelWorldRuntimeBridge({
         onEvent(event) {
           if (event?.type === "canvas_ready") {
@@ -5412,25 +5434,30 @@ function createPixelWorldHostAdapter({
         onFatal
       });
       bridge = runtime.bridge;
+      deriveRenderState = runtime.deriveRenderState || null;
       runtimeSource = runtime.source;
       runtimeModuleUrl = runtime.moduleUrl || null;
-      const result = bridge.mount(canvas, renderState);
+      const mountedRenderState = deriveRenderStateOrFallback(renderInput, renderState);
+      const result = bridge.mount(canvas, mountedRenderState);
       return {
         status: result?.status || "ready",
-        selection: renderState.selection,
+        selection: mountedRenderState.selection,
         fatal: result?.fatal || null,
+        renderState: mountedRenderState,
         runtimeSource,
         runtimeModuleUrl
       };
     },
-    update(renderState) {
-      const result = bridge?.update(renderState) || {
+    update(renderState, renderInput) {
+      const nextRenderState = deriveRenderStateOrFallback(renderInput, renderState);
+      const result = bridge?.update(nextRenderState) || {
         status: "detached"
       };
       return {
         status: result?.status || "ready",
-        selection: renderState.selection,
+        selection: nextRenderState.selection,
         fatal: result?.fatal || null,
+        renderState: nextRenderState,
         runtimeSource,
         runtimeModuleUrl
       };
@@ -5440,6 +5467,7 @@ function createPixelWorldHostAdapter({
         status: "detached"
       };
       bridge = null;
+      deriveRenderState = null;
       runtimeSource = "detached";
       runtimeModuleUrl = null;
       return result;
@@ -5464,15 +5492,39 @@ function createPixelWorldHostAdapter({
     },
     runtimeModuleUrl() {
       return runtimeModuleUrl;
+    },
+    deriveRenderState(renderInput) {
+      return deriveRenderStateOrFallback(renderInput, null);
     }
   };
 }
-function buildPixelWorldRenderState(locale = state.uiLocale) {
-  const lists = modelLists();
-  const gameplay = buildGameplaySummary(locale);
+function buildPixelWorldRenderInput(locale = state.uiLocale) {
   const worldScaleSurface = buildWorldScaleSurface(locale);
-  const snapshot = state.snapshot;
-  const selected = clone(state.selectedObject);
+  return {
+    locale,
+    snapshot: state.snapshot,
+    lists: modelLists(),
+    gameplay: buildGameplaySummary(locale),
+    selected: clone(state.selectedObject),
+    selectedKind: state.selectedKind,
+    selectedId: state.selectedId,
+    recentEvents: clone(state.recentEvents),
+    presentation: {
+      world_bounds_label: worldScaleSurface.physicalTruth.worldBoundsLabel,
+      marker_truth_note: worldScaleSurface.presentationScale.markerTruthNote
+    }
+  };
+}
+function buildPixelWorldRenderStateFromInput(input) {
+  const locale = input.locale || state.uiLocale;
+  const lists = input.lists || {
+    agents: [],
+    locations: []
+  };
+  const gameplay = input.gameplay;
+  const worldScaleSurface = buildWorldScaleSurface(locale);
+  const snapshot = input.snapshot;
+  const selected = input.selected;
   const space = snapshot?.config?.space || null;
   const worldBounds = space ? {
     width_cm: Number(space.width_cm) || 0,
@@ -5520,9 +5572,9 @@ function buildPixelWorldRenderState(locale = state.uiLocale) {
       size_hint_px: 12 + Math.min(10, countResourceEntries(resourceSummary$1) * 2 + (agent.location_id ? 2 : 0) + (agent.kind ? 1 : 0))
     };
   });
-  const selection = state.selectedKind && state.selectedId ? {
-    kind: state.selectedKind,
-    id: state.selectedId
+  const selection = input.selectedKind && input.selectedId ? {
+    kind: input.selectedKind,
+    id: input.selectedId
   } : null;
   const links = buildPixelWorldLinks(agents, locationById);
   const anchor = resolveSelectionPosition(selection, agents, locations) || agents.find((agent) => agent.pos)?.pos || locations[0]?.pos || worldCenterPosition(worldBounds);
@@ -5531,10 +5583,10 @@ function buildPixelWorldRenderState(locale = state.uiLocale) {
     objective: gameplay.objective || null
   } : null;
   const blockerHighlight = gameplay?.blockerKind || gameplay?.blockerDetail ? {
-    kind: gameplay.blockerKind || "blocked",
-    detail: gameplay.blockerDetail || null
+    kind: gameplay?.blockerKind || "blocked",
+    detail: gameplay?.blockerDetail || null
   } : null;
-  const recentEventHotspots = buildRecentEventHotspots(state.recentEvents);
+  const recentEventHotspots = buildRecentEventHotspots(input.recentEvents);
   const visualHotspots = buildVisualHotspots({
     worldBounds,
     anchor,
@@ -5579,7 +5631,7 @@ function PixelWorldCanvasRenderer(props) {
     props.onCanvasMount?.(canvasRef);
   });
   createEffect(() => {
-    props.renderState();
+    props.renderInput?.();
     if (!canvasRef) {
       return;
     }
@@ -5869,7 +5921,10 @@ function PixelWorldCanvasPlaceholder(props) {
 }
 function PixelWorldHost(props) {
   const locale = () => props.locale ?? state.uiLocale;
-  const renderState = createMemo(() => buildPixelWorldRenderState(locale()));
+  const renderInput = createMemo(() => buildPixelWorldRenderInput(locale()));
+  const fallbackRenderState = createMemo(() => buildPixelWorldRenderStateFromInput(renderInput()));
+  const [rustRenderState, setRustRenderState] = createSignal(null);
+  const renderState = () => rustRenderState() || fallbackRenderState();
   const [rendererStatus, setRendererStatus] = createSignal("booting");
   const [rendererFatal, setRendererFatal] = createSignal(null);
   const [hoverSelection, setHoverSelection] = createSignal(null);
@@ -5908,10 +5963,11 @@ function PixelWorldHost(props) {
   }));
   let mountedCanvas = null;
   function applyRendererUpdate() {
-    const result = adapter().update(renderState());
+    const result = adapter().update(fallbackRenderState(), renderInput());
     if (result?.fatal) {
       setRendererFatal(result.fatal);
     }
+    setRustRenderState(result?.renderState || null);
     setRendererStatus(result?.status || "ready");
     setRuntimeSource(result?.runtimeSource || adapter().runtimeSource());
     updatePixelWorldRuntimeMeta({
@@ -5961,10 +6017,11 @@ function PixelWorldHost(props) {
       });
       return;
     }
-    const result = await adapter().mount(mountedCanvas, renderState());
+    const result = await adapter().mount(mountedCanvas, fallbackRenderState(), renderInput());
     if (result?.fatal) {
       setRendererFatal(result.fatal);
     }
+    setRustRenderState(result?.renderState || null);
     setRendererStatus(result?.status || "ready");
     setRuntimeSource(result?.runtimeSource || adapter().runtimeSource());
     updatePixelWorldRuntimeMeta({
@@ -5977,6 +6034,7 @@ function PixelWorldHost(props) {
   }
   function setFallbackMode() {
     adapter().unmount();
+    setRustRenderState(null);
     setRendererStatus("fallback");
     setRuntimeSource("detached");
     setCameraState(null);
@@ -6016,6 +6074,7 @@ function PixelWorldHost(props) {
       get children() {
         return createComponent(PixelWorldCanvasRenderer, {
           locale,
+          renderInput,
           renderState,
           onFatal: (message) => adapter().simulateFatal(message),
           onCanvasMount: (canvas) => {

--- a/crates/pixel_world_bridge/src/host_state.rs
+++ b/crates/pixel_world_bridge/src/host_state.rs
@@ -1,0 +1,812 @@
+use serde_json::{json, Map, Value};
+
+const FRAGMENT_TERRAIN_PALETTE: &[(&str, [u8; 3])] = &[
+    ("silicate_matrix", [126, 144, 99]),
+    ("iron_nickel_alloy", [176, 184, 196]),
+    ("water_ice", [125, 211, 252]),
+    ("hydrated_mineral", [96, 165, 250]),
+    ("carbonaceous_organic", [120, 113, 108]),
+    ("sulfide_ore", [202, 138, 4]),
+    ("rare_earth_oxide", [167, 139, 250]),
+    ("uranium_bearing_ore", [132, 204, 22]),
+    ("thorium_bearing_ore", [244, 114, 182]),
+    ("unknown", [148, 163, 184]),
+];
+
+fn tr(locale: &str, zh: &str, en: &str) -> String {
+    if locale.to_ascii_lowercase().starts_with("zh") {
+        zh.to_string()
+    } else {
+        en.to_string()
+    }
+}
+
+fn obj<'a>(value: &'a Value, key: &str) -> &'a Value {
+    value.get(key).unwrap_or(&Value::Null)
+}
+
+fn arr<'a>(value: &'a Value, key: &str) -> &'a [Value] {
+    obj(value, key).as_array().map(Vec::as_slice).unwrap_or(&[])
+}
+
+fn str_value(value: &Value) -> Option<&str> {
+    value.as_str().filter(|text| !text.is_empty())
+}
+
+fn str_key<'a>(value: &'a Value, key: &str) -> Option<&'a str> {
+    str_value(obj(value, key))
+}
+
+fn string_key(value: &Value, key: &str) -> Option<String> {
+    str_key(value, key).map(ToString::to_string)
+}
+
+fn number(value: &Value, fallback: f64) -> f64 {
+    value.as_f64().filter(|n| n.is_finite()).unwrap_or(fallback)
+}
+
+fn number_key(value: &Value, key: &str, fallback: f64) -> f64 {
+    number(obj(value, key), fallback)
+}
+
+fn normalize_position(value: &Value) -> Option<Value> {
+    let x = number_key(value, "x_cm", f64::NAN);
+    let y = number_key(value, "y_cm", f64::NAN);
+    let z = number_key(value, "z_cm", f64::NAN);
+    if x.is_finite() && y.is_finite() && z.is_finite() {
+        Some(json!({ "x_cm": x, "y_cm": y, "z_cm": z }))
+    } else {
+        None
+    }
+}
+
+fn clamp(value: f64, min: f64, max: f64) -> f64 {
+    value.min(max).max(min)
+}
+
+fn clamp_world_position(pos: &Value, world_bounds: &Value) -> Option<Value> {
+    if !pos.is_object() || !world_bounds.is_object() {
+        return None;
+    }
+    Some(json!({
+        "x_cm": clamp(number_key(pos, "x_cm", 0.0), 0.0, number_key(world_bounds, "width_cm", 0.0)),
+        "y_cm": clamp(number_key(pos, "y_cm", 0.0), 0.0, number_key(world_bounds, "depth_cm", 0.0)),
+        "z_cm": clamp(number_key(pos, "z_cm", 0.0), 0.0, number_key(world_bounds, "height_cm", 0.0)),
+    }))
+}
+
+fn world_center_position(world_bounds: &Value) -> Option<Value> {
+    if !world_bounds.is_object() {
+        return None;
+    }
+    Some(json!({
+        "x_cm": number_key(world_bounds, "width_cm", 0.0) / 2.0,
+        "y_cm": number_key(world_bounds, "depth_cm", 0.0) / 2.0,
+        "z_cm": number_key(world_bounds, "height_cm", 0.0) / 2.0,
+    }))
+}
+
+fn resource_summary(resources: &Value) -> String {
+    let Some(resources) = resources.as_object() else {
+        return "-".to_string();
+    };
+    let entries: Vec<String> = resources
+        .iter()
+        .map(|(key, value)| {
+            if value.is_object() {
+                format!("{key}:{}", value)
+            } else if let Some(text) = value.as_str() {
+                format!("{key}:{text}")
+            } else {
+                format!("{key}:{value}")
+            }
+        })
+        .collect();
+    if entries.is_empty() {
+        "-".to_string()
+    } else {
+        entries.join(" · ")
+    }
+}
+
+fn count_resource_entries(summary: &str) -> usize {
+    if summary.is_empty() || summary == "-" {
+        return 0;
+    }
+    summary
+        .split(" · ")
+        .map(str::trim)
+        .filter(|entry| !entry.is_empty())
+        .count()
+}
+
+fn fragment_blocks(location: &Value) -> &[Value] {
+    obj(obj(obj(location, "fragment_profile"), "blocks"), "blocks")
+        .as_array()
+        .map(Vec::as_slice)
+        .unwrap_or(&[])
+}
+
+fn dominant_compound(block: &Value) -> String {
+    let Some(ppm) = obj(obj(block, "compounds"), "ppm").as_object() else {
+        return "unknown".to_string();
+    };
+    let mut ranked: Vec<(&String, f64)> = ppm
+        .iter()
+        .map(|(kind, value)| (kind, number(value, 0.0)))
+        .filter(|(_, value)| *value > 0.0)
+        .collect();
+    ranked.sort_by(|left, right| {
+        right
+            .1
+            .partial_cmp(&left.1)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| left.0.cmp(right.0))
+    });
+    ranked
+        .first()
+        .map(|(kind, _)| (*kind).clone())
+        .unwrap_or_else(|| "unknown".to_string())
+}
+
+fn fragment_terrain_color(compound: &str) -> [u8; 3] {
+    FRAGMENT_TERRAIN_PALETTE
+        .iter()
+        .find(|(kind, _)| *kind == compound)
+        .map(|(_, color)| *color)
+        .unwrap_or([148, 163, 184])
+}
+
+fn estimate_fragment_half_extent_cm(location: &Value, blocks: &[Value]) -> f64 {
+    let explicit_radius = number_key(obj(location, "profile"), "radius_cm", 0.0);
+    if explicit_radius > 0.0 {
+        return explicit_radius;
+    }
+    let max_extent = blocks.iter().fold(0.0_f64, |value, block| {
+        let origin = obj(block, "origin_cm");
+        let size = obj(block, "size_cm");
+        let origin_x = number_key(origin, "x_cm", 0.0);
+        let origin_z = number_key(origin, "z_cm", number_key(origin, "y_cm", 0.0));
+        let size_x = number_key(size, "x_cm", 0.0);
+        let size_z = number_key(size, "z_cm", number_key(size, "y_cm", 0.0));
+        value.max(origin_x + size_x).max(origin_z + size_z)
+    });
+    max_extent.max(2.0) / 2.0
+}
+
+fn build_fragment_terrain_for_location(location: &Value, world_bounds: &Value) -> Vec<Value> {
+    let Some(pos) = normalize_position(obj(location, "pos")) else {
+        return Vec::new();
+    };
+    let blocks = fragment_blocks(location);
+    if !world_bounds.is_object() || blocks.is_empty() {
+        return Vec::new();
+    }
+    let half_extent_cm = estimate_fragment_half_extent_cm(location, blocks);
+    blocks
+        .iter()
+        .enumerate()
+        .filter_map(|(index, block)| {
+            let size = obj(block, "size_cm");
+            let origin = obj(block, "origin_cm");
+            let size_x = number_key(size, "x_cm", 0.0);
+            let size_z = number_key(size, "z_cm", number_key(size, "y_cm", 0.0));
+            if size_x <= 0.0 || size_z <= 0.0 {
+                return None;
+            }
+            let origin_x = number_key(origin, "x_cm", 0.0);
+            let origin_z = number_key(origin, "z_cm", number_key(origin, "y_cm", 0.0));
+            let dominant = dominant_compound(block);
+            let local_x = origin_x + (size_x / 2.0) - half_extent_cm;
+            let local_y = origin_z + (size_z / 2.0) - half_extent_cm;
+            let terrain_pos = clamp_world_position(
+                &json!({
+                    "x_cm": number_key(&pos, "x_cm", 0.0) + local_x,
+                    "y_cm": number_key(&pos, "y_cm", 0.0) + local_y,
+                    "z_cm": number_key(&pos, "z_cm", 0.0),
+                }),
+                world_bounds,
+            )?;
+            Some(json!({
+                "id": format!("fragment:{}:{index}", str_key(location, "id").unwrap_or("")),
+                "location_id": str_key(location, "id").unwrap_or(""),
+                "pos": terrain_pos,
+                "footprint_cm": size_x.max(size_z).max(1.0),
+                "dominant_compound": dominant,
+                "color": fragment_terrain_color(&dominant),
+                "emphasis": 0.58,
+            }))
+        })
+        .collect()
+}
+
+fn deterministic_hash(input: &str) -> u32 {
+    input.chars().fold(2_166_136_261_u32, |hash, ch| {
+        hash.wrapping_mul(31).wrapping_add(ch as u32)
+    })
+}
+
+fn derive_agent_position(
+    agent: &Value,
+    location_by_id: &Map<String, Value>,
+    world_bounds: &Value,
+) -> Option<Value> {
+    let location_id = str_key(agent, "location_id")?;
+    let location = location_by_id.get(location_id)?;
+    let location_pos = obj(location, "pos");
+    if !location_pos.is_object() || !world_bounds.is_object() {
+        return None;
+    }
+    let hash = deterministic_hash(&format!(
+        "{}:{location_id}",
+        str_key(agent, "id").unwrap_or("")
+    ));
+    let angle = ((hash % 360) as f64).to_radians();
+    let max_dim =
+        number_key(world_bounds, "width_cm", 0.0).max(number_key(world_bounds, "depth_cm", 0.0));
+    let explicit_radius = number_key(location, "radius_cm", 0.0);
+    let radius_hint = if explicit_radius > 0.0 {
+        explicit_radius
+    } else {
+        35_000.0
+    };
+    let radius_cm = 10_000.0_f64.max((max_dim * 0.015).min(radius_hint));
+    clamp_world_position(
+        &json!({
+            "x_cm": number_key(location_pos, "x_cm", 0.0) + angle.cos() * radius_cm,
+            "y_cm": number_key(location_pos, "y_cm", 0.0) + angle.sin() * radius_cm,
+            "z_cm": number_key(location_pos, "z_cm", 0.0),
+        }),
+        world_bounds,
+    )
+}
+
+fn resolve_agent_position(
+    agent: &Value,
+    selected: &Value,
+    location_by_id: &Map<String, Value>,
+    world_bounds: &Value,
+) -> (Value, &'static str) {
+    let selected_pos = if str_key(selected, "id") == str_key(agent, "id") {
+        obj(selected, "pos")
+    } else {
+        &Value::Null
+    };
+    if let Some(pos) =
+        normalize_position(obj(agent, "pos")).or_else(|| normalize_position(selected_pos))
+    {
+        return (pos, "snapshot");
+    }
+    if let Some(pos) = derive_agent_position(agent, location_by_id, world_bounds) {
+        return (pos, "location_derived");
+    }
+    (Value::Null, "missing")
+}
+
+fn resolve_selection_position(
+    selection: &Value,
+    agents: &[Value],
+    locations: &[Value],
+) -> Option<Value> {
+    let kind = str_key(selection, "kind")?;
+    let id = str_key(selection, "id")?;
+    match kind {
+        "agent" => agents
+            .iter()
+            .find(|agent| str_key(agent, "id") == Some(id))
+            .and_then(|agent| normalize_position(obj(agent, "pos"))),
+        "location" => locations
+            .iter()
+            .find(|location| str_key(location, "id") == Some(id))
+            .and_then(|location| normalize_position(obj(location, "pos"))),
+        _ => None,
+    }
+}
+
+fn build_pixel_world_links(agents: &[Value], location_by_id: &Map<String, Value>) -> Vec<Value> {
+    agents
+        .iter()
+        .filter_map(|agent| {
+            let location_id = str_key(agent, "location_id")?;
+            let location = location_by_id.get(location_id)?;
+            let agent_pos = obj(agent, "pos");
+            let location_pos = obj(location, "pos");
+            if !agent_pos.is_object() || !location_pos.is_object() {
+                return None;
+            }
+            Some(json!({
+                "id": format!("link:{}:{location_id}", str_key(agent, "id").unwrap_or("")),
+                "kind": "agent_assignment",
+                "from": agent_pos,
+                "to": location_pos,
+                "emphasis": 0.72,
+            }))
+        })
+        .collect()
+}
+
+fn build_recent_event_hotspots(events: &[Value]) -> Vec<Value> {
+    events
+        .iter()
+        .take(4)
+        .enumerate()
+        .map(|(index, event)| {
+            json!({
+                "id": str_key(event, "eventId")
+                    .or_else(|| str_key(event, "event_id"))
+                    .map(ToString::to_string)
+                    .unwrap_or_else(|| format!("recent-{index}")),
+                "title": str_key(event, "title")
+                    .or_else(|| str_key(event, "summary"))
+                    .or_else(|| str_key(event, "kind"))
+                    .map(ToString::to_string)
+                    .unwrap_or_else(|| format!("event-{index}")),
+                "kind": str_key(event, "kind").unwrap_or("recent_event"),
+            })
+        })
+        .collect()
+}
+
+fn offset_world_position(
+    anchor: Option<Value>,
+    world_bounds: &Value,
+    x_ratio: f64,
+    y_ratio: f64,
+) -> Option<Value> {
+    if !world_bounds.is_object() {
+        return None;
+    }
+    let base = anchor.or_else(|| world_center_position(world_bounds))?;
+    clamp_world_position(
+        &json!({
+            "x_cm": number_key(&base, "x_cm", 0.0) + number_key(world_bounds, "width_cm", 0.0) * x_ratio,
+            "y_cm": number_key(&base, "y_cm", 0.0) + number_key(world_bounds, "depth_cm", 0.0) * y_ratio,
+            "z_cm": number_key(&base, "z_cm", 0.0),
+        }),
+        world_bounds,
+    )
+}
+
+fn build_visual_hotspots(
+    world_bounds: &Value,
+    anchor: Option<Value>,
+    goal_highlight: &Value,
+    blocker_highlight: &Value,
+    recent_event_hotspots: &[Value],
+) -> Vec<Value> {
+    if !world_bounds.is_object() {
+        return Vec::new();
+    }
+    let offsets = [
+        (-0.18, -0.14),
+        (0.18, -0.12),
+        (0.22, 0.14),
+        (-0.2, 0.16),
+        (0.0, -0.22),
+        (0.0, 0.22),
+    ];
+    let mut staged = Vec::new();
+    if let Some(title) = str_key(goal_highlight, "title") {
+        staged.push(json!({
+            "id": "goal-highlight",
+            "label": title,
+            "kind": "goal",
+            "emphasis": 1.0,
+            "size_hint_px": 14.0,
+        }));
+    }
+    if let Some(kind) = str_key(blocker_highlight, "kind") {
+        staged.push(json!({
+            "id": "blocker-highlight",
+            "label": kind,
+            "kind": "blocker",
+            "emphasis": 1.0,
+            "size_hint_px": 16.0,
+        }));
+    }
+    for hotspot in recent_event_hotspots.iter().take(4) {
+        staged.push(json!({
+            "id": format!("recent:{}", str_key(hotspot, "id").unwrap_or("")),
+            "label": str_key(hotspot, "title").unwrap_or(""),
+            "kind": str_key(hotspot, "kind").unwrap_or("recent_event"),
+            "emphasis": 0.72,
+            "size_hint_px": 10.0,
+        }));
+    }
+    staged
+        .into_iter()
+        .enumerate()
+        .filter_map(|(index, mut entry)| {
+            let (x_ratio, y_ratio) = offsets[index % offsets.len()];
+            let pos = offset_world_position(anchor.clone(), world_bounds, x_ratio, y_ratio)?;
+            entry.as_object_mut()?.insert("pos".to_string(), pos);
+            Some(entry)
+        })
+        .collect()
+}
+
+fn pick_known_agent_id(candidate_ids: Vec<Option<String>>, agents: &[Value]) -> Option<String> {
+    candidate_ids.into_iter().flatten().find(|candidate| {
+        agents
+            .iter()
+            .any(|agent| str_key(agent, "id") == Some(candidate.as_str()))
+    })
+}
+
+fn action_receipt_title(locale: &str, state: &str, present: bool) -> String {
+    if !present {
+        return tr(locale, "暂无行动回执", "No action receipt yet");
+    }
+    match state {
+        "accepted" => tr(locale, "行动已接受", "Action accepted"),
+        "blocked" => tr(locale, "行动被阻塞", "Action blocked"),
+        "completed" => tr(locale, "世界已改变", "World changed"),
+        "rejected" => tr(locale, "行动被拒绝", "Action rejected"),
+        _ => tr(locale, "行动进行中", "Action in progress"),
+    }
+}
+
+fn build_action_receipt(locale: &str, gameplay: &Value, active_agent_id: Option<&str>) -> Value {
+    let recent_feedback = obj(gameplay, "recentFeedback");
+    let has_world_delta = str_key(gameplay, "lastWorldChange").is_some()
+        || str_key(recent_feedback, "effect").is_some();
+    let has_player_intent = str_key(gameplay, "acceptedIntentId").is_some()
+        || str_key(gameplay, "acceptedIntentScope").is_some()
+        || str_key(gameplay, "acceptedIntentTarget").is_some()
+        || str_key(recent_feedback, "action").is_some();
+    let present =
+        has_world_delta || has_player_intent || str_key(recent_feedback, "reason").is_some();
+    let raw_state = str_key(gameplay, "executionState")
+        .or_else(|| str_key(recent_feedback, "stage"))
+        .unwrap_or("waiting_for_intent");
+    let state = if present {
+        raw_state
+    } else {
+        "waiting_for_intent"
+    };
+    let confidence = if has_world_delta {
+        "world_delta"
+    } else if has_player_intent {
+        "accepted_intent"
+    } else {
+        "none"
+    };
+    let summary = if present {
+        str_key(gameplay, "lastWorldChange")
+            .or_else(|| str_key(recent_feedback, "effect"))
+            .or_else(|| str_key(gameplay, "acceptedIntentSummary"))
+            .or_else(|| str_key(recent_feedback, "action"))
+            .or_else(|| str_key(gameplay, "executionSummary"))
+            .unwrap_or("")
+            .to_string()
+    } else {
+        tr(
+            locale,
+            "还没有一条玩家行动产生可确认的世界变化。",
+            "No player-caused world change has been confirmed yet.",
+        )
+    };
+    let detail = if present {
+        str_key(gameplay, "executionCauseDetail")
+            .or_else(|| str_key(recent_feedback, "reason"))
+            .or_else(|| str_key(recent_feedback, "hint"))
+            .or_else(|| str_key(gameplay, "acceptedIntentDetail"))
+            .or_else(|| str_key(gameplay, "progressDetail"))
+            .map(ToString::to_string)
+    } else {
+        Some(tr(
+            locale,
+            "先提交玩法动作或推进世界，再查看系统确认、阻塞或完成的回执。",
+            "Submit a gameplay action or advance the world, then read whether the system accepted, blocked, or completed it.",
+        ))
+    };
+    json!({
+        "present": present,
+        "state": state,
+        "confidence": confidence,
+        "title": action_receipt_title(locale, state, present),
+        "summary": summary,
+        "detail": detail,
+        "target_agent_id": if present {
+            string_key(gameplay, "acceptedIntentTarget")
+                .or_else(|| string_key(obj(gameplay, "recommendedAction"), "targetAgentId"))
+                .or_else(|| active_agent_id.map(ToString::to_string))
+                .map(Value::String)
+                .unwrap_or(Value::Null)
+        } else {
+            Value::Null
+        },
+        "effect_kind": if present {
+            string_key(gameplay, "executionCauseKind")
+                .or_else(|| string_key(recent_feedback, "stage"))
+                .map(Value::String)
+                .unwrap_or(Value::Null)
+        } else {
+            Value::Null
+        },
+        "delta_logical_time": if present { obj(recent_feedback, "deltaLogicalTime").clone() } else { Value::Null },
+        "delta_event_seq": if present { obj(recent_feedback, "deltaEventSeq").clone() } else { Value::Null },
+    })
+}
+
+fn build_commercial_surface(
+    locale: &str,
+    gameplay: &Value,
+    agents: &[Value],
+    links: &[Value],
+    fragment_terrain: &[Value],
+    visual_hotspots: &[Value],
+    selection: &Value,
+) -> Value {
+    let active_agent_id = pick_known_agent_id(
+        vec![
+            string_key(obj(gameplay, "recommendedAction"), "targetAgentId"),
+            string_key(gameplay, "acceptedIntentTarget"),
+            if str_key(selection, "kind") == Some("agent") {
+                string_key(selection, "id")
+            } else {
+                None
+            },
+            agents.first().and_then(|agent| string_key(agent, "id")),
+        ],
+        agents,
+    );
+    let objective_title = str_key(gameplay, "goalTitle")
+        .map(ToString::to_string)
+        .unwrap_or_else(|| {
+            tr(
+                locale,
+                "进入世界，建立第一条能力链",
+                "Enter the world and build the first capability chain",
+            )
+        });
+    let objective_detail = str_key(gameplay, "objective")
+        .or_else(|| str_key(gameplay, "progressDetail"))
+        .map(ToString::to_string)
+        .unwrap_or_else(|| {
+            tr(
+                locale,
+                "先让 Agent、路线和资源关系变得可读，再推进下一步。",
+                "Read the agent, route, and resource relationship before pushing the next move.",
+            )
+        });
+    let next_action_label = str_key(obj(gameplay, "recommendedAction"), "label")
+        .or_else(|| str_key(gameplay, "nextStepHint"))
+        .or_else(|| str_key(gameplay, "narrativeNextStep"))
+        .map(ToString::to_string)
+        .unwrap_or_else(|| {
+            tr(
+                locale,
+                "选择一个 Agent 或推进世界一步",
+                "Select an agent or advance the world one step",
+            )
+        });
+    let next_action_detail = str_key(obj(gameplay, "recommendedAction"), "disabledReason")
+        .or_else(|| str_key(gameplay, "nextStepHint"))
+        .or_else(|| str_key(gameplay, "executionSummary"))
+        .map(ToString::to_string);
+    let leverage_summary = str_key(gameplay, "acceptedIntentSummary")
+        .or_else(|| str_key(gameplay, "lastWorldChange"))
+        .map(ToString::to_string)
+        .unwrap_or_else(|| {
+            tr(
+                locale,
+                "还没有一条被正式接受的玩家意图",
+                "No player-facing accepted intent yet",
+            )
+        });
+    let leverage_detail = str_key(gameplay, "lastWorldChange")
+        .or_else(|| str_key(gameplay, "executionCauseDetail"))
+        .or_else(|| str_key(gameplay, "acceptedIntentDetail"))
+        .or_else(|| str_key(gameplay, "progressDetail"))
+        .map(ToString::to_string);
+    let action_receipt = build_action_receipt(locale, gameplay, active_agent_id.as_deref());
+
+    json!({
+        "objective": {
+            "title": objective_title,
+            "detail": objective_detail,
+            "progress_percent": obj(gameplay, "progressPercent").clone(),
+        },
+        "next_action": {
+            "label": next_action_label,
+            "detail": next_action_detail,
+            "target_agent_id": string_key(obj(gameplay, "recommendedAction"), "targetAgentId")
+                .or_else(|| active_agent_id.clone())
+                .map(Value::String)
+                .unwrap_or(Value::Null),
+            "execute_kind": string_key(obj(gameplay, "recommendedAction"), "executeKind")
+                .map(Value::String)
+                .unwrap_or(Value::Null),
+        },
+        "active_agent_id": active_agent_id,
+        "player_leverage": {
+            "state": str_key(gameplay, "executionState").unwrap_or("waiting_for_intent"),
+            "label": str_key(gameplay, "executionStateLabel")
+                .map(ToString::to_string)
+                .unwrap_or_else(|| tr(locale, "等待玩家意图", "Waiting for Intent")),
+            "summary": leverage_summary,
+            "detail": leverage_detail,
+        },
+        "action_receipt": action_receipt,
+        "blocker": {
+            "label": string_key(gameplay, "blockerLabel")
+                .or_else(|| string_key(gameplay, "blockerKind")),
+            "detail": string_key(gameplay, "narrativeBlockerDetail")
+                .or_else(|| string_key(gameplay, "blockerDetail")),
+        },
+        "world_read": {
+            "agents": agents.len(),
+            "routes": links.len(),
+            "fragments": fragment_terrain.len(),
+            "hotspots": visual_hotspots.len(),
+        },
+    })
+}
+
+fn build_world_bounds(input: &Value) -> Value {
+    let space = obj(obj(input, "snapshot"), "config")
+        .get("space")
+        .unwrap_or(&Value::Null);
+    if !space.is_object() {
+        return Value::Null;
+    }
+    json!({
+        "width_cm": number_key(space, "width_cm", 0.0),
+        "depth_cm": number_key(space, "depth_cm", 0.0),
+        "height_cm": number_key(space, "height_cm", 0.0),
+    })
+}
+
+pub(crate) fn build_render_state(input: &Value) -> Value {
+    let locale = str_key(input, "locale").unwrap_or("en");
+    let world_bounds = build_world_bounds(input);
+    let world_scale_base = number_key(&world_bounds, "width_cm", 1.0)
+        .min(number_key(&world_bounds, "depth_cm", 1.0))
+        .max(1.0);
+    let selected = obj(input, "selected");
+    let mut fragment_terrain = Vec::new();
+    let mut locations = Vec::new();
+
+    for location in arr(obj(input, "lists"), "locations") {
+        let terrain = build_fragment_terrain_for_location(location, &world_bounds);
+        fragment_terrain.extend(terrain.iter().cloned());
+        let resource_summary = resource_summary(obj(location, "resources"));
+        let resource_score = count_resource_entries(&resource_summary);
+        let has_terrain = !terrain.is_empty();
+        if let Some(pos) = normalize_position(obj(location, "pos")) {
+            let radius_cm = number_key(obj(location, "profile"), "radius_cm", 0.0);
+            let size_hint_px = if has_terrain {
+                10.0
+            } else {
+                16.0 + 18.0_f64
+                    .min((radius_cm / world_scale_base) * 420.0 + (resource_score * 2) as f64)
+            };
+            locations.push(json!({
+                "id": str_key(location, "id").unwrap_or(""),
+                "label": str_key(location, "name").or_else(|| str_key(location, "id")).unwrap_or(""),
+                "pos": pos,
+                "radius_cm": radius_cm,
+                "resource_summary": resource_summary,
+                "resource_score": resource_score,
+                "fragment_terrain_count": terrain.len(),
+                "marker_role": if has_terrain { "logic_anchor" } else { "primary_marker" },
+                "marker_alpha": if has_terrain { 0.32 } else { 0.72 },
+                "size_hint_px": size_hint_px,
+            }));
+        }
+    }
+    let location_by_id: Map<String, Value> = locations
+        .iter()
+        .filter_map(|location| Some((str_key(location, "id")?.to_string(), location.clone())))
+        .collect();
+
+    let agents: Vec<Value> = arr(obj(input, "lists"), "agents")
+        .iter()
+        .map(|agent| {
+            let (pos, position_source) =
+                resolve_agent_position(agent, selected, &location_by_id, &world_bounds);
+            let resource_summary = resource_summary(obj(agent, "resources"));
+            let resource_score = count_resource_entries(&resource_summary);
+            let mut status_badges = Vec::new();
+            if let Some(location_id) = str_key(agent, "location_id") {
+                status_badges.push(Value::String(format!("location={location_id}")));
+            }
+            if let Some(kind) = str_key(agent, "kind") {
+                status_badges.push(Value::String(format!("kind={kind}")));
+            }
+            if position_source == "location_derived" {
+                status_badges.push(Value::String("position=location_derived".to_string()));
+            }
+            json!({
+                "id": str_key(agent, "id").unwrap_or(""),
+                "label": str_key(agent, "name").or_else(|| str_key(agent, "id")).unwrap_or(""),
+                "location_id": string_key(agent, "location_id"),
+                "pos": pos,
+                "position_source": position_source,
+                "resource_summary": resource_summary,
+                "resource_score": resource_score,
+                "status_badges": status_badges,
+                "size_hint_px": 12.0 + 10.0_f64.min(
+                    (resource_score * 2) as f64
+                    + if str_key(agent, "location_id").is_some() { 2.0 } else { 0.0 }
+                    + if str_key(agent, "kind").is_some() { 1.0 } else { 0.0 }
+                ),
+            })
+        })
+        .collect();
+
+    let selection = match (str_key(input, "selectedKind"), str_key(input, "selectedId")) {
+        (Some(kind), Some(id)) => json!({ "kind": kind, "id": id }),
+        _ => Value::Null,
+    };
+    let links = build_pixel_world_links(&agents, &location_by_id);
+    let anchor = resolve_selection_position(&selection, &agents, &locations)
+        .or_else(|| {
+            agents
+                .iter()
+                .find(|agent| obj(agent, "pos").is_object())
+                .and_then(|agent| normalize_position(obj(agent, "pos")))
+        })
+        .or_else(|| {
+            locations
+                .first()
+                .and_then(|location| normalize_position(obj(location, "pos")))
+        })
+        .or_else(|| world_center_position(&world_bounds));
+    let gameplay = obj(input, "gameplay");
+    let goal_highlight = str_key(gameplay, "goalTitle")
+        .map(|title| json!({ "title": title, "objective": string_key(gameplay, "objective") }))
+        .unwrap_or(Value::Null);
+    let blocker_highlight = if str_key(gameplay, "blockerKind").is_some()
+        || str_key(gameplay, "blockerDetail").is_some()
+    {
+        json!({
+            "kind": str_key(gameplay, "blockerKind").unwrap_or("blocked"),
+            "detail": string_key(gameplay, "blockerDetail"),
+        })
+    } else {
+        Value::Null
+    };
+    let recent_event_hotspots = build_recent_event_hotspots(arr(input, "recentEvents"));
+    let visual_hotspots = build_visual_hotspots(
+        &world_bounds,
+        anchor,
+        &goal_highlight,
+        &blocker_highlight,
+        &recent_event_hotspots,
+    );
+    let commercial_surface = build_commercial_surface(
+        locale,
+        gameplay,
+        &agents,
+        &links,
+        &fragment_terrain,
+        &visual_hotspots,
+        &selection,
+    );
+    let presentation = obj(input, "presentation");
+
+    json!({
+        "locale": locale,
+        "world_bounds": world_bounds,
+        "locations": locations,
+        "fragment_terrain": fragment_terrain,
+        "agents": agents,
+        "links": links,
+        "selection": selection,
+        "goal_highlight": goal_highlight,
+        "blocker_highlight": blocker_highlight,
+        "recent_event_hotspots": recent_event_hotspots,
+        "visual_hotspots": visual_hotspots,
+        "commercial_surface": commercial_surface,
+        "presentation": {
+            "world_bounds_label": obj(presentation, "world_bounds_label").clone(),
+            "marker_truth_note": obj(presentation, "marker_truth_note").clone(),
+        },
+    })
+}
+
+#[cfg(test)]
+#[path = "host_state_tests.rs"]
+mod tests;

--- a/crates/pixel_world_bridge/src/host_state_tests.rs
+++ b/crates/pixel_world_bridge/src/host_state_tests.rs
@@ -1,0 +1,176 @@
+use super::*;
+
+fn sample_input() -> Value {
+    json!({
+        "locale": "en",
+        "snapshot": {
+            "config": {
+                "space": {
+                    "width_cm": 10_000_000.0,
+                    "depth_cm": 5_000_000.0,
+                    "height_cm": 1_000_000.0
+                }
+            }
+        },
+        "lists": {
+            "agents": [
+                {
+                    "id": "agent-0",
+                    "name": "Agent 0",
+                    "location_id": "loc-0",
+                    "resources": {}
+                }
+            ],
+            "locations": [
+                {
+                    "id": "loc-0",
+                    "name": "Factory Anchor",
+                    "pos": { "x_cm": 5_000_000.0, "y_cm": 2_500_000.0, "z_cm": 0.0 },
+                    "profile": { "radius_cm": 25_000.0 },
+                    "fragment_profile": {
+                        "blocks": {
+                            "blocks": [
+                                {
+                                    "origin_cm": { "x_cm": 0.0, "y_cm": 0.0, "z_cm": 0.0 },
+                                    "size_cm": { "x_cm": 12_000.0, "y_cm": 7_500.0, "z_cm": 8_000.0 },
+                                    "compounds": {
+                                        "ppm": {
+                                            "silicate_matrix": 800_000.0,
+                                            "water_ice": 200_000.0
+                                        }
+                                    }
+                                },
+                                {
+                                    "origin_cm": { "x_cm": 20_000.0, "y_cm": 1_000.0, "z_cm": 18_000.0 },
+                                    "size_cm": { "x_cm": 20_000.0, "y_cm": 8_000.0, "z_cm": 10_000.0 },
+                                    "compounds": {
+                                        "ppm": {
+                                            "iron_nickel_alloy": 900_000.0,
+                                            "sulfide_ore": 100_000.0
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "resources": {}
+                }
+            ]
+        },
+        "gameplay": {
+            "acceptedIntentId": "gameplay_action:build_factory_smelter_mk1",
+            "acceptedIntentSummary": "Queue build_factory_smelter_mk1 for agent-0",
+            "acceptedIntentScope": "gameplay_action",
+            "acceptedIntentTarget": "agent-0",
+            "goalTitle": "Recover sustainable capability",
+            "objective": "Stabilize the first production line before expanding.",
+            "progressDetail": "The primary line is blocked by missing material input.",
+            "progressPercent": 68,
+            "blockerKind": "material_shortage",
+            "blockerLabel": "Missing Material",
+            "blockerDetail": "iron input exhausted at factory-0",
+            "executionState": "blocked",
+            "executionStateLabel": "Blocked",
+            "executionCauseKind": "world_constraint",
+            "executionCauseDetail": "iron input exhausted at factory-0",
+            "lastWorldChange": "Smelter build request reached factory-0; iron shortage blocks construction.",
+            "nextStepHint": "Replenish upstream materials, then advance again to confirm the line resumes.",
+            "recommendedAction": {
+                "targetAgentId": "agent-0",
+                "label": "Build smelter mk1",
+                "executeKind": "gameplay_action"
+            },
+            "recentFeedback": {
+                "action": "build_factory_smelter_mk1",
+                "stage": "completed_no_progress",
+                "effect": "Smelter build request reached factory-0; iron shortage blocks construction.",
+                "reason": "iron input exhausted at factory-0",
+                "hint": "Replenish upstream materials, then advance again.",
+                "deltaLogicalTime": 1,
+                "deltaEventSeq": 2
+            }
+        },
+        "selected": Value::Null,
+        "selectedKind": Value::Null,
+        "selectedId": Value::Null,
+        "recentEvents": [
+            { "eventId": "evt-1", "title": "Transfer spike", "kind": "resource_transfer" },
+            { "eventId": "evt-2", "title": "Queue update", "kind": "build_queue" }
+        ],
+        "presentation": {
+            "world_bounds_label": "100km x 50km",
+            "marker_truth_note": "scaled"
+        }
+    })
+}
+
+#[test]
+fn rust_host_state_derives_fragment_agent_link_and_commercial_surface() {
+    let state = build_render_state(&sample_input());
+
+    assert_eq!(state["world_bounds"]["width_cm"], 10_000_000.0);
+    assert_eq!(state["locations"][0]["marker_role"], "logic_anchor");
+    assert_eq!(state["locations"][0]["marker_alpha"], 0.32);
+    assert_eq!(state["locations"][0]["fragment_terrain_count"], 2);
+
+    assert_eq!(state["fragment_terrain"].as_array().unwrap().len(), 2);
+    assert_eq!(state["fragment_terrain"][0]["id"], "fragment:loc-0:0");
+    assert_eq!(
+        state["fragment_terrain"][0]["dominant_compound"],
+        "silicate_matrix"
+    );
+    assert_eq!(state["fragment_terrain"][0]["color"], json!([126, 144, 99]));
+    assert_eq!(
+        state["fragment_terrain"][1]["dominant_compound"],
+        "iron_nickel_alloy"
+    );
+    assert_eq!(state["fragment_terrain"][1]["footprint_cm"], 20_000.0);
+
+    assert_eq!(state["agents"][0]["position_source"], "location_derived");
+    assert!(state["agents"][0]["pos"].is_object());
+    assert_eq!(state["links"].as_array().unwrap().len(), 1);
+    assert_eq!(state["links"][0]["kind"], "agent_assignment");
+    assert_eq!(state["visual_hotspots"].as_array().unwrap().len(), 4);
+
+    let surface = &state["commercial_surface"];
+    assert_eq!(surface["active_agent_id"], "agent-0");
+    assert_eq!(
+        surface["objective"]["title"],
+        "Recover sustainable capability"
+    );
+    assert_eq!(surface["next_action"]["label"], "Build smelter mk1");
+    assert_eq!(surface["player_leverage"]["state"], "blocked");
+    assert_eq!(surface["action_receipt"]["present"], true);
+    assert_eq!(surface["action_receipt"]["confidence"], "world_delta");
+    assert_eq!(surface["action_receipt"]["title"], "Action blocked");
+    assert_eq!(surface["world_read"]["agents"], 1);
+    assert_eq!(surface["world_read"]["routes"], 1);
+    assert_eq!(surface["world_read"]["fragments"], 2);
+    assert_eq!(surface["world_read"]["hotspots"], 4);
+}
+
+#[test]
+fn rust_host_state_keeps_no_receipt_ambient_events_out_of_player_progress() {
+    let mut input = sample_input();
+    input["gameplay"] = json!({
+        "goalTitle": "Recover sustainable capability",
+        "objective": "Stabilize the first production line before expanding.",
+        "progressDetail": "The first production line is waiting for a player command.",
+        "executionState": "executing",
+        "executionStateLabel": "Executing",
+        "acceptedIntentSummary": "No player-facing accepted intent yet",
+        "recentFeedback": Value::Null
+    });
+
+    let state = build_render_state(&input);
+    let receipt = &state["commercial_surface"]["action_receipt"];
+    assert_eq!(receipt["present"], false);
+    assert_eq!(receipt["state"], "waiting_for_intent");
+    assert_eq!(receipt["confidence"], "none");
+    assert_eq!(receipt["title"], "No action receipt yet");
+    assert_eq!(
+        receipt["summary"],
+        "No player-caused world change has been confirmed yet."
+    );
+    assert!(receipt["target_agent_id"].is_null());
+}

--- a/crates/pixel_world_bridge/src/lib.rs
+++ b/crates/pixel_world_bridge/src/lib.rs
@@ -4,7 +4,7 @@ use std::mem;
 
 use bevy::prelude::*;
 use bevy::window::{PrimaryWindow, WindowPlugin};
-use js_sys::Function;
+use js_sys::{Function, Object, Reflect};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use serde_wasm_bindgen::{from_value, Serializer};
@@ -241,6 +241,27 @@ fn js_value_from_serializable<T: Serialize>(value: &T) -> Result<JsValue, JsValu
         .map_err(|error| JsValue::from_str(&format!("serialize js payload failed: {error}")))
 }
 
+fn render_state_fatal_value(code: &str, message: &str) -> JsValue {
+    js_value_from_serializable(&json!({
+        "fatal": {
+            "code": code,
+            "message": message,
+        }
+    }))
+    .unwrap_or_else(|_| {
+        let root = Object::new();
+        let fatal = Object::new();
+        let _ = Reflect::set(&fatal, &JsValue::from_str("code"), &JsValue::from_str(code));
+        let _ = Reflect::set(
+            &fatal,
+            &JsValue::from_str("message"),
+            &JsValue::from_str(message),
+        );
+        let _ = Reflect::set(&root, &JsValue::from_str("fatal"), &fatal);
+        root.into()
+    })
+}
+
 fn status_value(status: &str) -> JsValue {
     js_value_from_serializable(&json!({ "status": status })).unwrap_or_else(|_| JsValue::NULL)
 }
@@ -255,16 +276,21 @@ pub fn build_pixel_world_render_state(raw_input: JsValue) -> JsValue {
     let input: Value = match from_value(raw_input) {
         Ok(value) => value,
         Err(error) => {
-            return js_value_from_serializable(&json!({
-                "fatal": {
-                    "code": "pixel_world_render_state_parse_failed",
-                    "message": format!("render state input parse failed: {error}"),
-                }
-            }))
-            .unwrap_or(JsValue::NULL)
+            return render_state_fatal_value(
+                "pixel_world_render_state_parse_failed",
+                &format!("render state input parse failed: {error}"),
+            )
         }
     };
-    js_value_from_serializable(&host_state::build_render_state(&input)).unwrap_or(JsValue::NULL)
+    let render_state = host_state::build_render_state(&input);
+    js_value_from_serializable(&render_state).unwrap_or_else(|error| {
+        render_state_fatal_value(
+            "pixel_world_render_state_serialize_failed",
+            &error
+                .as_string()
+                .unwrap_or_else(|| "render state serialization failed".to_string()),
+        )
+    })
 }
 
 fn fallback_point_for_entity(

--- a/crates/pixel_world_bridge/src/lib.rs
+++ b/crates/pixel_world_bridge/src/lib.rs
@@ -11,6 +11,7 @@ use serde_wasm_bindgen::{from_value, Serializer};
 use wasm_bindgen::prelude::*;
 use web_sys::HtmlCanvasElement;
 
+mod host_state;
 mod render;
 
 thread_local! {
@@ -247,6 +248,23 @@ fn status_value(status: &str) -> JsValue {
 fn parse_render_state(raw: JsValue) -> Result<RenderState, JsValue> {
     from_value(raw)
         .map_err(|error| JsValue::from_str(&format!("render state parse failed: {error}")))
+}
+
+#[wasm_bindgen]
+pub fn build_pixel_world_render_state(raw_input: JsValue) -> JsValue {
+    let input: Value = match from_value(raw_input) {
+        Ok(value) => value,
+        Err(error) => {
+            return js_value_from_serializable(&json!({
+                "fatal": {
+                    "code": "pixel_world_render_state_parse_failed",
+                    "message": format!("render state input parse failed: {error}"),
+                }
+            }))
+            .unwrap_or(JsValue::NULL)
+        }
+    };
+    js_value_from_serializable(&host_state::build_render_state(&input)).unwrap_or(JsValue::NULL)
 }
 
 fn fallback_point_for_entity(


### PR DESCRIPTION
## Summary
- move pixel-world host render-state pure derivation into Rust via `pixel_world_bridge::host_state`
- expose `build_pixel_world_render_state` through wasm and wire the software-safe runtime loader/host to consume Rust-derived DTOs
- keep Solid/UI lifecycle and JS fallback behavior intact, with refreshed checked-in viewer/wasm artifacts

## Verification
- `./scripts/pm/task-closeout.sh --role viewer_engineer --task-uid task_1c7bd1a781d24f81b0c9611861599eff --verify-command "..."` passed fresh closeout verification
- closeout verification included Rust fmt/test/wasm check, targeted UI tests, software-safe build, pixel-world visual smoke, doc governance, PM lint, and `git diff --check`
- `./scripts/prepare-task-pr.sh` preflight reports ahead 1, behind 0, rebase required no, local required scope full

## Draft reason
Local `ready_for_pr` full required gate was attempted, but it repeatedly hit unrelated timing-sensitive tests outside this task's diff surface:
- `tests::runtime_gossip_tracks_peer_committed_heads` timed out once, then passed when rerun exactly in a clean state
- `oasis7_newapi_bridge_service` mock chain/LetAI socket tests reported `Resource temporarily unavailable (os error 35)` on different cases across retries

Leaving this as draft for CI/reviewer confirmation instead of claiming local ready-for-PR.
