### PR TITLE
Enable daily release package builds

### DIFF
--- a/.github/workflows/daily-github-release.yml
+++ b/.github/workflows/daily-github-release.yml
@@ -12,6 +12,7 @@ on:
         type: string
 
 permissions:
+  actions: write
   contents: write
 
 concurrency:
@@ -108,6 +109,20 @@ jobs:
             --title "oasis7 ${TAG}" \
             --generate-notes \
             --prerelease
+
+      - name: Trigger package build
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.tag.outputs.tag }}
+          REPOSITORY: ${{ github.repository }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          gh workflow run release-packages.yml \
+            --repo "${REPOSITORY}" \
+            --ref main \
+            -f "tag=${TAG}"
 
       - name: Report release
         env:

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -4,10 +4,11 @@ on:
   push:
     tags:
       - "v*"
+      - "20??-??-??_v*"
   workflow_dispatch:
     inputs:
       tag:
-        description: "Release tag, e.g. v0.1.0"
+        description: "Release tag, e.g. v0.1.0 or 2026-06-03_v1"
         required: true
         type: string
 
@@ -463,8 +464,8 @@ jobs:
             echo "error: release tag is empty" >&2
             exit 1
           fi
-          if [[ "${tag}" != v* ]]; then
-            echo "error: release tag must start with 'v': ${tag}" >&2
+          if [[ ! "${tag}" =~ ^v[0-9].* && ! "${tag}" =~ ^20[0-9]{2}-[0-9]{2}-[0-9]{2}_v[0-9]+$ ]]; then
+            echo "error: release tag must be semver-like (v*) or daily date tag (YYYY-MM-DD_vN): ${tag}" >&2
             exit 1
           fi
           echo "value=${tag}" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -4,7 +4,7 @@ on:
   push:
     tags:
       - "v*"
-      - "20??-??-??_v*"
+      - "20*-*-*_v*"
   workflow_dispatch:
     inputs:
       tag:
@@ -22,7 +22,6 @@ env:
   RUST_TOOLCHAIN: 1.96.0
   BUILTIN_WASM_TOOLCHAIN: nightly-2025-12-11
   BUILTIN_WASM_TARGET: wasm32-unknown-unknown
-  RELEASE_CHECKOUT_REF: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
 
 jobs:
   release_gate_runtime_core:
@@ -31,7 +30,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ env.RELEASE_CHECKOUT_REF }}
+          ref: ${{ github.event.inputs.tag || github.ref }}
       - name: Install pinned Rust toolchain
         run: |
           rustup toolchain install "${RUST_TOOLCHAIN}" --profile default
@@ -62,7 +61,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ env.RELEASE_CHECKOUT_REF }}
+          ref: ${{ github.event.inputs.tag || github.ref }}
       - name: Install pinned Rust toolchain
         run: |
           rustup toolchain install "${RUST_TOOLCHAIN}" --profile default
@@ -93,7 +92,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ env.RELEASE_CHECKOUT_REF }}
+          ref: ${{ github.event.inputs.tag || github.ref }}
       - name: Install pinned Rust toolchain
         run: |
           rustup toolchain install "${RUST_TOOLCHAIN}" --profile default
@@ -135,7 +134,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ env.RELEASE_CHECKOUT_REF }}
+          ref: ${{ github.event.inputs.tag || github.ref }}
       - uses: actions/setup-node@v6
         with:
           node-version: '22'
@@ -191,7 +190,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ env.RELEASE_CHECKOUT_REF }}
+          ref: ${{ github.event.inputs.tag || github.ref }}
       - name: Install pinned Rust toolchain
         run: |
           rustup toolchain install "${RUST_TOOLCHAIN}" --profile default
@@ -276,7 +275,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ env.RELEASE_CHECKOUT_REF }}
+          ref: ${{ github.event.inputs.tag || github.ref }}
       - uses: actions/setup-node@v6
         with:
           node-version: '22'
@@ -335,7 +334,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ env.RELEASE_CHECKOUT_REF }}
+          ref: ${{ github.event.inputs.tag || github.ref }}
       - name: Install pinned Rust toolchain
         shell: bash
         run: |

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -22,6 +22,7 @@ env:
   RUST_TOOLCHAIN: 1.96.0
   BUILTIN_WASM_TOOLCHAIN: nightly-2025-12-11
   BUILTIN_WASM_TARGET: wasm32-unknown-unknown
+  RELEASE_CHECKOUT_REF: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
 
 jobs:
   release_gate_runtime_core:
@@ -29,6 +30,8 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ env.RELEASE_CHECKOUT_REF }}
       - name: Install pinned Rust toolchain
         run: |
           rustup toolchain install "${RUST_TOOLCHAIN}" --profile default
@@ -58,6 +61,8 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ env.RELEASE_CHECKOUT_REF }}
       - name: Install pinned Rust toolchain
         run: |
           rustup toolchain install "${RUST_TOOLCHAIN}" --profile default
@@ -87,6 +92,8 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ env.RELEASE_CHECKOUT_REF }}
       - name: Install pinned Rust toolchain
         run: |
           rustup toolchain install "${RUST_TOOLCHAIN}" --profile default
@@ -127,6 +134,8 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ env.RELEASE_CHECKOUT_REF }}
       - uses: actions/setup-node@v6
         with:
           node-version: '22'
@@ -181,6 +190,8 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ env.RELEASE_CHECKOUT_REF }}
       - name: Install pinned Rust toolchain
         run: |
           rustup toolchain install "${RUST_TOOLCHAIN}" --profile default
@@ -264,6 +275,8 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ env.RELEASE_CHECKOUT_REF }}
       - uses: actions/setup-node@v6
         with:
           node-version: '22'
@@ -321,6 +334,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ env.RELEASE_CHECKOUT_REF }}
       - name: Install pinned Rust toolchain
         shell: bash
         run: |

--- a/.pm/tasks/task_03818f4a06e94736b46605499a300353.execution.md
+++ b/.pm/tasks/task_03818f4a06e94736b46605499a300353.execution.md
@@ -1,0 +1,39 @@
+# task_03818f4a06e94736b46605499a300353 Execution Log
+
+- task_uid: task_03818f4a06e94736b46605499a300353
+- title: fix node keypair format check
+- owner_role: tpm
+- worktree_hint: /Users/scc/ccwork/worktrees/oasis7-site-trigger-latest-github-release
+
+<!-- Append entries using:
+Example:
+  ## YYYY-MM-DD HH:MM:SS CST / role_name
+  - 完成内容: ...
+  - 遗留事项: ...
+  - Action: ...
+  - Validation Command: ...
+  - Expected Result: ...
+  - Actual Result: ...
+- Blocker / Next Action: ...
+-->
+
+## 2026-06-03 20:05:00 CST / tpm
+- 完成内容: Bound follow-up task for PR #342 required-gate failure after the node keypair lock fix.
+- 遗留事项: Apply mechanical rustfmt correction, verify, close out, commit, push, and re-check PR status.
+- TODO decomposition: reproduce required-gate failure signature from Actions evidence; apply rustfmt only; run the failing check first; run focused regression and PM/doc gates; close out task; commit and push the formatting fix.
+- Subagent slice contract: none; this is a mechanical cargo fmt correction from a command diff, not a runtime/product/QA judgment.
+- Integration order: TPM records failure evidence, applies rustfmt, verifies locally, then updates PR branch and checks GitHub status.
+- Action: `gh pr checks 342 --repo eng-cc/oasis7`; local required-gate log `.tmp/gh-run-26883343092/required-gate.log`.
+- Validation Command: pending.
+- Expected Result: `cargo fmt --check` failure in `node_keypair_config.rs` is resolved without logic changes.
+- Actual Result: GitHub PR checks show `required-gate` failed; known failure signature is rustfmt diffs in `node_keypair_config.rs`.
+- Blocker / Next Action: Run rustfmt and fresh verification.
+
+## 2026-06-03 20:07:00 CST / tpm
+- 完成内容: Applied `cargo fmt --all`; diff is limited to rustfmt line wrapping in `node_keypair_config.rs`.
+- 遗留事项: Task closeout, commit, push, and remote PR check refresh remain.
+- Action: `env -u RUSTC_WRAPPER cargo fmt --all`
+- Validation Command: `env -u RUSTC_WRAPPER cargo fmt --all -- --check`; `env -u RUSTC_WRAPPER cargo test -p oasis7 node_keypair_config -- --nocapture`; `bash -n scripts/p2p-longrun-soak.sh`; `./scripts/pm/lint.sh`; `./scripts/doc-governance-check.sh`; `git diff --check`
+- Expected Result: Required-gate fmt failure is resolved and focused regression plus repo gates pass.
+- Actual Result: Passed; cargo fmt check exited zero, `node_keypair_config::tests::concurrent_first_writers_share_one_generated_keypair ... ok`, `pm-lint: OK`, `doc-governance-check: OK`, soak script syntax and diff whitespace checks exited zero.
+- Blocker / Next Action: Run task closeout with fresh verification command.

--- a/.pm/tasks/task_03818f4a06e94736b46605499a300353.yaml
+++ b/.pm/tasks/task_03818f4a06e94736b46605499a300353.yaml
@@ -1,0 +1,24 @@
+task_uid: task_03818f4a06e94736b46605499a300353
+title: "fix node keypair format check"
+owner_role: tpm
+worktree_hint: /Users/scc/ccwork/worktrees/oasis7-site-trigger-latest-github-release
+execution_log_path: .pm/tasks/task_03818f4a06e94736b46605499a300353.execution.md
+status: done
+priority: P1
+source_signal: null
+source_refs:
+  - AGENTS.md
+  - crates/oasis7/src/bin/oasis7_chain_runtime/node_keypair_config.rs
+doc_refs: []
+related_prd: []
+acceptance:
+  - "Rust required-gate cargo fmt failure after node keypair config lock fix is resolved and fresh verification is recorded."
+handoff_to: []
+updated_at: 2026-06-03T20:11:10+08:00
+last_started_at: 2026-06-03T20:09:54+08:00
+last_claim_type: task_complete
+last_verify_command: "env -u RUSTC_WRAPPER cargo fmt --all -- --check && env -u RUSTC_WRAPPER cargo test -p oasis7 node_keypair_config -- --nocapture && bash -n scripts/p2p-longrun-soak.sh && ./scripts/pm/lint.sh && ./scripts/doc-governance-check.sh && git diff --check"
+last_verified_at: 2026-06-03T20:11:08+08:00
+last_verification_exit_code: 0
+last_verification_status: verified
+last_closed_at: 2026-06-03T20:11:09+08:00

--- a/.pm/tasks/task_0432df4918bf4c75812ee558c7523117.execution.md
+++ b/.pm/tasks/task_0432df4918bf4c75812ee558c7523117.execution.md
@@ -1,0 +1,27 @@
+# task_0432df4918bf4c75812ee558c7523117 Execution Log
+
+- task_uid: task_0432df4918bf4c75812ee558c7523117
+- title: dispatch release packages from current PR
+- owner_role: tpm
+- worktree_hint: /Users/scc/ccwork/worktrees/oasis7-site-trigger-latest-github-release
+
+<!-- Append entries using:
+Example:
+  ## YYYY-MM-DD HH:MM:SS CST / role_name
+  - 完成内容: ...
+  - 遗留事项: ...
+  - Action: ...
+  - Validation Command: ...
+  - Expected Result: ...
+  - Actual Result: ...
+  - Blocker / Next Action: ...
+-->
+
+## 2026-06-03 17:56:00 CST / tpm
+- 完成内容: Dispatched the `Release Packages` workflow from current PR #342 branch for release tag `v0.0.56`.
+- 遗留事项: Full release workflow completion is still running remotely; this task records successful dispatch and initial run status.
+- Action: `gh workflow run release-packages.yml --repo eng-cc/oasis7 --ref codex/trigger-latest-github-release -f tag=v0.0.56`
+- Validation Command: `gh run view 26877365314 --repo eng-cc/oasis7 --json databaseId,name,workflowName,event,status,conclusion,url,headBranch,headSha,createdAt,updatedAt,displayTitle`
+- Expected Result: A new `Release Packages` workflow_dispatch run starts on PR branch `codex/trigger-latest-github-release` at PR head `43c3b8040bce95de406628bd295450869244d8e8`.
+- Actual Result: Run `26877365314` started at `2026-06-03T09:55:57Z`; status `in_progress`; event `workflow_dispatch`; headBranch `codex/trigger-latest-github-release`; headSha `43c3b8040bce95de406628bd295450869244d8e8`; URL `https://github.com/eng-cc/oasis7/actions/runs/26877365314`.
+- Blocker / Next Action: Monitor the remote release workflow if the user wants completion/failure handling.

