### PR TITLE
Clarify workflow bootstrap and subagent dispatch

### DIFF
--- a/.agents/roles/templates/subagent-slice-card.md
+++ b/.agents/roles/templates/subagent-slice-card.md
@@ -5,8 +5,12 @@
 ## Required Fields（固定字段）
 - role:
 - slice type:
-- model configuration: `gpt-5.4-medium` by default; record reason for any override.
-- mandatory context packet:
+- model configuration: compatibility marker; fill the intended/actual fields below.
+- intended model configuration: `gpt-5.4-medium` by default; record reason for any requested override.
+- actual dispatched model/reasoning: selected model/reasoning when the tool permits and reports it; otherwise `inherited/unverified` plus connector/tool limitation, including cases where selection was requested but actual dispatch cannot be verified.
+- context delivery mode: full-thread/full-history fork by default; explicit context packet is delivery supplement/fallback only, with reason recorded.
+- mandatory context packet: compatibility marker; fill the mandatory context checklist/packet below.
+- mandatory context checklist/packet:
   - identity and authority: assigned role + `.agents/roles/<role>.md` + owner role + TPM integration owner
   - workflow governance: `AGENTS.md` + `doc/engineering/workflow/source-of-truth.md` + selected workflow skill(s)
   - task truth: `.pm/tasks/<TASK-UID>.yaml` + `.pm/tasks/<TASK-UID>.execution.md` + canonical worktree/branch/base ref + PR link/status if present
@@ -30,8 +34,12 @@
 ## Example (copy/paste)
 - role: producer_system_designer
 - slice type: implementation
-- model configuration: `gpt-5.4-medium`
-- mandatory context packet: `AGENTS.md` + `.agents/roles/producer_system_designer.md` + `doc/engineering/workflow/source-of-truth.md` + `doc/<module>/project.md` task `<task slug>` + `.pm/tasks/<TASK-UID>.yaml` + `.pm/tasks/<TASK-UID>.execution.md` + current branch/diff summary
+- model configuration: see intended/actual fields
+- intended model configuration: `gpt-5.4-medium`
+- actual dispatched model/reasoning: `gpt-5.4-medium`, or `inherited/unverified` with reason if the connector cannot select/report the model or actual dispatch cannot be verified
+- context delivery mode: full-thread/full-history fork
+- mandatory context packet: see mandatory context checklist/packet
+- mandatory context checklist/packet: `AGENTS.md` + `.agents/roles/producer_system_designer.md` + `doc/engineering/workflow/source-of-truth.md` + `doc/<module>/project.md` task `<task slug>` + `.pm/tasks/<TASK-UID>.yaml` + `.pm/tasks/<TASK-UID>.execution.md` + current branch/diff summary
 - write scope: `crates/foo/**`（disjoint）
 - return contract: patch + test evidence
 - validation command: `./scripts/cargo-dev.sh test -p foo`

--- a/.agents/roles/tpm.md
+++ b/.agents/roles/tpm.md
@@ -9,8 +9,8 @@ TPM 只做 workflow coordination / integration，不做任何专业性工作本�
 - 默认 workflow orchestration：bootstrap、router、execution coordination、verification gate coordination、closeout、commit / PR 主链
 - 单一真值维护：一个 owner role、一个 `.pm` task、一个 canonical worktree、一个 PR chain
 - 专业角色派工：决定何时派生 `producer_system_designer` / `runtime_engineer` / `wasm_platform_engineer` / `agent_engineer` / `viewer_engineer` / `qa_engineer` / `liveops_community` subagent
-- 每个 subagent slice 的目标、model configuration、write scope、return contract、formal sink、integration owner/order
-- 每个 subagent slice 的 mandatory context packet：身份与权限、workflow governance、task truth、用户意图、相关 repo 背景和协作边界
+- 每个 subagent slice 的目标、intended/actual model configuration、context delivery mode、write scope、return contract、formal sink、integration owner/order
+- 每个 subagent slice 的 mandatory context checklist/packet：身份与权限、workflow governance、task truth、用户意图、相关 repo 背景和协作边界；默认通过 full-thread/full-history fork 或等价上下文交付，显式 packet 仅作补充或 fallback
 - 将 TODO decomposition、subagent slice contracts、integration order 在派工前写入 `.pm/tasks/<TASK-UID>.execution.md`
 - 跨角色结果合流、冲突升级、fresh verification gate 状态记录与 completion claim coordination
 
@@ -37,7 +37,9 @@ TPM 只做 workflow coordination / integration，不做任何专业性工作本�
 - 每个用户请求必须先创建或进入标准 task worktree 并绑定 `.pm` task；只读、聊天、纯事实读取和专业判断都不能绕过 task/worktree 真值。
 - 可决定哪些专业角色参与、参与顺序、是否允许互斥范围并行写入，以及哪些结果只读采纳。
 - 派工前必须把当前 TODO、slice contract、formal sink 和 integration order 写入 `.pm/tasks/<TASK-UID>.execution.md`；project、handoff、signal、memory 或 PR evidence 只能作为补充 sink。
