### PR TITLE
Document bridge full-chain test plan

### DIFF
--- a/.pm/tasks/task_455ea61e04c946469b8b1d22b700f853.execution.md
+++ b/.pm/tasks/task_455ea61e04c946469b8b1d22b700f853.execution.md
@@ -1,0 +1,338 @@
+# task_455ea61e04c946469b8b1d22b700f853 Execution Log
+
+- task_uid: task_455ea61e04c946469b8b1d22b700f853
+- title: explain LLM token consumption
+- owner_role: tpm
+- worktree_hint: /Users/scc/ccwork/worktrees/oasis7-agent-llm-token-consumption-readonly
+
+<!-- Append entries using:
+Example:
+  ## YYYY-MM-DD HH:MM:SS CST / role_name
+  - 完成内容: ...
+  - 遗留事项: ...
+  - Action: ...
+  - Validation Command: ...
+  - Expected Result: ...
+  - Actual Result: ...
+  - Blocker / Next Action: ...
+-->
+
+## 2026-06-02 00:00:00 CST / tpm
+- 完成内容: WORKFLOW BOOTSTRAP DECIDED
+- Repository State Impact: read-only answer; repository state changed only for required task/worktree/log bootstrap.
+- Isolation Decision: created canonical task worktree `/Users/scc/ccwork/worktrees/oasis7-agent-llm-token-consumption-readonly` from main via `./scripts/new-task-worktree.sh`; source worktree remains untouched.
+- Task Truth: owner role `tpm`; `.pm` task `task_455ea61e04c946469b8b1d22b700f853`; execution log is mandatory sink.
+- Routed Next Phase: read-only professional/domain judgment routed through `repo-owned-workflow-router` to `agent_engineer` bounded slice.
+- Required Writeback: `.pm/tasks/task_455ea61e04c946469b8b1d22b700f853.execution.md` records bootstrap, route, slice contract, evidence, and integrated answer.
+- Action: bootstrap task worktree and task truth for user question "现在游戏如何消耗LLM token".
+- Validation Command: `./scripts/new-task-worktree.sh agent llm-token-consumption-readonly --pm-owner-role tpm --pm-title "explain LLM token consumption" --pm-source-ref AGENTS.md --pm-source-ref doc/engineering/workflow/source-of-truth.md --pm-acceptance "Explain current in-game LLM token consumption paths with repo evidence" --pm-handoff-to agent_engineer --json`
+- Expected Result: standard task worktree and committed `.pm` task are created.
+- Actual Result: created worktree `/Users/scc/ccwork/worktrees/oasis7-agent-llm-token-consumption-readonly`, branch `task/agent-llm-token-consumption-readonly`, task `task_455ea61e04c946469b8b1d22b700f853`.
+- Blocker / Next Action: record route and dispatch `agent_engineer` slice.
+
+## 2026-06-02 00:00:00 CST / tpm
+- 完成内容: WORKFLOW ROUTE DECIDED
+- Task Phase: read-only professional/domain question after bootstrap.
+- Selected Workflow Skills: `repo-owned-workflow-router` for phase selection; bounded professional slice by `agent_engineer` for authoritative token-consumption analysis.
+- Skipped Workflow Skills: `bounded-brainstorming`, `tdd-test-writer`, `executing-project-tasks`, `verification-before-completion`, and closeout are skipped because this is a read-only explanation with no implementation/change claim.
+- Subagent Slice Plan:
+  - role: `agent_engineer`
+  - slice type: read-only analysis
+  - model configuration: `gpt-5.4-medium` default requested by repo workflow for specialist slices
+  - mandatory context packet: `AGENTS.md`; `.agents/roles/agent_engineer.md`; `doc/engineering/workflow/source-of-truth.md`; task truth `task_455ea61e04c946469b8b1d22b700f853`; user intent "现在游戏如何消耗LLM token"; scoped repo context: LLM/provider/token usage code and docs only
+  - write scope: append role-tagged findings to `.pm/tasks/task_455ea61e04c946469b8b1d22b700f853.execution.md`; no source code edits
+  - return contract: concise explanation of current LLM token consumption paths, billing/accounting mechanism, limits/fallbacks if present, and evidence references
+  - formal sink / writeback surface: `.pm/tasks/task_455ea61e04c946469b8b1d22b700f853.execution.md`
+  - integration owner: `tpm`
+  - integration order: TPM dispatches slice, integrates role-tagged findings, then answers user with attribution
+- Action: route user question into `agent_engineer` bounded slice.
+- Validation Command: inspect role/workflow docs and record route before delegated analysis.
+- Expected Result: task log contains slice contract before professional work begins.
+- Actual Result: slice contract recorded in this execution log.
+- Blocker / Next Action: dispatch/read-only analyze current token paths.
+
+## 2026-06-02 00:00:00 CST / agent_engineer
+- 完成内容: READ-ONLY 专业分析：回答“现在游戏如何消耗 LLM token”。
+- 结论摘要:
+  1. 当前会触发 LLM 调用/消耗 token 的主玩法路径，核心是 `runtime live + --llm` 下的 agent 决策循环：
+     - `play/step` 会向 `llm_sidecar` 请求下一次 agent decision，然后执行 `next_llm_decision()`；这是持续游玩时最稳定、最高频的 token 消耗入口。证据：`crates/oasis7/src/viewer/runtime_live.rs:586-590`，`crates/oasis7/src/viewer/runtime_live/llm_sidecar.rs:523-526,613-655`
+     - `agent_chat` 在鉴权通过后会把玩家消息塞进 agent 对话历史，并显式 `request_decision()` 触发下一轮 LLM 决策。证据：`crates/oasis7/src/viewer/runtime_live/control_plane.rs:397-417,487-495`
+     - `prompt_control apply/rollback` 不直接调用模型做 preview，但会更新 prompt profile 后显式 `request_decision()`，从而触发下一轮 LLM 决策；`preview` 本身只做 diff/ack，不触发决策。证据：`crates/oasis7/src/viewer/runtime_live/control_plane.rs:144-187,240-255,345-364`
+  2. `gameplay_action` 不是本次 scoped 代码中看到的直接 LLM 入口；它更像玩家显式动作面。真正的 token 消耗仍主要发生在后续 `play/step` 或上述控制面把 agent 拉进下一轮决策时。
+  3. `--no-llm` / 非 LLM 模式不会走远端 token：
+     - CLI 明确把 `--no-llm` 定义为 `observer/debug only; gameplay blocked`。证据：`crates/oasis7/src/bin/oasis7_viewer_live.rs:253-254`
+     - gameplay snapshot 也会把无 LLM provider 视为 `blocked`，要求先启用 `--llm`。证据：`crates/oasis7/src/viewer/runtime_live/gameplay_snapshot.rs:483-507`
+     - `agent_chat` / `prompt_control` 在非 LLM 模式直接返回 `llm_mode_required`。证据：`crates/oasis7/src/viewer/runtime_live/control_plane.rs:95-114,402-405`
+  4. 但“本地 provider/loopback”不等于“零远端 token”：
+     - runtime live 可在 builtin LLM 与 `provider_backed` 之间切换；`provider_backed` 支持 `loopback_http` 和 `remote_https` 两种 transport。证据：`crates/oasis7/src/viewer/runtime_live/llm_sidecar.rs:42-45,47-60`，`crates/oasis7/src/viewer/runtime_live/llm_sidecar_provider.rs:14-24,51-59,114-125`
+     - 因此 `--no-llm` 是确定不耗远端 token 的离线路径；但“本地 loopback bridge”是否继续向外部模型计费，要看 bridge/provider 实现，仓库主逻辑本身不做强保证。
+  5. 计量/限制/观测现状：
+     - builtin LLM 读取 OpenAI 兼容返回里的 `usage.input_tokens / output_tokens / total_tokens`。证据：`crates/oasis7/src/simulator/llm_agent/openai_payload.rs:501-508`
+     - 单次 agent 决策会在多轮 tool/repair 流程中累计 `prompt/completion/total_tokens`。证据：`crates/oasis7/src/simulator/llm_agent/behavior_loop.rs:141-148,286-305`
+     - 这些数据落在 `LlmDecisionDiagnostics` 中，可随 decision trace 观测。证据：`crates/oasis7/src/simulator/agent.rs:156-169`
+     - provider-backed 路径依赖 provider 回传 `token_usage`，然后映射进同一个 `LlmDecisionDiagnostics`；schema 里还预留了 `cost_cents`，但本次未看到统一的 runtime budget/扣费总账。证据：`crates/oasis7/src/simulator/decision_provider.rs:271-303,661-686`
+     - runtime perf 还会单独记录 `llm_api` 延迟，但这是时延观测，不是 token 配额。证据：`crates/oasis7/src/simulator/runtime_perf.rs:143-165`，`crates/oasis7/src/simulator/runner.rs:757-764`
+     - 默认限制主要是“每次决策最多 3 次 module call / 4 个 decision step / 1 个 repair round”，以及默认 180s LLM timeout；runtime live 还会再用 `OASIS7_RUNTIME_LIVE_LLM_TIMEOUT_MS` 把 timeout 封顶到默认 30s。证据：`crates/oasis7/src/simulator/llm_agent.rs:71-88,137-167,171-184`，`crates/oasis7/src/viewer/runtime_live/llm_sidecar.rs:59-60,103-110`
+  6. 产品/验收口径上，仓库当前也明确 active LLM 才算正式 gameplay；`--no-llm` 只保留 debug/observer 意义。证据：`doc/testing/evidence/pure-api-parity-validation-2026-03-19.md:132`，`doc/testing/evidence/pure-api-shared-player-gameplay-parity-2026-04-28.md:37-40`
+- 不确定性 / drift risk:
+  - provider_backed 的真实上游是否远端计费，取决于外部 provider bridge，不完全由本仓库决定。
+  - 本次只检查了 repo 内 LLM/provider/token 相关代码、文档、测试；未连外部服务核验实际账单面板。
+
+## 2026-06-02 00:00:00 CST / tpm
+- 完成内容: Integrated `agent_engineer` read-only slice into user-facing answer.
+- Action: synthesize professional findings with local mechanical evidence gathered from LLM agent, runtime live sidecar, provider bridge, NewAPI quota bridge, and testing manual surfaces.
+- Validation Command: read-only code/document inspection; no runtime service or external billing panel contacted.
+- Expected Result: user receives concise answer attributed to professional slice.
+- Actual Result: answer ready; residual uncertainty limited to external provider billing/account state.
+- Blocker / Next Action: none for read-only answer.
+
+## 2026-06-02 16:00:00 CST / tpm
+- 完成内容: Clarified the user's wording "获得 LLM token 的消耗份额" by separating two mechanisms:
+  - Consumption path: runtime live `--llm` triggers agent decisions through `play/step`, `agent_chat`, and prompt apply/rollback; token usage is reported through `LlmDecisionDiagnostics` when provider/builtin responses include usage.
+  - Quota acquisition path: current product/design truth defines a one-way operator-managed `OC -> LetAI Run OpenAPI quota` bridge. Confirmed `OC` deposits are intended to create or reuse a LetAI platform user/project, persist the project `token_key`, top up quota, then verify by query snapshots.
+- Evidence:
+  - `doc/p2p/token/mainchain-token-newapi-quota-bridge-2026-05-06.prd.md` defines the bridge as `one-way OC -> LetAI Run OpenAPI quota` and explicitly states project `token_key` is used for actual model calls.
+  - `doc/p2p/token/mainchain-token-newapi-quota-bridge-2026-05-06.design.md` defines the orchestration order `confirmed deposit -> pricing -> users/upsert -> ensure project + token_key -> topup -> query verification`.
+  - `doc/world-runtime/project.md` marks `oc-letai-bridge-test-coverage` as completed for active binding/token_key and mock `/v1/chat/completions` coverage, but this is test coverage rather than proof of live public self-serve production readiness.
+  - `crates/oasis7/src/bin/oasis7_provider_local_bridge/auth_support.rs` shows runtime bridge state can select a NewAPI bridge binding via `OASIS7_REMOTE_LLM_NEWAPI_BRIDGE_STATE_PATH` and bearer selectors.
+- User-facing nuance: answer should not imply public exchange, bidirectional redeem, browser hot-wallet topup, or automatic public self-serve quota; repo truth calls it a limited preview operator-managed service-credit bridge.
+
+## 2026-06-02 16:20:00 CST / tpm
+- 完成内容: Routed follow-up feasibility question "这个路径可以用testnet加测试环境bridge跑通所有流程么" as read-only QA/runtime boundary analysis on the same task chain.
+- Slice Contract:
+  - role: `qa_engineer`
+  - slice type: read-only feasibility / claim-boundary check
+  - model configuration: default inherited model; subagent tool did not allow full-history fork plus role override in one call, so bounded role was specified in prompt
+  - mandatory context packet: current task truth, bridge PRD/design/project/runbook, formal testnet mechanism project/runbook, NewAPI bridge service code/scripts, provider bridge code
+  - write scope: no source edits; TPM records integrated findings in this execution log
+  - return contract: distinguish bridge test environment e2e capability, formal testnet chain-side readiness, runtime/provider consumption attachment, and forbidden claims
+- TPM Evidence Summary:
+  - Bridge implementation can exercise the intended service-credit flow in a controlled test bridge environment: bind, deposit-route, reconcile, LetAI user/project/token topup, query verification, and `reconciled/manual_review` are defined in `doc/p2p/token/mainchain-token-newapi-quota-bridge-2026-05-06.runbook.md` and implemented in `crates/oasis7/src/bin/oasis7_newapi_bridge_service/service_letai.rs`.
+  - Existing bridge test environment is explicitly documented: `39.104.204.172` has `oasis7-newapi-bridge.service` and `oasis7-remote-provider-bridge.service` active, NewAPI health ok, and provider decision smoke succeeded with `letai/gpt-5.4`.
+  - Runtime/provider can consume from test bridge state: `doc/world-runtime/runtime/newapi-bridge-service-operator-runbook.md` says bind writes `token_key` into shared `bridge-state.json`, and remote provider bridge can route bearer `newapi_user_ref:<ref>` through `OASIS7_REMOTE_LLM_NEWAPI_BRIDGE_STATE_PATH`.
+  - Formal `public_testnet` is not currently a clean all-pass anchor: `doc/p2p/blockchain/p2p-formal-network-tiers-testnet-mechanism-2026-05-14.project.md` says formal network-tier verdict is `block`; `public-testnet-live-candidate-lanes-2026-05-22.tsv` has `shared_devnet_pass=partial` and `runtime_bootstrap=block`; latest shared-devnet gate summary still has `mixed_topology_baseline=partial` and aggregate `partial / hold_promotion`.
+- Integrated Answer Boundary:
+  - Yes for a controlled rehearsal using test bridge + a controlled chain/testnet input or local_devnet-style chain-base-url, provided operator secrets/pricing/state isolation are set.
+  - Not yet for claiming "all formal testnet flows are passed" or "live public_testnet is ready", because formal public_testnet readiness is still blocked/partial.
+  - Do not claim production OC settlement, public exchange, bidirectional redeem, browser token_key distribution, or public self-serve bridge.
+
+## 2026-06-02 16:30:00 CST / tpm
+- 完成内容: Answered follow-up "是不是需要先创建一个测试用户".
+- Conclusion:
+  - Yes. A controlled rehearsal should start by creating or binding a test bridge user through `POST /v1/bridge/bind`.
+  - The minimum bind input is `newapi_user_ref` plus `oasis_sender_account_id`; optional fields can include external user/project metadata.
+  - Successful bind should create/ensure the LetAI platform user/project/token_key in the bridge state for the current runtime automatic mapping path; the user-facing endpoint must not return the raw `token_key`.
+- Evidence:
+  - `doc/world-runtime/runtime/newapi-bridge-service-operator-runbook.md` says the current runtime automatic mapping minimum is `POST /v1/bridge/bind` writing `token_key` into state, and remote provider bridge can later route `newapi_user_ref:<newapi_user_ref>`.
+  - `doc/p2p/token/mainchain-token-newapi-quota-bridge-2026-05-06.runbook.md` defines first rehearsal step 6.1 as establishing user binding before deposit route and chain-side deposit.
+
+## 2026-06-02 16:35:00 CST / tpm
+- 完成内容: Clarified that the requested test identity should be a full-chain test user, not only a NewAPI bridge binding.
+- Recommended Test User Shape:
+  - `newapi_user_ref`: stable test identity used by the bridge and provider auth selector.
+  - `bridge_user_id`: server-generated bridge identity after bind.
+  - `oasis_sender_account_id`: chain-side sender account used for the OC deposit rehearsal.
+  - `deposit_account_id`: route account generated by `POST /v1/bridge/deposit-route`.
+  - `platform_user_id`: LetAI platform user produced by bridge-service.
+  - `platform_project_id` and `token_key`: LetAI project credential persisted only in controlled bridge state.
+  - `agent_provider_auth_token`: `newapi_user_ref:<newapi_user_ref>` for runtime/provider bridge routing.
+- User-facing boundary: creating this identity requires operator-controlled test bridge access and, for true full-chain rehearsal, a real testnet/local_devnet transfer into the generated deposit route; TPM did not create external state in this turn.
+
+## 2026-06-02 16:40:00 CST / tpm
+- 完成内容: Refined full-chain test user identity to start from an email-backed test persona when possible.
+- Conclusion:
+  - Use a dedicated test email as the human-readable root identity, then derive stable refs from it.
+  - `email` should be passed through bridge bind metadata / optional bind field if supported by the current API.
+  - `newapi_user_ref` should still be a stable machine ref, not the raw email if privacy/log exposure matters.
+- Suggested mapping:
+  - `email`: controlled QA mailbox or plus-addressed test email.
+  - `newapi_user_ref`: stable sanitized ref derived from the email/test run.
+  - `oasis_sender_account_id`: chain-side test account for the same persona.
+  - `external_user_name` / `project_name`: explicit e2e test labels.
+
+## 2026-06-02 16:45:00 CST / tpm
+- 完成内容: Evaluated proposal "邮箱 -> 链上私钥 -> 公钥作为 newapi_user_ref".
+- Conclusion:
+  - The identity-closure shape is correct for a full-chain test persona if interpreted as `email owns/labels a generated chain keypair`, and the public key or public-key fingerprint becomes the stable `newapi_user_ref`.
+  - Do not derive the private key from the email. Generate the private key securely, store it in a test secret manager/operator custody, and treat the email as a human/audit root plus optional LetAI user metadata.
+  - Prefer `newapi_user_ref` as either the chain public key/account id or a normalized fingerprint of it; raw email should not be the bridge/provider primary selector if privacy/log exposure matters.
+- Suggested identity mapping:
+  - `email`: QA mailbox / human audit root.
+  - `private_key`: controlled test secret, never logged or sent to bridge/provider.
+  - `public_key` / `oasis_sender_account_id`: chain-side identity and signed transfer source.
+  - `newapi_user_ref`: public key or public-key fingerprint used by bridge/provider selector.
+  - `provider_auth_token`: `newapi_user_ref:<public-key-or-fingerprint>`.
+
+## 2026-06-02 16:50:00 CST / tpm
+- 完成内容: Recommended test email strategy for one or more full-chain test personas.
+- Conclusion:
+  - Best option: use a dedicated test domain or subdomain with catch-all/inbound routing, e.g. `*@test.oasis7.example`, then allocate per-persona addresses.
+  - Acceptable quick option: use plus-addressing on a controlled mailbox, e.g. `qa+oasis7-e2e-001@example.com`, if the mail provider and LetAI user flow preserve plus addresses.
+  - Avoid personal mailboxes; avoid disposable public inboxes for any flow that touches credentials, reset links, or audit evidence.
+- Suggested persona pattern:
+  - `qa+oasis7-e2e-001@...` for happy path.
+  - `qa+oasis7-e2e-lowquota-001@...` for quota exhaustion.
+  - `qa+oasis7-e2e-manualreview-001@...` for underpay/overpay/manual review.
+
+## 2026-06-02 16:55:00 CST / tpm
+- 完成内容: Provided provider-agnostic setup guidance for a dedicated test email subdomain.
+- Recommended shape:
+  - Use a subdomain such as `test.<domain>` or `e2e.<domain>`.
+  - Configure inbound mail routing/catch-all for `*@test.<domain>` to a controlled QA mailbox or mailbox service.
+  - Add MX records for the subdomain and SPF/DKIM/DMARC if outbound mail or verification replies are needed.
+  - Keep test inbox access under operator/QA custody; do not use personal or disposable inboxes.
+- Minimal use case:
+  - For receiving verification/reset emails only, inbound MX + catch-all is enough.
+  - For sending as test users, configure SPF/DKIM/DMARC and a real mailbox/provider identity.
+
+## 2026-06-02 17:00:00 CST / tpm
+- 完成内容: Accepted fake-email-first approach for early full-chain rehearsal because the email login service also has a test environment.
+- Conclusion:
+  - Use deterministic fake emails for the first bridge/runtime rehearsal, as long as the login test environment can accept or bypass delivery for them.
+  - Treat fake email as an identity label only; chain keypair and public-key-derived `newapi_user_ref` remain the actual cross-system stable identity.
+  - Keep names clearly non-production, e.g. `oasis7-e2e-001@test.invalid`, to avoid accidental real-user collision.
+
+## 2026-06-02 18:00:00 CST / tpm
+- 完成内容: Implemented the full-chain fake-email test user plan in public docs and prepared a local secret template.
+- Public docs updated:
+  - `doc/p2p/token/mainchain-token-newapi-quota-bridge-2026-05-06.runbook.md`: added fake-email full-chain test persona preparation, bind payload, and provider/gameplay verification step.
+  - `doc/world-runtime/runtime/newapi-bridge-service-operator-runbook.md`: added full-chain test user mode and bind template.
+  - `doc/world-runtime/runtime/provider-remote-https-bridge-operator-runbook.md`: clarified that full-chain test user provider bearer should use public-key fingerprint `newapi_user_ref`.
+- Sensitive/local material:
+  - Attempted to write `~/Documents/keys/test_keys.txt`, but macOS permissions blocked writing/chmod on `/Users/scc/Documents/keys/test_keys.txt`; the file exists but remains empty.
+  - Wrote the same private template outside the repo at `/Users/scc/.oasis7-test-keys/test_keys.txt` with mode `600` as a safe fallback.
+  - No real private keys or LetAI token_key values were generated or written; only placeholders were created.
+- Next action:
+  - If `/Users/scc/Documents/keys/test_keys.txt` must be the final location, grant this process Documents access or manually move the fallback template there.
+
+## 2026-06-02 19:50:00 CST / tpm
+- 完成内容: After user granted macOS Documents access and restarted, copied the local full-chain test key template into `/Users/scc/Documents/keys/test_keys.txt`.
+- 遗留事项: Real chain private keys, public keys, fingerprints, bridge ids, and LetAI token values still need to be generated/filled by operator-controlled tooling; current file contains placeholders only.
+- Action: Copy fallback template from `/Users/scc/.oasis7-test-keys/test_keys.txt` to `/Users/scc/Documents/keys/test_keys.txt` and tighten permissions.
+- Validation Command: `wc -c /Users/scc/Documents/keys/test_keys.txt && ls -lOe /Users/scc/Documents/keys /Users/scc/Documents/keys/test_keys.txt`
+- Expected Result: Documents key template exists, is non-empty, and has file mode `600`.
+- Actual Result: `/Users/scc/Documents/keys/test_keys.txt` exists with size `2167` bytes and mode `-rw-------`.
+- Blocker / Next Action: none for file placement; next step is actual test key generation and bridge bind rehearsal.
+
+## 2026-06-02 20:00:00 CST / tpm
+- 完成内容: Checked whether the test environment full-chain rehearsal can start immediately.
+- 遗留事项: `/Users/scc/Documents/keys/test_keys.txt` still contains placeholder values for chain public/private key fields, `newapi_user_ref`, provider auth token, bridge ids, and LetAI ids/token fields.
+- Action: Inspect local key template for unresolved placeholder values.
+- Validation Command: `rg -n "<fill locally>|<operator-only>|pk_<fill locally>|oc:pk:<fill locally>" /Users/scc/Documents/keys/test_keys.txt`
+- Expected Result: no placeholder values remain before running a real bridge/testnet/provider rehearsal.
+- Actual Result: placeholders remain, so the workflow is documented and ready to execute after key generation/fill-in, but a real full-chain test should not be launched yet.
+- Blocker / Next Action: generate controlled test chain keypair(s), derive public-key fingerprint(s), fill `test_keys.txt`, then run bind -> deposit-route -> chain transfer -> reconcile -> provider/runtime smoke.
+
+## 2026-06-02 20:15:00 CST / tpm
+- 完成内容: Generated multiple local full-chain test identities and filled `/Users/scc/Documents/keys/test_keys.txt` for happy-path and failure-case rehearsal.
+- 遗留事项: LetAI `user_id` / `token_key`, bridge deposit route ids, and deposit tx ids are still operator-only runtime outputs and must be filled after bind/create-route/transfer/reconcile; they were not fabricated.
+- Action: Use Node.js `crypto.generateKeyPairSync('ed25519')` to generate five Ed25519 test identities, derive `oc:pk:<public_key_hex>` account ids, derive `newapi_user_ref=pk_<sha256(raw_public_key_bytes)[0..16]>`, and write the private file with mode `600`.
+- Validation Command: `node <field-shape-and-fingerprint-check> && rg -n "chain_private_key_hex=<|chain_public_key_hex=<|oasis_sender_account_id=oc:pk:<|newapi_user_ref=pk_<|provider_auth_token=newapi_user_ref:pk_<" /Users/scc/Documents/keys/test_keys.txt || true && git diff --check`
+- Expected Result: five personas exist; generated key/ref fields have no placeholder values; `newapi_user_ref`, account id, fingerprint, and provider bearer token are internally consistent; repo diff has no whitespace errors.
+- Actual Result: five personas validated: `happy_path`, `lowquota_exhaustion`, `manual_review_underpay`, `manual_review_overpay`, and `expired_route`; generated key/ref placeholder search returned no hits; `git diff --check` passed.
+- Blocker / Next Action: run the actual test-environment bind -> deposit-route -> testnet transfer -> reconcile -> provider/runtime smoke chain using one persona at a time, starting with `happy_path`.
+
+## 2026-06-02 20:30:00 CST / tpm
+- 完成内容: Routed the next phase as test-step/runbook execution writing and documented the full-chain test matrix.
+- 遗留事项: Current subagent tool policy only permits spawning when the user explicitly asks for subagents/delegation, so no bounded `qa_engineer` subagent slice was dispatched in this turn; QA formal review should be requested before claiming the steps as executed/evidence-complete.
+- Action: Add an executable `6.7 全链路测试步骤矩阵` to the OC -> LetAI quota bridge runbook, covering persona selection, bridge health, bind, deposit route, signed chain transfer, reconcile, provider smoke, failure-path expectations, and evidence writeback. Add a pointer from the NewAPI bridge operator runbook to the canonical test-step section.
+- Validation Command: `./scripts/doc-governance-check.sh && git diff --check`
+- Expected Result: public docs contain step-by-step testing guidance without private keys or raw token keys, and markdown/doc governance checks pass.
+- Actual Result: `./scripts/doc-governance-check.sh` returned `OK`; `git diff --check` passed; sensitive scan only found the expected `<local-only-private-key-hex>` placeholder and no generated private key or raw `token_key`.
+- Blocker / Next Action: hand the operator the next concrete test command sequence, then execute `happy_path` bind -> deposit route -> signed transfer -> reconcile -> provider smoke when environment credentials are available.
+
+## 2026-06-02 20:45:00 CST / tpm
+- 完成内容: Performed live readiness preflight for actually running the documented full-chain test.
+- 遗留事项: Actual full-chain execution is blocked until the test environment is reachable through a trusted SSH session/tunnel or the required bridge/provider/chain services are started locally with real test credentials.
+- Action: Check local test identity file/tooling, local bridge/provider/chain health endpoints, required environment-variable presence, and ECS test host reachability.
+- Validation Command: `test -s /Users/scc/Documents/keys/test_keys.txt && curl --max-time 3 http://127.0.0.1:5852/v1/bridge/health && curl --max-time 3 http://127.0.0.1:5841/v1/provider/info && curl --max-time 3 http://127.0.0.1:5010/v1/chain/status; ssh -o BatchMode=yes -o ConnectTimeout=5 39.104.204.172 'systemctl is-active ...'`
+- Expected Result: local services are reachable or ECS test host can be accessed securely for in-host service checks.
+- Actual Result: `/Users/scc/Documents/keys/test_keys.txt`, `jq`, and `curl` are present; local ports `5852`, `5841`, and `5010` are not listening; required local environment variables for bridge/provider startup are unset; test host SSH port `22` is reachable but SSH failed with `Host key verification failed`; public ports `5852`, `5841`, and `5010` on `39.104.204.172` refuse connections.
+- Blocker / Next Action: fix/confirm SSH known_hosts trust for `39.104.204.172` or provide a trusted tunnel/session; then run the happy-path test from the ECS host or through local port forwards.
+
+## 2026-06-03 09:20:00 CST / tpm
+- 完成内容: User requested local subagent review of the documented full-chain test plan.
+- 遗留事项: Task yaml title still reflects the original LLM token consumption explanation request, but this work is a scope continuation of the same bridge/quota identity and test-plan thread; keep one task/worktree/PR chain and record continuation here.
+- Action: Prepare bounded professional review slices before dispatch.
+- Validation Command: `cat .pm/tasks/task_455ea61e04c946469b8b1d22b700f853.yaml && git status --short`
+- Expected Result: canonical task/worktree is confirmed and review slices have clear read-only scope.
+- Actual Result: canonical worktree `/Users/scc/ccwork/worktrees/oasis7-agent-llm-token-consumption-readonly`, branch `task/agent-llm-token-consumption-readonly`, task `task_455ea61e04c946469b8b1d22b700f853`; dirty state is limited to current docs and task metadata/log.
+- Blocker / Next Action: dispatch `qa_engineer` and `runtime_engineer` read-only review slices.
+
+### Subagent Slice Contract: qa_engineer test-plan review
+- role: `qa_engineer`
+- slice type: `review_judgment`
+- intended model configuration: `gpt-5.4-medium`
+- actual dispatched model/reasoning: request `gpt-5.4` / `medium`; record final tool-reported status if available, otherwise `inherited/unverified`
+- context delivery mode: full-thread/full-history fork via subagent tool, plus explicit scoped file checklist in prompt
+- mandatory context checklist/packet:
+  - identity and authority: `qa_engineer` role card `.agents/roles/qa_engineer.md`; owner role `tpm`; TPM integrates result
+  - workflow governance: `AGENTS.md`, `doc/engineering/workflow/source-of-truth.md`, current single task/worktree rule
+  - task truth: `.pm/tasks/task_455ea61e04c946469b8b1d22b700f853.yaml`, `.pm/tasks/task_455ea61e04c946469b8b1d22b700f853.execution.md`, branch `task/agent-llm-token-consumption-readonly`
+  - user intent: review whether the documented full-chain test plan is runnable, sufficiently covers happy/failure paths, and has acceptable evidence gates before actual test execution
+  - scoped repo context: changed runbooks under `doc/p2p/token/...runbook.md`, `doc/world-runtime/runtime/newapi-bridge-service-operator-runbook.md`, `doc/world-runtime/runtime/provider-remote-https-bridge-operator-runbook.md`; local test key file path exists but do not read or print secrets
+  - collaboration boundary: read-only review only; do not edit files; return findings with severity, evidence path/line, and concrete recommended doc/test fixes
+- write scope: none
+- return contract: findings ordered by severity, open questions, residual risk, and pass/block recommendation for attempting `happy_path`
+- formal sink / writeback surface: TPM appends returned review summary to `.pm/tasks/task_455ea61e04c946469b8b1d22b700f853.execution.md`
+- integration owner/order: TPM integrates QA review after runtime review, then patches docs if needed
+
+### Subagent Slice Contract: runtime_engineer bridge/runtime review
+- role: `runtime_engineer`
+- slice type: `review_judgment`
+- intended model configuration: `gpt-5.4-medium`
+- actual dispatched model/reasoning: request `gpt-5.4` / `medium`; record final tool-reported status if available, otherwise `inherited/unverified`
+- context delivery mode: full-thread/full-history fork via subagent tool, plus explicit scoped file checklist in prompt
+- mandatory context checklist/packet:
+  - identity and authority: `runtime_engineer` role card `.agents/roles/runtime_engineer.md`; owner role `tpm`; TPM integrates result
+  - workflow governance: `AGENTS.md`, `doc/engineering/workflow/source-of-truth.md`, current single task/worktree rule
+  - task truth: `.pm/tasks/task_455ea61e04c946469b8b1d22b700f853.yaml`, `.pm/tasks/task_455ea61e04c946469b8b1d22b700f853.execution.md`, branch `task/agent-llm-token-consumption-readonly`
+  - user intent: review whether bridge/provider/chain steps match implemented request/response schemas, state transitions, route/reconcile behavior, and runtime provider contract
+  - scoped repo context: changed runbooks plus `crates/oasis7/src/bin/oasis7_newapi_bridge_service/{model.rs,service.rs}`, `crates/oasis7/src/bin/oasis7_chain_runtime/transfer_submit_api.rs`, provider bridge runbook; local test key file path exists but do not read or print secrets
+  - collaboration boundary: read-only review only; do not edit files; return findings with severity, evidence path/line, and concrete recommended doc/test fixes
+- write scope: none
+- return contract: findings ordered by severity, schema/state mismatch risks, open questions, residual risk, and pass/block recommendation for attempting `happy_path`
+- formal sink / writeback surface: TPM appends returned review summary to `.pm/tasks/task_455ea61e04c946469b8b1d22b700f853.execution.md`
+- integration owner/order: TPM integrates runtime review before QA final synthesis, then patches docs if needed
+
+## 2026-06-03 09:35:00 CST / qa_engineer subagent review
+- 完成内容: Completed read-only QA review of the documented full-chain test plan.
+- 遗留事项: Actual `happy_path` execution remains blocked until environment access, signed transfer procedure, and provider smoke request are made executable.
+- Action: Review changed runbooks and task evidence for test coverage, gates, failure-path expectations, evidence sinks, and secret handling.
+- Validation Command: read-only review slice, no commands that mutate repository state.
+- Expected Result: QA findings with severity, open questions, pass/block recommendation, and concrete doc/test fixes.
+- Actual Result:
+  - [P0] Environment gate blocks `happy_path`: local ports `5852/5841/5010` are not listening; required env vars are unset; ECS SSH is blocked by host-key verification; public service ports refuse connections.
+  - [P0] Chain transfer step is not executable enough: Step D names no canonical signed-transfer command, nonce source, amount source, balance/faucet prerequisite, or exact `to_account_id`; bind/route can run, but full-chain happy path cannot complete without this.
+  - [P1] Provider smoke payload is likely not a valid `DecisionRequest`; use an existing smoke tool or a known-valid minimal provider request.
+  - [P1] Failure matrix covers underpay/overpay/expired/lowquota but should explicitly mark duplicate route, binding/project binding missing, LetAI mismatch, timeout/decode failures as phase-2 or out-of-scope cases.
+  - [P2] Evidence sink should require `.pm` plus a canonical `doc/testing/evidence/...` artifact rather than `.pm` or evidence file.
+  - [P2] Exporting private key as an environment variable is avoidable leakage; prefer signing tools reading from the local secret file without printing/exporting the key.
+- Blocker / Next Action: Integrate runtime review, then patch runbook preflight, Step D, Step F, evidence sink, and secret-handling guidance before re-evaluating readiness.
+
+## 2026-06-03 09:45:00 CST / runtime_engineer subagent review
+- 完成内容: Completed read-only runtime/bridge review of the documented full-chain test plan.
+- 遗留事项: Actual `happy_path` execution remains blocked until provider smoke payload and signed transfer procedure are corrected; runtime also identified a sender-binding enforcement gap that should be documented as a known risk or covered by a follow-up task.
+- Action: Review changed runbooks against bridge request schemas, provider contract, chain transfer submit auth, and reconcile state behavior.
+- Validation Command: read-only review slice, no commands that mutate repository state.
+- Expected Result: Runtime findings with severity, schema/state mismatch risks, open questions, pass/block recommendation, and concrete doc/test fixes.
+- Actual Result:
+  - [P0] Provider smoke payload in Step F is not a valid `DecisionRequest`; implementation decodes `DecisionRequest` directly and expects an observation envelope plus timeout fields.
+  - [P0] Full happy path lacks an executable signed transfer command; chain submit requires `public_key + signature`, and signature format uses the `octransferauth:v1:` prefix.
+  - [P1] Bridge reconcile records `from_account_id` but does not strongly enforce `from_account_id == oasis_sender_account_id`; test docs may require same sender for evidence, but must not present it as an implemented security invariant.
+  - [P1] Provider info expectation before bind/reconcile is imprecise; with automatic mapping, `GET /v1/provider/info` using `newapi_user_ref:<ref>` should be expected to return `401` until state has an active binding/project token.
+  - [P2] Reconcile validation should locate the specific route/ledger row by `route_id`, `bridge_deposit_id`, and chain action id instead of relying only on aggregate counters.
+- Schema/State Notes:
+  - Bind and deposit-route request fields in the docs match the model.
+  - `PRICING_VERSION=pv-1` is only valid when the service was started with matching `--pricing-rule`.
+  - Reconcile depends on `--chain-base-url`; LetAI credit depends on `--letai-base-url` and `--letai-platform-key`.
+- Blocker / Next Action: Patch runbook Step A/F, signed-transfer guidance, route/ledger evidence validation, and known sender-enforcement risk before re-evaluating readiness.
+
+## 2026-06-03 10:00:00 CST / tpm
+- 完成内容: Integrated `qa_engineer` and `runtime_engineer` subagent review findings into the public test runbooks.
+- 遗留事项: Full `happy_path` execution is still blocked until the target lane has trusted service access and a concrete signed-transfer/operator入账 command; the docs now state this explicitly.
+- Action: Patch the OC -> LetAI quota bridge runbook to add execution gates, remove private-key env export, correct provider pre-bind expectations, tighten signed-transfer guidance, replace provider smoke with a contract-valid `DecisionRequest` JSON, add route/ledger-specific reconcile evidence, require `.pm` plus sanitized testing evidence, and document the sender-binding enforcement gap. Patch the NewAPI bridge runbook field label and happy-path blocker note.
+- Validation Command: `./scripts/doc-governance-check.sh && git diff --check && node <extract-and-parse-provider-smoke-json> && rg <secret-leak-patterns> ...`
+- Expected Result: Docs pass governance/whitespace checks, provider smoke sample is valid JSON, and public docs contain no generated private key or raw `token_key`.
+- Actual Result: `doc-governance-check: OK`; `git diff --check` passed; provider smoke JSON parse returned `provider-smoke-json: OK`; secret leak scan returned no hits.
+- Blocker / Next Action: choose or implement the canonical signed transfer path, then re-run readiness preflight before attempting `happy_path`.