--- a/.pm/tasks/task_0432df4918bf4c75812ee558c7523117.yaml
+++ b/.pm/tasks/task_0432df4918bf4c75812ee558c7523117.yaml
@@ -1,0 +1,24 @@
+task_uid: task_0432df4918bf4c75812ee558c7523117
+title: "dispatch release packages from current PR"
+owner_role: tpm
+worktree_hint: /Users/scc/ccwork/worktrees/oasis7-site-trigger-latest-github-release
+execution_log_path: .pm/tasks/task_0432df4918bf4c75812ee558c7523117.execution.md
+status: done
+priority: P1
+source_signal: null
+source_refs:
+  - AGENTS.md
+  - .github/workflows/release-packages.yml
+doc_refs: []
+related_prd: []
+acceptance:
+  - "Dispatch Release Packages workflow from PR #342 branch using the intended release tag and record the run URL/status."
+handoff_to: []
+updated_at: 2026-06-03T17:57:11+08:00
+last_started_at: 2026-06-03T17:55:20+08:00
+last_claim_type: task_complete
+last_verify_command: "gh run view 26877365314 --repo eng-cc/oasis7 --json workflowName,event,status,url,headBranch,headSha | jq -e '.workflowName == \"Release Packages\" and .event == \"workflow_dispatch\" and .headBranch == \"codex/trigger-latest-github-release\" and .headSha == \"43c3b8040bce95de406628bd295450869244d8e8\" and (.status == \"in_progress\" or .status == \"completed\")'"
+last_verified_at: 2026-06-03T17:57:08+08:00
+last_verification_exit_code: 0
+last_verification_status: verified
+last_closed_at: 2026-06-03T17:57:10+08:00

--- a/.pm/tasks/task_34bccd523e39476e8368860c539f9244.execution.md
+++ b/.pm/tasks/task_34bccd523e39476e8368860c539f9244.execution.md
@@ -1,0 +1,66 @@
+# task_34bccd523e39476e8368860c539f9244 Execution Log
+
+- task_uid: task_34bccd523e39476e8368860c539f9244
+- title: stabilize replication guard restart test
+- owner_role: tpm
+- worktree_hint: /Users/scc/ccwork/worktrees/oasis7-site-trigger-latest-github-release
+
+<!-- Append entries using:
+Example:
+  ## YYYY-MM-DD HH:MM:SS CST / role_name
+  - 完成内容: ...
+  - 遗留事项: ...
+  - Action: ...
+  - Validation Command: ...
+  - Expected Result: ...
+  - Actual Result: ...
+  - Blocker / Next Action: ...
+-->
+
+## 2026-06-03 16:48:00 CST / tpm
+- 完成内容: Task entered committed status and workflow-report start was recorded for PR #342 Rust required-gate blocker.
+- 遗留事项: Required-gate Rust blocker still needed implementation and verification at this point.
+- TODO decomposition: inspect required-gate log evidence, dispatch a bounded runtime_engineer slice for the failing restart replication guard test, integrate a focused patch only in the failing test surface, run focused Rust verification plus existing release/comment regression checks, then close out and push.
+- Subagent slice contract: runtime_engineer; intended model gpt-5.4-medium; actual dispatched model inherited/unverified; scope diagnose `runtime_gossip_replication_persists_guard_across_restart` failure at `crates/oasis7_node/src/tests_storage_replication.rs:1073` and recommend minimal stabilization; write scope none unless explicitly directed; mandatory context checklist includes AGENTS role boundary, PR #342 head `fd2f428`, failed run `26873498882` / job `79254586249`, failure assertion `guard_after.last_sequence > guard_before.last_sequence`, and local failing test excerpt.
+- Integration order: TPM records contract, runtime_engineer returns focused diagnosis/recommendation, TPM applies/reviews minimal patch, TPM runs verification and closeout.
+- Action: `./scripts/pm/move-task.sh --task-uid task_34bccd523e39476e8368860c539f9244 --to-status committed --json && ./scripts/pm/workflow-report.sh --role tpm --phase start --task-uid task_34bccd523e39476e8368860c539f9244 --json`
+- Validation Command: pending.
+- Expected Result: Task truth exists before CI blocker fix and specialist slice is recorded before professional runtime conclusion.
+- Actual Result: Task moved to committed and workflow start recorded at 2026-06-03T16:47:41+08:00.
+- Blocker / Next Action: Dispatch runtime_engineer slice and patch the test wait/assertion if confirmed.
+
+## 2026-06-03 16:56:00 CST / runtime_engineer
+- 完成内容: Specialist slice diagnosed the required-gate failure as likely CI timing around the second restart replication guard advance, not a runtime semantics regression.
+- 遗留事项: TPM still needed to integrate and verify the focused test stabilization patch.
+- Action: Inspected `runtime_gossip_replication_persists_guard_across_restart` and nearby wait patterns.
+- Validation Command: read-only specialist slice; no command mutation.
+- Expected Result: Recommend a focused test stabilization if appropriate.
+- Actual Result: Recommended replacing the manual 2s loop with `wait_until(Instant::now() + Duration::from_secs(5), ...)`, capture `guard_advanced`, preserve `writer_before`, and assert with guard/snapshot diagnostics after stop. Actual dispatched model inherited/unverified due fork constraints.
+- Blocker / Next Action: TPM integrate the focused test-only patch.
+
+## 2026-06-03 16:59:00 CST / tpm
+- 完成内容: Integrated the runtime_engineer recommendation in `crates/oasis7_node/src/tests_storage_replication.rs`.
+- 遗留事项: Combined PR verification and task closeout still pending at this point.
+- Action: Replaced the restart guard manual polling loop with `wait_until`, retained the target writer id, captured `guards_after_wait`, and expanded the final assertion diagnostics.
+- Validation Command: `env -u RUSTC_WRAPPER cargo test -p oasis7_node tests::runtime_gossip_replication_persists_guard_across_restart -- --exact --nocapture`
+- Expected Result: Focused failing Rust test passes locally after the test stabilization patch.
+- Actual Result: Passed; `test tests::runtime_gossip_replication_persists_guard_across_restart ... ok`, 1 passed, 0 failed.
+- Blocker / Next Action: Run combined PR verification including release workflow YAML checks and prior comment regression smoke.
+
+## 2026-06-03 17:04:00 CST / tpm
+- 完成内容: Ran combined verification for the PR comment fixes plus Rust required-gate stabilization.
+- 遗留事项: Task closeout, commit, push, and PR check re-inspection remain.
+- Action: Fresh local verification before closeout.
+- Validation Command: `env -u RUSTC_WRAPPER cargo test -p oasis7_node tests::runtime_gossip_replication_persists_guard_across_restart -- --exact --nocapture && ruby -e 'require "yaml"; YAML.load_file(".github/workflows/daily-github-release.yml"); YAML.load_file(".github/workflows/release-packages.yml"); puts "workflow yaml parsed"' && bash -n scripts/viewer-software-safe-step-regression.sh scripts/viewer-software-safe-step-regression-smoke.sh && ./scripts/viewer-software-safe-step-regression-smoke.sh && ./scripts/pm/lint.sh && ./scripts/doc-governance-check.sh && git diff --check`
+- Expected Result: Focused Rust test, release workflow YAML, software-safe smoke, PM lint, doc governance, and diff whitespace checks pass.
+- Actual Result: Passed; Rust exact test ok, workflow YAML parsed, software-safe smoke passed, `pm-lint: OK`, `doc-governance-check: OK`, and `git diff --check` exited zero.
+- Blocker / Next Action: Run `task-closeout.sh` with the same verification command.
+
+## 2026-06-03 17:08:00 CST / tpm
+- 完成内容: Closed out the CI blocker task with verified claim evidence.
+- 遗留事项: Commit, push, and PR check re-inspection remain.
+- Action: `./scripts/pm/task-closeout.sh --role tpm --task-uid task_34bccd523e39476e8368860c539f9244 --verify-command '<combined verification command>'`
+- Validation Command: `env -u RUSTC_WRAPPER cargo test -p oasis7_node tests::runtime_gossip_replication_persists_guard_across_restart -- --exact --nocapture && ruby -e 'require "yaml"; YAML.load_file(".github/workflows/daily-github-release.yml"); YAML.load_file(".github/workflows/release-packages.yml"); puts "workflow yaml parsed"' && bash -n scripts/viewer-software-safe-step-regression.sh scripts/viewer-software-safe-step-regression-smoke.sh && ./scripts/viewer-software-safe-step-regression-smoke.sh && ./scripts/pm/lint.sh && ./scripts/doc-governance-check.sh && git diff --check`
+- Expected Result: `task-closeout.sh` records verified claim evidence and moves task to done.
+- Actual Result: Passed; previous_status committed, final_status done, claim_verification_status verified, pm_lint ok.
+- Blocker / Next Action: Stage, commit, push, and recheck PR #342.

--- a/.pm/tasks/task_34bccd523e39476e8368860c539f9244.yaml
+++ b/.pm/tasks/task_34bccd523e39476e8368860c539f9244.yaml
@@ -1,0 +1,24 @@
+task_uid: task_34bccd523e39476e8368860c539f9244
+title: "stabilize replication guard restart test"
+owner_role: tpm
+worktree_hint: /Users/scc/ccwork/worktrees/oasis7-site-trigger-latest-github-release
+execution_log_path: .pm/tasks/task_34bccd523e39476e8368860c539f9244.execution.md
+status: done
+priority: P1
+source_signal: null
+source_refs:
+  - AGENTS.md
+  - crates/oasis7_node/src/tests_storage_replication.rs
+doc_refs: []
+related_prd: []
+acceptance:
+  - "Rust required-gate failure in runtime_gossip_replication_persists_guard_across_restart is diagnosed, fixed if needed, and fresh verification is recorded."
+handoff_to: []
+updated_at: 2026-06-03T17:08:13+08:00
+last_started_at: 2026-06-03T16:47:41+08:00
+last_claim_type: task_complete
+last_verify_command: "env -u RUSTC_WRAPPER cargo test -p oasis7_node tests::runtime_gossip_replication_persists_guard_across_restart -- --exact --nocapture && ruby -e 'require \"yaml\"; YAML.load_file(\".github/workflows/daily-github-release.yml\"); YAML.load_file(\".github/workflows/release-packages.yml\"); puts \"workflow yaml parsed\"' && bash -n scripts/viewer-software-safe-step-regression.sh scripts/viewer-software-safe-step-regression-smoke.sh && ./scripts/viewer-software-safe-step-regression-smoke.sh && ./scripts/pm/lint.sh && ./scripts/doc-governance-check.sh && git diff --check"
+last_verified_at: 2026-06-03T17:08:12+08:00
+last_verification_exit_code: 0
+last_verification_status: verified
+last_closed_at: 2026-06-03T17:08:13+08:00

--- a/.pm/tasks/task_5ad6fb100e3c4fd79ff4d7837d7c9e4b.execution.md
+++ b/.pm/tasks/task_5ad6fb100e3c4fd79ff4d7837d7c9e4b.execution.md
@@ -1,0 +1,39 @@
+# task_5ad6fb100e3c4fd79ff4d7837d7c9e4b Execution Log
+
+- task_uid: task_5ad6fb100e3c4fd79ff4d7837d7c9e4b
+- title: address PR 342 review comments
+- owner_role: tpm
+- worktree_hint: /Users/scc/ccwork/worktrees/oasis7-site-trigger-latest-github-release
+
+<!-- Append entries using:
+Example:
+  ## YYYY-MM-DD HH:MM:SS CST / role_name
+  - 完成内容: ...
+  - 遗留事项: ...
+  - Action: ...
+  - Validation Command: ...
+  - Expected Result: ...
+  - Actual Result: ...
+- Blocker / Next Action: ...
+-->
+
+## 2026-06-03 20:43:00 CST / tpm
+- 完成内容: Inspected PR #342 review threads and identified one active actionable thread.
+- 遗留事项: Closeout, commit, push, and optional GitHub thread resolution remain.
+- TODO decomposition: fetch unresolved PR review threads; separate outdated/non-actionable comments from active actionable comments; patch the active blocker DOM assertion gap; run focused smoke and repo gates; close out task; commit and push.
+- Subagent slice contract: none; this is scripted QA harness feedback with a concrete inline assertion gap, handled as a bounded mechanical test harness fix by TPM.
+- Integration order: TPM reads review thread state, applies focused shell harness assertion fix, verifies smoke first, then PM/doc/diff gates.
+- Action: `gh pr view 342 --repo eng-cc/oasis7 --json ...`; GitHub reviewThreads read for PR #342.
+- Validation Command: pending.
+- Expected Result: Active P2 thread on `scripts/viewer-software-safe-step-regression.sh` is addressed; outdated daily-release trigger thread remains non-actionable.
+- Actual Result: Found one outdated P1 thread on daily workflow triggering and one active P2 thread requiring DOM checks for blocker signals from `executionState`, `recentFeedback`, and `narrativeBlockerDetail`.
+- Blocker / Next Action: Strengthen DOM and smoke assertions for expected blocker status/detail.
+
+## 2026-06-03 20:45:00 CST / tpm
+- 完成内容: Strengthened viewer software-safe regression assertions for new blocker fields.
+- 遗留事项: PM/doc gates, closeout, commit, push, and PR check refresh remain.
+- Action: Updated `scripts/viewer-software-safe-step-regression.sh` so explicit blocker signals require blocked/阻塞 text in the DOM and record `expectedBlockerDetail` in summary output; updated `scripts/viewer-software-safe-step-regression-smoke.sh` to assert the fixture provider-unavailable detail is captured.
+- Validation Command: `bash -n scripts/viewer-software-safe-step-regression.sh && bash -n scripts/viewer-software-safe-step-regression-smoke.sh`; `./scripts/viewer-software-safe-step-regression-smoke.sh`; `git diff --check`
+- Expected Result: Syntax passes, smoke proves the active review scenario is covered, and whitespace checks pass.
+- Actual Result: Passed; smoke output `viewer software_safe step regression smoke checks passed`; `git diff --check` exited zero.
+- Blocker / Next Action: Rerun PM/doc governance gates and close out.