-- 专业角色 slice 默认使用 `gpt-5.4` + `reasoning_effort=medium`（`gpt-5.4-medium`）；非默认 model / reasoning 必须在 slice contract 写明用户要求或任务理由。
+- 专业角色 slice 默认请求 `gpt-5.4` + `reasoning_effort=medium`（`gpt-5.4-medium`）；slice contract 必须同时写明 intended model 与 actual dispatched model/reasoning。非默认、继承父线程、请求选择后无法验证 actual model、或其他无法验证 actual model 的情况都必须记录原因。
+- 专业角色 slice 默认使用 full-thread/full-history fork 或等价上下文；若改用手工显式 context packet，必须记录 fallback 原因，例如工具限制、上下文安全、模型选择冲突或默认 fork 卡住。
+- 兼容契约词：`mandatory context packet` 在当前语义下指必须记录的 mandatory context checklist/packet，不等同于必须手工组装显式上下文包。
 - 非窄范围只读 explorer 的 subagent 必须获得 `AGENTS.md`、对应 role card、workflow source-of-truth、当前 `.pm` task yaml/execution log、相关 PRD/project/handoff、当前 diff/evidence 和 sibling slice 边界。
 - 可要求专业 subagent 补充验证、缩小 write scope 或重跑 evidence；不得用 TPM 自己的判断替代专业 subagent 结论，也不得用 subagent 结果替代 TPM 的最终流程合流和 fresh verification gate 记录。
 - 涉及世界规则、runtime 安全、玩家承诺或对外口径时，必须派生相应专业角色 subagent，而不是由 TPM 单独拍板。
@@ -45,7 +47,7 @@ TPM 只做 workflow coordination / integration，不做任何专业性工作本�
 
 ## Done Criteria
 - 用户请求已在标准 task worktree 中执行，并绑定单一 `.pm` task。
-- 所有专业角色工作均以 subagent slice 形式出现，并且对应 TODO、model configuration、mandatory context packet、write scope、return contract、mandatory `.pm` execution-log sink 与 integration order 已先写入 `.pm/tasks/<TASK-UID>.execution.md`。
+- 所有专业角色工作均以 subagent slice 形式出现，并且对应 TODO、intended/actual model configuration、context delivery mode、mandatory context checklist/packet、write scope、return contract、mandatory `.pm` execution-log sink 与 integration order 已先写入 `.pm/tasks/<TASK-UID>.execution.md`。
 - TPM 已在 canonical worktree 中完成合流、fresh verification、closeout 和 PR 准备。
 - 专业结论与最终用户说明能追溯到 `.pm` execution log、handoff、project/prd 或 PR evidence。
 
@@ -56,7 +58,7 @@ TPM 只做 workflow coordination / integration，不做任何专业性工作本�
 
 ## Checklist
 - 是否已为本请求创建或进入标准 task worktree，并绑定单一 `.pm` task。
-- 是否在派工前把 TPM TODO decomposition 和每个专业角色 subagent 的 slice type、model configuration、mandatory context packet、write scope、return contract、mandatory `.pm` execution-log sink、integration order 写入 `.pm/tasks/<TASK-UID>.execution.md`。
+- 是否在派工前把 TPM TODO decomposition 和每个专业角色 subagent 的 slice type、intended/actual model configuration、context delivery mode、mandatory context checklist/packet、write scope、return contract、mandatory `.pm` execution-log sink、integration order 写入 `.pm/tasks/<TASK-UID>.execution.md`。
 - 是否把 subagent 结果合流回同一个 `.pm` task / canonical worktree / PR chain。
 - 是否避免专业角色直接变成第二 owner、第二 worktree 或第二 PR 主链。
 - 是否在 completion claim 前 fresh 运行并读取验证命令。

--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -40,7 +40,7 @@
 Canonical phase mapping lives in `doc/engineering/workflow/source-of-truth.md#11-skill-map-by-phase`; this README is an index, not the workflow authority.
 
 - 启动任何用户请求、需要先确认标准 task worktree / `.pm` task / owner role 真值，并把后续阶段接回 repo-owned 主链时：`.agents/skills/default-workflow-bootstrap/SKILL.md`
-- 只读/聊天请求也默认进入 task/worktree bootstrap；如果要输出专业结论，进入 task truth 后仍由 TPM 派发对应 bounded 专业角色 slice。纯路径查找、命令输出复述等客观事实读取可由 TPM 在已绑定 task/worktree 内直接处理。
+- 只读/聊天请求也默认进入 task/worktree bootstrap；不要先用“只读/聊天/纯事实”分类决定是否跳过 bootstrap。如果要输出专业结论，进入 task truth 后仍由 TPM 派发对应 bounded 专业角色 slice。纯路径查找、命令输出复述等客观事实读取可由 TPM 在已绑定 task/worktree 内直接处理。
 - 启动已具备 task 真值的仓库变更 task、或不确定下一步该走哪条 repo-owned workflow surface 时：`.agents/skills/repo-owned-workflow-router/SKILL.md`
 - 需求仍偏模糊、需要 scope 拆分、方案对比或判断是否需要 visual companion 时：`.agents/skills/bounded-brainstorming/SKILL.md`
 - 行为变更类实现任务、且存在稳定自动化测试面时：`.agents/skills/tdd-test-writer/SKILL.md`
