### PR TITLE
Handle missing archived external effects in retention

### DIFF
--- a/.pm/tasks/task_96e92d21a9114d34a9f5b4b90c578217.execution.md
+++ b/.pm/tasks/task_96e92d21a9114d34a9f5b4b90c578217.execution.md
@@ -1,0 +1,233 @@
+# task_96e92d21a9114d34a9f5b4b90c578217 Execution Log
+
+- task_uid: task_96e92d21a9114d34a9f5b4b90c578217
+- title: ECS 205 storage cleanup assessment
+- owner_role: tpm
+- worktree_hint: /Users/scc/ccwork/worktrees/oasis7-engineering-ecs-205-storage-cleanup
+
+<!-- Append entries using:
+Example:
+  ## YYYY-MM-DD HH:MM:SS CST / role_name
+  - 完成内容: ...
+  - 遗留事项: ...
+  - Action: ...
+  - Validation Command: ...
+  - Expected Result: ...
+  - Actual Result: ...
+  - Blocker / Next Action: ...
+-->
+
+## 2026-06-03 17:53:20 CST / tpm
+- 完成内容: WORKFLOW BOOTSTRAP DECIDED
+  - Repository State Impact: remote ECS read-only storage inspection requested; local repo state changed only by standard task/worktree bootstrap and this execution log.
+  - Isolation Decision: created dedicated task worktree `/Users/scc/ccwork/worktrees/oasis7-engineering-ecs-205-storage-cleanup` on branch `task/engineering-ecs-205-storage-cleanup` from current HEAD.
+  - Task Truth: owner_role `tpm`, `.pm` task `task_96e92d21a9114d34a9f5b4b90c578217`, source refs `AGENTS.md` and `doc/engineering/workflow/source-of-truth.md`.
+  - Routed Next Phase: repo-owned workflow router, read-only operational evidence collection with cleanup risk classification.
+- 遗留事项: Need inspect ECS 205 disk usage over SSH and classify cleanup candidates without deleting data.
+- Action: `./scripts/new-task-worktree.sh engineering ecs-205-storage-cleanup --pm-owner-role tpm ... --json`
+- Validation Command: inspect generated task yaml and execution log.
+- Expected Result: single canonical worktree and `.pm` task exist before substantive handling.
+- Actual Result: task/worktree created successfully.
+- Blocker / Next Action: Write routing and slice contract before remote inspection.
+
+## 2026-06-03 17:54:15 CST / tpm
+- 完成内容: WORKFLOW ROUTE DECIDED
+  - Current phase: read-only operational assessment before any destructive cleanup.
+  - Selected workflow skills: `default-workflow-bootstrap` completed; `repo-owned-workflow-router` selected; `verification-before-completion` required before final claim.
+  - Skipped workflow skills: `bounded-brainstorming` skipped because the user intent is concrete; `tdd-test-writer` skipped because this is remote ops evidence collection; `executing-project-tasks` skipped because no repo implementation task is requested; `finishing-a-development-branch` skipped unless repo closeout/commit is explicitly needed.
+- TPM TODO decomposition:
+  - Confirm SSH target details from `/Users/scc/Documents/keys/aliyun_ecs.txt` without exposing secrets in user-facing output.
+  - Run non-destructive disk inventory commands on ECS 205.
+  - Identify high-confidence cleanup candidates, caution candidates, and items not to delete.
+  - Do not delete files unless the user explicitly approves a concrete cleanup command set.
+- Subagent Slice Plan:
+  - role: `qa_engineer`
+  - slice type: read-only operational risk review for cleanup recommendations.
+  - intended model configuration: `gpt-5.4-medium` by project default.
+  - actual dispatched model/reasoning: not dispatched; current `multi_agent_v1.spawn_agent` tool policy permits spawning only when the user explicitly asks for sub-agents/delegation/parallel agent work, which conflicts with repo AGENTS default slice requirement.
+  - context delivery mode: no fork dispatched due tool policy; TPM records evidence directly in this mandatory sink.
+  - mandatory context checklist/packet: AGENTS.md workflow rule; `.agents/roles/tpm.md`; `.agents/roles/qa_engineer.md`; task yaml/log; user intent "阿里云ECS 205节点的存储要满了，看看哪些内容可以清"; remote inspection is read-only unless user approves deletion.
+  - write scope: `.pm/tasks/task_96e92d21a9114d34a9f5b4b90c578217.execution.md` only.
+  - return contract: cleanup candidates grouped by safety/risk with command evidence.
+  - formal sink / writeback surface: this execution log.
+  - integration owner/order: `tpm` gathers objective command output, records evidence, then summarizes recommendations with source limitations.
+  - context exemption: subagent dispatch blocked by higher-priority tool policy; no professional conclusion will be represented as an actual subagent result.
+- 遗留事项: Remote evidence collection still pending.
+- Action: Record route and constrained slice contract.
+- Validation Command: `sed -n '1,220p' .pm/tasks/task_96e92d21a9114d34a9f5b4b90c578217.execution.md`
+- Expected Result: execution log contains bootstrap, route, TODO, and slice constraints before remote inspection.
+- Actual Result: pending follow-up inspection.
+- Blocker / Next Action: SSH to ECS 205 and gather disk usage evidence.
+
+## 2026-06-03 18:05:30 CST / tpm
+- 完成内容: Remote read-only storage assessment for ECS 205.
+- Evidence:
+  - `df -hT`: root filesystem `/dev/vda3` is 30G total, 28G used, 174M available, 100% used.
+  - Top-level `du -xhd1 /`: `/opt` is 24G; `/usr` 2.4G; `/var` 813M; `/root` 388M; `/tmp` 371M.
+  - `/opt/oasis7` is 22G. Within it, `/opt/oasis7/p2p-testnet/data/storage` is 21G and `/opt/oasis7/p2p-testnet/data/storage/blobs` accounts for essentially all of that.
+  - Active process evidence: `oasis7-testnet-storage.service` runs `oasis7_chain_runtime` with `--storage-root /opt/oasis7/p2p-testnet/data/storage`; lsof shows the active process has `/opt/oasis7/p2p-testnet/data/storage` and `blobs` open.
+  - Status API evidence for `127.0.0.1:6632`: `storage.last_gc_result=success`, `storage.last_gc_error=null`, `storage.orphan_blob_count=0`, `storage.blob_counts.execution_store_blobs=30130`, `storage.bytes_by_dir.execution_store_root=22006405426`.
+  - Blob age inventory: `/opt/oasis7/p2p-testnet/data/storage/blobs` has 30130 blob files; files older than 6h account for about 20.48G, older than 12h about 19.33G.
+  - Low-risk system cleanup candidates: `/var/cache/apt` 124M, `/var/lib/apt/lists` 245M, journald 248M, `/tmp/oasis7_chain_runtime.*` about 4 x 93M, old non-current releases under `/opt/oasis7/*/releases` total only a few hundred MB.
+  - No large deleted-open files were found by `lsof +L1`; inode pressure is not the issue (`/` inode use 13%).
+- Cleanup classification:
+  - Safe/low-risk with normal ops care: apt cache/list cleanup; journald vacuum; remove stale `/tmp/oasis7_chain_runtime.*` files if no process has them open; optionally remove clearly non-current old release dirs while preserving current and at least one rollback.
+  - Not safe to delete directly: `/opt/oasis7/p2p-testnet/data/storage/blobs/*.blob` because active service uses the storage root and status says orphan count is zero.
+  - Real capacity fix: either enlarge the 30G disk or perform an application-aware/coordinated reset/prune of the p2p-testnet storage state with explicit service stop/backup/resync acceptance.
+- 遗留事项: User has not approved destructive cleanup commands.
+- Action: Non-destructive SSH inventory only.
+- Validation Command: `df -hT`, `du -xhd*`, `curl http://127.0.0.1:6632/v1/chain/status`, `lsof`.
+- Expected Result: Identify cleanup candidates before deleting anything.
+- Actual Result: Root cause is active p2p-testnet execution storage, not logs/package cache.
+- Blocker / Next Action: Need user approval for any cleanup execution; recommend immediate disk expansion or controlled application-level reset/prune for multi-GB relief.
+
+## 2026-06-03 18:16:40 CST / tpm
+- 完成内容: Follow-up systematic debugging for user observation that testnet should not retain 21G storage.
+- Reproduced Failure Signature:
+  - `release_default` effective budget reports `execution_hot_head_heights=64`, `execution_checkpoint_interval=64`, `execution_checkpoint_keep=8`.
+  - Remote `/v1/chain/status.storage.replay_summary` reports `retained_height_count=23017`, `earliest_retained_height=1`, `latest_retained_height=23017`.
+  - Remote execution records are schema v2 (`schema_counts {'2': 23017}`), so pre-v2 migration branch is not the blocker.
+  - Record ref presence shows only 64 records retain `latest_state_ref/snapshot_ref/journal_ref`, matching hot-window compaction intent, but all 23017 records retain `external_effect_ref`.
+- Hypothesis Tested: automatic execution store pruning is blocked or did not complete, leaving unpinned CAS blobs on disk.
+- Evidence:
+  - Runtime log shows repeated `execution bridge retention maintenance failed ... pin execution store ref ... failed: BlobNotFound` around heights 22929+.
+  - Current remote dry-run against `/opt/oasis7/p2p-testnet/data/storage/pins.json`:
+    - `blob_count=30130`
+    - `pin_count=10063`
+    - `missing_pinned_blob_count=0`
+    - `unpinned_blob_count=20067`
+    - `unpinned_blob_size_gb=20.482054956257343`
+    - `pinned_blob_size_gb=0.006569492630660534`
+    - `unpinned_older_6h_count=20067 size_gb=20.482054956257343`
+    - `unpinned_older_12h_count=19415 size_gb=19.32306149136275`
+- Updated Cleanup Classification:
+  - The 21G usage is abnormal and mostly consists of execution-store blobs no longer listed in `pins.json`.
+  - A controlled CAS-prune/delete of unpinned blobs should recover about 20.48G.
+  - Because this is remote production-like state and the active service uses the storage root, destructive cleanup still requires explicit user approval. Preferred operational shape: stop `oasis7-testnet-storage.service`, back up `pins.json`, dry-run list unpinned blobs, delete only blobs not in pins, restart service, verify `df` and `/v1/chain/status`.
+- 遗留事项: Need user approval before deleting unpinned blobs or stopping service.
+- Action: Read-only dry-run comparison of pins vs blobs.
+- Validation Command: remote Python compare `/opt/oasis7/p2p-testnet/data/storage/pins.json` against `/opt/oasis7/p2p-testnet/data/storage/blobs/*.blob`.
+- Expected Result: Determine whether the 21G blobs are pinned/live or orphaned.
+- Actual Result: ~20.48G is unpinned and eligible for controlled prune.
+- Blocker / Next Action: Await explicit cleanup approval, then run controlled stop/backup/delete/restart/verify sequence.
+
+## 2026-06-03 18:18:20 CST / tpm
+- 完成内容: User approved destructive cleanup with exact scope: "可以清 unpinned blobs".
+- Planned Cleanup Sequence:
+  - Stop `oasis7-testnet-storage.service`.
+  - Create timestamped backup directory under `/opt/oasis7/p2p-testnet/backups/`.
+  - Copy `/opt/oasis7/p2p-testnet/data/storage/pins.json`.
+  - Generate `unpinned-blobs.txt` from current `pins.json` vs `blobs/*.blob`.
+  - Delete only files matching `/opt/oasis7/p2p-testnet/data/storage/blobs/<hash>.blob` whose hash is absent from `pins.json`.
+  - Restart `oasis7-testnet-storage.service`.
+  - Verify `df -hT /`, service status, storage status, and pin/blob counts.
+- 遗留事项: Execute and record actual freed size plus post-cleanup status.
+- Action: Approved controlled cleanup.
+- Validation Command: pending remote cleanup script.
+- Expected Result: recover about 20.48G without deleting pinned blobs.
+- Actual Result: pending.
+- Blocker / Next Action: Run cleanup.
+
+## 2026-06-03 19:47:30 CST / tpm
+- 完成内容: Executed approved cleanup of unpinned ECS 205 p2p-testnet execution-store blobs.
+- Cleanup Evidence:
+  - Pre-cleanup `df -hT /`: `/dev/vda3` 30G total, 28G used, 173M available, 100% used.
+  - Stopped `oasis7-testnet-storage.service` before deletion.
+  - Backup directory: `/opt/oasis7/p2p-testnet/backups/storage-cleanup-20260603-194626`.
+  - Backed up `pins.json` and wrote `unpinned-blobs.txt`.
+  - Deleted only direct files under `/opt/oasis7/p2p-testnet/data/storage/blobs/*.blob` whose hash was absent from `pins.json`.
+  - Deleted count: 20067.
+  - Freed bytes: 21992439048.
+  - Freed GiB: 20.482.
+  - Post-delete blob/pin count: `blob_count_after=10063`, `pin_count=10063`, `missing_pinned_after=0`, `unpinned_after=0`.
+  - Restarted `oasis7-testnet-storage.service`; service is active/running.
+  - Post-cleanup `df -hT /`: `/dev/vda3` 30G total, 7.1G used, 21G available, 26% used.
+- Post-Start Verification:
+  - `curl http://127.0.0.1:6632/v1/chain/status` succeeded after a short startup delay.
+  - Service status: active/running, listening on 6632 and 6832.
+  - Status summary: `running=true`, `node_id=triad-testnet-storage`, `height=23019`, `storage.last_gc_result=success`, `storage.last_gc_error=null`, `storage.orphan_blob_count=0`, `storage.degraded_reason=null`.
+  - Storage bytes after restart: `execution_store_root=22309159` bytes.
+  - Immediate post-restart count: `blob_count=10070`, `pin_count=10063`, `missing_pinned=0`, `unpinned=7`, `blob_size_gib=0.0182`; the 7 new unpinned blobs appeared after restart.
+- Residual Root Cause:
+  - Runtime log still reports retention maintenance failure: `BlobNotFound` for content hash `000cfcd6b7b0599253049466b3d17a5794a1a7a5675ed5487c73d4b61bcba422`.
+  - Read-only search found the bad ref only in `/opt/oasis7/p2p-testnet/data/execution-records/00000000000000005870.json`, field `external_effect_ref`, schema `2`.
+  - No checkpoint manifests reference the bad hash.
+  - Risk: automatic retention prune can continue failing until this bad historical `external_effect_ref` is repaired or retention code tolerates missing non-critical external-effect refs, so small unpinned blob accumulation may recur.
+- 遗留事项: Need a separate root-cause fix or approved one-off repair for record height 5870 / `external_effect_ref`.
+- Action: Destructive cleanup executed within approved scope.
+- Validation Command: remote stop/backup/delete/start/status script; follow-up status/count probe; bad-ref locator probe.
+- Expected Result: Recover about 20.48G and leave service running without deleting pinned blobs.
+- Actual Result: Recovered 20.482 GiB; root FS now 26%; service running; pinned blob integrity check passed; residual retention bug remains.
+- Blocker / Next Action: Decide whether to repair the bad external-effect ref on ECS 205 or implement/code-roll a retention fix.
+
+## 2026-06-03 19:52:00 CST / tpm
+- 完成内容: User requested the same cleanup for ECS 204: "204节点也需要清理".
+- Plan:
+  - Reuse this task/worktree because the scope is the same ECS storage cleanup incident.
+  - Read-only inspect 204 first to identify service name, root disk usage, p2p-testnet storage path, current pins/blobs state, and any missing pinned blobs.
+  - If 204 has the same unpinned blob accumulation and no missing pinned blobs, execute the same controlled stop/backup/delete-unpinned/restart/verify sequence.
+- 遗留事项: Execute 204 inspection and cleanup if eligible.
+- Action: Record scope extension before remote access.
+- Validation Command: pending remote 204 inventory script.
+- Expected Result: determine whether 204 has safe unpinned blobs to clear.
+- Actual Result: pending.
+- Blocker / Next Action: SSH to ECS 204 and inspect.
+
+## 2026-06-03 20:08:50 CST / tpm
+- 完成内容: Inspected and performed low-risk cleanup on ECS 204.
+- Read-only Inspection Evidence:
+  - Pre-cleanup root disk: `/dev/vda3` 30G total, 14G used, 15G available, 49% used.
+  - `/opt/oasis7` total about 7.2G; largest areas: `p2p-triad` 3.9G, `p2p-testnet` 3.2G.
+  - Active services: `oasis7-testnet-sequencer.service`, `oasis7-triad-sequencer.service`, plus hosted login and bridge services.
+  - `p2p-testnet` status on port 6631: running, height 23015, `storage.last_gc_result=success`, `orphan_blob_count=0`, `execution_store_root=308358843`, `execution_store_blobs=23104`.
+  - `p2p-triad` status on port 5631: running, height 12357, `storage.last_gc_result=success`, `orphan_blob_count=0`, `execution_store_root=167400951`, `execution_store_blobs=12446`.
+  - Pins/blobs dry-run:
+    - `/opt/oasis7/p2p-testnet/data/storage`: `blob_count=23104`, `pin_count=23104`, `missing_pinned_blob_count=0`, `unpinned_blob_count=0`.
+    - `/opt/oasis7/p2p-triad/data/storage`: `blob_count=12446`, `pin_count=12446`, `missing_pinned_blob_count=0`, `unpinned_blob_count=0`.
+  - Conclusion: ECS 204 does not have the ECS 205 unpinned-blob leak pattern.
+- Cleanup Executed:
+  - Ran `apt-get clean`.
+  - Removed `/var/lib/apt/lists/*`.
+  - Vacuumed journald to `100M`.
+  - Deleted only direct `/tmp` or `/var/tmp` files matching `tmp.*` or `oasis7_chain_runtime.*` and older than 60 minutes.
+- Cleanup Evidence:
+  - `/var/cache/apt`: 123M -> 32K.
+  - `/var/lib/apt/lists`: 245M -> 16K.
+  - `/var/log/journal`: 606M -> 89M.
+  - `/tmp`: 503M -> 41M.
+  - Post-cleanup root disk: `/dev/vda3` 30G total, 13G used, 16G available, 44% used.
+  - Services remained active: `oasis7-testnet-sequencer.service` and `oasis7-triad-sequencer.service`.
+  - Status probes succeeded: `http://127.0.0.1:6631/v1/chain/status` and `http://127.0.0.1:5631/v1/chain/status`.
+- Deferred Higher-Risk Candidates:
+  - `/opt/oasis7/p2p-testnet/releases`: 1.7G; current is `c3a8fe431-repub-20260603-1109`.
+  - `/opt/oasis7/p2p-testnet/backups`: 658M.
+  - `/opt/oasis7/p2p-triad/releases`: 1.2G; current is `4d9891cf5-main-20260602-155510`.
+  - `/opt/oasis7/p2p-triad/backups`: 2.3G.
+  - These were not deleted because they may be rollback or historical state material.
+- 遗留事项: Need explicit policy if old release/backups should be pruned on ECS 204.
+- Action: Low-risk system cleanup only; no live storage blobs deleted.
+- Validation Command: remote inventory, apt/journal/tmp cleanup, service active checks, status curls.
+- Expected Result: clean safe cache/log/temp without disrupting active nodes.
+- Actual Result: root usage reduced from 49% to 44%; active services and status endpoints OK.
+- Blocker / Next Action: User decision on old release/backups retention policy.
+
+## 2026-06-03 20:19:04 CST / tpm
+- 完成内容: User requested code change: "改代码".
+- Implementation:
+  - Added `ExecutionBridgePinSet::best_effort_pinned_refs` for retained refs that should be pinned when present but should not fail retention maintenance when already missing.
+  - Moved execution bridge `external_effect_ref` retention into the best-effort pin set.
+  - Updated `sync_execution_bridge_pin_set` to include best-effort refs only when `LocalCasStore::has(ref)` succeeds, while keeping hard refs pinned through the existing `pin()` path.
+  - Required refs such as latest state/checkpoint/hot-window refs still fail with `BlobNotFound` if the blob is missing.
+- Regression Tests Added:
+  - `execution_bridge_retention_maintenance_tolerates_missing_archive_external_effect_ref`
+  - `execution_bridge_retention_maintenance_fails_for_missing_required_refs`
+- Validation Commands:
+  - `cargo fmt --check`
+  - `./scripts/cargo-dev.sh test -p oasis7 --bin oasis7_chain_runtime execution_bridge_retention_maintenance -- --nocapture`
+  - `./scripts/cargo-dev.sh test -p oasis7 --bin oasis7_chain_runtime execution_bridge_pin_set -- --nocapture`
+- Expected Result: ECS 205-style missing historical `external_effect_ref` no longer blocks retention pruning; critical missing blobs still surface as errors.
+- Actual Result: Formatting check passed; retention maintenance tests passed 4/4; pin-set tests passed 2/2.
+- 遗留事项: Need deploy/release path if this fix should be rolled onto ECS 205.
+- Action: Implemented retention code change and regression tests.
+- Validation Command: `cargo fmt --check`; `./scripts/cargo-dev.sh test -p oasis7 --bin oasis7_chain_runtime execution_bridge_retention_maintenance -- --nocapture`; `./scripts/cargo-dev.sh test -p oasis7 --bin oasis7_chain_runtime execution_bridge_pin_set -- --nocapture`.
+- Blocker / Next Action: Need deploy/release path if this fix should be rolled onto ECS 205.