--- a/.pm/tasks/task_5ad6fb100e3c4fd79ff4d7837d7c9e4b.yaml
+++ b/.pm/tasks/task_5ad6fb100e3c4fd79ff4d7837d7c9e4b.yaml
@@ -1,0 +1,24 @@
+task_uid: task_5ad6fb100e3c4fd79ff4d7837d7c9e4b
+title: "address PR 342 review comments"
+owner_role: tpm
+worktree_hint: /Users/scc/ccwork/worktrees/oasis7-site-trigger-latest-github-release
+execution_log_path: .pm/tasks/task_5ad6fb100e3c4fd79ff4d7837d7c9e4b.execution.md
+status: done
+priority: P1
+source_signal: null
+source_refs:
+  - AGENTS.md
+  - scripts/viewer-software-safe-step-regression.sh
+doc_refs: []
+related_prd: []
+acceptance:
+  - "Unresolved actionable PR review comments on PR 342 are inspected, addressed locally or summarized when non-actionable, and fresh verification is recorded."
+handoff_to: []
+updated_at: 2026-06-03T20:49:03+08:00
+last_started_at: 2026-06-03T20:43:25+08:00
+last_claim_type: task_complete
+last_verify_command: "bash -n scripts/viewer-software-safe-step-regression.sh && bash -n scripts/viewer-software-safe-step-regression-smoke.sh && ./scripts/viewer-software-safe-step-regression-smoke.sh && ./scripts/pm/lint.sh && ./scripts/doc-governance-check.sh && git diff --check"
+last_verified_at: 2026-06-03T20:49:02+08:00
+last_verification_exit_code: 0
+last_verification_status: verified
+last_closed_at: 2026-06-03T20:49:02+08:00

--- a/.pm/tasks/task_70df8dbe2ed1450fae1372f5e5a96de2.execution.md
+++ b/.pm/tasks/task_70df8dbe2ed1450fae1372f5e5a96de2.execution.md
@@ -1,0 +1,31 @@
+# task_70df8dbe2ed1450fae1372f5e5a96de2 Execution Log
+
+- task_uid: task_70df8dbe2ed1450fae1372f5e5a96de2
+- title: fix release packages workflow planning failure
+- owner_role: tpm
+- worktree_hint: /Users/scc/ccwork/worktrees/oasis7-site-trigger-latest-github-release
+
+<!-- Append entries using:
+Example:
+  ## YYYY-MM-DD HH:MM:SS CST / role_name
+  - 完成内容: ...
+  - 遗留事项: ...
+  - Action: ...
+  - Validation Command: ...
+  - Expected Result: ...
+  - Actual Result: ...
+- Blocker / Next Action: ...
+-->
+
+## 2026-06-03 15:18:45 CST / tpm
+- 完成内容: Investigated the post-push Release Packages planning failure surfaced while monitoring the `v0.0.56` fix PR.
+- 遗留事项: Needs local verification, commit/push, and a fresh GitHub PR branch push run to confirm GitHub no longer creates a no-job failed Release Packages run.
+- Action: Inspected PR #342 checks and run `26869519673`. The run was created for a branch `push` on `codex/trigger-latest-github-release`, completed immediately with `conclusion=failure`, and had `jobs=[]`, indicating a GitHub Actions planning/configuration failure rather than a release gate script failure.
+- Validation Command: `gh pr checks 342 --repo eng-cc/oasis7 --json name,state,link,startedAt,completedAt,workflow`; `gh run view 26869519673 --repo eng-cc/oasis7 --json databaseId,status,conclusion,event,headBranch,headSha,displayTitle,workflowName,createdAt,updatedAt,jobs,url,workflowDatabaseId,name,attempt`; `gh api repos/eng-cc/oasis7/actions/runs/26869519673 --jq '{id, name, path, event, status, conclusion, head_branch, head_sha, check_suite_id, run_attempt, created_at, updated_at, run_started_at, html_url}'`.
+- Expected Result: Identify whether the failure came from a release gate job or from Actions planning.
+- Actual Result: `Release Packages` had no jobs or logs and failed at run planning time on the PR branch push.
+- Action: Removed the cross-event top-level `RELEASE_CHECKOUT_REF` expression, changed checkout refs to `${{ github.event.inputs.tag || github.ref }}`, and relaxed the daily date tag glob to `20*-*-*_v*` while leaving the existing publish-step regex validation as the strict tag gate.
+- Validation Command: pending.
+- Expected Result: Workflow remains parseable locally and avoids the observed GitHub planning-time failure shape.
+- Actual Result: pending.
+- Blocker / Next Action: Run local verification, close out task, commit/push, then recheck GitHub.

--- a/.pm/tasks/task_70df8dbe2ed1450fae1372f5e5a96de2.yaml
+++ b/.pm/tasks/task_70df8dbe2ed1450fae1372f5e5a96de2.yaml
@@ -1,0 +1,25 @@
+task_uid: task_70df8dbe2ed1450fae1372f5e5a96de2
+title: "fix release packages workflow planning failure"
+owner_role: tpm
+worktree_hint: /Users/scc/ccwork/worktrees/oasis7-site-trigger-latest-github-release
+execution_log_path: .pm/tasks/task_70df8dbe2ed1450fae1372f5e5a96de2.execution.md
+status: done
+priority: P1
+source_signal: null
+source_refs:
+  - AGENTS.md
+  - .github/workflows/release-packages.yml
+doc_refs:
+  - doc/site/project.md
+related_prd: []
+acceptance:
+  - "Release Packages workflow does not fail at GitHub Actions planning time on PR branch pushes after the v0.0.56 checkout fix; YAML/script verification is recorded."
+handoff_to: []
+updated_at: 2026-06-03T15:44:21+08:00
+last_started_at: 2026-06-03T15:43:47+08:00
+last_claim_type: task_complete
+last_verify_command: "ruby -e 'require \"yaml\"; YAML.load_file(\".github/workflows/release-packages.yml\"); puts \"workflow yaml parsed\"' && bash -n scripts/viewer-software-safe-step-regression.sh scripts/viewer-software-safe-step-regression-smoke.sh && ./scripts/viewer-software-safe-step-regression-smoke.sh && git diff --check"
+last_verified_at: 2026-06-03T15:44:19+08:00
+last_verification_exit_code: 0
+last_verification_status: verified
+last_closed_at: 2026-06-03T15:44:21+08:00

--- a/.pm/tasks/task_8c6cadfbece54baf944ecc9190606c5a.execution.md
+++ b/.pm/tasks/task_8c6cadfbece54baf944ecc9190606c5a.execution.md
@@ -1,0 +1,31 @@
+# task_8c6cadfbece54baf944ecc9190606c5a Execution Log
+
+- task_uid: task_8c6cadfbece54baf944ecc9190606c5a
+- title: fix v0.0.56 release package failures
+- owner_role: tpm
+- worktree_hint: /Users/scc/ccwork/worktrees/oasis7-site-trigger-latest-github-release
+
+<!-- Append entries using:
+Example:
+  ## YYYY-MM-DD HH:MM:SS CST / role_name
+  - 完成内容: ...
+  - 遗留事项: ...
+  - Action: ...
+  - Validation Command: ...
+  - Expected Result: ...
+  - Actual Result: ...
+  - Blocker / Next Action: ...
+-->
+
+## 2026-06-03 15:03:42 CST / tpm
+- 完成内容: Investigated and patched the failed `v0.0.56` Release Packages rerun.
+- 遗留事项: Needs commit/push to PR #342 and a rerun of `release-packages.yml` with `tag=v0.0.56` after the PR branch update is available; S9 failure on run `26867434448` was observed on `main` checkout, not on the actual `v0.0.56` tag checkout.
+- Action: Inspected `gh run view 26867434448`, failed job logs/artifacts for `release-gate-soak` and `release-gate-web`, the PR branch workflow run `26868674338`, and the workflow checkout configuration.
+- Validation Command: `gh run view 26867434448 --json databaseId,status,conclusion,url,workflowName,createdAt,updatedAt,headBranch,headSha,jobs`; `gh run view 26867434448 --job 79234213378 --log`; `gh run view 26867434448 --job 79234213391 --log`; `gh run download 26867434448 --name release-gate-soak-summary --dir .tmp/gh-run-26867434448/soak-artifact`; `gh run download 26867434448 --name release-gate-web-summary --dir .tmp/gh-run-26867434448/web-artifact`.
+- Expected Result: Identify whether the failed rerun really built `v0.0.56`, then identify actionable failure signatures.
+- Actual Result: Run `26867434448` was `workflow_dispatch` with `tag=v0.0.56` intent but checked out `main` (`headSha=770dee5b6dc417051fac8c3c7011474b91af20cb`) rather than the `v0.0.56` tag SHA (`4eb0fe9099aa91af408e5bb41eddd52d3af3ee0f`). `release-gate-soak` failed S9 after pause chaos (`consensus_hash_samples_missing`, `settlement_apply_attempts_zero`, `known_peer_heads_zero_samples=111`). `release-gate-web` failed because the script saw no logical/event progress and did not recognize the current blocked fields, even though artifacts showed `gameplaySummary.executionState=blocked` and `gameplaySummary.recentFeedback.stage=blocked` for provider unreachable.
+- Action: Updated `.github/workflows/release-packages.yml` so every `actions/checkout@v6` uses `RELEASE_CHECKOUT_REF`, resolving to `inputs.tag` for `workflow_dispatch` and `github.ref` for tag pushes. Updated `scripts/viewer-software-safe-step-regression.sh` to recognize explicit blockers from `gameplaySummary.executionState`, `gameplaySummary.recentFeedback.stage`, and `gameplaySummary.narrativeBlockerDetail`, and replaced the macOS-incompatible `${AGENT_ID@Q}` with Python JSON quoting. Updated the smoke fixture to cover the current provider-unreachable blocked field shape.
+- Validation Command: `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release-packages.yml"); puts "workflow yaml parsed"' && bash -n scripts/viewer-software-safe-step-regression.sh scripts/viewer-software-safe-step-regression-smoke.sh && ./scripts/viewer-software-safe-step-regression-smoke.sh && git diff --check`.
+- Expected Result: Workflow YAML parses, shell scripts parse on local macOS bash, the smoke accepts the current blocked state shape, and the diff has no whitespace errors.
+- Actual Result: Workflow YAML parsed; `viewer software_safe step regression smoke checks passed`; `git diff --check` passed.
+- Blocker / Next Action: Close out this task, commit/push the PR branch update, then rerun/monitor the package workflow.

--- a/.pm/tasks/task_8c6cadfbece54baf944ecc9190606c5a.yaml
+++ b/.pm/tasks/task_8c6cadfbece54baf944ecc9190606c5a.yaml
@@ -1,0 +1,25 @@
+task_uid: task_8c6cadfbece54baf944ecc9190606c5a
+title: "fix v0.0.56 release package failures"
+owner_role: tpm
+worktree_hint: /Users/scc/ccwork/worktrees/oasis7-site-trigger-latest-github-release
+execution_log_path: .pm/tasks/task_8c6cadfbece54baf944ecc9190606c5a.execution.md
+status: done
+priority: P1
+source_signal: null
+source_refs:
+  - AGENTS.md
+  - .github/workflows/release-packages.yml
+doc_refs:
+  - doc/site/project.md
+related_prd: []
+acceptance:
+  - "Identify the v0.0.56 release package workflow failure signatures, patch the current release workflow PR branch if needed, and record verification."
+handoff_to: []
+updated_at: 2026-06-03T15:10:10+08:00
+last_started_at: 2026-06-03T14:54:54+08:00
+last_claim_type: task_complete
+last_verify_command: "./scripts/pm/lint.sh && ./scripts/doc-governance-check.sh && ruby -e 'require \"yaml\"; YAML.load_file(\".github/workflows/release-packages.yml\"); puts \"workflow yaml parsed\"' && bash -n scripts/viewer-software-safe-step-regression.sh scripts/viewer-software-safe-step-regression-smoke.sh && ./scripts/viewer-software-safe-step-regression-smoke.sh && git diff --check"
+last_verified_at: 2026-06-03T15:10:07+08:00
+last_verification_exit_code: 0
+last_verification_status: verified
+last_closed_at: 2026-06-03T15:10:10+08:00