@@ -52,7 +52,7 @@ Canonical phase mapping lives in `doc/engineering/workflow/source-of-truth.md#11
 - PR 收到 review comments / requested changes，需要核实、修复、回证据并保持 thread resolution 与 merge readiness 分离时：`.agents/skills/receiving-code-review/SKILL.md`
 - 新增或修改本地 repo-owned skill、替换上游 skill 或调整 skill governance 时：`.agents/skills/writing-repo-owned-skills/SKILL.md`
 
-Specialist skills are domain-triggered through TPM routing or professional subagent slice planning. They are intentionally not mandatory phases in the default workflow chain. TPM routing is coordination only; specialist conclusions must be owned by the matching professional role slice.
+Specialist skills are domain-triggered through TPM routing or professional subagent slice planning. They are intentionally not mandatory phases in the default workflow chain. TPM routing is coordination only; specialist conclusions must be owned by the matching professional role slice. Professional slice contracts record intended model, actual dispatched model/reasoning or `inherited/unverified`, context delivery mode, and mandatory context checklist/packet; default context delivery is full-thread/full-history fork, with explicit context packets only as delivery supplement/fallback.
 
 ## Bounded Borrowing From `writing-skills`
 

--- a/.agents/skills/default-workflow-bootstrap/SKILL.md
+++ b/.agents/skills/default-workflow-bootstrap/SKILL.md
@@ -42,7 +42,7 @@ Read-only caveat:
 
 ## Core Workflow
 
-1. Treat the request as requiring standard worktree + `.pm` task truth before substantive handling:
+1. Treat the request as requiring standard worktree + `.pm` task truth before substantive handling. Do not first classify the request type to decide whether bootstrap is needed:
    - repository-changing: requires standard worktree + `.pm` task truth before edits
    - read-only/chat-only pure fact lookup: requires standard worktree + `.pm` task truth before direct answer
    - read-only/chat-only professional judgment: requires standard worktree + `.pm` task truth before dispatching the matching professional role slice
@@ -117,6 +117,7 @@ WORKFLOW BOOTSTRAP DECIDED
 ## Guardrails
 
 - Do not create a second planning or bootstrap truth outside repo-owned surfaces.
+- Do not infer a read-only/chat-only bypass before bootstrap; request-type routing happens only after task truth exists.
 - Do not treat project, handoff, signal, memory, chat transcript, or PR evidence as a replacement for `.pm/tasks/<TASK-UID>.execution.md`.
 - Do not skip worktree / `.pm` task creation for any user request unless the user explicitly authorized reuse of a specific task worktree that is already bound to the same `.pm` task.
 - Do not stop after saying which workflow surface should be used; continue into that phase.

--- a/.agents/skills/repo-owned-workflow-router/SKILL.md
+++ b/.agents/skills/repo-owned-workflow-router/SKILL.md
@@ -33,7 +33,7 @@ Do not use this skill when:
 3. It only chooses and orders repo-owned workflow skills.
 4. If the task truth changes, route decisions must be written back into `.pm/tasks/<TASK-UID>.execution.md`; formal docs may supplement but not replace it.
 5. Use the narrowest applicable workflow surface; do not force every phase if it is not needed.
-6. If the route implies multi-role or subagent-driven execution, the route output must also include a minimal slice contract: role, slice type, model configuration, mandatory context packet, write scope, return contract, mandatory `.pm` execution-log sink, and integration owner/order.
+6. If the route implies multi-role or subagent-driven execution, the route output must also include a minimal slice contract: role, slice type, intended model configuration, actual dispatched model/reasoning or `inherited/unverified`, context delivery mode, mandatory context checklist/packet, write scope, return contract, mandatory `.pm` execution-log sink, and integration owner/order.
 7. TPM TODO decomposition and subagent slice contracts must be recorded in `.pm/tasks/<TASK-UID>.execution.md` before delegated execution begins.
 8. TPM routing is coordination only. If the task needs professional/domain analysis, implementation, verification judgment, review judgment, or external messaging, route to the matching professional role slice before presenting that conclusion as authoritative.
 9. Read-only/chat-only requests enter this router after `default-workflow-bootstrap` has established task truth. Read-only professional/domain questions still require the matching bounded role slice, and the slice contract/sink must be recorded in `.pm/tasks/<TASK-UID>.execution.md`.
@@ -110,8 +110,12 @@ WORKFLOW ROUTE DECIDED
 ## Subagent Slice Plan (If Needed)
 - role:
 - slice type:
-- model configuration: `gpt-5.4-medium` by default; record reason for any override
-- mandatory context packet:
+- model configuration: compatibility marker; fill the intended/actual fields below
+- intended model configuration: `gpt-5.4-medium` by default; record reason for any requested override
+- actual dispatched model/reasoning: record the selected model/reasoning when the tool permits and reports it; otherwise record `inherited/unverified` plus the connector/tool limitation, including cases where selection was requested but actual dispatch cannot be verified
+- context delivery mode: full-thread/full-history fork by default; explicit context packet is delivery supplement/fallback only, with reason recorded
+- mandatory context packet: compatibility marker; fill the mandatory context checklist/packet below
+- mandatory context checklist/packet:
   - identity and authority:
   - workflow governance:
   - task truth:
@@ -138,5 +142,5 @@ WORKFLOW ROUTE DECIDED
 - Do not skip `verification-before-completion` when you are about to make a completion claim.
 - Do not use this router as a replacement for closeout; switch to `finishing-a-development-branch` when the task is done.
 - Do not treat specialist domain skills as mandatory default workflow phases; route to them only when the task domain matches their trigger.
-- Do not dispatch implementation, verification, review, or specialist subagents without `AGENTS.md`, the assigned role card, workflow source-of-truth, current `.pm` task truth, and scoped repo context in the mandatory context packet.
+- Do not dispatch implementation, verification, review, or specialist subagents without `AGENTS.md`, the assigned role card, workflow source-of-truth, current `.pm` task truth, and scoped repo context recorded in the mandatory context checklist/packet.
 - Do not let TPM direct exploration become a professional conclusion; professional findings must be owned or verified by the matching role slice.

--- a/.pm/tasks/task_57ce723d36ed4496a26667783f7f69f5.execution.md
+++ b/.pm/tasks/task_57ce723d36ed4496a26667783f7f69f5.execution.md
@@ -1,0 +1,120 @@
+# task_57ce723d36ed4496a26667783f7f69f5 Execution Log
+
+- task_uid: task_57ce723d36ed4496a26667783f7f69f5
+- title: clarify workflow bootstrap and subagent dispatch
+- owner_role: tpm
+- worktree_hint: /Users/scc/ccwork/worktrees/oasis7-engineering-workflow-subagent-dispatch-clarity
+
+<!-- Append entries using:
+Example:
+  ## YYYY-MM-DD HH:MM:SS CST / role_name
+  - 完成内容: ...
+  - 遗留事项: ...
+  - Action: ...
+  - Validation Command: ...
+  - Expected Result: ...
+  - Actual Result: ...
+  - Blocker / Next Action: ...
+-->
+
+## 2026-06-02 13:06:09 CST / tpm
+- 完成内容: WORKFLOW BOOTSTRAP DECIDED for workflow governance correction.
+- 遗留事项: Need source-of-truth-first edits and synchronized workflow surfaces.
+- Action: Created dedicated task worktree with `./scripts/new-task-worktree.sh engineering workflow-subagent-dispatch-clarity --base main --branch codex/engineering-workflow-subagent-dispatch-clarity --pm-owner-role tpm ...`.
+- Validation Command: `git worktree list`
+- Expected Result: Dedicated worktree exists and `.pm` task is bound with owner_role `tpm`.
+- Actual Result: Worktree `/Users/scc/ccwork/worktrees/oasis7-engineering-workflow-subagent-dispatch-clarity` created on branch `codex/engineering-workflow-subagent-dispatch-clarity`; task `task_57ce723d36ed4496a26667783f7f69f5` is committed.
+- Blocker / Next Action: Apply source-of-truth-first workflow documentation fixes.
+
+## 2026-06-02 13:07:00 CST / tpm
+- 完成内容: Planned narrow workflow corrections from user feedback.
+- 遗留事项: Need verification after edits.
+- Action: Update workflow governance to clarify (1) request type must not be classified before bootstrap, (2) subagent default context should use full-thread/full-history fork when available and explicit packet only as fallback/supplement, (3) model configuration must distinguish intended default from actual dispatched runtime and record any inherited/non-default model reason.
+- Validation Command: `rg -n "read-only|只读|subagent|model|gpt-5\\.4|context|fork" doc/engineering/workflow/source-of-truth.md AGENTS.md .agents/skills .agents/roles`
+- Expected Result: Identify minimal affected workflow surfaces.
+- Actual Result: Affected surfaces include `doc/engineering/workflow/source-of-truth.md`, `AGENTS.md`, `.agents/skills/repo-owned-workflow-router/SKILL.md`, and `.agents/roles/templates/subagent-slice-card.md`.
+- Blocker / Next Action: Patch source-of-truth first, then sync downstream surfaces.
+
+## 2026-06-02 13:16:00 CST / tpm
+- 完成内容: Applied source-of-truth-first workflow corrections and synchronized downstream workflow surfaces.
+- 遗留事项: None for the requested corrections; no business code changed.
+- Action: Updated `doc/engineering/workflow/source-of-truth.md` to v1.4.9, then synchronized `AGENTS.md`, `.agents/roles/tpm.md`, `.agents/roles/templates/subagent-slice-card.md`, `.agents/skills/default-workflow-bootstrap/SKILL.md`, `.agents/skills/repo-owned-workflow-router/SKILL.md`, and `.agents/skills/README.md`.
+- Validation Command: `./scripts/pm/workflow-behavior-eval.sh`
+- Expected Result: Workflow contract markers and scenario checks pass after preserving compatibility markers.
+- Actual Result: Passed with `workflow behavior eval: OK`.
+- Blocker / Next Action: Run remaining governance checks.
+
+## 2026-06-02 13:17:00 CST / tpm
+- 完成内容: Fresh verification completed for workflow documentation correction.
+- 遗留事项: None.
+- Action: Ran PM lint, doc governance, and diff whitespace checks.
+- Validation Command: `./scripts/pm/lint.sh`; `./scripts/doc-governance-check.sh`; `git diff --check`
+- Expected Result: All commands pass.
+- Actual Result: `pm-lint: OK`; `doc-governance-check: OK`; `git diff --check` exited 0.
+- Blocker / Next Action: Summarize changes to user.
+
+## 2026-06-02 13:22:00 CST / tpm
+- 完成内容: Added a requested TPM-role review slice contract for ambiguity/completeness audit.
+- 遗留事项: Await subagent findings and integrate any valid follow-up edits.
+- Action: Dispatch bounded `tpm` read-only review slice over the workflow wording changes.
+- Validation Command: Review current diff and relevant workflow surfaces.
+- Expected Result: Identify remaining ambiguity, incomplete synchronization, or contract/tool mismatches, if any.
+- Actual Result: Pending.
+- Blocker / Next Action: Spawn full-history/default-context subagent and record findings.
+
+### Subagent Slice Contract: TPM workflow ambiguity review
+- role: `tpm`
+- slice_type: `review_judgment`
+- model configuration: compatibility marker; fill intended/actual fields below.
+- intended model configuration: `gpt-5.4-medium`
+- actual dispatched model/reasoning: `inherited/unverified`; current subagent tool requires inherited model when using full-history fork, so actual model cannot be explicitly selected or verified here.
+- context delivery mode: full-thread/full-history fork.
+- mandatory context packet: full forked thread plus current task/worktree truth; key files are `AGENTS.md`, `doc/engineering/workflow/source-of-truth.md`, `.agents/roles/tpm.md`, `.agents/skills/default-workflow-bootstrap/SKILL.md`, `.agents/skills/repo-owned-workflow-router/SKILL.md`, `.agents/roles/templates/subagent-slice-card.md`, `.agents/skills/README.md`, and `.pm/tasks/task_57ce723d36ed4496a26667783f7f69f5.execution.md`.
+- exact_question: Are the workflow descriptions still ambiguous or incomplete after the latest edits, especially around bootstrap ordering, subagent context delivery, and intended/actual model recording?
+- explicit_non_goals: Do not change repository files; do not review unrelated workflow areas; do not replace TPM integration judgment.
+- write_scope: none; return findings only.
+- return_contract: ordered findings with file/line references, suggested wording if needed, residual risks, and whether follow-up edits are required.
+- formal_sink: TPM will append returned findings and integration decision to this execution log.
+- integration_order: TPM records contract, subagent reviews, TPM integrates valid findings, then reruns affected verification if edits are made.
+
+## 2026-06-02 13:32:00 CST / tpm
+- 完成内容: Default full-history TPM review slice did not return in a bounded time window.
+- 遗留事项: Need fallback review slice with explicit context packet.
+- Action: Closed subagent `019e86f5-f82a-7cc0-a7db-001c9382cb4a` after repeated waits timed out.
+- Validation Command: `multi_agent_v1.wait_agent` and `multi_agent_v1.close_agent`
+- Expected Result: Either receive review findings or stop the stalled slice cleanly.
+- Actual Result: Slice remained running through repeated waits and was closed with previous_status `running`.
+- Blocker / Next Action: Dispatch fallback `tpm` review slice using explicit minimal context because the default full-history delivery did not complete.
+
+### Subagent Slice Contract: TPM workflow ambiguity review fallback
+- role: `tpm`
+- slice_type: `review_judgment`
+- model configuration: compatibility marker; fill intended/actual fields below.
+- intended model configuration: `gpt-5.4-medium`
+- actual dispatched model/reasoning: `inherited/unverified`; explicit model selection is omitted to avoid tool/model conflict and actual model is not exposed.
+- context delivery mode: explicit context packet fallback; reason: default full-thread/full-history fork slice stalled and was closed after repeated waits.
+- mandatory context packet: current user request; current git diff; key excerpts from `AGENTS.md`, `doc/engineering/workflow/source-of-truth.md`, `.agents/roles/tpm.md`, `.agents/skills/default-workflow-bootstrap/SKILL.md`, `.agents/skills/repo-owned-workflow-router/SKILL.md`, `.agents/roles/templates/subagent-slice-card.md`, `.agents/skills/README.md`, and this execution log.
+- exact_question: Are the workflow descriptions still ambiguous or incomplete after the latest edits, especially around bootstrap ordering, subagent context delivery, and intended/actual model recording?
+- explicit_non_goals: Do not change files; do not broaden beyond workflow governance wording.
+- write_scope: none; return findings only.
+- return_contract: ordered findings with file/line references, suggested wording if needed, residual risks, and whether follow-up edits are required.
+- formal_sink: TPM will append returned findings and integration decision to this execution log.
+- integration_order: TPM records fallback contract, subagent reviews, TPM integrates valid findings, then reruns affected verification if edits are made.
+
+## 2026-06-02 13:40:00 CST / tpm
+- 完成内容: Received fallback TPM review slice findings and accepted both narrow wording fixes.
+- 遗留事项: Need apply wording fixes and rerun verification.
+- Action: Reviewed subagent `019e8700-e6b4-7910-83c7-bea963eb61bf` findings.
+- Validation Command: `multi_agent_v1.wait_agent`
+- Expected Result: TPM review findings identify remaining ambiguity or explicitly report no findings.
+- Actual Result: Findings: P2 context terminology ambiguity between full-history context delivery and `mandatory context packet`; P3 actual model wording should cover cases where model selection was requested but actual dispatch cannot be verified. No bootstrap-ordering ambiguity found.
+- Blocker / Next Action: Apply accepted wording fixes to source-of-truth and synchronized workflow surfaces, then rerun workflow/doc/pm/diff checks.
+
+## 2026-06-02 13:50:00 CST / tpm
+- 完成内容: Integrated TPM review findings and reran fresh verification.
+- 遗留事项: None for the requested TPM review pass.
+- Action: Clarified `mandatory context checklist/packet` versus explicit context delivery packet; expanded actual model wording to include requested-but-unverifiable dispatch; preserved workflow eval compatibility markers without changing the new semantics.
+- Validation Command: `./scripts/pm/workflow-behavior-eval.sh`; `./scripts/pm/lint.sh`; `./scripts/doc-governance-check.sh`; `git diff --check`
+- Expected Result: All governance checks pass after follow-up wording edits.
+- Actual Result: `workflow behavior eval: OK`; `pm-lint: OK`; `doc-governance-check: OK`; `git diff --check` exited 0.
+- Blocker / Next Action: Report review outcome to user.

--- a/.pm/tasks/task_57ce723d36ed4496a26667783f7f69f5.yaml
+++ b/.pm/tasks/task_57ce723d36ed4496a26667783f7f69f5.yaml
@@ -1,0 +1,26 @@
+task_uid: task_57ce723d36ed4496a26667783f7f69f5
+title: "clarify workflow bootstrap and subagent dispatch"
+owner_role: tpm
+worktree_hint: /Users/scc/ccwork/worktrees/oasis7-engineering-workflow-subagent-dispatch-clarity
+execution_log_path: .pm/tasks/task_57ce723d36ed4496a26667783f7f69f5.execution.md
+status: done
+priority: P2
+source_signal: null
+source_refs:
+  - AGENTS.md
+  - doc/engineering/workflow/source-of-truth.md
+doc_refs:
+  - .agents/skills/default-workflow-bootstrap/SKILL.md
+  - .agents/skills/writing-repo-owned-skills/SKILL.md
+related_prd: []
+acceptance:
+  - "Clarify read-only bootstrap ordering, subagent context defaults, and actual model configuration recording without contradicting connector tool constraints."
+handoff_to: []
+updated_at: 2026-06-02T15:42:25+08:00
+last_started_at: 2026-06-02T13:06:09+08:00
+last_claim_type: task_complete
+last_verify_command: ./scripts/pm/workflow-behavior-eval.sh
+last_verified_at: 2026-06-02T15:42:25+08:00
+last_verification_exit_code: 0
+last_verification_status: verified
+last_closed_at: 2026-06-02T15:42:25+08:00

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,8 @@
 4. 只读专业 slice 的 contract、证据和 sink 必须写入 `.pm/tasks/<TASK-UID>.execution.md`；带角色归因的用户答案只能作为对外摘要，不能替代 `.pm` execution-log sink。
 5. 仓库变更任务按统一阶段推进：bootstrap → router →（可选）brainstorming/TDD → execution → verification → closeout。
 6. 禁止在 `main` 分支 / 主 worktree 直接修改任何文件；所有改动必须先创建或进入对应 task worktree。
-7. 所有 gate、责任边界、失败回退路径，统一引用：
+7. 不得在 bootstrap 前先把请求判定为“只读/聊天/纯事实/专业判断”来决定是否需要 task/worktree；任何看似允许只读绕过的旧说明，都以 `doc/engineering/workflow/source-of-truth.md` 当前版本为准。
+8. 所有 gate、责任边界、失败回退路径，统一引用：
    - 阶段图：`doc/engineering/workflow/source-of-truth.md#1-phase-diagram`
    - 责任边界：`doc/engineering/workflow/source-of-truth.md#2-responsibility-boundary`
    - 必需/可选 gate：`doc/engineering/workflow/source-of-truth.md#3-gates`