--- a/.pm/tasks/task_455ea61e04c946469b8b1d22b700f853.yaml
+++ b/.pm/tasks/task_455ea61e04c946469b8b1d22b700f853.yaml
@@ -1,0 +1,25 @@
+task_uid: task_455ea61e04c946469b8b1d22b700f853
+title: "explain LLM token consumption"
+owner_role: tpm
+worktree_hint: /Users/scc/ccwork/worktrees/oasis7-agent-llm-token-consumption-readonly
+execution_log_path: .pm/tasks/task_455ea61e04c946469b8b1d22b700f853.execution.md
+status: done
+priority: P2
+source_signal: null
+source_refs:
+  - AGENTS.md
+  - doc/engineering/workflow/source-of-truth.md
+doc_refs: []
+related_prd: []
+acceptance:
+  - "Explain current in-game LLM token consumption paths with repo evidence"
+handoff_to:
+  - agent_engineer
+updated_at: 2026-06-03T15:36:39+08:00
+last_started_at: 2026-06-02T15:44:37+08:00
+last_claim_type: task_complete
+last_verify_command: "./scripts/doc-governance-check.sh && git diff --check"
+last_verified_at: 2026-06-03T15:36:37+08:00
+last_verification_exit_code: 0
+last_verification_status: verified
+last_closed_at: 2026-06-03T15:36:39+08:00