--- a/.pm/tasks/task_9e7bfff968094e3dafbeaf0f71442dcf.execution.md
+++ b/.pm/tasks/task_9e7bfff968094e3dafbeaf0f71442dcf.execution.md
@@ -1,0 +1,66 @@
+# task_9e7bfff968094e3dafbeaf0f71442dcf Execution Log
+
+- task_uid: task_9e7bfff968094e3dafbeaf0f71442dcf
+- title: fix PR release soak gate failure
+- owner_role: tpm
+- worktree_hint: /Users/scc/ccwork/worktrees/oasis7-site-trigger-latest-github-release
+
+<!-- Append entries using:
+Example:
+  ## YYYY-MM-DD HH:MM:SS CST / role_name
+  - 完成内容: ...
+  - 遗留事项: ...
+  - Action: ...
+  - Validation Command: ...
+  - Expected Result: ...
+  - Actual Result: ...
+  - Blocker / Next Action: ...
+-->
+
+## 2026-06-03 19:44:00 CST / tpm
+- 完成内容: Recorded Release Packages run `26877365314` failure and started GitHub Actions failure diagnosis.
+- 遗留事项: Runtime/QA specialist conclusion, focused fix, verification, commit/push, and release rerun remain.
+- TODO decomposition: inspect failed soak job logs and artifacts; dispatch bounded runtime/QA specialist slice; integrate a minimal script/runtime fix if confirmed; run focused local reproduction or script checks; close out task; push PR update; rerun release workflow or failed job.
+- Subagent slice contract: runtime_engineer; intended model gpt-5.4-medium; actual dispatched model inherited/unverified; scope diagnose release soak S9 failure for run `26877365314`, with evidence from `release-gate-soak` job `79268128571`, `chaos_events.log`, `summary.json`, `timeline.csv`, and `scripts/p2p-longrun-soak.sh`; write scope none; mandatory context checklist includes AGENTS role boundary, PR #342 branch, failure notes `continuous-triad_distributed-0 failed`, `consensus_hash_samples_missing`, `settlement_apply_attempts_zero`, `balances_load_error_samples=37`, `known_peer_heads_zero_samples=111`, and sequencer bootstrap `fetch-commit ErrUnsupported` warning.
+- Integration order: TPM gathers logs/artifacts, runtime_engineer returns root-cause/fix recommendation, TPM applies focused fix, TPM verifies and reruns/reports.
+- Action: `gh run view 26877365314 --repo eng-cc/oasis7 --job 79268128571 --log`; `gh run download 26877365314 --repo eng-cc/oasis7 --name release-gate-soak-summary --dir .tmp/gh-run-26877365314/artifacts/release-gate-soak-summary`
+- Validation Command: pending.
+- Expected Result: Identify whether the release soak failure is a real runtime regression or a gate/harness instability.
+- Actual Result: Failure localized to S9 `triad_distributed` continuous pause; artifact shows a pause of sequencer at 90s for 2s followed by `recovery_timeout=24s`; timeline stayed at committed height 0; node stderr empty; sequencer stdout contains bootstrap `fetch-commit ErrUnsupported` warning.
+- Blocker / Next Action: Await runtime specialist conclusion and patch the smallest confirmed issue.
+
+## 2026-06-03 19:54:00 CST / runtime_engineer
+- 完成内容: Specialist slice identified a likely runtime startup race rather than a release asset upload failure.
+- 遗留事项: TPM still needed to integrate and verify the focused runtime fix.
+- Action: Inspected `node_keypair_config.rs`, `oasis7_chain_runtime.rs`, `scripts/p2p-longrun-soak.sh`, and the failed S9 artifact evidence.
+- Validation Command: read-only specialist slice; no command mutation.
+- Expected Result: Provide a minimal root-cause fix recommendation for the release soak failure.
+- Actual Result: Recommended adding per-config locking around `ensure_node_keypair_in_config`; without a lock, concurrent first-start triad nodes can each generate a different root keypair for the same default `config.toml`, derive inconsistent validator signer bindings, and never commit. Also noted that `wait_for_topology_ready` only checks `/healthz`, so chaos can begin before consensus actually starts; that is diagnostic hardening, not the primary root fix.
+- Blocker / Next Action: Add config lock and concurrent first-writer test.
+
+## 2026-06-03 19:56:00 CST / tpm
+- 完成内容: Added a per-config lock for node keypair generation and a concurrent first-writer regression test.
+- 遗留事项: Commit, push, and remote release rerun evidence remain.
+- Action: Wrapped `ensure_node_keypair_in_config` with `config.toml.lock` acquisition using `create_new(true)` and a bounded wait; added a test that eight concurrent callers all receive the same generated keypair and the persisted config matches.
+- Validation Command: `env -u RUSTC_WRAPPER cargo test -p oasis7 node_keypair_config -- --nocapture`
+- Expected Result: New concurrent keypair test executes and passes.
+- Actual Result: Passed; `test node_keypair_config::tests::concurrent_first_writers_share_one_generated_keypair ... ok`.
+- Blocker / Next Action: Run combined verification and prepare PR update.
+
+## 2026-06-03 20:00:00 CST / tpm
+- 完成内容: Ran combined verification for the keypair lock fix.
+- 遗留事项: Task closeout, commit, push, and remote PR/release rerun remain.
+- Action: Fresh local verification.
+- Validation Command: `env -u RUSTC_WRAPPER cargo test -p oasis7 node_keypair_config -- --nocapture && bash -n scripts/p2p-longrun-soak.sh && ./scripts/pm/lint.sh && ./scripts/doc-governance-check.sh && git diff --check`
+- Expected Result: Focused Rust test, soak script syntax, PM lint, doc governance, and diff whitespace checks pass.
+- Actual Result: Passed; concurrent keypair test ok, `pm-lint: OK`, `doc-governance-check: OK`, and command exited zero.
+- Blocker / Next Action: Run `task-closeout.sh` with the same verification command.
+
+## 2026-06-03 20:00:00 CST / tpm
+- 完成内容: Closed out the release soak failure fix task with verified claim evidence.
+- 遗留事项: Commit, push, and remote PR/release rerun remain.
+- Action: `./scripts/pm/task-closeout.sh --role tpm --task-uid task_9e7bfff968094e3dafbeaf0f71442dcf --verify-command '<combined verification command>'`
+- Validation Command: `env -u RUSTC_WRAPPER cargo test -p oasis7 node_keypair_config -- --nocapture && bash -n scripts/p2p-longrun-soak.sh && ./scripts/pm/lint.sh && ./scripts/doc-governance-check.sh && git diff --check`
+- Expected Result: Task moves to done with verified claim evidence.
+- Actual Result: Passed; previous_status committed, final_status done, claim_verification_status verified, pm_lint ok.
+- Blocker / Next Action: Commit and push the PR update.

--- a/.pm/tasks/task_9e7bfff968094e3dafbeaf0f71442dcf.yaml
+++ b/.pm/tasks/task_9e7bfff968094e3dafbeaf0f71442dcf.yaml
@@ -1,0 +1,25 @@
+task_uid: task_9e7bfff968094e3dafbeaf0f71442dcf
+title: "fix PR release soak gate failure"
+owner_role: tpm
+worktree_hint: /Users/scc/ccwork/worktrees/oasis7-site-trigger-latest-github-release
+execution_log_path: .pm/tasks/task_9e7bfff968094e3dafbeaf0f71442dcf.execution.md
+status: done
+priority: P1
+source_signal: null
+source_refs:
+  - AGENTS.md
+  - .github/workflows/release-packages.yml
+  - scripts/p2p-longrun-soak.sh
+doc_refs: []
+related_prd: []
+acceptance:
+  - "Release Packages run 26877365314 soak gate failure is diagnosed, fixed if needed, and fresh verification or rerun evidence is recorded."
+handoff_to: []
+updated_at: 2026-06-03T19:59:38+08:00
+last_started_at: 2026-06-03T19:43:53+08:00
+last_claim_type: task_complete
+last_verify_command: "env -u RUSTC_WRAPPER cargo test -p oasis7 node_keypair_config -- --nocapture && bash -n scripts/p2p-longrun-soak.sh && ./scripts/pm/lint.sh && ./scripts/doc-governance-check.sh && git diff --check"
+last_verified_at: 2026-06-03T19:59:37+08:00
+last_verification_exit_code: 0
+last_verification_status: verified
+last_closed_at: 2026-06-03T19:59:38+08:00

--- a/.pm/tasks/task_c88e1bea1b4643aba1e70ee8d280f4bf.execution.md
+++ b/.pm/tasks/task_c88e1bea1b4643aba1e70ee8d280f4bf.execution.md
@@ -1,0 +1,31 @@
+# task_c88e1bea1b4643aba1e70ee8d280f4bf Execution Log
+
+- task_uid: task_c88e1bea1b4643aba1e70ee8d280f4bf
+- title: stabilize runtime pos restart required test
+- owner_role: tpm
+- worktree_hint: /Users/scc/ccwork/worktrees/oasis7-site-trigger-latest-github-release
+
+<!-- Append entries using:
+Example:
+  ## YYYY-MM-DD HH:MM:SS CST / role_name
+  - 完成内容: ...
+  - 遗留事项: ...
+  - Action: ...
+  - Validation Command: ...
+  - Expected Result: ...
+  - Actual Result: ...
+- Blocker / Next Action: ...
+-->
+
+## 2026-06-03 15:53:10 CST / tpm
+- 完成内容: Investigated the Rust required-gate failure on PR #342 after pushing the release workflow hardening commit.
+- 遗留事项: Needs fresh local verification, closeout, commit/push, and recheck of PR checks.
+- Action: Inspected run `26870986553` job `79245981440` logs. The only failing test was `tests::runtime_pos_state_persists_across_restart`, panicking at `crates/oasis7_node/src/tests_clock_and_replication.rs:516` because `first.consensus.committed_height >= 8` was false.
+- Validation Command: `gh run view 26870986553 --repo eng-cc/oasis7 --job 79245981440 --log`; `nl -ba crates/oasis7_node/src/tests_clock_and_replication.rs | sed -n '450,560p'`; `rg -n "fn wait_until|wait_until\\(" crates/oasis7_node/src`.
+- Expected Result: Identify whether the PR failure is related to the release workflow changes or a focused Rust test stability issue.
+- Actual Result: Failure is a timing-sensitive runtime test that used fixed sleeps while adjacent restart tests use `wait_until` deadlines for the same committed-height progression pattern.
+- Action: Replaced fixed sleep assumptions in `runtime_pos_state_persists_across_restart` with `wait_until` checks for the seed height/execution height before stop and for post-restart advancement.
+- Validation Command: `env -u RUSTC_WRAPPER cargo test -p oasis7_node tests::runtime_pos_state_persists_across_restart -- --exact --nocapture && ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release-packages.yml"); puts "workflow yaml parsed"' && bash -n scripts/viewer-software-safe-step-regression.sh scripts/viewer-software-safe-step-regression-smoke.sh && ./scripts/viewer-software-safe-step-regression-smoke.sh && ./scripts/pm/lint.sh && ./scripts/doc-governance-check.sh && git diff --check`
+- Expected Result: The test still proves POS state persistence and post-restart progression, but does not depend on a precise 180ms/40ms CI scheduling window.
+- Actual Result: Focused Rust test passed, workflow YAML parsed, viewer smoke passed, PM lint passed, doc governance passed, and `git diff --check` passed during task closeout.
+- Blocker / Next Action: Commit and push the PR branch, then recheck PR checks.

--- a/.pm/tasks/task_c88e1bea1b4643aba1e70ee8d280f4bf.yaml
+++ b/.pm/tasks/task_c88e1bea1b4643aba1e70ee8d280f4bf.yaml
@@ -1,0 +1,25 @@
+task_uid: task_c88e1bea1b4643aba1e70ee8d280f4bf
+title: "stabilize runtime pos restart required test"
+owner_role: tpm
+worktree_hint: /Users/scc/ccwork/worktrees/oasis7-site-trigger-latest-github-release
+execution_log_path: .pm/tasks/task_c88e1bea1b4643aba1e70ee8d280f4bf.execution.md
+status: done
+priority: P1
+source_signal: null
+source_refs:
+  - AGENTS.md
+  - crates/oasis7_node/src/tests_clock_and_replication.rs
+doc_refs:
+  - doc/site/project.md
+related_prd: []
+acceptance:
+  - "Rust required-gate failure in runtime_pos_state_persists_across_restart is reproduced or diagnosed, a focused fix is applied if needed, and fresh local verification is recorded."
+handoff_to: []
+updated_at: 2026-06-03T15:59:37+08:00
+last_started_at: 2026-06-03T15:57:12+08:00
+last_claim_type: task_complete
+last_verify_command: "env -u RUSTC_WRAPPER cargo test -p oasis7_node tests::runtime_pos_state_persists_across_restart -- --exact --nocapture && ruby -e 'require \"yaml\"; YAML.load_file(\".github/workflows/release-packages.yml\"); puts \"workflow yaml parsed\"' && bash -n scripts/viewer-software-safe-step-regression.sh scripts/viewer-software-safe-step-regression-smoke.sh && ./scripts/viewer-software-safe-step-regression-smoke.sh && ./scripts/pm/lint.sh && ./scripts/doc-governance-check.sh && git diff --check"
+last_verified_at: 2026-06-03T15:59:36+08:00
+last_verification_exit_code: 0
+last_verification_status: verified
+last_closed_at: 2026-06-03T15:59:37+08:00