@@ -19,15 +20,18 @@
    - 关键规范细节（worktree/执行证据/closeout/PR）：`doc/engineering/workflow/source-of-truth.md#5-normative-details-from-legacy-agents-workflow`
    - skill 阶段映射：`doc/engineering/workflow/source-of-truth.md#11-skill-map-by-phase`
    - 语义迁移核对清单：`doc/engineering/workflow/source-of-truth.md#8-semantic-migration-checklist`
-7. 流程改动必须先改 source-of-truth，再同步脚本/技能/其余文档。
+9. 流程改动必须先改 source-of-truth，再同步脚本/技能/其余文档。
 
 ### Workflow Eval Contract Markers
 本段保留 `scripts/pm/workflow-behavior-eval.sh` 的稳定契约词；语义解释仍以 `doc/engineering/workflow/source-of-truth.md` 为唯一真值。
 
 - `default-workflow-bootstrap`: 任何用户请求都必须先经过 repo-owned bootstrap，确认标准 task worktree / `.pm` task / owner role 真值，再进入后续 workflow surface；禁止用只读、聊天、纯事实读取绕过 bootstrap。
 - 只读专业判断分流：只读/聊天请求也必须先进入 task/worktree bootstrap；但凡输出产品/系统设计、runtime、WASM、agent、viewer、QA、LiveOps/community 等专业结论，仍必须由对应专业角色 slice 给出或验证，TPM 只能合流与标注来源。