--- a/.pm/tasks/task_96e92d21a9114d34a9f5b4b90c578217.yaml
+++ b/.pm/tasks/task_96e92d21a9114d34a9f5b4b90c578217.yaml
@@ -1,0 +1,24 @@
+task_uid: task_96e92d21a9114d34a9f5b4b90c578217
+title: "ECS 205 storage cleanup assessment"
+owner_role: tpm
+worktree_hint: /Users/scc/ccwork/worktrees/oasis7-engineering-ecs-205-storage-cleanup
+execution_log_path: .pm/tasks/task_96e92d21a9114d34a9f5b4b90c578217.execution.md
+status: done
+priority: P2
+source_signal: null
+source_refs:
+  - AGENTS.md
+  - doc/engineering/workflow/source-of-truth.md
+doc_refs: []
+related_prd: []
+acceptance:
+  - "Inspect ECS 205 disk usage and identify safe cleanup candidates before any destructive action"
+handoff_to: []
+updated_at: 2026-06-03T20:39:43+08:00
+last_started_at: 2026-06-03T17:52:32+08:00
+last_claim_type: task_complete
+last_verify_command: "./scripts/cargo-dev.sh test -p oasis7 --bin oasis7_chain_runtime execution_bridge_retention_maintenance -- --nocapture && ./scripts/cargo-dev.sh test -p oasis7 --bin oasis7_chain_runtime execution_bridge_pin_set -- --nocapture"
+last_verified_at: 2026-06-03T20:39:41+08:00
+last_verification_exit_code: 0
+last_verification_status: verified
+last_closed_at: 2026-06-03T20:39:42+08:00

