### PR TITLE
Allow testnet IPv4 subnet peer limit override

### DIFF
--- a/.pm/tasks/task_202b9f812d49432a9f4360b8a66c5364.execution.md
+++ b/.pm/tasks/task_202b9f812d49432a9f4360b8a66c5364.execution.md
@@ -1,0 +1,345 @@
+# task_202b9f812d49432a9f4360b8a66c5364 Execution Log
+
+- task_uid: task_202b9f812d49432a9f4360b8a66c5364
+- title: expand testnet to fourth local node
+- owner_role: tpm
+- worktree_hint: /Users/scc/ccwork/worktrees/oasis7-engineering-expand-testnet-fourth-node
+
+<!-- Append entries using:
+Example:
+  ## YYYY-MM-DD HH:MM:SS CST / role_name
+  - 完成内容: ...
+  - 遗留事项: ...
+  - Action: ...
+  - Validation Command: ...
+  - Expected Result: ...
+  - Actual Result: ...
+  - Blocker / Next Action: ...
+-->
+
+## 2026-06-03 15:19:00 CST / tpm
+- Workflow Bootstrap Decided:
+  - Repository State Impact: runtime deployment task; no source-code edits intended, but runtime artifacts and task evidence are written under the canonical task worktree.
+  - Isolation Decision: created dedicated worktree `/Users/scc/ccwork/worktrees/oasis7-engineering-expand-testnet-fourth-node` on branch `task/engineering-expand-testnet-fourth-node`.
+  - Task Truth: `.pm/tasks/task_202b9f812d49432a9f4360b8a66c5364.yaml`, owner role `tpm`.
+  - Formal Sources: `AGENTS.md`, `/Users/scc/Documents/keys/aliyun_ecs.txt`, prior health evidence from `/Users/scc/ccwork/worktrees/oasis7-engineering-check-testnet-triad-health/.tmp/testnet-triad-health/`.
+  - Routed Next Phase: executing deployment plus verification-before-completion style live status check.
+  - Scope Boundary: TPM will perform mechanical deployment and evidence collection. Tool policy does not permit spawning subagents unless the user explicitly requests delegation, so no runtime/QA subagent slice is dispatched in this turn.
+- Existing Local Runtime Context:
+  - Existing local cloud-sync testnet process is PID `84658` on `127.0.0.1:19081`; it remains running and will not be modified.
+  - Existing local mainnet rehearsal process is PID `48080` on `127.0.0.1:19082`; it remains running and will not be modified.
+- Existing Public Testnet Peer Evidence:
+  - `triad-testnet-sequencer`: `/ip4/39.104.204.172/tcp/6831/p2p/12D3KooWEW92HgYzyCBw1xHWB9MqTWeDx2XAL48XKPJfM6UZM7K3`
+  - `triad-testnet-storage`: `/ip4/39.104.205.67/tcp/6832/p2p/12D3KooWL6Lyw6KtnsD6WxqZUy3suZfiqNXXAcjzKTBSQvTCupJs`
+  - `triad-testnet-local`: peer id `12D3KooWNphsGixZxpqmZf9RSVhCWHH7hWFYZBN8izmWfXQYAXTQ`; public-testnet status is SSH-local `127.0.0.1:6633` on `192.168.1.4`.
+- Planned Fourth Node:
+  - `node_id=triad-testnet-fourth-local`
+  - `role=observer`
+  - `world_id=oasis7-public-testnet-parallel-20260518`
+  - status bind `127.0.0.1:19083`
+  - replication listen `/ip4/127.0.0.1/tcp/0`
+  - direct bootstrap peers to the two public ECS testnet nodes via `/ip4/.../tcp/.../p2p/...`.
+
+## 2026-06-03 15:46:00 CST / tpm
+- Action:
+  - Created local fourth-node runtime artifacts under `.tmp/testnet-fourth-node/`.
+  - Created `/Users/scc/Library/LaunchAgents/com.oasis7.testnet-fourth-local.plist` to keep the fourth node running independently of the Codex shell.
+  - Bootstrapped and kickstarted the LaunchAgent in `gui/501`.
+- Runtime Artifacts:
+  - `.tmp/testnet-fourth-node/runtime-bundle.json`
+  - `.tmp/testnet-fourth-node/genesis.json`
+  - `.tmp/testnet-fourth-node/bootstrap.txt`
+  - `.tmp/testnet-fourth-node/manifest.json`
+  - `.tmp/testnet-fourth-node/config.toml`
+  - `.tmp/testnet-fourth-node/status-launchd-final.json`
+- Manifest / Runtime Validation:
+  - Command: `./scripts/network-tier-manifest.sh validate --manifest .tmp/testnet-fourth-node/manifest.json`
+  - Result: `validate_result=pass`
+  - Manifest tier/status: `public_testnet` / `rehearsal`
+  - Chain id: `oasis7-public-testnet-parallel-20260518`
+  - Bootstrap peer count: `2`
+  - Runtime binary SHA256 in manifest: `f935267b2936264c82e9bbb40edd76b8e1c73ce3077d55d8d68ed9d0760770d5`
+- LaunchAgent Evidence:
+  - Label: `com.oasis7.testnet-fourth-local`
+  - State: `running`
+  - PID: `83631`
+  - Process parent: `1`
+  - Status listener: `127.0.0.1:19083`
+  - Log output includes `oasis7_chain_runtime ready` and status URL `http://127.0.0.1:19083/v1/chain/status`.
+- Local Fourth Node Status:
+  - `curl http://127.0.0.1:19083/healthz` returned `{"ok":true}`.
+  - `node_id=triad-testnet-fourth-local`
+  - `world_id=oasis7-public-testnet-parallel-20260518`
+  - `role=observer`
+  - `liveness.status=ok`
+  - `readiness.status=not_ready`
+  - `readiness.failed_gates=consensus_peer_head_unavailable,replication_recent_errors,p2p_reachability_degraded`
+  - `observability.status=warn`
+  - `replication.local_peer_id=12D3KooWAkDbJby8wGRhnESJYFR7q6DWfNXQ7Ea2ZrZvehezj47s`
+  - `replication.connected_peers=[]`
+  - `observability.connected_peer_count=0`
+  - `observability.active_peer_count=0`
+  - `consensus.committed_height=0`
+  - `consensus.network_committed_height=0`
+  - `observability.replication_persisted_height=0`
+  - `last_error=null`
+  - Recent errors show direct transport activity to both ECS peers, followed by peer-manager suspect/candidate state:
+    - `libp2p transport active peer=12D3KooWEW92HgYzyCBw1xHWB9MqTWeDx2XAL48XKPJfM6UZM7K3 ... /ip4/39.104.204.172/tcp/6831/...`
+    - `libp2p transport active peer=12D3KooWL6Lyw6KtnsD6WxqZUy3suZfiqNXXAcjzKTBSQvTCupJs ... /ip4/39.104.205.67/tcp/6832/...`
+    - `MissingPeerRecord, InsufficientActiveDiscoverySources`
+- Remote Peer Visibility Evidence:
+  - `http://39.104.204.172:6631/v1/chain/status` reports peer health for fourth node peer id `12D3KooWAkDbJby8wGRhnESJYFR7q6DWfNXQ7Ea2ZrZvehezj47s` as `candidate` with discovery sources `dht,static_bootstrap`.
+  - `http://39.104.205.67:6632/v1/chain/status` reports peer health for fourth node peer id `12D3KooWAkDbJby8wGRhnESJYFR7q6DWfNXQ7Ea2ZrZvehezj47s` as `candidate` with discovery sources `dht,static_bootstrap`.
+  - Both remote nodes still report `connected_peer_count=2` and `active_peer_count=2`; the fourth node is visible as candidate, not active.
+- Current Network-State Boundary:
+  - Fourth local testnet node is running and health-checkable as a local observer node.
+  - Existing public testnet nodes can see the fourth node peer id as a candidate.
+  - The four-node expansion is not yet fully healthy/active: fourth node has not synced height and is not counted as an active connected peer by the remote nodes.
+  - Existing sequencer remains critical from prior evidence; this deployment did not fix the sequencer gap-sync/hash-mismatch issue.
+- Useful Control Commands:
+  - Inspect service: `launchctl print gui/$(id -u)/com.oasis7.testnet-fourth-local`
+  - Stop service: `launchctl bootout gui/$(id -u) /Users/scc/Library/LaunchAgents/com.oasis7.testnet-fourth-local.plist`
+  - Start service: `launchctl bootstrap gui/$(id -u) /Users/scc/Library/LaunchAgents/com.oasis7.testnet-fourth-local.plist && launchctl kickstart -k gui/$(id -u)/com.oasis7.testnet-fourth-local`
+
+## 2026-06-03 15:54:43 CST / tpm
+- User Request:
+  - Check current sync status after expanding the public testnet node count with the fourth local node.
+- Fourth Local Node Service:
+  - LaunchAgent label: `com.oasis7.testnet-fourth-local`
+  - State: `running`
+  - PID: `83631`
+  - Status URL: `http://127.0.0.1:19083/v1/chain/status`
+  - Health URL returned `ok=true`.
+- Fourth Local Node Sync Snapshot:
+  - `node_id=triad-testnet-fourth-local`
+  - `liveness.status=ok`
+  - `readiness.status=not_ready`
+  - `readiness.failed_gates=consensus_peer_head_unavailable,replication_recent_errors,p2p_reachability_degraded`
+  - `sync.status=unknown`
+  - `observability.status=warn`
+  - `observability.summary=network head is unknown because no peer committed heads are visible; +2 more alerts`
+  - `observability.connected_peer_count=0`
+  - `observability.active_peer_count=0`
+  - `observability.known_peer_heads=0`
+  - `observability.network_head_available=false`
+  - `observability.network_height_lag=0`
+  - `observability.replication_persisted_height=0`
+  - `observability.replication_state_gap=0`
+  - `observability.recent_replication_error_count=10`
+  - Consensus heights: latest applied `0`, committed `0`, network committed `0`, replication persisted `0`.
+  - `replication.connected_peers=[]`
+  - `replication.peer_healths=[]`
+  - `last_error=null`
+  - Recent errors include transient libp2p established/closed events and transport activity for both public ECS bootstrap peers, then peer-manager suspect/candidate state due `MissingPeerRecord` and `InsufficientActiveDiscoverySources`.
+- Remote Sequencer Snapshot:
+  - URL: `http://39.104.204.172:6631/v1/chain/status`
+  - `node_id=triad-testnet-sequencer`
+  - `liveness.status=critical`
+  - `readiness.status=not_ready`
+  - `observability.status=critical`
+  - `observability.connected_peer_count=2`
+  - `observability.active_peer_count=2`
+  - `observability.known_peer_heads=1`
+  - `observability.network_height_lag=2`
+  - `observability.replication_persisted_height=23015`
+  - Consensus heights: committed `23015`, network committed `23017`.
+  - `last_commit_age_ms=18857305`
+  - `observability.recent_replication_error_count=113`
+  - Last error remains a gap-sync execution hash validation failure at height `23016`.
+  - Fourth node peer id `12D3KooWAkDbJby8wGRhnESJYFR7q6DWfNXQ7Ea2ZrZvehezj47s` is visible in peer health as `candidate` with discovery sources `dht,static_bootstrap`, but is not active.
+- Remote Storage Snapshot:
+  - URL: `http://39.104.205.67:6632/v1/chain/status`
+  - `node_id=triad-testnet-storage`
+  - `liveness.status=ok`
+  - `readiness.status=not_ready`
+  - `observability.status=warn`
+  - `observability.connected_peer_count=2`
+  - `observability.active_peer_count=2`
+  - `observability.known_peer_heads=0`
+  - `observability.network_height_lag=0`
+  - `observability.replication_persisted_height=23017`
+  - Consensus heights: committed `23017`, network committed `23017`.
+  - `last_commit_age_ms=13289535`
+  - `observability.recent_replication_error_count=87`
+  - `last_error=null`
+  - Fourth node peer id `12D3KooWAkDbJby8wGRhnESJYFR7q6DWfNXQ7Ea2ZrZvehezj47s` is visible in peer health as `candidate` with discovery sources `dht,static_bootstrap`, but is not active.
+- Objective Conclusion:
+  - The fourth local testnet node is alive, but it has not synced: height remains `0`, no connected/active peers are reported locally, and no peer heads are visible locally.
+  - The two public ECS nodes can discover the fourth node as a candidate peer, but still report only two connected/active peers, so the four-node topology is not fully active.
+  - Public storage is at committed height `23017`; public sequencer remains behind at committed height `23015` and still reports the prior gap-sync execution-hash validation failure.
+
+## 2026-06-03 16:21:33 CST / tpm
+- User Request:
+  - Refresh sync status.
+- Fourth Local Node Service:
+  - LaunchAgent label: `com.oasis7.testnet-fourth-local`
+  - State: `running`
+  - PID: `83631`
+  - Health/status listener remains `127.0.0.1:19083`.
+- Fourth Local Node Sync Snapshot:
+  - `node_id=triad-testnet-fourth-local`
+  - `liveness.status=ok`
+  - `readiness.status=not_ready`
+  - `readiness.failed_gates=consensus_peer_head_unavailable,replication_recent_errors,replication_transport_unstable,p2p_reachability_degraded`
+  - `sync.status=unknown`
+  - `observability.status=warn`
+  - `observability.summary=network head is unknown because no peer committed heads are visible; +3 more alerts`
+  - `observability.connected_peer_count=0`
+  - `observability.active_peer_count=0`
+  - `observability.known_peer_heads=0`
+  - `observability.network_head_available=false`
+  - `observability.replication_persisted_height=0`
+  - Consensus heights: committed `0`, network committed `0`, latest applied `null`.
+  - `replication.connected_peers=[]`
+  - `replication.peer_healths=[]`
+  - `last_error=null`
+- Remote Sequencer Snapshot:
+  - `node_id=triad-testnet-sequencer`
+  - `liveness.status=critical`
+  - `readiness.status=not_ready`
+  - `observability.status=critical`
+  - `observability.connected_peer_count=2`
+  - `observability.active_peer_count=2`
+  - `observability.known_peer_heads=1`
+  - `observability.network_height_lag=2`
+  - Consensus heights: committed `23015`, network committed `23017`.
+  - `observability.replication_persisted_height=23015`
+  - `observability.recent_replication_error_count=116`
+  - Last error remains gap-sync execution hash validation failure at height `23016`.
+  - Fourth local peer remains visible as `candidate` with discovery sources `dht,static_bootstrap`, not active.
+- Remote Storage Snapshot:
+  - `node_id=triad-testnet-storage`
+  - `liveness.status=ok`
+  - `readiness.status=not_ready`
+  - `observability.status=warn`
+  - `observability.connected_peer_count=2`
+  - `observability.active_peer_count=2`
+  - `observability.known_peer_heads=0`
+  - Consensus heights: committed `23017`, network committed `23017`.
+  - `observability.replication_persisted_height=23017`
+  - `observability.recent_replication_error_count=86`
+  - `last_error=null`
+  - Fourth local peer remains visible as `candidate` with discovery sources `dht,static_bootstrap`, not active.
+- Objective Conclusion:
+  - No sync progress since the 15:54 snapshot. The fourth node is still alive but unsynced at height `0`.
+  - Public ECS nodes still report two active peers, so the fourth node has not joined the active replication topology.
+  - Storage remains at height `23017`; sequencer remains at height `23015` with the same execution hash mismatch blocker.
+
+## 2026-06-03 16:24:00 CST / tpm
+- User Request:
+  - Diagnose why the fourth local public-testnet node keeps failing to sync.
+- Workflow / Debug Route:
+  - Current worktree is still the bound canonical task worktree: `/Users/scc/ccwork/worktrees/oasis7-engineering-expand-testnet-fourth-node`.
+  - Current `.pm` task remains `task_202b9f812d49432a9f4360b8a66c5364`, owner role `tpm`.
+  - Selected skill path: `systematic-debugging` after existing bootstrap/task truth.
+  - Tool limitation: no callable subagent-dispatch tool is available in this turn, so TPM will collect objective runtime evidence and avoid presenting unverified professional design conclusions.
+- Reproduced Failure:
+  - Fourth local node is alive, but sync remains `unknown`, height remains `0`, `connected_peer_count=0`, and remote ECS nodes list the fourth peer only as `candidate`.
+- Initial Hypothesis:
+  - The node establishes transient libp2p transport to bootstrap peers, but peer-manager admission/active-peer promotion fails because the peers lack sufficient active discovery/source/reachability state from this node's perspective.
+- Planned Small Probes:
+  - Inspect fourth-node runtime logs for peer-manager rejection reasons, handshake failures, gossipsub/identify/Kademlia events, and replication gap-sync attempts.
+  - Inspect code paths for `MissingPeerRecord`, `InsufficientActiveDiscoverySources`, and active peer admission thresholds.
+  - Compare fourth-node launch/config against the existing local public-testnet node and public ECS peer configuration.
+
+## 2026-06-03 16:34:00 CST / tpm
+- Systematic Debugging Evidence:
+  - Fourth-node stdout/stderr logs are sparse; runtime status `replication.recent_errors` and `traffic.libp2p_replication` provide the useful failure signature.
+  - Fourth local node recent errors include:
+    - `libp2p peer manager suspect peer=<sequencer> issues=[MissingPeerRecord, InsufficientActiveDiscoverySources { observed_sources: 0, required_sources: 2 }]`
+    - `libp2p peer manager suspect peer=<storage> issues=[MissingPeerRecord, InsufficientActiveDiscoverySources { observed_sources: 0, required_sources: 2 }]`
+    - `libp2p peer record request failed: ConnectionClosed`
+    - repeated direct transport active events to both ECS bootstrap peers followed by connection closed events.
+  - Fourth local node traffic counters:
+    - `/aw/rr/1.0.0/get_local_peer_record`: outbound `6993`, inbound `0`
+    - `/aw/rr/1.0.0/get_cached_discovery_peers`: outbound `6993`, inbound `0`
+    - `/aw/node/replication/fetch-commit/1.0.0`: outbound `267`, inbound `0`
+    - control-plane events include `request_response.outbound_failure=14253`, `transport.connection_established=6993`, `transport.connection_closed=6993`.
+  - Fourth local p2p status:
+    - `effective_user_mode=private_safe`
+    - `deployment_mode=private`
+    - `node_role_claim=observer_light`
+    - `detected_reachability=null`
+    - `relay_available=false`
+    - `confirmed_external_direct_addrs=[]`
+- Remote Peer-Manager Evidence:
+  - Both ECS nodes have a signed peer record for the fourth peer and list it as `candidate` with discovery sources `dht,static_bootstrap`.
+  - When the fourth peer attempts an active direct path, both ECS nodes report:
+    - `libp2p peer manager suspect peer=12D3KooWAkDbJby8wGRhnESJYFR7q6DWfNXQ7Ea2ZrZvehezj47s issues=[Ipv4SubnetConcentration { subnet: "111.197.237", peers_in_bucket: 2, active_peer_count: 3, limit_per_mille: 500 }]`
+    - `libp2p peer manager quarantine disconnect peer=12D3KooWAkDbJby8wGRhnESJYFR7q6DWfNXQ7Ea2ZrZvehezj47s`
+  - Remote active peer set still includes the existing local testnet peer `12D3KooWNphsGixZxpqmZf9RSVhCWHH7hWFYZBN8izmWfXQYAXTQ`, also observed via the same public IPv4 `/24` bucket `111.197.237`.
+- Code Evidence:
+  - `PeerManagerPolicy::default()` in `crates/oasis7_net/src/libp2p_net/peer_manager.rs` sets `min_active_discovery_sources=2`, `min_peer_discovery_sources=2`, and `block_ipv4_subnet_share_per_mille=500`.
+  - `candidate_status_with_active_set()` in `crates/oasis7_net/src/libp2p_net/peer_manager_active_set.rs` hard-blocks/quarantines a candidate when adding it would make at least two active peers share the same IPv4 `/24` and the bucket share meets or exceeds the block threshold.
+  - `refresh_peer_manager_healths()` then puts such peers into `quarantined_active_peers`, causing disconnect/suppressed failover.
+- Narrowed Cause:
+  - The fourth node is not syncing because it is not admitted into the active replication topology. It transiently connects to ECS peers, but peer-record/request exchange fails with `ConnectionClosed`, and remote ECS peer-manager quarantines it due IPv4 `/24` concentration with the already-active local testnet peer.
+  - This is separate from the sequencer's existing gap-sync execution-hash mismatch at height `23016`, although that sequencer issue remains an independent network-health blocker.
+- Practical Remediation Options:
+  - Put the fourth node behind a different public egress IP/subnet, or deploy it on a separate cloud host/network.
+  - Temporarily stop the already-active local testnet peer that shares the same public `/24`; this would test the subnet-concentration hypothesis but would not preserve a true four-active-node topology.
+  - Add/configure a relay or other accepted path so the fourth node does not appear as a second direct active peer from the same IPv4 `/24`.
+  - For a controlled testnet-only experiment, add a configurable peer-manager policy override and restart the affected nodes with a relaxed `/24` concentration threshold; this is a code/config change and should be treated as a separate runtime/QA-owned change.
+
+## 2026-06-03 16:40:00 CST / tpm
+- User Decision:
+  - Select remediation option 4 and set the IPv4 `/24` active-peer threshold to `3`.
+- Implementation Route:
+  - Add a code/config surface rather than changing the default peer-manager policy globally.
+  - Preserve existing default behavior.
+  - Add a chain-runtime CLI flag that converts an explicit max same-IPv4-subnet active peer count into peer-manager policy per-mille thresholds.
+  - Target testnet runtime launch with explicit threshold `3`.
+- Boundary:
+  - This changes runtime code and requires rebuilding/restarting nodes that enforce the peer-manager admission policy. Updating only the fourth local node is insufficient because the quarantine is emitted by the remote ECS nodes.
+
+## 2026-06-03 17:02:00 CST / tpm
+- User Correction:
+  - The requested limit semantics are: active peers in the same IPv4 `/24` are allowed up to `3`; the fourth peer in that `/24` is blocked.
+- Implementation:
+  - Added `PeerManagerPolicy.max_ipv4_subnet_active_peers: Option<usize>`.
+  - Preserved existing default behavior with `None`.
+  - Updated peer health recompute, candidate admission, and candidate degradation checks to use count-based semantics when the override is set:
+    - `projected_bucket_count <= 3` is allowed.
+    - `projected_bucket_count > 3` is blocked/quarantined.
+  - Threaded peer-manager policy through `Libp2pReplicationNetworkConfig` into `Libp2pNetworkConfig`.
+  - Added chain-runtime CLI flag `--p2p-max-ipv4-subnet-active-peers <n>`.
+  - Applied the CLI flag in `build_default_replication_network_config()`.
+- Verification Commands:
+  - `./scripts/cargo-dev.sh fmt`
+  - `./scripts/cargo-dev.sh test -p oasis7_net libp2p_net::peer_manager --features libp2p`
+  - `./scripts/cargo-dev.sh test -p oasis7_net active_set_candidate --features libp2p`
+  - `./scripts/cargo-dev.sh test -p oasis7 ipv4_subnet_active_peer_limit`
+- Verification Results:
+  - Formatting passed.
+  - `oasis7_net` peer-manager tests passed: `9 passed`.
+  - `oasis7_net` active-set candidate tests passed: `5 passed`.
+  - `oasis7` chain-runtime filtered tests passed, including:
+    - `parse_options_rejects_invalid_ipv4_subnet_active_peer_limit`
+    - `replication_network_config_applies_ipv4_subnet_active_peer_limit`
+- PR Boundary:
+  - User requested PR before applying the code path to live nodes.
+  - No cloud or local node restart/deployment was performed after this code change.
+
+## 2026-06-03 21:05:00 CST / tpm
+- User Request:
+  - Address open PR review comments on PR #345.
+- Review Threads Addressed:
+  - `crates/oasis7_net/src/libp2p_net/peer_manager.rs`: count-based IPv4 subnet limit emitted an `Ipv4SubnetConcentration` issue labeled only with `limit_per_mille`, which was misleading for runtime diagnostics.
+  - `crates/oasis7_net/src/libp2p_net/peer_manager.rs`: test name said "blocks fourth peer" while the assertion verifies all peers in the over-limit bucket become blocked.
+  - `.pm/roles/tpm/backlog/committed.yaml`: role backlog view is regenerated/local view and should not be changed in the PR.
+- Fixes:
+  - Added a distinct `PeerManagerHealthIssue::Ipv4SubnetActivePeerLimit` issue for the count-based limit.
+  - Count-based subnet limit now emits `ipv4_subnet_active_peer_limit ... max_active_peers=3` in replication peer-health issue labels; share-based policy continues emitting `ipv4_subnet_concentration ... limit_per_mille=...`.
+  - Renamed the test to `recompute_count_limit_blocks_all_peers_when_four_share_same_ipv4_subnet`.
+  - Restored `.pm/roles/tpm/backlog/committed.yaml` to the base `tasks: []` view.
+  - Kept the wasm replication-network stub config API aligned with the non-wasm config shape after adding `peer_manager_policy`.
+- Verification Commands:
+  - `./scripts/cargo-dev.sh fmt`
+  - `./scripts/cargo-dev.sh test -p oasis7_net libp2p_net::peer_manager --features libp2p`
+  - `./scripts/cargo-dev.sh test -p oasis7_net active_set_candidate --features libp2p`
+  - `./scripts/cargo-dev.sh test -p oasis7 ipv4_subnet_active_peer_limit`
+- Verification Results:
+  - Formatting passed.
+  - `oasis7_net` peer-manager tests passed: `9 passed`.
+  - `oasis7_net` active-set candidate tests passed: `5 passed`.
+  - `oasis7` chain-runtime filtered tests passed: `2 passed`.