-- subagent 默认模型：专业角色 slice 默认使用 `gpt-5.4` + `reasoning_effort=medium`（简写 `gpt-5.4-medium`）；若用户要求其他模型，或 slice 明确需要更强/更快/更省配置，必须在 slice contract 记录 model / reasoning 与原因。
-- 默认协作口径：`tpm` 主 Agent + 专业角色 subagents；TPM 只做 workflow coordination / integration。对已绑定 task 或会改变仓库状态的工作，TPM 的 TODO decomposition、subagent slice contracts、mandatory context packet 和 integration order 必须先写入 `.pm/tasks/<TASK-UID>.execution.md`，其他 formal sink 只能补充，不能替代 task execution log。
+- subagent 默认模型：专业角色 slice 默认请求 `gpt-5.4` + `reasoning_effort=medium`（简写 `gpt-5.4-medium`）；若用户要求其他模型、slice 明确需要更强/更快/更省配置，当前 subagent 工具只能继承父线程模型，或请求选择后无法验证实际派发模型，必须在 slice contract 同时记录 intended model、actual dispatched model/reasoning 与原因；无法验证实际模型时记录 `actual model: inherited/unverified`。
+- subagent 默认上下文：专业角色 slice 默认使用 full-thread/full-history fork 或最接近的等价上下文；slice contract 仍必须记录 mandatory context checklist。手工显式 context packet 只能作为补充或 fallback，且必须记录为什么不能使用默认 fork（例如工具限制、上下文安全、模型选择冲突或默认 fork 卡住）。
+- 兼容契约词：`mandatory context packet` 在当前语义下指必须记录的 mandatory context checklist/packet，不等同于必须手工组装显式上下文包。
+- 兼容契约词：TPM 的 TODO decomposition、subagent slice contracts、mandatory context packet 和 integration order 必须先写入 `.pm/tasks/<TASK-UID>.execution.md`；其中 `mandatory context packet` 按当前语义解释为 mandatory context checklist/packet。
+- 默认协作口径：`tpm` 主 Agent + 专业角色 subagents；TPM 只做 workflow coordination / integration。对已绑定 task 或会改变仓库状态的工作，TPM 的 TODO decomposition、subagent slice contracts、mandatory context checklist/packet 和 integration order 必须先写入 `.pm/tasks/<TASK-UID>.execution.md`，其他 formal sink 只能补充，不能替代 task execution log。
 - 专业结论来源约束：产品/系统设计、runtime、WASM、agent、viewer、QA、LiveOps/community 等专业分析、实现、验证、评审或对外口径，必须来自对应专业角色 slice；TPM 只能合流和标注证据来源。
 - 高风险或大 diff 收敛前，补充 review 入口是 `.agents/skills/requesting-repo-owned-review/SKILL.md`；它只补强 GitHub PR review、required checks 与 review/approval 主链。
 - 涉及对外说明、社区反馈、事故复盘、玩家承诺或渠道 runbook 的任务，`liveops_community` 必须参与至少一个 slice。