--- a/.pm/tasks/task_ea9150678da342d68c70107e3ef4d856.execution.md
+++ b/.pm/tasks/task_ea9150678da342d68c70107e3ef4d856.execution.md
@@ -1,0 +1,70 @@
+# task_ea9150678da342d68c70107e3ef4d856 Execution Log
+
+- task_uid: task_ea9150678da342d68c70107e3ef4d856
+- title: trigger latest GitHub release
+- owner_role: tpm
+- worktree_hint: /Users/scc/ccwork/worktrees/oasis7-site-trigger-latest-github-release
+
+<!-- Append entries using:
+Example:
+  ## YYYY-MM-DD HH:MM:SS CST / role_name
+  - 完成内容: ...
+  - 遗留事项: ...
+  - Action: ...
+  - Validation Command: ...
+  - Expected Result: ...
+  - Actual Result: ...
+  - Blocker / Next Action: ...
+-->
+
+## 2026-06-03 14:19:54 CST / tpm
+- 完成内容: WORKFLOW BOOTSTRAP DECIDED
+- 遗留事项: Daily release asset build path still needed investigation before user-facing completion.
+- Repository State Impact: Changes repository state: yes; triggering a GitHub Actions release workflow changes remote GitHub state and task truth was created locally.
+- Isolation Decision: Current workspace state: original root was `main`; Reuse allowed: no explicit reuse authorization; Worktree action: created `/Users/scc/ccwork/worktrees/oasis7-site-trigger-latest-github-release` on branch `codex/trigger-latest-github-release`.
+- Task Truth: Owner role: `tpm`; `.pm` task: `task_ea9150678da342d68c70107e3ef4d856`; Formal docs: `AGENTS.md`, `.github/workflows/daily-github-release.yml`, `.github/workflows/release-packages.yml`, `doc/site/prd.md`, `doc/site/project.md`.
+- Routed Next Phase: Selected workflow surface: `repo-owned-workflow-router` then mechanical GitHub dispatch evidence collection; Why now: user asked to trigger latest GitHub release, and the task requires identifying the correct release workflow/tag before dispatch.
+- Required Writeback: `prd.md`: no planned change; `project.md`: no planned change; `.pm` execution log: mandatory evidence sink; handoff: skipped unless release failure requires follow-up.
+- Next Action: Inspect release workflows, determine latest release tag/date, trigger the matching GitHub workflow, and record run evidence.
+- 完成内容: WORKFLOW ROUTE DECIDED
+- Task Phase: Current phase: execution/verification; Why: no repository implementation change is required, but remote workflow dispatch and status evidence are required.
+- Selected Workflow Skills: `repo-owned-workflow-router` for route writeback; `verification-before-completion` conceptually for fresh evidence after dispatch.
+- Skipped Workflow Skills: `bounded-brainstorming` skipped because scope is concrete; `tdd-test-writer` skipped because no behavior change or stable RED target; `executing-project-tasks` skipped as no repo implementation steps; `finishing-a-development-branch` skipped because no commit/PR closeout requested.
+- Specialist Skills Considered: QA/LiveOps professional slices considered for release judgment/messaging, but the available subagent tool requires explicit user authorization for subagents; this task is therefore limited to mechanical workflow dispatch and run evidence, not release-readiness or external-communication judgment.
+- Subagent Slice Plan: no subagent dispatched due current tool policy; actual model: inherited/unverified is not applicable because no slice was spawned.
+- Action: Inspect `.github/workflows/daily-github-release.yml`, `.github/workflows/release-packages.yml`, remote releases, and recent release workflow runs.
+- Validation Command: `gh release list --limit 10`; `gh run list --workflow release-packages.yml --limit 10 --json databaseId,displayTitle,event,headBranch,headSha,status,conclusion,createdAt,url`.
+- Expected Result: Identify whether today's daily release already exists and identify the latest semver release tag for package workflow dispatch.
+- Actual Result: Daily prerelease `2026-06-03_v1` already exists; latest semver release is `v0.0.56`; latest `release-packages.yml` tag-push run for `v0.0.56` was successful at `https://github.com/eng-cc/oasis7/actions/runs/26639453860`.
+- Blocker / Next Action: Trigger `release-packages.yml` with `tag=v0.0.56` rather than `daily-github-release.yml`, because the date release already exists and would fail on duplicate release/tag.
+
+## 2026-06-03 14:21:08 CST / tpm
+- 完成内容: Triggered the latest semver GitHub release package workflow mechanically; no QA release-readiness or LiveOps external-message judgment is claimed.
+- 遗留事项: Remote workflow run remained in progress, and daily date release assets were not addressed by this semver dispatch.
+- Action: `gh workflow run release-packages.yml --ref main -f tag=v0.0.56`.
+- Validation Command: `gh run view 26867434448 --json databaseId,displayTitle,event,headBranch,headSha,status,conclusion,createdAt,updatedAt,url,workflowName`; `git diff --check`.
+- Expected Result: A new `Release Packages` workflow_dispatch run exists for `main`, has a GitHub Actions URL, and local task-log edits have no whitespace errors.
+- Actual Result: Created run `26867434448` at `https://github.com/eng-cc/oasis7/actions/runs/26867434448`; workflow `Release Packages`; event `workflow_dispatch`; head branch `main`; head SHA `770dee5b6dc417051fac8c3c7011474b91af20cb`; status `in_progress`; conclusion empty; created `2026-06-03T06:20:28Z`; `git diff --check` passed.
+- Blocker / Next Action: Remote run is still in progress; monitor GitHub Actions for pass/fail if release completion evidence is needed.
+
+## 2026-06-03 14:23:32 CST / tpm
+- 完成内容: Confirmed the user's report that `daily-github-release.yml` succeeds without building or uploading release assets, then patched the package workflow trigger path.
+- 遗留事项: Patch must land on `main` before the existing `2026-06-03_v1` date release can be backfilled through the corrected `release-packages.yml` dispatch path.
+- Action: Inspected `daily-github-release.yml`, `release-packages.yml`, the `2026-06-03_v1` release, and recent workflow runs; updated `.github/workflows/release-packages.yml`.
+- Validation Command: `gh release view 2026-06-03_v1 --json tagName,name,isPrerelease,isDraft,assets,publishedAt,url,targetCommitish`; `gh run list --workflow daily-github-release.yml --limit 5 --json databaseId,displayTitle,event,headBranch,headSha,status,conclusion,createdAt,url`; `gh run list --workflow release-packages.yml --limit 5 --json databaseId,displayTitle,event,headBranch,headSha,status,conclusion,createdAt,url`.
+- Expected Result: Determine whether the daily release has assets and whether the package workflow is reachable from the daily date tag.
+- Actual Result: Release `2026-06-03_v1` exists at `https://github.com/eng-cc/oasis7/releases/tag/2026-06-03_v1`, is prerelease, and has `assets: []`; daily workflow run `26852474621` completed successfully, but only created tag/release. Existing `release-packages.yml` only listened to `v*` tag pushes and rejected non-`v*` tags in `publish-release`, so the daily date tag could not build/publish assets.
+- Action: Patched `.github/workflows/release-packages.yml` to listen to `20??-??-??_v*` tag pushes, updated the workflow_dispatch input description, and relaxed publish tag validation to accept either semver-like `v*` tags or daily `YYYY-MM-DD_vN` tags.
+- Validation Command: `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release-packages.yml"); puts "workflow yaml parsed"'`; Bash tag-regex smoke for `v0.0.56`, `2026-06-03_v1`, `2026-6-3_v1`, and `foo`; `./scripts/package-native-installer.sh --platform macos-x64 --bundle-dir .tmp/nonexistent-dry-run-bundle --out-dir .tmp/nonexistent-dry-run-out --asset-name oasis7-macos-x64.dmg --version 2026-06-03_v1 --dry-run`; `git diff --check`.
+- Expected Result: Workflow YAML parses, tag validation accepts semver/date tags and rejects malformed tags, package version plumbing tolerates the date tag, and the diff has no whitespace errors.
+- Actual Result: Workflow YAML parsed; tag smoke accepted `v0.0.56` and `2026-06-03_v1`, rejected `2026-6-3_v1` and `foo`; macOS package dry-run accepted `2026-06-03_v1`; `git diff --check` passed. Linux `.deb` dry-run could not run on this macOS host because `dpkg-deb` is unavailable.
+- Blocker / Next Action: This local workflow fix must land on `main`; then `release-packages.yml` can be dispatched with `tag=2026-06-03_v1` to backfill assets for today's daily release, and future daily tag pushes should automatically trigger the packaging workflow.
+
+## 2026-06-03 14:26:46 CST / tpm
+- 完成内容: Ran fresh local verification for the workflow fix and checked the remote release package run status.
+- 遗留事项: Remote `Release Packages` run `26867434448` is still `in_progress`; current daily release asset backfill still requires the workflow fix to land on `main` before dispatching `tag=2026-06-03_v1`.
+- Action: Verified PM/task governance, doc governance, diff whitespace, workflow YAML parsing, and remote run status.
+- Validation Command: `./scripts/pm/lint.sh`; `./scripts/doc-governance-check.sh`; `git diff --check && ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release-packages.yml"); puts "workflow yaml parsed"'`; `gh run view 26867434448 --json databaseId,status,conclusion,url,workflowName,updatedAt`.
+- Expected Result: Local governance checks pass, YAML parses, diff has no whitespace errors, and remote run status is reported without overclaiming completion.
+- Actual Result: `pm-lint: OK`; `doc-governance-check: OK`; `git diff --check` passed; workflow YAML parsed; remote run `26867434448` remains `in_progress` with empty conclusion at `https://github.com/eng-cc/oasis7/actions/runs/26867434448`.
+- Blocker / Next Action: Commit/PR the workflow fix, merge to `main`, then manually dispatch `release-packages.yml` with `tag=2026-06-03_v1` to populate today's daily release assets.

--- a/.pm/tasks/task_ea9150678da342d68c70107e3ef4d856.yaml
+++ b/.pm/tasks/task_ea9150678da342d68c70107e3ef4d856.yaml
@@ -1,0 +1,27 @@
+task_uid: task_ea9150678da342d68c70107e3ef4d856
+title: "trigger latest GitHub release"
+owner_role: tpm
+worktree_hint: /Users/scc/ccwork/worktrees/oasis7-site-trigger-latest-github-release
+execution_log_path: .pm/tasks/task_ea9150678da342d68c70107e3ef4d856.execution.md
+status: done
+priority: P2
+source_signal: null
+source_refs:
+  - AGENTS.md
+  - .github/workflows/daily-github-release.yml
+  - .github/workflows/release-packages.yml
+doc_refs:
+  - doc/site/prd.md
+  - doc/site/project.md
+related_prd: []
+acceptance:
+  - "Dispatch the appropriate GitHub release workflow for the latest Asia/Shanghai release date and report the run URL/status."
+handoff_to: []
+updated_at: 2026-06-03T14:50:17+08:00
+last_started_at: 2026-06-03T14:18:13+08:00
+last_claim_type: task_complete
+last_verify_command: "./scripts/pm/lint.sh && ./scripts/doc-governance-check.sh && git diff --check && ruby -e 'require \"yaml\"; YAML.load_file(\".github/workflows/release-packages.yml\"); puts \"workflow yaml parsed\"'"
+last_verified_at: 2026-06-03T14:50:14+08:00
+last_verification_exit_code: 0
+last_verification_status: verified
+last_closed_at: 2026-06-03T14:50:16+08:00

--- a/.pm/tasks/task_f66e562f0d3d4bec8fcf3200fa79175e.execution.md
+++ b/.pm/tasks/task_f66e562f0d3d4bec8fcf3200fa79175e.execution.md
@@ -1,0 +1,31 @@
+# task_f66e562f0d3d4bec8fcf3200fa79175e Execution Log
+
+- task_uid: task_f66e562f0d3d4bec8fcf3200fa79175e
+- title: address release PR review comments
+- owner_role: tpm
+- worktree_hint: /Users/scc/ccwork/worktrees/oasis7-site-trigger-latest-github-release
+
+<!-- Append entries using:
+Example:
+  ## YYYY-MM-DD HH:MM:SS CST / role_name
+  - 完成内容: ...
+  - 遗留事项: ...
+  - Action: ...
+  - Validation Command: ...
+  - Expected Result: ...
+  - Actual Result: ...
+- Blocker / Next Action: ...
+-->
+
+## 2026-06-03 16:25:10 CST / tpm
+- 完成内容: Inspected unresolved PR #342 review threads and applied fixes for both actionable comments.
+- 遗留事项: Needs fresh validation, task closeout, commit/push, and recheck PR comments/checks.
+- Action: Used thread-aware GitHub review reads. Found unresolved thread `PRRT_kwDORHhWec6GqEIa` noting daily tag pushes from `GITHUB_TOKEN` do not trigger package workflows, and unresolved thread `PRRT_kwDORHhWec6GrTS1` noting the software-safe regression did not require DOM proof for new blocker fields.
+- Validation Command: `python3 /Users/scc/.codex/plugins/cache/openai-curated/github/83d1f0d2/skills/gh-address-comments/scripts/fetch_comments.py --repo eng-cc/oasis7 --pr 342 --json`; GraphQL `reviewThreads` query for PR #342.
+- Expected Result: Identify actionable unresolved review feedback.
+- Actual Result: Two actionable threads found: explicit daily workflow dispatch and blocker detail DOM assertions.
+- Action: Added `actions: write` and an explicit `gh workflow run release-packages.yml -f tag=...` step to `daily-github-release.yml`. Updated `scripts/viewer-software-safe-step-regression.sh` to derive expected blocker detail from `blockerDetail`, `narrativeBlockerDetail`, or `recentFeedback.reason`, and require that detail in the DOM. Updated the smoke fixture to render and assert the new provider-unavailable blocker detail path.
+- Validation Command: `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/daily-github-release.yml"); YAML.load_file(".github/workflows/release-packages.yml"); puts "workflow yaml parsed"' && bash -n scripts/viewer-software-safe-step-regression.sh scripts/viewer-software-safe-step-regression-smoke.sh && ./scripts/viewer-software-safe-step-regression-smoke.sh && ./scripts/pm/lint.sh && ./scripts/doc-governance-check.sh && git diff --check`
+- Expected Result: Daily releases explicitly start packaging even when the tag was pushed by `GITHUB_TOKEN`; viewer regression fails if the new blocker detail is absent from DOM.
+- Actual Result: Workflow YAML parsed, shell syntax checks passed, software-safe smoke passed with the new blocker-detail DOM path, PM lint passed, doc governance passed, and `git diff --check` passed during task closeout.
+- Blocker / Next Action: Commit and push the PR branch, then recheck PR comments and checks.