--- a/.pm/tasks/task_202b9f812d49432a9f4360b8a66c5364.yaml
+++ b/.pm/tasks/task_202b9f812d49432a9f4360b8a66c5364.yaml
@@ -1,0 +1,18 @@
+task_uid: task_202b9f812d49432a9f4360b8a66c5364
+title: "expand testnet to fourth local node"
+owner_role: tpm
+worktree_hint: /Users/scc/ccwork/worktrees/oasis7-engineering-expand-testnet-fourth-node
+execution_log_path: .pm/tasks/task_202b9f812d49432a9f4360b8a66c5364.execution.md
+status: committed
+priority: P2
+source_signal: null
+source_refs:
+  - AGENTS.md
+  - /Users/scc/Documents/keys/aliyun_ecs.txt
+doc_refs: []
+related_prd: []
+acceptance:
+  - "Start one additional local public testnet node and verify four-node topology evidence."
+handoff_to: []
+updated_at: 2026-06-03T15:18:38+08:00
+last_started_at: 2026-06-03T15:18:38+08:00

--- a/crates/oasis7/src/bin/oasis7_chain_runtime.rs
+++ b/crates/oasis7/src/bin/oasis7_chain_runtime.rs
@@ -673,6 +673,9 @@ fn build_default_replication_network_config(
                 .map_err(|err| format!("invalid --replication-network-peer {raw}: {err}"))
         })
         .collect::<Result<_, _>>()?;