--- a/crates/oasis7/src/bin/oasis7_chain_runtime/execution_bridge/checkpoint.rs
+++ b/crates/oasis7/src/bin/oasis7_chain_runtime/execution_bridge/checkpoint.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeSet;
 use std::fs;
 use std::path::Path;
 
-use oasis7::runtime::LocalCasStore;
+use oasis7::runtime::{BlobStore, LocalCasStore};
 
 use super::{
     write_bytes_atomic, ExecutionBridgePinSet, ExecutionBridgeRecord,
@@ -377,9 +377,13 @@ fn collect_execution_bridge_record_retained_refs(
     retain_latest_head: bool,
     retain_hot_window: bool,
     pinned_refs: &mut BTreeSet<String>,
+    best_effort_pinned_refs: &mut BTreeSet<String>,
 ) {
     maybe_insert_pin_ref(pinned_refs, record.commit_log_ref.as_deref());
-    maybe_insert_pin_ref(pinned_refs, record.external_effect_ref.as_deref());
+    maybe_insert_pin_ref(
+        best_effort_pinned_refs,
+        record.external_effect_ref.as_deref(),
+    );
 
     if retain_latest_head {
         maybe_insert_pin_ref(pinned_refs, record.latest_state_ref.as_deref());
@@ -466,6 +470,7 @@ fn build_execution_bridge_pin_set(
         hot_window_start_height: Some(hot_window_start_height),
         checkpoint_heights,
         pinned_refs: BTreeSet::new(),
+        best_effort_pinned_refs: BTreeSet::new(),
     };
 
     for height in record_heights {
@@ -477,6 +482,7 @@ fn build_execution_bridge_pin_set(
             record.height == latest_height,
             record.height >= hot_window_start_height,
             &mut pin_set.pinned_refs,
+            &mut pin_set.best_effort_pinned_refs,
         );
     }
     collect_execution_checkpoint_retained_refs(execution_records_dir, &mut pin_set.pinned_refs)?;
@@ -490,24 +496,39 @@ pub(super) fn sync_execution_bridge_pin_set(
     hot_window_heights: u64,
 ) -> Result<ExecutionBridgePinSet, String> {
     let pin_set = build_execution_bridge_pin_set(execution_records_dir, hot_window_heights)?;
+    let mut desired_pins = pin_set.pinned_refs.clone();
+    for pinned_ref in pin_set
+        .best_effort_pinned_refs
+        .difference(&pin_set.pinned_refs)
+    {
+        if execution_store
+            .has(pinned_ref.as_str())
+            .map_err(|err| format!("check execution store ref {} failed: {:?}", pinned_ref, err))?
+        {
+            desired_pins.insert(pinned_ref.clone());
+        }
+    }
     let current_pins = execution_store
         .list_pins()
         .map_err(|err| format!("list execution store pins failed: {:?}", err))?
         .into_iter()
         .collect::<BTreeSet<_>>();
 
-    for stale_ref in current_pins.difference(&pin_set.pinned_refs) {
+    for stale_ref in current_pins.difference(&desired_pins) {
         execution_store
             .unpin(stale_ref.as_str())
             .map_err(|err| format!("unpin execution store ref {} failed: {:?}", stale_ref, err))?;
     }
-    for pinned_ref in pin_set.pinned_refs.difference(&current_pins) {
+    for pinned_ref in desired_pins.difference(&current_pins) {
         execution_store
             .pin(pinned_ref.as_str())
             .map_err(|err| format!("pin execution store ref {} failed: {:?}", pinned_ref, err))?;
     }
 
-    Ok(pin_set)
+    Ok(ExecutionBridgePinSet {
+        pinned_refs: desired_pins,
+        ..pin_set
+    })
 }
 
 fn list_execution_bridge_pre_v2_heights(execution_records_dir: &Path) -> Result<Vec<u64>, String> {

--- a/crates/oasis7/src/bin/oasis7_chain_runtime/execution_bridge/mod.rs
+++ b/crates/oasis7/src/bin/oasis7_chain_runtime/execution_bridge/mod.rs
@@ -270,6 +270,7 @@ pub(super) struct ExecutionBridgePinSet {
     pub hot_window_start_height: Option<u64>,
     pub checkpoint_heights: BTreeSet<u64>,
     pub pinned_refs: BTreeSet<String>,
+    pub best_effort_pinned_refs: BTreeSet<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/oasis7/src/bin/oasis7_chain_runtime/execution_bridge/tests/retention.rs
+++ b/crates/oasis7/src/bin/oasis7_chain_runtime/execution_bridge/tests/retention.rs
@@ -17,6 +17,11 @@ use oasis7_proto::storage_profile::{StorageProfile, StorageProfileConfig};
 use oasis7_wasm_abi::ModuleOutput;
 use oasis7_wasm_executor::FixedSandbox;
 
+fn remove_test_store_blob(store: &LocalCasStore, content_ref: &str) {
+    fs::remove_file(store.blobs_dir().join(format!("{content_ref}.blob")))
+        .expect("remove test store blob");
+}
+
 #[test]
 fn execution_checkpoint_cadence_trims_old_manifests_and_clears_record_refs() {
     let dir = temp_dir("execution-checkpoint-cadence-trim");
@@ -224,6 +229,88 @@ fn execution_bridge_retention_maintenance_clears_archive_refs_and_prunes_orphans
                 .expect("record5 journal ref")
         )
         .expect("check hot journal"));
+
+    let _ = fs::remove_dir_all(dir);
+}
+
+#[test]
+fn execution_bridge_retention_maintenance_tolerates_missing_archive_external_effect_ref() {
+    let dir = temp_dir("execution-bridge-retention-missing-external-effect");
+    let records_dir = dir.join("records");
+    let store = LocalCasStore::new(dir.join("store"));
+    fs::create_dir_all(records_dir.as_path()).expect("create records dir");
+
+    let mut records = Vec::new();
+    for height in 1..=6 {
+        let mut record =
+            persist_test_execution_record_with_store_refs(records_dir.as_path(), &store, height);
+        record.checkpoint_ref =
+            maybe_persist_execution_checkpoint_for_record(records_dir.as_path(), &record, 2, 2)
+                .expect("maybe persist checkpoint");
+        persist_execution_bridge_record(records_dir.as_path(), &record)
+            .expect("persist checkpointed record");
+        records.push(record);
+    }
+
+    let missing_external_effect_ref = records[0]
+        .external_effect_ref
+        .as_deref()
+        .expect("record1 external effect ref")
+        .to_string();
+    remove_test_store_blob(&store, missing_external_effect_ref.as_str());
+
+    let freed_bytes = run_execution_bridge_retention_maintenance(records_dir.as_path(), &store, 2)
+        .expect("run retention maintenance with missing archive external effect");
+    assert!(freed_bytes > 0, "expected orphan sweep to free bytes");
+
+    let record_1 = load_execution_bridge_record(
+        execution_bridge_record_path(records_dir.as_path(), 1).as_path(),
+    )
+    .expect("load record 1");
+    assert!(record_1.snapshot_ref.is_none());
+    assert!(record_1.journal_ref.is_none());
+    assert!(!store
+        .is_pinned(missing_external_effect_ref.as_str())
+        .expect("check missing external effect pin"));
+    assert!(!store
+        .has(missing_external_effect_ref.as_str())
+        .expect("check missing external effect blob"));
+
+    let _ = fs::remove_dir_all(dir);
+}
+
+#[test]
+fn execution_bridge_retention_maintenance_fails_for_missing_required_refs() {
+    let dir = temp_dir("execution-bridge-retention-missing-required-ref");
+    let records_dir = dir.join("records");
+    let store = LocalCasStore::new(dir.join("store"));
+    fs::create_dir_all(records_dir.as_path()).expect("create records dir");
+
+    let mut records = Vec::new();
+    for height in 1..=6 {
+        let mut record =
+            persist_test_execution_record_with_store_refs(records_dir.as_path(), &store, height);
+        record.checkpoint_ref =
+            maybe_persist_execution_checkpoint_for_record(records_dir.as_path(), &record, 2, 2)
+                .expect("maybe persist checkpoint");
+        persist_execution_bridge_record(records_dir.as_path(), &record)
+            .expect("persist checkpointed record");
+        records.push(record);
+    }
+
+    let missing_latest_state_ref = records[5]
+        .latest_state_ref
+        .as_deref()
+        .expect("record6 latest state ref")
+        .to_string();
+    remove_test_store_blob(&store, missing_latest_state_ref.as_str());
+
+    let err = run_execution_bridge_retention_maintenance(records_dir.as_path(), &store, 2)
+        .expect_err("missing latest state ref should fail retention maintenance");
+    assert!(
+        err.contains(missing_latest_state_ref.as_str()),
+        "expected missing ref in error, got {err}"
+    );
 
     let _ = fs::remove_dir_all(dir);
 }


### PR DESCRIPTION
## Summary
- Treat execution bridge `external_effect_ref` retention as best-effort when syncing CAS pins.
- Keep required retention refs on the hard pin path so missing latest/checkpoint/hot-window blobs still fail loudly.
- Add regression coverage for the ECS 205-style missing archived external effect blob and for missing required refs.

## Root Cause
ECS 205 had a historical execution record whose `external_effect_ref` pointed at a missing blob. Retention maintenance attempted to pin every retained ref before pruning, so that single missing archived external effect caused the whole maintenance pass to fail and prevented orphan pruning.

## Validation
- `cargo fmt --check`
- `./scripts/cargo-dev.sh test -p oasis7 --bin oasis7_chain_runtime execution_bridge_retention_maintenance -- --nocapture`
- `./scripts/cargo-dev.sh test -p oasis7 --bin oasis7_chain_runtime execution_bridge_pin_set -- --nocapture`
- `./scripts/pm/task-closeout.sh --role tpm --task-uid task_96e92d21a9114d34a9f5b4b90c578217 --verify-command './scripts/cargo-dev.sh test -p oasis7 --bin oasis7_chain_runtime execution_bridge_retention_maintenance -- --nocapture && ./scripts/cargo-dev.sh test -p oasis7 --bin oasis7_chain_runtime execution_bridge_pin_set -- --nocapture'`
- `./scripts/pm/lint.sh`