--- a/.pm/tasks/task_f66e562f0d3d4bec8fcf3200fa79175e.yaml
+++ b/.pm/tasks/task_f66e562f0d3d4bec8fcf3200fa79175e.yaml
@@ -1,0 +1,25 @@
+task_uid: task_f66e562f0d3d4bec8fcf3200fa79175e
+title: "address release PR review comments"
+owner_role: tpm
+worktree_hint: /Users/scc/ccwork/worktrees/oasis7-site-trigger-latest-github-release
+execution_log_path: .pm/tasks/task_f66e562f0d3d4bec8fcf3200fa79175e.execution.md
+status: done
+priority: P1
+source_signal: null
+source_refs:
+  - AGENTS.md
+  - .github/workflows/daily-github-release.yml
+  - scripts/viewer-software-safe-step-regression.sh
+doc_refs: []
+related_prd: []
+acceptance:
+  - "Address actionable PR #342 review comments for daily release package dispatch and software-safe blocker DOM verification, with fresh validation recorded."
+handoff_to: []
+updated_at: 2026-06-03T16:34:29+08:00
+last_started_at: 2026-06-03T16:24:17+08:00
+last_claim_type: task_complete
+last_verify_command: "ruby -e 'require \"yaml\"; YAML.load_file(\".github/workflows/daily-github-release.yml\"); YAML.load_file(\".github/workflows/release-packages.yml\"); puts \"workflow yaml parsed\"' && bash -n scripts/viewer-software-safe-step-regression.sh scripts/viewer-software-safe-step-regression-smoke.sh && ./scripts/viewer-software-safe-step-regression-smoke.sh && ./scripts/pm/lint.sh && ./scripts/doc-governance-check.sh && git diff --check"
+last_verified_at: 2026-06-03T16:34:27+08:00
+last_verification_exit_code: 0
+last_verification_status: verified
+last_closed_at: 2026-06-03T16:34:28+08:00

--- a/crates/oasis7/src/bin/oasis7_chain_runtime/node_keypair_config.rs
+++ b/crates/oasis7/src/bin/oasis7_chain_runtime/node_keypair_config.rs
@@ -1,5 +1,8 @@
-use std::fs;
-use std::path::Path;
+use std::fs::{self, OpenOptions};
+use std::io::ErrorKind;
+use std::path::{Path, PathBuf};
+use std::thread;
+use std::time::{Duration, Instant};
 
 use ed25519_dalek::SigningKey;
 
@@ -14,6 +17,11 @@ pub(super) struct NodeKeypairConfig {
 }
 
 pub(super) fn ensure_node_keypair_in_config(path: &Path) -> Result<NodeKeypairConfig, String> {
+    let _lock = ConfigFileLock::acquire(path)?;
+    ensure_node_keypair_in_config_unlocked(path)
+}
+
+fn ensure_node_keypair_in_config_unlocked(path: &Path) -> Result<NodeKeypairConfig, String> {
     let mut table = load_config_table(path)?;
     let mut wrote = false;
 
@@ -84,6 +92,55 @@ pub(super) fn ensure_node_keypair_in_config(path: &Path) -> Result<NodeKeypairCo
     Ok(keypair)
 }
 
+struct ConfigFileLock {
+    path: PathBuf,
+}
+
+impl ConfigFileLock {
+    fn acquire(config_path: &Path) -> Result<Self, String> {
+        let path = config_lock_path(config_path);
+        if let Some(parent) = path.parent() {
+            if !parent.as_os_str().is_empty() {
+                fs::create_dir_all(parent).map_err(|err| {
+                    format!(
+                        "create config lock parent dir {} failed: {}",
+                        parent.display(),
+                        err
+                    )
+                })?;
+            }
+        }
+
+        let deadline = Instant::now() + Duration::from_secs(30);
+        loop {
+            match OpenOptions::new().write(true).create_new(true).open(&path) {
+                Ok(_) => return Ok(Self { path }),
+                Err(err) if err.kind() == ErrorKind::AlreadyExists => {
+                    if Instant::now() >= deadline {
+                        return Err(format!("timed out waiting for config lock {}", path.display()));
+                    }
+                    thread::sleep(Duration::from_millis(10));
+                }
+                Err(err) => {
+                    return Err(format!("create config lock {} failed: {}", path.display(), err));
+                }
+            }
+        }
+    }
+}
+
+impl Drop for ConfigFileLock {
+    fn drop(&mut self) {
+        let _ = fs::remove_file(&self.path);
+    }
+}
+
+fn config_lock_path(config_path: &Path) -> PathBuf {
+    let mut lock_path = config_path.as_os_str().to_os_string();
+    lock_path.push(".lock");
+    PathBuf::from(lock_path)
+}
+
 fn load_config_table(path: &Path) -> Result<toml::map::Map<String, toml::Value>, String> {
     if !path.exists() {
         return Ok(toml::map::Map::new());
@@ -139,4 +196,50 @@ fn signing_key_from_hex(private_key_hex: &str) -> Result<SigningKey, String> {
         .try_into()
         .map_err(|_| "node.private_key must be 32-byte hex".to_string())?;
     Ok(SigningKey::from_bytes(&private_array))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Arc, Barrier};
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn temp_config_path(label: &str) -> PathBuf {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time")
+            .as_nanos();
+        std::env::temp_dir()
+            .join(format!("oasis7-node-keypair-config-{label}-{unique}"))
+            .join("config.toml")
+    }
+
+    #[test]
+    fn concurrent_first_writers_share_one_generated_keypair() {
+        let config_path = temp_config_path("concurrent");
+        let lock_path = config_lock_path(&config_path);
+        let barrier = Arc::new(Barrier::new(8));
+        let handles = (0..8)
+            .map(|_| {
+                let config_path = config_path.clone();
+                let barrier = Arc::clone(&barrier);
+                thread::spawn(move || {
+                    barrier.wait();
+                    ensure_node_keypair_in_config(&config_path).expect("ensure keypair")
+                })
+            })
+            .collect::<Vec<_>>();
+
+        let keypairs = handles
+            .into_iter()
+            .map(|handle| handle.join().expect("join keypair worker"))
+            .collect::<Vec<_>>();
+        let first = keypairs.first().expect("first keypair");
+        assert!(keypairs.iter().all(|keypair| keypair == first));
+        assert!(!lock_path.exists(), "config lock should be removed");
+
+        let persisted = ensure_node_keypair_in_config(&config_path).expect("read persisted keypair");
+        assert_eq!(persisted, *first);
+        let _ = fs::remove_dir_all(config_path.parent().expect("config parent"));
+    }
 }

--- a/crates/oasis7/src/bin/oasis7_chain_runtime/node_keypair_config.rs
+++ b/crates/oasis7/src/bin/oasis7_chain_runtime/node_keypair_config.rs
@@ -117,12 +117,19 @@ impl ConfigFileLock {
                 Ok(_) => return Ok(Self { path }),
                 Err(err) if err.kind() == ErrorKind::AlreadyExists => {
                     if Instant::now() >= deadline {
-                        return Err(format!("timed out waiting for config lock {}", path.display()));
+                        return Err(format!(
+                            "timed out waiting for config lock {}",
+                            path.display()
+                        ));
                     }
                     thread::sleep(Duration::from_millis(10));
                 }
                 Err(err) => {
-                    return Err(format!("create config lock {} failed: {}", path.display(), err));
+                    return Err(format!(
+                        "create config lock {} failed: {}",
+                        path.display(),
+                        err
+                    ));
                 }
             }
         }
@@ -238,7 +245,8 @@ mod tests {
         assert!(keypairs.iter().all(|keypair| keypair == first));
         assert!(!lock_path.exists(), "config lock should be removed");
 
-        let persisted = ensure_node_keypair_in_config(&config_path).expect("read persisted keypair");
+        let persisted =
+            ensure_node_keypair_in_config(&config_path).expect("read persisted keypair");
         assert_eq!(persisted, *first);
         let _ = fs::remove_dir_all(config_path.parent().expect("config parent"));
     }

--- a/crates/oasis7_node/src/tests_clock_and_replication.rs
+++ b/crates/oasis7_node/src/tests_clock_and_replication.rs
@@ -509,12 +509,22 @@ fn runtime_pos_state_persists_across_restart() {
         RecordingExecutionHook::new(Arc::new(Mutex::new(Vec::new()))),
     );
     runtime.start().expect("start first");
-    thread::sleep(Duration::from_millis(180));
+    let reached = wait_until(Instant::now() + Duration::from_secs(2), || {
+        let snapshot = runtime.snapshot();
+        snapshot.consensus.committed_height >= 8 && snapshot.consensus.last_execution_height >= 8
+    });
     runtime.stop().expect("stop first");
     let first = runtime.snapshot();
     assert!(first.last_error.is_none());
-    assert!(first.consensus.committed_height >= 8);
-    assert!(first.consensus.last_execution_height >= 8);
+    assert!(
+        reached
+            && first.consensus.committed_height >= 8
+            && first.consensus.last_execution_height >= 8,
+        "runtime did not reach seed height before restart: committed={} execution={} last_error={:?}",
+        first.consensus.committed_height,
+        first.consensus.last_execution_height,
+        first.last_error
+    );
 
     let state_path = dir.join("node_pos_state.json");
     assert!(state_path.exists());
@@ -533,12 +543,25 @@ fn runtime_pos_state_persists_across_restart() {
         RecordingExecutionHook::new(Arc::new(Mutex::new(Vec::new()))),
     );
     runtime.start().expect("start second");
-    thread::sleep(Duration::from_millis(40));
+    let advanced = wait_until(Instant::now() + Duration::from_secs(2), || {
+        let snapshot = runtime.snapshot();
+        snapshot.consensus.committed_height > first.consensus.committed_height
+            && snapshot.consensus.last_execution_height > first.consensus.last_execution_height
+    });
     runtime.stop().expect("stop second");
     let second = runtime.snapshot();
     assert!(second.last_error.is_none());
-    assert!(second.consensus.committed_height > first.consensus.committed_height);
-    assert!(second.consensus.last_execution_height > first.consensus.last_execution_height);
+    assert!(
+        advanced
+            && second.consensus.committed_height > first.consensus.committed_height
+            && second.consensus.last_execution_height > first.consensus.last_execution_height,
+        "runtime should advance after restart: first_committed={} second_committed={} first_execution={} second_execution={} last_error={:?}",
+        first.consensus.committed_height,
+        second.consensus.committed_height,
+        first.consensus.last_execution_height,
+        second.consensus.last_execution_height,
+        second.last_error
+    );
     assert!(second.consensus.last_observed_slot >= first.consensus.last_observed_slot);
 
     let _ = fs::remove_dir_all(&dir);

--- a/crates/oasis7_node/src/tests_storage_replication.rs
+++ b/crates/oasis7_node/src/tests_storage_replication.rs
@@ -1035,29 +1035,25 @@ fn runtime_gossip_replication_persists_guard_across_restart() {
         runtime_b.snapshot()
     );
     runtime_a.start().expect("start a second");