+    if let Some(limit) = options.p2p_max_ipv4_subnet_active_peers {
+        config.peer_manager_policy.max_ipv4_subnet_active_peers = Some(limit);
+    }
     apply_traffic_profile_to_replication_network_config(&mut config, options.traffic_profile);
     Ok(config)
 }

--- a/crates/oasis7/src/bin/oasis7_chain_runtime/cli.rs
+++ b/crates/oasis7/src/bin/oasis7_chain_runtime/cli.rs
@@ -88,6 +88,7 @@ pub(super) struct CliOptions {
     pub p2p_node_role: PeerNodeRole,
     pub p2p_source_operator: Option<String>,
     pub p2p_source_asn: Option<String>,
+    pub p2p_max_ipv4_subnet_active_peers: Option<usize>,
     pub node_tick_ms: u64,
     pub pos_slot_duration_ms: u64,
     pub pos_ticks_per_slot: u64,
@@ -145,6 +146,7 @@ impl Default for CliOptions {
             p2p_node_role: PeerNodeRole::ValidatorCore,
             p2p_source_operator: None,
             p2p_source_asn: None,
+            p2p_max_ipv4_subnet_active_peers: None,
             node_tick_ms: DEFAULT_NODE_TICK_MS,
             pos_slot_duration_ms: DEFAULT_POS_SLOT_DURATION_MS,
             pos_ticks_per_slot: DEFAULT_POS_TICKS_PER_SLOT,
@@ -279,6 +281,18 @@ pub(super) fn parse_options<'a>(args: impl Iterator<Item = &'a str>) -> Result<C
                     raw.as_str(),
                     "--p2p-source-asn",
                 )?);