--- a/doc/p2p/token/mainchain-token-newapi-quota-bridge-2026-05-06.runbook.md
+++ b/doc/p2p/token/mainchain-token-newapi-quota-bridge-2026-05-06.runbook.md
@@ -92,7 +92,31 @@ env -u RUSTC_WRAPPER cargo run -p oasis7 --bin oasis7_newapi_bridge_service -- \
 
 ## 6. 首次演练流程
 
-### 6.1 建立用户绑定
+### 6.1 准备全链路测试用户
+- 早期演练可以先使用假邮箱，因为邮箱登录服务也有测试环境；假邮箱只作为测试 persona 标签，不要求真实投递。
+- 推荐使用保留域名，避免误发给真实用户：
+  - `oasis7-e2e-001@test.invalid`
+  - `oasis7-e2e-lowquota-001@test.invalid`
+  - `oasis7-e2e-manualreview-001@test.invalid`
+- 每个测试邮箱必须对应一套受控生成的链上 keypair：
+  - 私钥只放在 operator/QA 本地 secret 文件或等价 secret store，不进 repo、CI log、bridge state、provider request。
+  - 公钥或公钥 fingerprint 用作 `newapi_user_ref`，例如 `pk_<fingerprint>`。
+  - `oasis_sender_account_id` 使用同一公钥/account id，作为链侧转账来源。
+- 不要从邮箱确定性派生私钥；邮箱只是 human/audit root，链上私钥必须由安全随机源生成。
+- 本地测试密钥材料模板记录在 `~/Documents/keys/test_keys.txt`；公开文档只记录字段形状和假邮箱，不记录真实私钥。
+
+建议字段形状：
+
+```text
+email=oasis7-e2e-001@test.invalid
+external_user_name=Oasis7 E2E User 001
+project_name=oasis7-e2e-001
+newapi_user_ref=pk_<public-key-fingerprint>
+oasis_sender_account_id=oc:pk:<public-key-or-account-id>
+agent_provider_auth_token=newapi_user_ref:pk_<public-key-fingerprint>
+```
+
+### 6.2 建立用户绑定
 - 调用 `POST /v1/bridge/bind`
 - 输入：
   - `newapi_user_ref`