-    let deadline = Instant::now() + Duration::from_secs(2);
-    loop {
-        let maybe_guard = fs::read(&guard_path).ok().and_then(|bytes| {
-            serde_json::from_slice::<BTreeMap<String, SingleWriterReplicationGuard>>(&bytes).ok()
-        });
-        if maybe_guard
-            .as_ref()
-            .and_then(|guards| {
-                guard_before
-                    .writer_id
-                    .as_deref()
-                    .and_then(|writer_id| guards.get(writer_id))
+    let writer_before = guard_before
+        .writer_id
+        .as_deref()
+        .expect("writer before")
+        .to_string();
+    let guard_advanced = wait_until(Instant::now() + Duration::from_secs(5), || {
+        fs::read(&guard_path)
+            .ok()
+            .and_then(|bytes| {
+                serde_json::from_slice::<BTreeMap<String, SingleWriterReplicationGuard>>(&bytes)
+                    .ok()
             })
+            .and_then(|guards| guards.get(&writer_before).cloned())
             .is_some_and(|guard| guard.last_sequence > guard_before.last_sequence)
-        {
-            break;
-        }
-        if Instant::now() >= deadline {
-            break;
-        }
-        thread::sleep(Duration::from_millis(20));
-    }
+    });
     let snapshot_b_second = runtime_b.snapshot();
+    let guards_after_wait = fs::read(&guard_path).ok().and_then(|bytes| {
+        serde_json::from_slice::<BTreeMap<String, SingleWriterReplicationGuard>>(&bytes).ok()
+    });
     runtime_a.stop().expect("stop a second");
     runtime_b.stop().expect("stop b second");
     assert!(snapshot_b_second.last_error.is_none());
@@ -1066,11 +1062,18 @@ fn runtime_gossip_replication_persists_guard_across_restart() {
         &fs::read(&guard_path).expect("read guard after"),
     )
     .expect("parse guard after")
-    .get(guard_before.writer_id.as_deref().expect("writer before"))
+    .get(&writer_before)
     .cloned()
     .expect("remote guard after");
     assert_eq!(guard_after.writer_id, guard_before.writer_id);
-    assert!(guard_after.last_sequence > guard_before.last_sequence);
+    assert!(
+        guard_advanced && guard_after.last_sequence > guard_before.last_sequence,
+        "replication guard did not advance after restart: before={:?} after={:?} guards_after_wait={:?} snapshot={:?}",
+        guard_before,
+        guard_after,
+        guards_after_wait,
+        snapshot_b_second
+    );
 
     let store_b = LocalCasStore::new(dir_b.join("store"));
     let files = store_b.list_files().expect("list files");

--- a/scripts/viewer-software-safe-step-regression-smoke.sh
+++ b/scripts/viewer-software-safe-step-regression-smoke.sh
@@ -99,9 +99,12 @@ cat >"$fixture_root/software_safe.html" <<'EOF'
           logicalTime: 0,
           eventSeq: 0,
           gameplaySummary: {
-            stageStatus: "running",
+            stageStatus: "active",
             blockerKind: null,
             blockerDetail: null,
+            executionState: null,
+            narrativeBlockerDetail: null,
+            recentFeedback: null,
           },
         };
 
@@ -146,9 +149,12 @@ cat >"$fixture_root/software_safe.html" <<'EOF'
             const [kind, id] = String(target || "").split(":");
             state.selectedKind = kind || null;
             state.selectedId = id || null;
-            state.gameplaySummary.stageStatus = "blocked";
-            state.gameplaySummary.blockerKind = "fixture_blocker";
-            state.gameplaySummary.blockerDetail = "fixture smoke blocker";
+            state.gameplaySummary.executionState = "blocked";
+            state.gameplaySummary.narrativeBlockerDetail = "fixture provider unavailable";
+            state.gameplaySummary.recentFeedback = {
+              stage: "blocked",
+              reason: "fixture provider unavailable",
+            };
             render();
             return cloneState();
           },
@@ -269,15 +275,17 @@ assert summary["autoProgressObserved"] is False, summary
 assert summary["logicalTimeAdvanced"] is False, summary
 assert summary["eventSeqAdvanced"] is False, summary
 assert summary["blockerDomVisible"] is True, summary
-assert summary["stageStatus"] == "blocked", summary
-assert summary["blockerKind"] == "fixture_blocker", summary
+assert summary["stageStatus"] == "active", summary
+assert summary["blockerKind"] is None, summary
 assert summary["selectedAgentVisible"] is True, summary
 assert summary["playbackControlsVisible"] is False, summary
 assert after_select["selectedId"] == "agent-0", after_select
 assert after_select["selectedKind"] == "agent", after_select
 assert after_progress["connectionStatus"] == "connected", after_progress
-assert after_progress["gameplaySummary"]["stageStatus"] == "blocked", after_progress
-assert after_progress["gameplaySummary"]["blockerKind"] == "fixture_blocker", after_progress
+assert after_progress["gameplaySummary"]["stageStatus"] == "active", after_progress
+assert after_progress["gameplaySummary"]["blockerKind"] is None, after_progress
+assert after_progress["gameplaySummary"]["executionState"] == "blocked", after_progress
+assert after_progress["gameplaySummary"]["recentFeedback"]["stage"] == "blocked", after_progress
 PY
 
 ensure_file_contains "$summary_json" '"failCategory": null'

--- a/scripts/viewer-software-safe-step-regression-smoke.sh
+++ b/scripts/viewer-software-safe-step-regression-smoke.sh
@@ -133,9 +133,14 @@ cat >"$fixture_root/software_safe.html" <<'EOF'
           } else {
             selectionRoot.textContent = "No agent selected yet.";
           }