--- a/doc/engineering/workflow/source-of-truth.md
+++ b/doc/engineering/workflow/source-of-truth.md
@@ -1,7 +1,7 @@
 # Engineering Workflow Source of Truth
 
-Version: **v1.4.8**
-Last Updated: **2026-06-01**
+Version: **v1.4.9**
+Last Updated: **2026-06-02**
 
 ## 0. Purpose
 This file is the **only normative workflow specification** for engineering task execution in oasis7.
@@ -76,6 +76,7 @@ If a specialist skill is used, TPM must still bind it to the same owner, `.pm` t
 - For every request, TPM planning, TODO decomposition when needed, subagent slice contracts, and integration order are task execution truth and must be written to `.pm/tasks/<TASK-UID>.execution.md` before the delegated work begins.
 - Every user request must enter the standard worktree flow before any substantive handling begins, including chat-only answers, read-only inspection, fact lookup, professional slice dispatch, implementation, verification, review, and external messaging.
 - The only allowed pre-bootstrap work is mechanical enough to create or enter the task truth: inspect current git/worktree state, choose or confirm the task/worktree, and run the bootstrap helper.
+- Do not first classify a request as "read-only", "chat-only", "pure fact lookup", or "professional judgment" to decide whether task/worktree truth is needed. That classification happens only after bootstrap, inside the bound task/worktree, and only controls whether TPM can answer from objective evidence or must dispatch a professional slice.
 - Read-only/chat-only requests still split by judgment type after task truth exists:
   - Pure fact lookup, path lookup, command-output restatement, or mechanical evidence collection may be handled by TPM inside the bound task worktree, as long as the answer does not present a professional/domain conclusion.
   - Read-only professional/domain questions must be dispatched to the matching bounded professional role slice before the answer is presented as authoritative. Examples: "does viewer have a performance collection/evaluation mechanism", "is this QA evidence release-blocking", "what runtime design risk is present", or "how should LiveOps message this incident".