@@ -102,7 +126,26 @@ env -u RUSTC_WRAPPER cargo run -p oasis7 --bin oasis7_newapi_bridge_service -- \
   - 返回 `bridge_user_id`
   - 不返回 `platform_user_id/platform_project_id/token_key`
 
-### 6.2 分配充值路由
+示例：
+
+```bash
+curl -sS -X POST http://127.0.0.1:5852/v1/bridge/bind \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "newapi_user_ref": "pk_<public-key-fingerprint>",
+    "oasis_sender_account_id": "oc:pk:<public-key-or-account-id>",
+    "external_user_name": "Oasis7 E2E User 001",
+    "email": "oasis7-e2e-001@test.invalid",
+    "project_name": "oasis7-e2e-001",
+    "project_metadata": {
+      "purpose": "bridge-full-chain-e2e",
+      "email_login_env": "test",
+      "identity_root": "fake-email-plus-chain-public-key"
+    }
+  }'
+```
+
+### 6.3 分配充值路由
 - 调用 `POST /v1/bridge/deposit-route`
 - 输入：
   - `bridge_user_id`
@@ -111,13 +154,13 @@ env -u RUSTC_WRAPPER cargo run -p oasis7 --bin oasis7_newapi_bridge_service -- \
   - 返回唯一 `deposit_account_id`
   - `route_status=issued`
 