+            }
+            "--p2p-max-ipv4-subnet-active-peers" => {
+                let raw = parse_required_value(&mut iter, "--p2p-max-ipv4-subnet-active-peers")?;
+                options.p2p_max_ipv4_subnet_active_peers = Some(
+                    raw.parse::<usize>()
+                        .ok()
+                        .filter(|value| *value > 0)
+                        .ok_or_else(|| {
+                            "--p2p-max-ipv4-subnet-active-peers requires a positive integer"
+                                .to_string()
+                        })?,
+                );
             }
             "--node-tick-ms" => {
                 let raw = parse_required_value(&mut iter, "--node-tick-ms")?;
@@ -713,6 +727,8 @@ Options:\n\
   --p2p-node-role <role>            validator_core|sentry|relay|full_storage|observer_light\n\
   --p2p-source-operator <label>     canonical operator label for peer diversity policy\n\
   --p2p-source-asn <label>          canonical ASN label for peer diversity policy\n\
+  --p2p-max-ipv4-subnet-active-peers <n>\n\
+                                    max active peers allowed in one IPv4 /24 before blocking\n\
   --node-tick-ms <n>                worker poll/fallback interval ms (default: {DEFAULT_NODE_TICK_MS})\n\
   --pos-slot-duration-ms <n>        PoS slot duration in milliseconds (default: {DEFAULT_POS_SLOT_DURATION_MS})\n\
   --pos-ticks-per-slot <n>          logical ticks per PoS slot (default: {DEFAULT_POS_TICKS_PER_SLOT})\n\

--- a/crates/oasis7/src/bin/oasis7_chain_runtime/oasis7_chain_runtime_tests.rs
+++ b/crates/oasis7/src/bin/oasis7_chain_runtime/oasis7_chain_runtime_tests.rs
@@ -58,6 +58,7 @@ fn parse_options_defaults() {
     assert!(options.replication_network_listen_addrs.is_empty());
     assert!(options.replication_network_bootstrap_peers.is_empty());
     assert!(options.replication_remote_writer_public_keys.is_empty());
+    assert_eq!(options.p2p_max_ipv4_subnet_active_peers, None);
 }
 
 #[test]
@@ -94,6 +95,8 @@ fn parse_options_reads_custom_values() {
             "--node-validator",
             "node-b:45",
             "--node-auto-attest-all",
+            "--p2p-max-ipv4-subnet-active-peers",
+            "3",
             "--execution-world-dir",
             "custom/world",
             "--reward-runtime-epoch-duration-secs",
@@ -129,6 +132,7 @@ fn parse_options_reads_custom_values() {
     assert_eq!(options.node_validators.len(), 2);
     assert!(options.node_validator_signer_public_keys.is_empty());
     assert!(options.node_auto_attest_all_validators);
+    assert_eq!(options.p2p_max_ipv4_subnet_active_peers, Some(3));
     assert_eq!(options.reward_runtime_epoch_duration_secs, Some(60));
     assert_eq!(options.reward_points_per_credit, 100);
     assert!(options.reward_runtime_auto_redeem);
@@ -140,6 +144,13 @@ fn parse_options_reads_custom_values() {
             .map(|p| p.to_string_lossy().to_string()),
         Some("custom/world".to_string())
     );
+}
+
+#[test]
+fn parse_options_rejects_invalid_ipv4_subnet_active_peer_limit() {
+    let err = parse_options(["--p2p-max-ipv4-subnet-active-peers", "0"].into_iter())
+        .expect_err("should reject zero peer limit");
+    assert!(err.contains("--p2p-max-ipv4-subnet-active-peers requires a positive integer"));
 }
 
 #[test]
@@ -423,6 +434,32 @@ fn triad_low_traffic_replication_network_config_slows_control_plane_churn() {
     assert_eq!(config.discovery_query_interval_ms, 180_000);
     assert_eq!(config.republish_interval_ms, 30 * 60 * 1000);
     assert!(!config.enable_autonat);
+}
+
+#[test]
+fn replication_network_config_applies_ipv4_subnet_active_peer_limit() {
+    let signing_key = SigningKey::from_bytes(&[13_u8; 32]);
+    let keypair = node_keypair_config::NodeKeypairConfig {
+        private_key_hex: hex::encode(signing_key.to_bytes()),
+        public_key_hex: hex::encode(signing_key.verifying_key().to_bytes()),
+    };
+    let options = parse_options(
+        [
+            "--p2p-max-ipv4-subnet-active-peers",
+            "3",
+            "--replication-network-peer",
+            "/ip4/39.104.204.172/tcp/5611",
+        ]
+        .into_iter(),
+    )
+    .expect("parse should succeed");
+    let config = build_default_replication_network_config(&options, &keypair)
+        .expect("replication network config should build");
+
+    assert_eq!(
+        config.peer_manager_policy.max_ipv4_subnet_active_peers,
+        Some(3)
+    );
 }
 
 #[test]

--- a/crates/oasis7_net/src/libp2p_net/peer_manager.rs
+++ b/crates/oasis7_net/src/libp2p_net/peer_manager.rs
@@ -12,6 +12,7 @@ use super::transport_paths::{TransportPath, TransportPathKind};
 pub struct PeerManagerPolicy {
     pub min_active_discovery_sources: usize,
     pub min_peer_discovery_sources: usize,
+    pub max_ipv4_subnet_active_peers: Option<usize>,
     pub max_ipv4_subnet_share_per_mille: u16,
     pub block_ipv4_subnet_share_per_mille: u16,
     pub max_relay_domain_share_per_mille: u16,
@@ -28,6 +29,7 @@ impl Default for PeerManagerPolicy {
         Self {
             min_active_discovery_sources: 2,
             min_peer_discovery_sources: 2,
+            max_ipv4_subnet_active_peers: None,
             max_ipv4_subnet_share_per_mille: 250,
             block_ipv4_subnet_share_per_mille: 500,
             max_relay_domain_share_per_mille: 250,
@@ -65,6 +67,12 @@ pub enum PeerManagerHealthIssue {
         peers_in_bucket: usize,
         active_peer_count: usize,
         limit_per_mille: u16,
+    },
+    Ipv4SubnetActivePeerLimit {
+        subnet: String,
+        peers_in_bucket: usize,
+        active_peer_count: usize,
+        max_active_peers: usize,
     },
     RelayDomainConcentration {
         relay_domain: String,
@@ -172,7 +180,17 @@ pub(super) fn recompute_peer_manager_healths(
                     .get(bucket.as_str())
                     .copied()
                     .unwrap_or(0);
-                if bucket_count >= 2
+                if let Some(limit) = policy.max_ipv4_subnet_active_peers {
+                    if bucket_count > limit {
+                        issues.push(PeerManagerHealthIssue::Ipv4SubnetActivePeerLimit {
+                            subnet: bucket,
+                            peers_in_bucket: bucket_count,
+                            active_peer_count: active_set_stats.active_peer_count,
+                            max_active_peers: limit,
+                        });
+                        hard_block = true;
+                    }
+                } else if bucket_count >= 2
                     && meets_or_exceeds_share_limit(
                         bucket_count,
                         active_set_stats.active_peer_count,
@@ -571,6 +589,103 @@ mod tests {
             PeerManagerHealthIssue::Ipv4SubnetConcentration { subnet, .. } if subnet == "192.168.10"
         )));
         assert_eq!(healths[&peer_c].status, PeerManagerHealthStatus::Active);
+    }
+
+    #[test]
+    fn recompute_count_limit_blocks_all_peers_when_four_share_same_ipv4_subnet() {
+        let peers = [
+            PeerId::random(),
+            PeerId::random(),
+            PeerId::random(),
+            PeerId::random(),
+        ];
+        let discovery_sources = vec![
+            PeerDiscoverySource::StaticBootstrap,
+            PeerDiscoverySource::Dht,
+        ];
+        let discovered =
+            HashMap::from(peers.map(|peer| (peer, sample_record(peer, discovery_sources.clone()))));
+        let active_three = HashMap::from([
+            (
+                peers[0],
+                transport_path(
+                    peers[0],
+                    "/ip4/192.168.10.1/udp/4101/quic-v1",
+                    TransportPathKind::Direct,
+                ),
+            ),
+            (
+                peers[1],
+                transport_path(
+                    peers[1],
+                    "/ip4/192.168.10.2/udp/4102/quic-v1",
+                    TransportPathKind::Direct,
+                ),
+            ),
+            (
+                peers[2],
+                transport_path(
+                    peers[2],
+                    "/ip4/192.168.10.3/udp/4103/quic-v1",
+                    TransportPathKind::Direct,
+                ),
+            ),
+        ]);
+        let active_four = HashMap::from([
+            (
+                peers[0],
+                transport_path(
+                    peers[0],
+                    "/ip4/192.168.10.1/udp/4101/quic-v1",
+                    TransportPathKind::Direct,
+                ),
+            ),
+            (
+                peers[1],
+                transport_path(
+                    peers[1],
+                    "/ip4/192.168.10.2/udp/4102/quic-v1",
+                    TransportPathKind::Direct,
+                ),
+            ),
+            (
+                peers[2],
+                transport_path(
+                    peers[2],
+                    "/ip4/192.168.10.3/udp/4103/quic-v1",
+                    TransportPathKind::Direct,
+                ),
+            ),
+            (
+                peers[3],
+                transport_path(
+                    peers[3],
+                    "/ip4/192.168.10.4/udp/4104/quic-v1",
+                    TransportPathKind::Direct,
+                ),
+            ),
+        ]);
+        let policy = PeerManagerPolicy {
+            max_ipv4_subnet_active_peers: Some(3),
+            ..PeerManagerPolicy::default()
+        };
+
+        let healths_three = recompute_peer_manager_healths(&discovered, &active_three, &policy);
+        for peer in peers.iter().take(3) {
+            assert_eq!(healths_three[peer].status, PeerManagerHealthStatus::Active);
+        }
+
+        let healths_four = recompute_peer_manager_healths(&discovered, &active_four, &policy);
+        for peer in peers {
+            assert_eq!(healths_four[&peer].status, PeerManagerHealthStatus::Blocked);
+            assert!(healths_four[&peer].issues.iter().any(|issue| matches!(
+                issue,
+                PeerManagerHealthIssue::Ipv4SubnetActivePeerLimit {
+                    max_active_peers: 3,
+                    ..
+                }
+            )));
+        }
     }
 
     #[test]

--- a/crates/oasis7_net/src/libp2p_net/peer_manager_active_set.rs
+++ b/crates/oasis7_net/src/libp2p_net/peer_manager_active_set.rs
@@ -139,7 +139,11 @@ pub(super) fn candidate_status_with_active_set(
             .copied()
             .unwrap_or(0)
             .saturating_add(1);
-        if projected_bucket_count >= 2
+        if let Some(limit) = policy.max_ipv4_subnet_active_peers {
+            if projected_bucket_count > limit {
+                hard_block = true;
+            }
+        } else if projected_bucket_count >= 2
             && meets_or_exceeds_share_limit(
                 projected_bucket_count,
                 projected_active_peer_count,
@@ -270,7 +274,11 @@ pub(super) fn candidate_would_degrade_admitted_peers(
             .copied()
             .unwrap_or(0);
         let projected_bucket_count = current_bucket_count.saturating_add(1);
-        if current_bucket_count > 0
+        if let Some(limit) = policy.max_ipv4_subnet_active_peers {
+            if current_bucket_count > 0 && projected_bucket_count > limit {
+                return true;
+            }
+        } else if current_bucket_count > 0
             && projected_bucket_count >= 2
             && (meets_or_exceeds_share_limit(
                 projected_bucket_count,

--- a/crates/oasis7_net/src/libp2p_net/tests/active_set_candidate_tests.rs
+++ b/crates/oasis7_net/src/libp2p_net/tests/active_set_candidate_tests.rs
@@ -61,6 +61,56 @@ fn active_set_candidate_status_flags_bucket_overflow_without_full_recompute() {
 }
 
 #[test]
+fn active_set_candidate_count_limit_allows_third_and_blocks_fourth_subnet_peer() {
+    let candidate = ActivePeerCandidate {
+        discovery_sources: vec![
+            crate::dht::PeerDiscoverySource::Dht,
+            crate::dht::PeerDiscoverySource::Rendezvous,
+        ],
+        ipv4_subnet_bucket: Some("10.0.0".to_string()),
+        relay_domain: None,
+        source_operator: None,
+        source_asn: None,
+        relay_reserved: false,
+    };
+    let policy = PeerManagerPolicy {
+        max_ipv4_subnet_active_peers: Some(3),
+        ..PeerManagerPolicy::default()
+    };
+    let two_peer_stats = ActivePeerSetStats {
+        active_peer_count: 2,
+        active_discovery_sources: BTreeSet::from(["dht", "rendezvous"]),
+        ipv4_subnet_counts: HashMap::from([("10.0.0".to_string(), 2)]),
+        ..ActivePeerSetStats::default()
+    };
+    let three_peer_stats = ActivePeerSetStats {
+        active_peer_count: 3,
+        active_discovery_sources: BTreeSet::from(["dht", "rendezvous"]),
+        ipv4_subnet_counts: HashMap::from([("10.0.0".to_string(), 3)]),
+        ..ActivePeerSetStats::default()
+    };
+
+    assert_eq!(
+        candidate_status_with_active_set(&candidate, &two_peer_stats, &policy),
+        PeerManagerHealthStatus::Active
+    );
+    assert!(!candidate_would_degrade_admitted_peers(
+        &candidate,
+        &two_peer_stats,
+        &policy,
+    ));
+    assert_eq!(
+        candidate_status_with_active_set(&candidate, &three_peer_stats, &policy),
+        PeerManagerHealthStatus::Blocked
+    );
+    assert!(candidate_would_degrade_admitted_peers(
+        &candidate,
+        &three_peer_stats,
+        &policy,
+    ));
+}
+
+#[test]
 fn active_set_candidate_status_admits_distinct_peer_without_degrading_existing_active_set() {
     let admitted_key = Keypair::generate_ed25519();
     let admitted_peer = PeerId::from(admitted_key.public());

--- a/crates/oasis7_net/src/tests.rs
+++ b/crates/oasis7_net/src/tests.rs
@@ -138,6 +138,7 @@ fn libp2p_smoke_request_response_and_pubsub_work_between_peers() {
     let peer_manager_policy = PeerManagerPolicy {
         min_active_discovery_sources: 0,
         min_peer_discovery_sources: 0,
+        max_ipv4_subnet_active_peers: None,
         max_ipv4_subnet_share_per_mille: 1_000,
         block_ipv4_subnet_share_per_mille: 1_000,
         max_relay_domain_share_per_mille: 1_000,

--- a/crates/oasis7_net/src/tests_libp2p_traffic.rs
+++ b/crates/oasis7_net/src/tests_libp2p_traffic.rs
@@ -24,6 +24,7 @@ fn libp2p_traffic_metrics_track_requests_and_gossip_payloads() {
     let peer_manager_policy = PeerManagerPolicy {
         min_active_discovery_sources: 0,
         min_peer_discovery_sources: 0,
+        max_ipv4_subnet_active_peers: None,
         max_ipv4_subnet_share_per_mille: 1_000,
         block_ipv4_subnet_share_per_mille: 1_000,
         max_relay_domain_share_per_mille: 1_000,

--- a/crates/oasis7_node/src/libp2p_replication_network.rs
+++ b/crates/oasis7_node/src/libp2p_replication_network.rs
@@ -8,6 +8,7 @@ use libp2p::{Multiaddr, PeerId};
 use oasis7_net::{
     world_error_is_missing_handler, world_error_is_retryable_connection_gap, Libp2pNetwork,
     Libp2pNetworkConfig, Libp2pReachabilitySnapshot, Libp2pTrafficMetricsSnapshot,
+    PeerManagerPolicy,
 };
 use oasis7_proto::distributed::WorldHeadAnnounce;
 use oasis7_proto::distributed::{DistributedErrorCode, ErrorResponse};
@@ -78,6 +79,7 @@ pub struct Libp2pReplicationNetworkConfig {
     pub discovery_query_interval_ms: i64,
     pub discovery_query_cooldown_ms: i64,
     pub enable_autonat: bool,
+    pub peer_manager_policy: PeerManagerPolicy,
     pub allow_local_handler_fallback_when_no_peers: bool,
     pub protocol_retry_cooldown_after: Duration,
 }
@@ -95,6 +97,7 @@ impl Default for Libp2pReplicationNetworkConfig {
             discovery_query_interval_ms: inner_defaults.discovery_query_interval_ms,
             discovery_query_cooldown_ms: inner_defaults.discovery_query_cooldown_ms,
             enable_autonat: inner_defaults.enable_autonat,
+            peer_manager_policy: inner_defaults.peer_manager_policy,
             allow_local_handler_fallback_when_no_peers: false,
             protocol_retry_cooldown_after: Duration::from_millis(PROTOCOL_RETRY_COOLDOWN_AFTER_MS),
         }
@@ -125,6 +128,7 @@ impl Libp2pReplicationNetwork {
             discovery_query_interval_ms: config.discovery_query_interval_ms,
             discovery_query_cooldown_ms: config.discovery_query_cooldown_ms,
             enable_autonat: config.enable_autonat,
+            peer_manager_policy: config.peer_manager_policy,
             ..Libp2pNetworkConfig::default()
         });
 
@@ -743,6 +747,14 @@ fn replication_peer_health_issue_label(issue: oasis7_net::PeerManagerHealthIssue
             limit_per_mille,
         } => format!(
             "ipv4_subnet_concentration subnet={subnet} peers_in_bucket={peers_in_bucket} active_peer_count={active_peer_count} limit_per_mille={limit_per_mille}"
+        ),
+        oasis7_net::PeerManagerHealthIssue::Ipv4SubnetActivePeerLimit {
+            subnet,
+            peers_in_bucket,
+            active_peer_count,
+            max_active_peers,
+        } => format!(
+            "ipv4_subnet_active_peer_limit subnet={subnet} peers_in_bucket={peers_in_bucket} active_peer_count={active_peer_count} max_active_peers={max_active_peers}"
         ),
         oasis7_net::PeerManagerHealthIssue::RelayDomainConcentration {
             relay_domain,

--- a/crates/oasis7_node/src/libp2p_replication_network_wasm.rs
+++ b/crates/oasis7_node/src/libp2p_replication_network_wasm.rs
@@ -1,8 +1,13 @@
+use std::time::Duration;
+
 use libp2p::identity::Keypair;
 use libp2p::{Multiaddr, PeerId};
+use oasis7_net::PeerManagerPolicy;
 use oasis7_proto::distributed_dht::PeerRecord;
 use oasis7_proto::distributed_net::{DistributedNetwork, NetworkSubscription};
 use oasis7_proto::world_error::WorldError;
+
+const PROTOCOL_RETRY_COOLDOWN_AFTER_MS: u64 = 5_000;
 
 // wasm32 target intentionally does not ship a full-node networking stack.
 // This stub exists only to keep API shape stable for compile-time compatibility.
@@ -12,6 +17,14 @@ pub struct Libp2pReplicationNetworkConfig {
     pub peer_record: Option<PeerRecord>,
     pub listen_addrs: Vec<Multiaddr>,
     pub bootstrap_peers: Vec<Multiaddr>,
+    pub bootstrap_redial_interval_ms: i64,
+    pub republish_interval_ms: i64,
+    pub discovery_query_interval_ms: i64,
+    pub discovery_query_cooldown_ms: i64,
+    pub enable_autonat: bool,
+    pub peer_manager_policy: PeerManagerPolicy,
+    pub allow_local_handler_fallback_when_no_peers: bool,
+    pub protocol_retry_cooldown_after: Duration,
 }
 
 impl Default for Libp2pReplicationNetworkConfig {
@@ -21,6 +34,14 @@ impl Default for Libp2pReplicationNetworkConfig {
             peer_record: None,
             listen_addrs: Vec::new(),
             bootstrap_peers: Vec::new(),
+            bootstrap_redial_interval_ms: 1_000,
+            republish_interval_ms: 5 * 60 * 1_000,
+            discovery_query_interval_ms: 15_000,
+            discovery_query_cooldown_ms: 60_000,
+            enable_autonat: true,
+            peer_manager_policy: PeerManagerPolicy::default(),
+            allow_local_handler_fallback_when_no_peers: false,
+            protocol_retry_cooldown_after: Duration::from_millis(PROTOCOL_RETRY_COOLDOWN_AFTER_MS),
         }
     }
 }


### PR DESCRIPTION
## Summary
- Adds an optional peer-manager count limit for active peers in the same IPv4 /24.
- Threads the policy through libp2p replication config and exposes `--p2p-max-ipv4-subnet-active-peers <n>` on `oasis7_chain_runtime`.
- Preserves default behavior unless the override is explicitly set; with `3`, the first three peers in a /24 are allowed and the fourth is blocked.

## Verification
- `./scripts/cargo-dev.sh fmt`
- `./scripts/cargo-dev.sh test -p oasis7_net libp2p_net::peer_manager --features libp2p`
- `./scripts/cargo-dev.sh test -p oasis7_net active_set_candidate --features libp2p`
- `./scripts/cargo-dev.sh test -p oasis7 ipv4_subnet_active_peer_limit`
- `git diff --check`

## Deployment note
This PR only adds the code/config surface. The testnet nodes still need a rebuilt binary and explicit `--p2p-max-ipv4-subnet-active-peers 3` on the nodes enforcing peer admission before retrying the fourth-node sync.