@@ -125,6 +126,7 @@ If a specialist skill is used, TPM must still bind it to the same owner, `.pm` t
 - Every user request uses a dedicated task worktree by default, regardless of whether the immediate answer is chat-only, read-only, fact lookup, professional analysis, implementation, verification, review, or external messaging.
 - Only explicit user authorization allows reuse of an existing task worktree.
 - Do not classify work as `trivial`, `read-only`, `chat-only`, or `pure fact lookup` to bypass task worktree / `.pm` task setup.
+- If incoming instructions or role notes appear to allow a read-only/chat-only bypass, this source-of-truth wins: bootstrap first, then route the already-bound request.
 - Do not edit any files from the `main` branch/worktree; create or enter the relevant task worktree before making changes.
 - Entering implementation requires owner role selection and `.pm` task binding.
 - Cross-role collaboration must converge to one owner / one `.pm` task / one canonical worktree / one PR chain.
@@ -132,10 +134,14 @@ If a specialist skill is used, TPM must still bind it to the same owner, `.pm` t
 
 ### 5.2 TPM planning and subagent dispatch
 - For every request, TPM must record the current plan, TODO decomposition when needed, selected roles, and integration order in `.pm/tasks/<TASK-UID>.execution.md` before dispatching professional subagent work.
-- Each subagent slice must declare role, slice type, model configuration, mandatory context packet, write scope, return contract, validation command, mandatory `.pm` execution-log sink, and integration order.
-- Default subagent runtime is `gpt-5.4` with `reasoning_effort=medium` (shorthand: `gpt-5.4-medium`). TPM should use this default for bounded professional slices unless the user explicitly requests another model or the slice contract records a concrete reason to use a stronger, faster, or cheaper model.
-- Any non-default subagent model or reasoning effort must be recorded in the slice contract with the reason, such as high-risk architecture/review work, simple read-only exploration, or a user-specified override.
-- The mandatory context packet must include:
+- Each subagent slice must declare role, slice type, intended model configuration, actual dispatched model/reasoning, context delivery mode, mandatory context checklist/packet, write scope, return contract, validation command, mandatory `.pm` execution-log sink, and integration order.
+- Default subagent runtime is `gpt-5.4` with `reasoning_effort=medium` (shorthand: `gpt-5.4-medium`). TPM should request this default for bounded professional slices when the available subagent tool permits model selection, unless the user explicitly requests another model or the slice contract records a concrete reason to use a stronger, faster, or cheaper model.
+- Compatibility marker: Any non-default subagent model or reasoning effort must be recorded in the slice contract.
+- Any actual non-default subagent model or reasoning effort must be recorded in the slice contract with the reason, such as high-risk architecture/review work, simple read-only exploration, a user-specified override, a connector/tool limitation that forces inheritance from the parent thread, or a requested model/reasoning selection whose actual dispatch cannot be verified. If the actual dispatched model cannot be verified, the contract must say `actual model: inherited/unverified` and explain why.
+- Context delivery defaults to full-thread/full-history fork or the closest available equivalent so the subagent receives the same conversation and repository-governance context as TPM. The slice contract must still record a mandatory context checklist identifying the governance/task/user/repo/collaboration context the subagent is expected to have. A manually assembled explicit context packet is allowed only as a delivery supplement or fallback when full-history fork is unavailable, unsafe, stalled, or incompatible with required model/reasoning selection; the slice contract must record that fallback reason.
+- Compatibility marker: mandatory context packet means the recorded mandatory context checklist/packet, not necessarily a manually assembled explicit delivery packet.
+- Compatibility marker: The mandatory context packet must include:
+- The mandatory context checklist/packet must include:
   - identity and authority: assigned role, role card path, owner role, and TPM integration owner
   - workflow governance: `AGENTS.md`, `doc/engineering/workflow/source-of-truth.md`, and the selected workflow skills
   - task truth: current `.pm/tasks/<TASK-UID>.yaml`, `.pm/tasks/<TASK-UID>.execution.md`, canonical worktree, branch, base ref, and PR link/status when present