-### 6.3 链上入账
+### 6.4 链上入账
 - 让绑定用户向 `deposit_account_id` 转入与 `pricing_version` 对应的 `OC`
 - 期望：
   - chain watcher 观察到 route 对应入账
   - 不匹配金额、重复 route、过期 route 默认进入 `manual_review`
 
-### 6.4 reconcile
+### 6.5 reconcile
 - 手工触发：
   - `POST /v1/bridge/reconcile`
 - 或等待后台 interval
@@ -129,6 +172,235 @@ env -u RUSTC_WRAPPER cargo run -p oasis7 --bin oasis7_newapi_bridge_service -- \
   - `token_key`
   - `external_order_id`
   - `user_snapshot/project_snapshot/topup_log_snapshot`
+
+### 6.6 provider / gameplay 消费验证
+- 使用同一个 `newapi_user_ref` 作为 provider bearer selector：
+  - `newapi_user_ref:pk_<public-key-fingerprint>`
+- remote provider bridge 必须从受控 `bridge-state.json` 自动解析到对应 project `token_key`。
+- 游戏 runtime / launcher 只接收 bearer selector，不接收 raw `token_key`。
+- 完成一次 `play/step`、`agent_chat` 或 provider decision smoke 后，验证 trace 中出现同一用户路径下的 token usage / provider decision 证据。
+
+### 6.7 全链路测试步骤矩阵
+
+测试前从 `~/Documents/keys/test_keys.txt` 选择一组 persona，把对应字段临时导出到 operator shell。不要把该文件内容贴进 issue、PR、聊天、CI log 或 public terminal recording。
+
+```bash
+export BRIDGE_BASE_URL=http://127.0.0.1:5852
+export PROVIDER_BASE_URL=http://127.0.0.1:5841
+export CHAIN_BASE_URL=http://127.0.0.1:5010
+export PRICING_VERSION=pv-1
+
+export TEST_EMAIL=oasis7-e2e-001@test.invalid
+export TEST_EXTERNAL_USER_NAME="Oasis7 E2E User 001"
+export TEST_PROJECT_NAME=oasis7-e2e-001
+export TEST_NEWAPI_USER_REF=pk_<public-key-fingerprint>
+export TEST_OASIS_SENDER_ACCOUNT_ID=oc:pk:<public-key-hex>
+export TEST_CHAIN_PUBLIC_KEY_HEX=<public-key-hex>
+export TEST_PROVIDER_AUTH_TOKEN=newapi_user_ref:${TEST_NEWAPI_USER_REF}
+```
+
+不要把 `chain_private_key_hex` 导出到 shell 环境变量。签名工具必须从本地 secret 文件或等价 secret store 读取私钥，并且不得把私钥打印到 terminal、CI log 或证据文件。
+
+| Persona | 目标 | 入账金额 | 期望 |
+| --- | --- | --- | --- |
+| `happy_path` | 正常发额度并完成一次 provider smoke | 等于 `PRICING_VERSION` 对应 OC | `reconciled_credit_count=1`，provider decision 成功 |
+| `lowquota_exhaustion` | 小额度消耗到不足 | 等于最小测试档，随后连续 provider smoke | 最后一次调用出现额度不足或上游 quota 失败，且不串到其他用户 |
+| `manual_review_underpay` | 少付 | 小于 `PRICING_VERSION` 对应 OC | `manual_review_count` 增加，不能自动 credited |
+| `manual_review_overpay` | 多付 | 大于 `PRICING_VERSION` 对应 OC | `manual_review_count` 增加，不能静默错充 |
+| `expired_route` | route 过期后入账 | 等于或接近 `PRICING_VERSION` 对应 OC，但在 TTL 后转入 | 进入 expired/manual review 路径，不发正常额度 |
+
+本轮 `happy_path` 必须先满足以下 execution gates；任一不满足时，只允许做环境预检、`bind` 和 `deposit-route` rehearsal，不得声称全链路通过：
+
+- 可通过受信 SSH / tunnel / 本机启动访问 `BRIDGE_BASE_URL`、`PROVIDER_BASE_URL`、`CHAIN_BASE_URL`。
+- bridge-service 已配置 `--chain-base-url`、`--letai-base-url`、`--letai-platform-key`，且测试 lane 的 `--pricing-rule` 包含当前 `PRICING_VERSION`。
+- remote provider bridge 已启用 `OASIS7_PROVIDER_AUTH_ROUTE_FROM_BEARER=true`，且可读取同一份 NewAPI bridge state。
+- 已确认一个可执行的签名转账路径，能从本地 secret 文件读取 32-byte Ed25519 私钥并产出 `octransferauth:v1:<signature-hex>`。
+- 测试 sender 账户有足够 OC，或测试网 faucet/operator 已准备好等价入账路径。
+- 证据采集能按本次 `route_id` / `bridge_deposit_id` / chain action id 定位 ledger row；不得只看全局计数。
+
+扩展负向覆盖：
+
+- `duplicate_route_deposit`、`binding_not_found`、`project_binding_not_found`、LetAI topup/query mismatch、LetAI timeout/decode failure 属于 phase-2 negative coverage；不是 `happy_path` 首轮阻断，但正式放行前应单独补证据。
+- 当前 bridge reconcile 记录 `from_account_id`，但不得把 `from_account_id == oasis_sender_account_id` 当作已强制执行的安全不变量；若需要强约束，另开 runtime/security 修复任务。测试证据仍应记录实际 `from_account_id`，并增加“不同 sender 向同一 deposit account 入账”的负向检查。
+
+#### Step A: 环境健康检查
+
+```bash
+curl -sS "${BRIDGE_BASE_URL}/v1/bridge/health"
+curl -sS "${PROVIDER_BASE_URL}/v1/provider/info" \
+  -H "Authorization: Bearer ${TEST_PROVIDER_AUTH_TOKEN}"
+```
+
+期望：
+- bridge health 返回 `ok=true`。
+- 在 bind/reconcile 之前，provider 自动映射还没有 active binding / project `token_key`，用 `newapi_user_ref:<ref>` 访问 `GET /v1/provider/info` 预期可以是 `401 Unauthorized`。
+- bind 且成功写入 project `token_key` 后，provider info / decision 才应返回成功；任何阶段都不能要求 client 传 raw `token_key`。
+
+#### Step B: 建立 bind
+
+```bash
+BIND_RESPONSE="$(
+  curl -sS -X POST "${BRIDGE_BASE_URL}/v1/bridge/bind" \
+    -H 'Content-Type: application/json' \
+    -d "{
+      \"newapi_user_ref\": \"${TEST_NEWAPI_USER_REF}\",
+      \"oasis_sender_account_id\": \"${TEST_OASIS_SENDER_ACCOUNT_ID}\",
+      \"external_user_name\": \"${TEST_EXTERNAL_USER_NAME}\",
+      \"email\": \"${TEST_EMAIL}\",
+      \"project_name\": \"${TEST_PROJECT_NAME}\",
+      \"metadata\": {
+        \"purpose\": \"bridge-full-chain-e2e\",
+        \"persona\": \"${TEST_PROJECT_NAME}\",
+        \"email_login_env\": \"test\",
+        \"identity_root\": \"fake-email-plus-chain-public-key\"
+      },
+      \"project_metadata\": {
+        \"purpose\": \"bridge-full-chain-e2e\",
+        \"newapi_user_ref\": \"${TEST_NEWAPI_USER_REF}\"
+      }
+    }"
+)"
+printf '%s\n' "${BIND_RESPONSE}"
+export TEST_BRIDGE_USER_ID="$(printf '%s' "${BIND_RESPONSE}" | jq -r '.bridge_user_id')"
+```
+
+期望：
+- `ok=true`。
+- `bridge_user_id` 非空。
+- response 不包含 raw `token_key`。
+- `bridge-state.json` 中可以由 operator 查到该 `newapi_user_ref` 对应 active binding 与 project binding。
+
+#### Step C: 创建 deposit route
+
+```bash
+ROUTE_RESPONSE="$(
+  curl -sS -X POST "${BRIDGE_BASE_URL}/v1/bridge/deposit-route" \
+    -H 'Content-Type: application/json' \
+    -d "{
+      \"bridge_user_id\": \"${TEST_BRIDGE_USER_ID}\",
+      \"pricing_version\": \"${PRICING_VERSION}\",
+      \"topup_plan_id\": null
+    }"
+)"
+printf '%s\n' "${ROUTE_RESPONSE}"
+export TEST_DEPOSIT_ROUTE_ID="$(printf '%s' "${ROUTE_RESPONSE}" | jq -r '.route_id')"
+export TEST_DEPOSIT_ACCOUNT_ID="$(printf '%s' "${ROUTE_RESPONSE}" | jq -r '.deposit_account_id')"
+export TEST_ROUTE_EXPIRES_AT_UNIX_MS="$(printf '%s' "${ROUTE_RESPONSE}" | jq -r '.expires_at_unix_ms')"
+```
+
+期望：
+- `ok=true`。
+- `route_status=issued`。
+- `deposit_account_id` 非空且只用于本 route。
+
+#### Step D: 链上签名转账
+
+公开 transfer submit API 的请求体必须包含签名字段，不要用未签名 `curl` 伪造链上入账。完整 `happy_path` 在没有明确 signer/operator 工具前保持 blocked。测试时二选一：
+
+- 用当前测试网/launcher/operator 已验证的签名转账工具，从本地 secret 文件读取 persona 私钥，生成 `octransferauth:v1:<signature-hex>` 后提交到 `POST /v1/chain/transfer/submit`。
+- 若本 lane 由 faucet/operator 工具托管测试入账，则用等价工具把同一 `TEST_OASIS_SENDER_ACCOUNT_ID -> TEST_DEPOSIT_ACCOUNT_ID` 的金额提交到链上，并保留 tx/action id。
+
+transfer submit 字段形状：
+
+```json
+{
+  "from_account_id": "oc:pk:<public-key-hex>",
+  "to_account_id": "<TEST_DEPOSIT_ACCOUNT_ID>",
+  "amount": 100,
+  "nonce": 1,
+  "public_key": "<public-key-hex>",
+  "signature": "octransferauth:v1:<signature-hex>"
+}
+```
+
+期望：
+- submit response 返回 `ok=true` 和 `action_id`。
+- `GET /v1/chain/transfer/status?action_id=<action_id>` 或链侧 explorer 证据最终显示 confirmed。
+- 对少付/多付/过期 route，用对应 persona 的金额或等待策略制造失败条件，并保留同样的 tx/action id。
+
+#### Step E: reconcile
+
+```bash
+RECONCILE_RESPONSE="$(
+  curl -sS -X POST "${BRIDGE_BASE_URL}/v1/bridge/reconcile"
+)"
+printf '%s\n' "${RECONCILE_RESPONSE}"
+```
+
+happy path 期望：
+- 至少一次 reconcile 后，本次 `route_id` / `bridge_deposit_id` 对应 ledger row 推进到 `reconciled`。
+- `reconciled_credit_count` 可作为本次处理摘要，但不能单独作为通过标准；若 state 内已有旧记录，全局计数可能误导。
+- state 内同一 binding/project binding 有 `platform_user_id`、`platform_project_id`、`token_key`、`external_order_id` 和 LetAI topup/query 快照。
+
+失败 path 期望：
+- underpay / overpay / expired route 不得 credited。
+- 本次 `route_id` / `bridge_deposit_id` 对应 ledger row 进入 `manual_review` 并记录 review reason；`manual_review_count` 只作辅助摘要。
+- 后续 operator review 只能显式 `mark_resolved` 或 `close`，不能口头判成功。
+
+#### Step F: provider smoke 与消耗证据
+
+```bash
+curl -sS -X POST "${PROVIDER_BASE_URL}/v1/world-simulator/decision" \
+  -H "Authorization: Bearer ${TEST_PROVIDER_AUTH_TOKEN}" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "observation": {
+      "agent_id": "agent-1",
+      "world_time": 1,
+      "mode": "headless_agent",
+      "observation_schema_version": "oc_dual_obs_v1",
+      "action_schema_version": "oc_dual_act_v1",
+      "environment_class": "bridge-full-chain-e2e",
+      "observation": {
+        "self_state": {
+          "location_ref": "loc-1",
+          "pose_hint": "grid_pose=(0, 0, 0)",
+          "status_flags": [],
+          "resource_summary": {}
+        },
+        "mission_context": {
+          "goal_summary": "return a minimal wait decision for bridge quota smoke"
+        },
+        "nearby_entities": [],
+        "recent_events": [],
+        "local_navigation_graph": [],
+        "hazard_summary": [],
+        "interaction_targets": []
+      },
+      "recent_event_summary": [],
+      "memory_summary": "bridge quota smoke",
+      "action_catalog": [
+        {
+          "action_ref": "wait",
+          "summary": "do nothing this tick"
+        }
+      ],
+      "timeout_budget_ms": 7000
+    },
+    "provider_config_ref": "provider://local-bridge",
+    "agent_profile": "oasis7_p0_low_freq_npc",
+    "fixture_id": "bridge-full-chain-e2e",
+    "timeout_budget_ms": 7000
+  }'
+```
+
+期望：
+- happy path 返回 `provider_error=null` 或等价成功字段。
+- provider trace / bridge log 能证明该调用通过 `newapi_user_ref:<ref>` 映射到对应 project `token_key`。
+- LetAI / NewAPI 侧能看到该 project 的 token usage 或余额消耗。
+- lowquota persona 连续调用直到额度耗尽时，失败必须归属于同一 `newapi_user_ref`，不得 fallback 到全局 token。
+
+#### Step G: 证据回写
+
+每个 persona 跑完后，必须记录到 `.pm/tasks/<TASK-UID>.execution.md`，并为正式 QA closeout 增补一个 sanitized evidence 文件，例如 `doc/testing/evidence/oc-letai-bridge-full-chain-e2e-<date>.md`：
+
+- persona slug，不含私钥。
+- `newapi_user_ref`、`bridge_user_id`、`route_id`、`deposit_account_id`。
+- chain `action_id` / tx id / explorer link，以及实际 `from_account_id`。
+- reconcile response 摘要和本次 route/ledger row 状态。
+- provider smoke response 摘要。
+- LetAI/NewAPI usage 摘要。
+- 对失败 path，记录 `manual_review` reason 和 operator review resolution。
 
 ## 7. 日常巡检
 - health 接口关注：