-          if (state.gameplaySummary.stageStatus === "blocked") {
+          const blockerDetail =
+            state.gameplaySummary.blockerDetail ||
+            state.gameplaySummary.narrativeBlockerDetail ||
+            state.gameplaySummary.recentFeedback?.reason ||
+            null;
+          if (state.gameplaySummary.stageStatus === "blocked" || blockerDetail) {
             blockerRoot.textContent =
-              `blocked ${state.gameplaySummary.blockerKind} ${state.gameplaySummary.blockerDetail}`;
+              `blocked ${state.gameplaySummary.blockerKind || "provider"} ${blockerDetail}`;
           } else {
             blockerRoot.textContent = "No blocker active.";
           }
@@ -277,6 +282,7 @@ assert summary["eventSeqAdvanced"] is False, summary
 assert summary["blockerDomVisible"] is True, summary
 assert summary["stageStatus"] == "active", summary
 assert summary["blockerKind"] is None, summary
+assert summary["blockerDetail"] is None, summary
 assert summary["selectedAgentVisible"] is True, summary
 assert summary["playbackControlsVisible"] is False, summary
 assert after_select["selectedId"] == "agent-0", after_select
@@ -285,7 +291,9 @@ assert after_progress["connectionStatus"] == "connected", after_progress
 assert after_progress["gameplaySummary"]["stageStatus"] == "active", after_progress
 assert after_progress["gameplaySummary"]["blockerKind"] is None, after_progress
 assert after_progress["gameplaySummary"]["executionState"] == "blocked", after_progress
+assert after_progress["gameplaySummary"]["narrativeBlockerDetail"] == "fixture provider unavailable", after_progress
 assert after_progress["gameplaySummary"]["recentFeedback"]["stage"] == "blocked", after_progress
+assert after_progress["gameplaySummary"]["recentFeedback"]["reason"] == "fixture provider unavailable", after_progress
 PY
 
 ensure_file_contains "$summary_json" '"failCategory": null'

--- a/scripts/viewer-software-safe-step-regression-smoke.sh
+++ b/scripts/viewer-software-safe-step-regression-smoke.sh
@@ -283,6 +283,7 @@ assert summary["blockerDomVisible"] is True, summary
 assert summary["stageStatus"] == "active", summary
 assert summary["blockerKind"] is None, summary
 assert summary["blockerDetail"] is None, summary
+assert summary["expectedBlockerDetail"] == "fixture provider unavailable", summary
 assert summary["selectedAgentVisible"] is True, summary
 assert summary["playbackControlsVisible"] is False, summary
 assert after_select["selectedId"] == "agent-0", after_select

--- a/scripts/viewer-software-safe-step-regression.sh
+++ b/scripts/viewer-software-safe-step-regression.sh
@@ -134,6 +134,31 @@ state_blocker_kind() { json_get "$1" gameplaySummary.blockerKind; }
 state_blocker_detail() { json_get "$1" gameplaySummary.blockerDetail; }
 state_stage_status() { json_get "$1" gameplaySummary.stageStatus; }
 state_last_control_stage() { json_get "$1" lastControlFeedback.stage; }
+state_execution_state() { json_get "$1" gameplaySummary.executionState; }
+state_recent_feedback_stage() { json_get "$1" gameplaySummary.recentFeedback.stage; }
+state_narrative_blocker_detail() { json_get "$1" gameplaySummary.narrativeBlockerDetail; }
+
+refresh_explicit_blocker_state() {
+  local state=$1
+  stage_status=$(state_stage_status "$state")
+  blocker_kind=$(state_blocker_kind "$state")
+  blocker_detail=$(state_blocker_detail "$state")
+  execution_state=$(state_execution_state "$state")
+  recent_feedback_stage=$(state_recent_feedback_stage "$state")
+  narrative_blocker_detail=$(state_narrative_blocker_detail "$state")
+  explicit_blocker_state=false
+  if [[ -n "${blocker_kind:-}" && "$blocker_kind" != "null" ]]; then
+    explicit_blocker_state=true
+  elif [[ "${stage_status:-}" == "blocked" ]]; then
+    explicit_blocker_state=true
+  elif [[ "${execution_state:-}" == "blocked" ]]; then
+    explicit_blocker_state=true
+  elif [[ "${recent_feedback_stage:-}" == "blocked" ]]; then
+    explicit_blocker_state=true
+  elif [[ -n "${narrative_blocker_detail:-}" && "$narrative_blocker_detail" != "null" ]]; then
+    explicit_blocker_state=true
+  fi
+}
 
 wait_for_api() {
   local timeout_ms=${1:-20000}
@@ -414,12 +439,18 @@ render_mode="$(state_render_mode "$initial_state")"
 [[ "$render_mode" == "viewer" || "$render_mode" == "software_safe" ]] || { echo "error: expected renderMode=viewer-compatible, got $render_mode" >&2; exit 1; }
 
 log_note select_agent
+agent_id_json=$(python3 - "$AGENT_ID" <<'PY'
+import json
+import sys
+print(json.dumps(sys.argv[1]))
+PY
+)
 ab_eval "$session" "window.__AW_TEST__.select('agent:${AGENT_ID}')" >>"$ab_log" 2>&1
-wait_for_js_true "(() => window.__AW_TEST__?.getState?.()?.selectedId === ${AGENT_ID@Q})()" 6000 || {
+wait_for_js_true "(() => window.__AW_TEST__?.getState?.()?.selectedId === ${agent_id_json})()" 6000 || {
   echo "error: failed to select agent ${AGENT_ID}" >&2
   exit 1
 }
-wait_for_js_true "(() => { const agentId = ${AGENT_ID@Q}; return !!document.querySelector('[data-select-kind=\"agent\"][data-select-id=\"' + agentId + '\"][data-selected=\"true\"]'); })()" 6000 || {
+wait_for_js_true "(() => { const agentId = ${agent_id_json}; return !!document.querySelector('[data-select-kind=\"agent\"][data-select-id=\"' + agentId + '\"][data-selected=\"true\"]'); })()" 6000 || {
   echo "error: selected agent ${AGENT_ID} is not reflected in DOM" >&2
   exit 1
 }
@@ -532,14 +563,7 @@ if [[ "$auto_progress_observed" != "true" ]]; then
     if [[ "$logical_time_advanced" == "true" || "$event_seq_advanced" == "true" ]]; then
       auto_progress_observed=true
     fi
-    stage_status=$(state_stage_status "$after_progress_state")
-    blocker_kind=$(state_blocker_kind "$after_progress_state")
-    blocker_detail=$(state_blocker_detail "$after_progress_state")
-    if [[ -n "${blocker_kind:-}" && "$blocker_kind" != "null" ]]; then
-      explicit_blocker_state=true
-    elif [[ "${stage_status:-}" == "blocked" ]]; then
-      explicit_blocker_state=true
-    fi
+    refresh_explicit_blocker_state "$after_progress_state"
 
     if [[ "$auto_progress_observed" != "true" && "$explicit_blocker_state" != "true" && "$(state_last_control_stage "$after_progress_state")" == "queued" ]]; then
       log_note resume_play
@@ -576,14 +600,7 @@ if [[ "$auto_progress_observed" != "true" ]]; then
       if [[ "$logical_time_advanced" == "true" || "$event_seq_advanced" == "true" ]]; then
         auto_progress_observed=true
       fi
-      stage_status=$(state_stage_status "$after_progress_state")
-      blocker_kind=$(state_blocker_kind "$after_progress_state")
-      blocker_detail=$(state_blocker_detail "$after_progress_state")
-      if [[ -n "${blocker_kind:-}" && "$blocker_kind" != "null" ]]; then
-        explicit_blocker_state=true
-      elif [[ "${stage_status:-}" == "blocked" ]]; then
-        explicit_blocker_state=true
-      fi
+      refresh_explicit_blocker_state "$after_progress_state"
     fi
   fi
 

--- a/scripts/viewer-software-safe-step-regression.sh
+++ b/scripts/viewer-software-safe-step-regression.sh
@@ -148,6 +148,7 @@ refresh_explicit_blocker_state() {
   recent_feedback_stage=$(state_recent_feedback_stage "$state")
   recent_feedback_reason=$(state_recent_feedback_reason "$state")
   narrative_blocker_detail=$(state_narrative_blocker_detail "$state")
+  expected_blocker_status=""
   expected_blocker_detail=""
   if [[ -n "${blocker_detail:-}" && "$blocker_detail" != "null" ]]; then
     expected_blocker_detail="$blocker_detail"
@@ -161,14 +162,19 @@ refresh_explicit_blocker_state() {
     explicit_blocker_state=true
   elif [[ "${stage_status:-}" == "blocked" ]]; then
     explicit_blocker_state=true
+    expected_blocker_status="blocked"
   elif [[ "${execution_state:-}" == "blocked" ]]; then
     explicit_blocker_state=true
+    expected_blocker_status="blocked"
   elif [[ "${recent_feedback_stage:-}" == "blocked" ]]; then
     explicit_blocker_state=true
+    expected_blocker_status="blocked"
   elif [[ -n "${narrative_blocker_detail:-}" && "$narrative_blocker_detail" != "null" ]]; then
     explicit_blocker_state=true
+    expected_blocker_status="blocked"
   elif [[ -n "${recent_feedback_reason:-}" && "$recent_feedback_reason" != "null" ]]; then
     explicit_blocker_state=true
+    expected_blocker_status="blocked"
   fi
 }
 
@@ -281,6 +287,7 @@ payload = {
     "stageStatus": None if sys.argv[13] == "null" else sys.argv[13],
     "blockerKind": None if sys.argv[14] == "null" else sys.argv[14],
     "blockerDetail": None if sys.argv[15] == "null" else sys.argv[15],
+    "expectedBlockerDetail": None if sys.argv[16] == "null" else sys.argv[16],
 }
 print(json.dumps(payload, ensure_ascii=False, indent=2))
 PY
@@ -614,14 +621,15 @@ if [[ "$auto_progress_observed" != "true" ]]; then
   if [[ "$auto_progress_observed" == "true" ]]; then
     :
   elif [[ "$explicit_blocker_state" == "true" ]]; then
-    blocker_dom_check_js=$(python3 - "${stage_status:-null}" "${blocker_kind:-null}" "${blocker_detail:-null}" "${expected_blocker_detail:-null}" <<'PY'
+    blocker_dom_check_js=$(python3 - "${expected_blocker_status:-null}" "${stage_status:-null}" "${blocker_kind:-null}" "${blocker_detail:-null}" "${expected_blocker_detail:-null}" <<'PY'
 import json
 import sys
 
-stage_status = sys.argv[1]
-blocker_kind = sys.argv[2]
-blocker_detail = sys.argv[3]
-expected_blocker_detail = sys.argv[4]
+expected_blocker_status = sys.argv[1]
+stage_status = sys.argv[2]
+blocker_kind = sys.argv[3]
+blocker_detail = sys.argv[4]
+expected_blocker_detail = sys.argv[5]
 
 print(r"""
 (() => {
@@ -630,6 +638,7 @@ print(r"""
     .replace(/\s+/g, ' ')
     .trim();
   const text = normalize(document.body && document.body.innerText ? document.body.innerText : '');
+  const expectedBlockerStatus = %s;
   const stageStatus = %s;
   const blockerKind = %s;
   const blockerDetail = %s;
@@ -653,10 +662,14 @@ print(r"""
     !expectedBlockerDetail ||
     expectedBlockerDetail === 'null' ||
     text.includes(normalize(expectedBlockerDetail));
-  const statusOk = stageStatus !== 'blocked' || text.includes('blocked') || text.includes('阻塞');
+  const statusOk =
+    (stageStatus !== 'blocked' && expectedBlockerStatus !== 'blocked') ||
+    text.includes('blocked') ||
+    text.includes('阻塞');
   return hasSurface && kindOk && detailOk && expectedDetailOk && statusOk;
 })()
 """ % (
+    json.dumps(expected_blocker_status),
     json.dumps(stage_status),
     json.dumps(blocker_kind),
     json.dumps(blocker_detail),
@@ -693,7 +706,8 @@ summary_raw=$(summary_json \
   "${blocker_dom_visible:-null}" \
   "${stage_status:-null}" \
   "${blocker_kind:-null}" \
-  "${blocker_detail:-null}")
+  "${blocker_detail:-null}" \
+  "${expected_blocker_detail:-null}")
 printf '%s\n' "$summary_raw" >"$summary_json_path"
 python3 - "$summary_json_path" "$summary_md_path" <<'PY'
 import json
@@ -719,6 +733,7 @@ lines = [
     f"- stageStatus: `{data['stageStatus']}`",
     f"- blockerKind: `{data['blockerKind']}`",
     f"- blockerDetail: `{data['blockerDetail']}`",
+    f"- expectedBlockerDetail: `{data['expectedBlockerDetail']}`",
     f"- gameUrl: `{data['gameUrl']}`",
 ]
 out.write_text("\n".join(lines) + "\n", encoding='utf-8')

--- a/scripts/viewer-software-safe-step-regression.sh
+++ b/scripts/viewer-software-safe-step-regression.sh
@@ -136,6 +136,7 @@ state_stage_status() { json_get "$1" gameplaySummary.stageStatus; }
 state_last_control_stage() { json_get "$1" lastControlFeedback.stage; }
 state_execution_state() { json_get "$1" gameplaySummary.executionState; }
 state_recent_feedback_stage() { json_get "$1" gameplaySummary.recentFeedback.stage; }
+state_recent_feedback_reason() { json_get "$1" gameplaySummary.recentFeedback.reason; }
 state_narrative_blocker_detail() { json_get "$1" gameplaySummary.narrativeBlockerDetail; }
 
 refresh_explicit_blocker_state() {
@@ -145,7 +146,16 @@ refresh_explicit_blocker_state() {
   blocker_detail=$(state_blocker_detail "$state")
   execution_state=$(state_execution_state "$state")
   recent_feedback_stage=$(state_recent_feedback_stage "$state")
+  recent_feedback_reason=$(state_recent_feedback_reason "$state")
   narrative_blocker_detail=$(state_narrative_blocker_detail "$state")
+  expected_blocker_detail=""
+  if [[ -n "${blocker_detail:-}" && "$blocker_detail" != "null" ]]; then
+    expected_blocker_detail="$blocker_detail"
+  elif [[ -n "${narrative_blocker_detail:-}" && "$narrative_blocker_detail" != "null" ]]; then
+    expected_blocker_detail="$narrative_blocker_detail"
+  elif [[ -n "${recent_feedback_reason:-}" && "$recent_feedback_reason" != "null" ]]; then
+    expected_blocker_detail="$recent_feedback_reason"
+  fi
   explicit_blocker_state=false
   if [[ -n "${blocker_kind:-}" && "$blocker_kind" != "null" ]]; then
     explicit_blocker_state=true
@@ -156,6 +166,8 @@ refresh_explicit_blocker_state() {
   elif [[ "${recent_feedback_stage:-}" == "blocked" ]]; then
     explicit_blocker_state=true
   elif [[ -n "${narrative_blocker_detail:-}" && "$narrative_blocker_detail" != "null" ]]; then
+    explicit_blocker_state=true
+  elif [[ -n "${recent_feedback_reason:-}" && "$recent_feedback_reason" != "null" ]]; then
     explicit_blocker_state=true
   fi
 }
@@ -521,12 +533,7 @@ if [[ "$(state_connection "$after_progress_state")" != "connected" ]]; then
 fi
 fail_category=null
 if [[ "$auto_progress_observed" != "true" ]]; then
-  explicit_blocker_state=false
-  if [[ -n "${blocker_kind:-}" && "$blocker_kind" != "null" ]]; then
-    explicit_blocker_state=true
-  elif [[ "${stage_status:-}" == "blocked" ]]; then
-    explicit_blocker_state=true
-  fi
+  refresh_explicit_blocker_state "$after_progress_state"
 
   if [[ "$explicit_blocker_state" != "true" ]]; then
     log_note step_once
@@ -607,13 +614,14 @@ if [[ "$auto_progress_observed" != "true" ]]; then
   if [[ "$auto_progress_observed" == "true" ]]; then
     :
   elif [[ "$explicit_blocker_state" == "true" ]]; then
-    blocker_dom_check_js=$(python3 - "${stage_status:-null}" "${blocker_kind:-null}" "${blocker_detail:-null}" <<'PY'
+    blocker_dom_check_js=$(python3 - "${stage_status:-null}" "${blocker_kind:-null}" "${blocker_detail:-null}" "${expected_blocker_detail:-null}" <<'PY'
 import json
 import sys
 
 stage_status = sys.argv[1]
 blocker_kind = sys.argv[2]
 blocker_detail = sys.argv[3]
+expected_blocker_detail = sys.argv[4]
 
 print(r"""
 (() => {
@@ -625,6 +633,7 @@ print(r"""
   const stageStatus = %s;
   const blockerKind = %s;
   const blockerDetail = %s;
+  const expectedBlockerDetail = %s;
   const surfaceKeywords = [
     'formal gameplay summary',
     'recent feedback',
@@ -640,10 +649,19 @@ print(r"""
   const hasSurface = surfaceKeywords.some((token) => text.includes(normalize(token)));
   const kindOk = !blockerKind || blockerKind === 'null' || text.includes(normalize(blockerKind));
   const detailOk = !blockerDetail || blockerDetail === 'null' || text.includes(normalize(blockerDetail));
+  const expectedDetailOk =
+    !expectedBlockerDetail ||
+    expectedBlockerDetail === 'null' ||
+    text.includes(normalize(expectedBlockerDetail));
   const statusOk = stageStatus !== 'blocked' || text.includes('blocked') || text.includes('阻塞');
-  return hasSurface && kindOk && detailOk && statusOk;
+  return hasSurface && kindOk && detailOk && expectedDetailOk && statusOk;
 })()
-""" % (json.dumps(stage_status), json.dumps(blocker_kind), json.dumps(blocker_detail)))
+""" % (
+    json.dumps(stage_status),
+    json.dumps(blocker_kind),
+    json.dumps(blocker_detail),
+    json.dumps(expected_blocker_detail),
+))
 PY
 )
     blocker_dom_visible=$(normalize_eval_token "$(ab_eval "$session" "$blocker_dom_check_js" 2>>"$ab_log" || printf 'false')")


### PR DESCRIPTION
## Summary
- Allow `release-packages.yml` to run for daily date tags like `2026-06-03_v1`.
- Ensure `workflow_dispatch` package runs checkout the requested release tag instead of defaulting to `main`.
- Harden the release workflow checkout expression and daily tag glob so branch pushes no longer create no-job failed Release Packages runs.
- Recognize current software-safe provider-unreachable blocker fields in the web strict regression.
- Stabilize `runtime_pos_state_persists_across_restart` by waiting for runtime progress instead of relying on fixed CI timing.
- Record task execution evidence for the daily release asset gap, failed `v0.0.56` rerun, workflow planning failure, and Rust required-gate failure.

## Root Cause
`daily-github-release.yml` created the date tag and prerelease, but `release-packages.yml` only listened to `v*` tag pushes and rejected non-`v*` tags before publishing. The daily release could therefore succeed with an empty asset list.

The manual `v0.0.56` rerun also exposed that `workflow_dispatch` jobs used plain `actions/checkout`, so they checked out `main` (`770dee...`) while publishing against the input tag. This made the rerun test the wrong code instead of the `v0.0.56` tag SHA (`4eb0fe...`).

A subsequent branch push exposed a GitHub Actions planning-time failure shape for `release-packages.yml` with no jobs. The checkout ref expression is now event-safe, and date-tag shape is still strictly validated in the publish step.

## v0.0.56 Status
- `v0.0.56` already has published release assets: checksums, Linux `.deb`, Linux AppImage, macOS DMG, and Windows EXE.
- The original tag push Release Packages run `26639453860` completed successfully and published those assets.
- The manual validation rerun `26871103896` hit the old tag's soak instability and was cancelled after evidence was collected, so it did not overwrite the existing successful release state.

## Validation
- `./scripts/pm/task-closeout.sh --role tpm --task-uid task_ea9150678da342d68c70107e3ef4d856 --verify-command './scripts/pm/lint.sh && ./scripts/doc-governance-check.sh && git diff --check && ruby -e '\''require "yaml"; YAML.load_file(".github/workflows/release-packages.yml"); puts "workflow yaml parsed"'\'''`
- `./scripts/pm/task-closeout.sh --role tpm --task-uid task_8c6cadfbece54baf944ecc9190606c5a --verify-command './scripts/pm/lint.sh && ./scripts/doc-governance-check.sh && ruby -e '\''require "yaml"; YAML.load_file(".github/workflows/release-packages.yml"); puts "workflow yaml parsed"'\'' && bash -n scripts/viewer-software-safe-step-regression.sh scripts/viewer-software-safe-step-regression-smoke.sh && ./scripts/viewer-software-safe-step-regression-smoke.sh && git diff --check'`
- `./scripts/pm/task-closeout.sh --role tpm --task-uid task_70df8dbe2ed1450fae1372f5e5a96de2 --verify-command 'ruby -e '\''require "yaml"; YAML.load_file(".github/workflows/release-packages.yml"); puts "workflow yaml parsed"'\'' && bash -n scripts/viewer-software-safe-step-regression.sh scripts/viewer-software-safe-step-regression-smoke.sh && ./scripts/viewer-software-safe-step-regression-smoke.sh && git diff --check'`
- `./scripts/pm/task-closeout.sh --role tpm --task-uid task_c88e1bea1b4643aba1e70ee8d280f4bf --verify-command 'env -u RUSTC_WRAPPER cargo test -p oasis7_node tests::runtime_pos_state_persists_across_restart -- --exact --nocapture && ruby -e '\''require "yaml"; YAML.load_file(".github/workflows/release-packages.yml"); puts "workflow yaml parsed"'\'' && bash -n scripts/viewer-software-safe-step-regression.sh scripts/viewer-software-safe-step-regression-smoke.sh && ./scripts/viewer-software-safe-step-regression-smoke.sh && ./scripts/pm/lint.sh && ./scripts/doc-governance-check.sh && git diff --check'`
- PR checks on head `ec9f8df3`: Rust required-gate success, Wasm Determinism Gate success, Hosted Login Linux Build success.

## Follow-up
After this lands on `main`, manually dispatch `release-packages.yml` with `tag=2026-06-03_v1` to backfill today's daily release assets.