@@ -155,7 +161,9 @@ If a specialist skill is used, TPM must still bind it to the same owner, `.pm` t
 - Therefore, a read-only request must enter `default-workflow-bootstrap` first and may still require a professional role slice.
 - Minimal read-only specialist slice contract:
   - role and slice type (`read_only_analysis`, `verification_judgment`, `review_judgment`, or `liveops_messaging`)
-  - model configuration, defaulting to `gpt-5.4-medium` unless an override reason is recorded
+  - intended model configuration, defaulting to `gpt-5.4-medium` unless an override reason is recorded
+  - actual dispatch model/reasoning, or `inherited/unverified` with the connector/tool limitation, stalled default context delivery, or unverifiable actual dispatch reason
+  - context delivery mode, defaulting to full-thread/full-history fork unless a recorded fallback reason requires explicit context
   - exact question to answer and explicit non-goals
   - scoped files/commands/evidence to inspect
   - return contract with conclusion, evidence, uncertainty, and whether repository writeback is recommended
@@ -188,6 +196,10 @@ If a specialist skill is used, TPM must still bind it to the same owner, `.pm` t
 - Closeout: closeout command output, task status update, and PR linkage.
 
 ## 7. Change Log
+- **v1.4.9 (2026-06-02)**
+  - Clarified that request-type classification cannot happen before task/worktree bootstrap; bootstrap happens first, then read-only/professional routing.
+  - Required subagent slice contracts to distinguish intended default model from actual dispatched model, including inherited/unverified connector cases.
+  - Made full-thread/full-history context the default subagent context delivery mode, with mandatory context checklist recording and explicit context packets as delivery supplement/fallback only when recorded.
 - **v1.4.8 (2026-06-01)**
   - Required every user request to create or enter standard task worktree / `.pm` task truth before substantive handling, including read-only, chat-only, and pure fact lookup requests.
   - Removed the read-only/chat-only bypass for `default-workflow-bootstrap`; read-only professional slices now record their contract and sink in `.pm/tasks/<TASK-UID>.execution.md`.
@@ -248,8 +260,8 @@ This checklist records whether key legacy `AGENTS.md` workflow semantics were pr
 - [x] TPM planning/TODO decomposition and subagent slice contracts written to `.pm` execution log before delegated execution.
 - [x] TPM is workflow coordinator/integrator only; professional findings and judgments must come from matching role slices.
 - [x] Read-only professional/domain questions require matching bounded role slices after task/worktree bootstrap.
-- [x] Subagent model configuration defaults to `gpt-5.4-medium` and non-default overrides require recorded rationale.
-- [x] Subagent context packet includes identity, governance, task truth, user intent, scoped repo context, and collaboration boundaries.
+- [x] Subagent intended model configuration defaults to `gpt-5.4-medium`; actual dispatched model/reasoning and non-default/inherited/unverified rationale are recorded.
+- [x] Subagent context checklist/packet includes identity, governance, task truth, user intent, scoped repo context, and collaboration boundaries.
 - [x] Mandatory execution evidence fields and blocker recording.
 - [x] Current-round fresh verification before completion claim.
 - [x] Closeout command chain and `done` verification strictness.


### PR DESCRIPTION
## Summary
- Clarify that request-type classification happens only after task/worktree bootstrap.
- Record intended versus actual subagent model/reasoning, including inherited or unverifiable dispatch.
- Make full-thread/full-history fork the default context delivery mode while preserving mandatory context checklist/packet recording and compatibility markers.

## Verification
- ./scripts/pm/task-closeout.sh --role tpm --task-uid task_57ce723d36ed4496a26667783f7f69f5 --verify-command "./scripts/pm/workflow-behavior-eval.sh"
- ./scripts/pm/workflow-behavior-eval.sh
- ./scripts/pm/lint.sh
- ./scripts/doc-governance-check.sh
- git diff --check refs/remotes/origin/main..HEAD