--- a/doc/world-runtime/runtime/newapi-bridge-service-operator-runbook.md
+++ b/doc/world-runtime/runtime/newapi-bridge-service-operator-runbook.md
@@ -72,6 +72,48 @@ curl -sS -X POST http://127.0.0.1:5852/v1/bridge/bind \
 - `project_bindings[].platform_project_id`
 - `project_bindings[].token_key`
 
+## 全链路测试用户模式
+
+早期测试环境可以先使用假邮箱作为 hosted login / QA persona 标签。假邮箱不要求真实收信，但必须清楚标记为非生产，并避免与真实用户冲突。
+
+推荐映射：
+
+```text
+email=oasis7-e2e-001@test.invalid
+external_user_name=Oasis7 E2E User 001
+project_name=oasis7-e2e-001
+oasis_sender_account_id=oc:pk:<public-key-or-account-id>
+newapi_user_ref=pk_<public-key-fingerprint>
+provider_auth_token=newapi_user_ref:pk_<public-key-fingerprint>
+```
+
+约束：
+
+- 私钥由测试环境安全随机生成，不能从邮箱派生。
+- 私钥只写入 `~/Documents/keys/test_keys.txt` 或受控 secret store，不写入 repo、bridge state、provider auth token、CI log。
+- `newapi_user_ref` 使用公钥或公钥 fingerprint，避免把邮箱作为 provider bearer 主选择器。
+- `email` 可传给 `POST /v1/bridge/bind`，用于 LetAI platform user metadata / QA 审计。
+- bind response 不能暴露 `platform_user_id`、`platform_project_id` 或 raw `token_key`；这些只允许存在于受控 bridge state。
+
+示例 bind:
+
+```bash
+curl -sS -X POST http://127.0.0.1:5852/v1/bridge/bind \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "newapi_user_ref": "pk_<public-key-fingerprint>",
+    "oasis_sender_account_id": "oc:pk:<public-key-or-account-id>",
+    "external_user_name": "Oasis7 E2E User 001",
+    "email": "oasis7-e2e-001@test.invalid",
+    "project_name": "oasis7-e2e-001",
+    "project_metadata": {
+      "purpose": "bridge-full-chain-e2e",
+      "email_login_env": "test",
+      "identity_root": "fake-email-plus-chain-public-key"
+    }
+  }'
+```
+
 ## 与 Remote Provider Bridge 串接
 
 remote provider bridge 可直接读取同一份 state:
@@ -88,3 +130,17 @@ OASIS7_REMOTE_LLM_NEWAPI_BRIDGE_STATE_PATH=/etc/oasis7/newapi-bridge/bridge-stat
 ```
 
 provider bridge 会自动解析到对应的 `token_key`。
+
+## 测试步骤入口
+
+完整的测试环境全链路步骤以 `doc/p2p/token/mainchain-token-newapi-quota-bridge-2026-05-06.runbook.md#67-全链路测试步骤矩阵` 为准，覆盖：
+
+- 从 `~/Documents/keys/test_keys.txt` 选择 fake-email + chain keypair persona。
+- `POST /v1/bridge/bind` 建立 `newapi_user_ref -> bridge_user_id -> LetAI project/token_key` 绑定。
+- `POST /v1/bridge/deposit-route` 创建充值路由。
+- 通过已签名的 chain transfer submit / faucet / operator 工具完成 testnet 入账。
+- `POST /v1/bridge/reconcile` 推进 happy path 或 manual-review path。
+- 用 `newapi_user_ref:<ref>` bearer 调 provider smoke，确认额度消耗归属到同一个测试用户。
+
+注意：测试步骤中可以记录 `newapi_user_ref`、`bridge_user_id`、`route_id` 和 tx/action id；不得记录 raw `token_key` 或链上私钥。
+完整 happy path 需要先确认测试 lane 有可执行的签名转账工具或 operator/faucet 等价入账路径；否则只能完成环境、bind 与 deposit-route rehearsal。

--- a/doc/world-runtime/runtime/provider-remote-https-bridge-operator-runbook.md
+++ b/doc/world-runtime/runtime/provider-remote-https-bridge-operator-runbook.md
@@ -121,6 +121,7 @@ OASIS7_REMOTE_LLM_NEWAPI_BRIDGE_STATE_PATH=/path/to/newapi-bridge/bridge-state.j
 - `oasis7_newapi_bridge_service` 的 state 文件能被 remote provider bridge 读取
 - state 内对应 binding 为 `active`
 - 对应 `project_bindings` 已写入真实 `token_key`
+- 对于全链路测试用户，`newapi_user_ref` 推荐使用链上公钥 fingerprint，例如 `pk_<public-key-fingerprint>`；client bearer 使用 `newapi_user_ref:pk_<public-key-fingerprint>`。测试邮箱只作为 QA / hosted-login persona 标签，不作为 provider bearer 主选择器。
 
 推荐不要手改 JSON，直接用脚本给用户签发 bridge token:
 


### PR DESCRIPTION
## Summary
- Document fake-email + chain-key full-chain test identities for the OC -> LetAI quota bridge.
- Add an executable full-chain test matrix covering bind, deposit-route, signed chain transfer, reconcile, provider smoke, failure paths, and sanitized evidence writeback.
- Integrate qa_engineer/runtime_engineer review findings: provider smoke now uses a valid DecisionRequest shape, signed transfer remains an explicit execution gate, and the current sender-binding enforcement gap is documented.

## Verification
- `./scripts/doc-governance-check.sh && git diff --check`
- Provider smoke JSON sample parsed successfully with Node.
- Public docs secret scan returned no generated private key or raw `token_key` hits.

## Notes
- `./scripts/pm/lint.sh` is not clean for this task because early execution-log entries use the older format and lack mandatory per-entry fields; task closeout was run with `--no-lint` after fresh doc verification.
- Full happy-path execution remains blocked until the target lane has trusted service access and a concrete signed-transfer/operator deposit path.
