### PR TITLE
Add chain transfer submit client

### DIFF
--- a/.pm/tasks/task_5ea9d9779665405face4c4984c056613.execution.md
+++ b/.pm/tasks/task_5ea9d9779665405face4c4984c056613.execution.md
@@ -1,0 +1,63 @@
+# task_5ea9d9779665405face4c4984c056613 Execution Log
+
+- task_uid: task_5ea9d9779665405face4c4984c056613
+- title: chain transfer submit client
+- owner_role: runtime_engineer
+- worktree_hint: /Users/scc/ccwork/worktrees/oasis7-p2p-chain-transfer-submit-client
+
+<!-- Append entries using:
+Example:
+  ## YYYY-MM-DD HH:MM:SS CST / role_name
+  - 完成内容: ...
+  - 遗留事项: ...
+  - Action: ...
+  - Validation Command: ...
+  - Expected Result: ...
+  - Actual Result: ...
+  - Blocker / Next Action: ...
+-->
+
+## 2026-06-03 21:10:00 CST / runtime_engineer
+- 完成内容: Implemented the first pass of the signed chain transfer submit client and connected the bridge runbook Step D to it.
+- 遗留事项: Need final verification, PM closeout, commit, push, and PR creation; actual local happy-path execution still requires local bridge/provider/chain services and test account OC balance.
+- Action: Added `crates/oasis7/src/bin/oasis7_chain_transfer_submit_client.rs` with `sign` and `submit` subcommands. The client reads `chain_private_key_hex`, `chain_public_key_hex`, and `oasis_sender_account_id` from a local keys file persona, reuses `sign_main_token_runtime_action_auth`, and posts signed JSON to `/v1/chain/transfer/submit` in submit mode. Updated the OC -> LetAI bridge runbook to use this client in Step D.
+- Validation Command: `./scripts/cargo-dev.sh test -p oasis7 --bin oasis7_chain_transfer_submit_client -- --nocapture`
+- Expected Result: binary tests pass, and generated transfer proof verifies through runtime main-token auth.
+- Actual Result: passed; 3 tests passed, including parser coverage, account/public-key mismatch rejection, and `verify_main_token_runtime_action_auth` acceptance of the generated `octransferauth:v1:` signature.
+- Blocker / Next Action: run doc governance, whitespace, and broader targeted checks before closeout.
+
+## 2026-06-03 21:25:00 CST / runtime_engineer
+- 完成内容: Completed final targeted verification for the signed transfer submit client and runbook update.
+- 遗留事项: Local full-chain happy-path execution still requires running bridge/provider/chain services, configured LetAI test credentials, and a funded sender account.
+- Action: Ran CLI sign smoke with a temporary keys file, formatted the crate, reran binary tests, checked docs, whitespace, and public secret patterns.
+- Validation Command: `transfer-client sign smoke; cargo fmt -p oasis7; ./scripts/cargo-dev.sh test -p oasis7 --bin oasis7_chain_transfer_submit_client -- --nocapture; ./scripts/doc-governance-check.sh; git diff --check; rg <secret-leak-patterns> ...`
+- Expected Result: signed transfer JSON is generated without printing private key material, tests pass, docs pass governance, whitespace is clean, and public docs/code do not contain generated private keys or raw token keys.
+- Actual Result: `transfer-client-sign-smoke: OK`; `cargo fmt -p oasis7` completed; binary tests passed with 3/3 tests; `doc-governance-check: OK`; `git diff --check` passed; public secret scan returned no hits.
+- Blocker / Next Action: close task, commit, push, and open the requested follow-up PR.
+
+## 2026-06-03 21:32:00 CST / runtime_engineer
+- 完成内容: Ran task closeout for this task and confirmed the task YAML recorded verified/done status for the targeted verification command.
+- 遗留事项: Repository-wide PM lint has a pre-existing failure in `.pm/tasks/task_455ea61e04c946469b8b1d22b700f853.execution.md`, which is outside this task's touched files.
+- Action: Executed `task-closeout.sh` with the targeted binary test, doc governance, and whitespace verification command.
+- Validation Command: `./scripts/pm/task-closeout.sh --role runtime_engineer --task-uid task_5ea9d9779665405face4c4984c056613 --verify-command './scripts/cargo-dev.sh test -p oasis7 --bin oasis7_chain_transfer_submit_client -- --nocapture && ./scripts/doc-governance-check.sh && git diff --check'`
+- Expected Result: task closeout records verified task state and repository-wide PM lint passes.
+- Actual Result: task YAML now records `status: done`, `last_verification_status: verified`, and `last_verification_exit_code: 0`; final script exit was blocked by PM lint failures in unrelated tracked task `task_455ea61e04c946469b8b1d22b700f853`.
+- Blocker / Next Action: continue PR creation for this scoped change and disclose the unrelated PM lint baseline blocker in the PR notes.
+
+## 2026-06-03 21:41:00 CST / runtime_engineer
+- 完成内容: Rebased onto `origin/main` and reran targeted verification after the commit SHA changed.
+- 遗留事项: Full local bridge happy-path execution still requires live local services and funded test sender account.
+- Action: Ran the transfer client binary tests, doc governance check, and whitespace check after rebase.
+- Validation Command: `./scripts/cargo-dev.sh test -p oasis7 --bin oasis7_chain_transfer_submit_client -- --nocapture && ./scripts/doc-governance-check.sh && git diff --check`
+- Expected Result: all targeted checks pass after rebase.
+- Actual Result: binary tests passed with 3/3 tests; `doc-governance-check: OK`; command exited 0, so `git diff --check` also passed.
+- Blocker / Next Action: amend this evidence into the commit, push branch, and open the requested draft PR.
+
+## 2026-06-03 22:14:00 CST / runtime_engineer
+- 完成内容: Addressed PR review comments for mixed-case key input, zero timeout handling, and runbook persona field clarity.
+- 遗留事项: Review threads remain unresolved on GitHub until the PR owner decides whether to resolve/comment there.
+- Action: Canonicalized persona hex fields to lowercase while accepting mixed-case input, compared `oasis_sender_account_id` public key case-insensitively, clamped parsed `--timeout-ms 0` to 1ms, updated runbook text to list all required persona fields, and added regression tests for both code paths.
+- Validation Command: `cargo fmt -p oasis7 && ./scripts/cargo-dev.sh test -p oasis7 --bin oasis7_chain_transfer_submit_client -- --nocapture; ./scripts/doc-governance-check.sh && git diff --check`
+- Expected Result: formatting completes, transfer client tests pass including new review-comment regressions, docs pass governance, and diff whitespace is clean.
+- Actual Result: `cargo fmt -p oasis7` completed; binary tests passed with 5/5 tests; `doc-governance-check: OK`; `git diff --check` passed.
+- Blocker / Next Action: amend review fixes into the PR branch, rebase if needed, push, and report the addressed threads.

--- a/.pm/tasks/task_5ea9d9779665405face4c4984c056613.yaml
+++ b/.pm/tasks/task_5ea9d9779665405face4c4984c056613.yaml
@@ -1,0 +1,28 @@
+task_uid: task_5ea9d9779665405face4c4984c056613
+title: "chain transfer submit client"
+owner_role: runtime_engineer
+worktree_hint: /Users/scc/ccwork/worktrees/oasis7-p2p-chain-transfer-submit-client
+execution_log_path: .pm/tasks/task_5ea9d9779665405face4c4984c056613.execution.md
+status: done
+priority: P2
+source_signal: null
+source_refs:
+  - AGENTS.md
+  - doc/p2p/token/mainchain-token-newapi-quota-bridge-2026-05-06.runbook.md
+  - crates/oasis7/src/bin/oasis7_chain_runtime/transfer_submit_api.rs
+doc_refs: []
+related_prd: []
+acceptance:
+  - "Add a repo-owned signed transfer submit client for bridge happy-path testing"
+  - "Client reads private keys from local secret file without printing them"
+  - "Update bridge runbook Step D to use the client"
+handoff_to:
+  - qa_engineer
+updated_at: 2026-06-03T21:15:26+08:00
+last_started_at: 2026-06-03T21:02:29+08:00
+last_claim_type: task_complete
+last_verify_command: "./scripts/cargo-dev.sh test -p oasis7 --bin oasis7_chain_transfer_submit_client -- --nocapture && ./scripts/doc-governance-check.sh && git diff --check"
+last_verified_at: 2026-06-03T21:15:24+08:00
+last_verification_exit_code: 0
+last_verification_status: verified
+last_closed_at: 2026-06-03T21:15:26+08:00

--- a/crates/oasis7/src/bin/oasis7_chain_transfer_submit_client.rs
+++ b/crates/oasis7/src/bin/oasis7_chain_transfer_submit_client.rs
@@ -1,0 +1,471 @@
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::ExitCode;
+use std::time::Duration;
+
+use oasis7::consensus_action_payload::sign_main_token_runtime_action_auth;
+use oasis7::runtime::Action;
+use reqwest::blocking::Client;
+use serde::{Deserialize, Serialize};
+
+fn main() -> ExitCode {
+    match run(std::env::args().skip(1)) {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(message) => {
+            eprintln!("{message}");
+            ExitCode::from(2)
+        }
+    }
+}
+
+fn run(args: impl IntoIterator<Item = String>) -> Result<(), String> {
+    let config = CliConfig::parse(args)?;
+    let request = build_signed_transfer_request(&config)?;
+    match config.command {
+        Command::Sign => {
+            print_json(&request)?;
+        }
+        Command::Submit => {
+            let chain_base_url = config
+                .chain_base_url
+                .as_deref()
+                .ok_or_else(|| "--chain-base-url is required for submit".to_string())?;
+            let response = submit_transfer(chain_base_url, &request, config.timeout_ms)?;
+            print_json(&response)?;
+        }
+    }
+    Ok(())
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Command {
+    Sign,
+    Submit,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct CliConfig {
+    command: Command,
+    keys_file: PathBuf,
+    persona: String,
+    to_account_id: String,
+    amount: u64,
+    nonce: u64,
+    chain_base_url: Option<String>,
+    timeout_ms: u64,
+}
+
+impl CliConfig {
+    fn parse(args: impl IntoIterator<Item = String>) -> Result<Self, String> {
+        let mut args = args.into_iter();
+        let command = match args.next().as_deref() {
+            Some("sign") => Command::Sign,
+            Some("submit") => Command::Submit,
+            Some("-h") | Some("--help") | None => return Err(usage()),
+            Some(other) => return Err(format!("unknown subcommand `{other}`\n\n{}", usage())),
+        };
+
+        let mut keys_file = None;
+        let mut persona = None;
+        let mut to_account_id = None;
+        let mut amount = None;
+        let mut nonce = None;
+        let mut chain_base_url = None;
+        let mut timeout_ms = 5_000_u64;
+
+        while let Some(flag) = args.next() {
+            let value = match flag.as_str() {
+                "--keys-file" => &mut keys_file,
+                "--persona" => &mut persona,
+                "--to-account-id" => &mut to_account_id,
+                "--amount" => {
+                    let raw = args
+                        .next()
+                        .ok_or_else(|| "--amount requires a value".to_string())?;
+                    amount = Some(
+                        raw.parse::<u64>()
+                            .map_err(|_| format!("invalid --amount value `{raw}`"))?,
+                    );
+                    continue;
+                }
+                "--nonce" => {
+                    let raw = args
+                        .next()
+                        .ok_or_else(|| "--nonce requires a value".to_string())?;
+                    nonce = Some(
+                        raw.parse::<u64>()
+                            .map_err(|_| format!("invalid --nonce value `{raw}`"))?,
+                    );
+                    continue;
+                }
+                "--chain-base-url" => &mut chain_base_url,
+                "--timeout-ms" => {
+                    let raw = args
+                        .next()
+                        .ok_or_else(|| "--timeout-ms requires a value".to_string())?;
+                    timeout_ms = raw
+                        .parse::<u64>()
+                        .map_err(|_| format!("invalid --timeout-ms value `{raw}`"))?
+                        .max(1);
+                    continue;
+                }
+                "-h" | "--help" => return Err(usage()),
+                other => return Err(format!("unknown option `{other}`\n\n{}", usage())),
+            };
+            let raw = args
+                .next()
+                .ok_or_else(|| format!("{flag} requires a value"))?;
+            *value = Some(raw);
+        }
+
+        Ok(Self {
+            command,
+            keys_file: PathBuf::from(
+                keys_file.ok_or_else(|| "--keys-file is required".to_string())?,
+            ),
+            persona: persona.ok_or_else(|| "--persona is required".to_string())?,
+            to_account_id: to_account_id
+                .ok_or_else(|| "--to-account-id is required".to_string())?,
+            amount: amount.ok_or_else(|| "--amount is required".to_string())?,
+            nonce: nonce.ok_or_else(|| "--nonce is required".to_string())?,
+            chain_base_url,
+            timeout_ms,
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct TestPersona {
+    slug: String,
+    private_key_hex: String,
+    public_key_hex: String,
+    account_id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct ChainTransferSubmitRequest {
+    from_account_id: String,
+    to_account_id: String,
+    amount: u64,
+    nonce: u64,
+    public_key: String,
+    signature: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct ChainTransferSubmitResponse {
+    ok: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    action_id: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    submitted_at_unix_ms: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    lifecycle_status: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error_code: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error: Option<String>,
+}
+
+fn usage() -> String {
+    "Usage: oasis7_chain_transfer_submit_client <sign|submit> --keys-file <path> --persona <slug> --to-account-id <account> --amount <n> --nonce <n> [--chain-base-url <url>] [--timeout-ms <n>]\n\n\
+Reads the persona private key from a local secret file, signs a TransferMainToken request with the canonical octransferauth:v1 proof, and either prints the submit JSON or posts it to /v1/chain/transfer/submit.\n"
+        .to_string()
+}
+
+fn build_signed_transfer_request(config: &CliConfig) -> Result<ChainTransferSubmitRequest, String> {
+    let persona = load_persona(config.keys_file.as_path(), config.persona.as_str())?;
+    let action = Action::TransferMainToken {
+        from_account_id: persona.account_id.clone(),
+        to_account_id: config.to_account_id.clone(),
+        amount: config.amount,
+        nonce: config.nonce,
+    };
+    let proof = sign_main_token_runtime_action_auth(
+        &action,
+        persona.account_id.as_str(),
+        persona.public_key_hex.as_str(),
+        persona.private_key_hex.as_str(),
+    )
+    .map_err(|err| format!("sign transfer request failed: {err}"))?;
+    Ok(ChainTransferSubmitRequest {
+        from_account_id: persona.account_id,
+        to_account_id: config.to_account_id.clone(),
+        amount: config.amount,
+        nonce: config.nonce,
+        public_key: proof
+            .public_key
+            .ok_or_else(|| "signed transfer proof missing public_key".to_string())?,
+        signature: proof
+            .signature
+            .ok_or_else(|| "signed transfer proof missing signature".to_string())?,
+    })
+}
+
+fn load_persona(path: &Path, slug: &str) -> Result<TestPersona, String> {
+    let content =
+        fs::read_to_string(path).map_err(|err| format!("read keys file failed: {err}"))?;
+    parse_persona(content.as_str(), slug)
+}
+
+fn parse_persona(content: &str, slug: &str) -> Result<TestPersona, String> {
+    let mut current_slug = None::<String>;
+    let mut current = BTreeMap::<String, String>::new();
+    let mut matches = Vec::new();
+
+    for raw in content.lines() {
+        let line = raw.trim();
+        if line.starts_with("## ") {
+            collect_persona_match(&mut matches, current_slug.as_deref(), &current, slug)?;
+            current.clear();
+            current_slug = parse_heading_slug(line);
+            continue;
+        }
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        if let Some((key, value)) = line.split_once('=') {
+            current.insert(key.trim().to_string(), value.trim().to_string());
+        }
+    }
+    collect_persona_match(&mut matches, current_slug.as_deref(), &current, slug)?;
+
+    match matches.len() {
+        1 => Ok(matches.remove(0)),
+        0 => Err(format!("persona `{slug}` not found in keys file")),
+        _ => Err(format!(
+            "persona `{slug}` appears more than once in keys file"
+        )),
+    }
+}
+
+fn parse_heading_slug(line: &str) -> Option<String> {
+    let title = line.trim_start_matches('#').trim();
+    let after_index = title
+        .split_once('.')
+        .map(|(_, rest)| rest.trim())
+        .unwrap_or(title);
+    (!after_index.is_empty()).then(|| after_index.to_string())
+}
+
+fn collect_persona_match(
+    matches: &mut Vec<TestPersona>,
+    current_slug: Option<&str>,
+    current: &BTreeMap<String, String>,
+    wanted_slug: &str,
+) -> Result<(), String> {
+    if current_slug != Some(wanted_slug) {
+        return Ok(());
+    }
+    let private_key_hex = normalize_hex_field(
+        required_persona_field(current, "chain_private_key_hex", wanted_slug)?.as_str(),
+        64,
+        "chain_private_key_hex",
+    )?;
+    let public_key_hex = normalize_hex_field(
+        required_persona_field(current, "chain_public_key_hex", wanted_slug)?.as_str(),
+        64,
+        "chain_public_key_hex",
+    )?;
+    let account_id = required_persona_field(current, "oasis_sender_account_id", wanted_slug)?;
+    let Some(account_public_key_hex) = account_id.strip_prefix("oc:pk:") else {
+        return Err(format!(
+            "persona `{wanted_slug}` oasis_sender_account_id must start with oc:pk:"
+        ));
+    };
+    if !account_public_key_hex.eq_ignore_ascii_case(public_key_hex.as_str()) {
+        return Err(format!(
+            "persona `{wanted_slug}` oasis_sender_account_id does not match chain_public_key_hex"
+        ));
+    }
+    let account_id = format!("oc:pk:{public_key_hex}");
+    matches.push(TestPersona {
+        slug: wanted_slug.to_string(),
+        private_key_hex,
+        public_key_hex,
+        account_id,
+    });
+    Ok(())
+}
+
+fn required_persona_field(
+    current: &BTreeMap<String, String>,
+    key: &str,
+    wanted_slug: &str,
+) -> Result<String, String> {
+    current
+        .get(key)
+        .filter(|value| !value.trim().is_empty())
+        .cloned()
+        .ok_or_else(|| format!("persona `{wanted_slug}` missing {key}"))
+}
+
+fn normalize_hex_field(value: &str, expected_len: usize, label: &str) -> Result<String, String> {
+    if value.len() != expected_len || !value.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        return Err(format!("{label} must be {expected_len} hex chars"));
+    }
+    Ok(value.to_ascii_lowercase())
+}
+
+fn submit_transfer(
+    chain_base_url: &str,
+    request: &ChainTransferSubmitRequest,
+    timeout_ms: u64,
+) -> Result<ChainTransferSubmitResponse, String> {
+    let timeout_ms = timeout_ms.max(1);
+    let client = Client::builder()
+        .timeout(Duration::from_millis(timeout_ms))
+        .build()
+        .map_err(|err| format!("build http client failed: {err}"))?;
+    let url = format!(
+        "{}/v1/chain/transfer/submit",
+        chain_base_url.trim_end_matches('/')
+    );
+    let response = client
+        .post(url)
+        .json(request)
+        .send()
+        .map_err(|err| format!("submit transfer request failed: {err}"))?;
+    let status = response.status();
+    let payload = response
+        .json::<ChainTransferSubmitResponse>()
+        .map_err(|err| format!("decode transfer submit response failed: {err}"))?;
+    if !status.is_success() || !payload.ok {
+        return Err(format!(
+            "transfer submit failed: http_status={status} error_code={} error={}",
+            payload.error_code.as_deref().unwrap_or("unknown"),
+            payload.error.as_deref().unwrap_or("unknown")
+        ));
+    }
+    Ok(payload)
+}
+
+fn print_json<T: Serialize>(value: &T) -> Result<(), String> {
+    let serialized =
+        serde_json::to_string_pretty(value).map_err(|err| format!("encode json failed: {err}"))?;
+    println!("{serialized}");
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ed25519_dalek::SigningKey;
+    use oasis7::consensus_action_payload::{
+        verify_main_token_runtime_action_auth, MainTokenActionAuthProof, MainTokenActionAuthScheme,
+    };
+
+    fn sample_keys_file() -> String {
+        let seed = [7_u8; 32];
+        let signing_key = SigningKey::from_bytes(&seed);
+        let private_key = hex::encode(seed);
+        let public_key = hex::encode(signing_key.verifying_key().to_bytes());
+        format!(
+            "# test\n\n## 1. happy_path\nemail=oasis7-e2e-001@test.invalid\nchain_private_key_hex={private_key}\nchain_public_key_hex={public_key}\noasis_sender_account_id=oc:pk:{public_key}\n\n## 2. other\nchain_private_key_hex={private_key}\nchain_public_key_hex={public_key}\noasis_sender_account_id=oc:pk:{public_key}\n"
+        )
+    }
+
+    #[test]
+    fn parse_persona_reads_expected_section() {
+        let persona = parse_persona(sample_keys_file().as_str(), "happy_path").expect("persona");
+        assert_eq!(persona.slug, "happy_path");
+        assert_eq!(
+            persona.account_id,
+            format!("oc:pk:{}", persona.public_key_hex)
+        );
+        assert_eq!(persona.private_key_hex.len(), 64);
+    }
+
+    #[test]
+    fn sign_request_verifies_with_runtime_auth() {
+        let dir = std::env::temp_dir();
+        let path = dir.join(format!(
+            "oasis7-chain-transfer-submit-client-{}.txt",
+            std::process::id()
+        ));
+        fs::write(&path, sample_keys_file()).expect("write keys file");
+        let config = CliConfig {
+            command: Command::Sign,
+            keys_file: path.clone(),
+            persona: "happy_path".to_string(),
+            to_account_id: "oc:bridge:test-route".to_string(),
+            amount: 100,
+            nonce: 42,
+            chain_base_url: None,
+            timeout_ms: 5_000,
+        };
+        let request = build_signed_transfer_request(&config).expect("signed request");
+        let action = Action::TransferMainToken {
+            from_account_id: request.from_account_id.clone(),
+            to_account_id: request.to_account_id.clone(),
+            amount: request.amount,
+            nonce: request.nonce,
+        };
+        let proof = MainTokenActionAuthProof {
+            scheme: MainTokenActionAuthScheme::Ed25519,
+            account_id: request.from_account_id.clone(),
+            public_key: Some(request.public_key.clone()),
+            signature: Some(request.signature.clone()),
+            threshold: None,
+            participant_signatures: Vec::new(),
+        };
+        verify_main_token_runtime_action_auth(&action, &proof).expect("verify signature");
+        assert!(request.signature.starts_with("octransferauth:v1:"));
+        assert!(!serde_json::to_string(&request)
+            .expect("request json")
+            .contains("chain_private_key_hex"));
+        let _ = fs::remove_file(path);
+    }
+
+    #[test]
+    fn parser_rejects_account_public_key_mismatch() {
+        let private_key = "a".repeat(64);
+        let public_key = "b".repeat(64);
+        let account_key = "c".repeat(64);
+        let bad = format!(
+            "## 1. happy_path\nchain_private_key_hex={private_key}\nchain_public_key_hex={public_key}\noasis_sender_account_id=oc:pk:{account_key}\n"
+        );
+        let err = parse_persona(bad.as_str(), "happy_path").expect_err("mismatch");
+        assert!(err.contains("does not match"));
+    }
+
+    #[test]
+    fn parser_accepts_mixed_case_hex_and_canonicalizes_account_id() {
+        let seed = [7_u8; 32];
+        let signing_key = SigningKey::from_bytes(&seed);
+        let private_key = hex::encode(seed).to_ascii_uppercase();
+        let public_key = hex::encode(signing_key.verifying_key().to_bytes()).to_ascii_uppercase();
+        let keys = format!(
+            "## 1. happy_path\nchain_private_key_hex={private_key}\nchain_public_key_hex={public_key}\noasis_sender_account_id=oc:pk:{public_key}\n"
+        );
+        let persona = parse_persona(keys.as_str(), "happy_path").expect("persona");
+        assert_eq!(persona.private_key_hex, private_key.to_ascii_lowercase());
+        assert_eq!(persona.public_key_hex, public_key.to_ascii_lowercase());
+        assert_eq!(
+            persona.account_id,
+            format!("oc:pk:{}", public_key.to_ascii_lowercase())
+        );
+    }
+
+    #[test]
+    fn parse_clamps_zero_timeout_to_one_ms() {
+        let config = CliConfig::parse([
+            "sign".to_string(),
+            "--keys-file".to_string(),
+            "keys.txt".to_string(),
+            "--persona".to_string(),
+            "happy_path".to_string(),
+            "--to-account-id".to_string(),
+            "oc:bridge:test-route".to_string(),
+            "--amount".to_string(),
+            "100".to_string(),
+            "--nonce".to_string(),
+            "1".to_string(),
+            "--timeout-ms".to_string(),
+            "0".to_string(),
+        ])
+        .expect("config");
+        assert_eq!(config.timeout_ms, 1);
+    }
+}

--- a/doc/p2p/token/mainchain-token-newapi-quota-bridge-2026-05-06.runbook.md
+++ b/doc/p2p/token/mainchain-token-newapi-quota-bridge-2026-05-06.runbook.md
@@ -214,7 +214,7 @@ export TEST_PROVIDER_AUTH_TOKEN=newapi_user_ref:${TEST_NEWAPI_USER_REF}
 - 可通过受信 SSH / tunnel / 本机启动访问 `BRIDGE_BASE_URL`、`PROVIDER_BASE_URL`、`CHAIN_BASE_URL`。
 - bridge-service 已配置 `--chain-base-url`、`--letai-base-url`、`--letai-platform-key`，且测试 lane 的 `--pricing-rule` 包含当前 `PRICING_VERSION`。
 - remote provider bridge 已启用 `OASIS7_PROVIDER_AUTH_ROUTE_FROM_BEARER=true`，且可读取同一份 NewAPI bridge state。
-- 已确认一个可执行的签名转账路径，能从本地 secret 文件读取 32-byte Ed25519 私钥并产出 `octransferauth:v1:<signature-hex>`。
+- 已确认 `oasis7_chain_transfer_submit_client` 可从本地 secret 文件读取当前 persona 的 `chain_private_key_hex`、`chain_public_key_hex`、`oasis_sender_account_id`，并产出 `octransferauth:v1:<signature-hex>`。
 - 测试 sender 账户有足够 OC，或测试网 faucet/operator 已准备好等价入账路径。
 - 证据采集能按本次 `route_id` / `bridge_deposit_id` / chain action id 定位 ledger row；不得只看全局计数。
 
@@ -295,10 +295,26 @@ export TEST_ROUTE_EXPIRES_AT_UNIX_MS="$(printf '%s' "${ROUTE_RESPONSE}" | jq -r 
 
 #### Step D: 链上签名转账
 
-公开 transfer submit API 的请求体必须包含签名字段，不要用未签名 `curl` 伪造链上入账。完整 `happy_path` 在没有明确 signer/operator 工具前保持 blocked。测试时二选一：
+公开 transfer submit API 的请求体必须包含签名字段，不要用未签名 `curl` 伪造链上入账。默认使用 repo-owned signed transfer client：
 
-- 用当前测试网/launcher/operator 已验证的签名转账工具，从本地 secret 文件读取 persona 私钥，生成 `octransferauth:v1:<signature-hex>` 后提交到 `POST /v1/chain/transfer/submit`。
-- 若本 lane 由 faucet/operator 工具托管测试入账，则用等价工具把同一 `TEST_OASIS_SENDER_ACCOUNT_ID -> TEST_DEPOSIT_ACCOUNT_ID` 的金额提交到链上，并保留 tx/action id。
+```bash
+env -u RUSTC_WRAPPER cargo run -p oasis7 --bin oasis7_chain_transfer_submit_client -- \
+  submit \
+  --keys-file ~/Documents/keys/test_keys.txt \
+  --persona happy_path \
+  --chain-base-url "${CHAIN_BASE_URL}" \
+  --to-account-id "${TEST_DEPOSIT_ACCOUNT_ID}" \
+  --amount 100 \
+  --nonce 1
+```
+
+约束：
+
+- `--persona` 必须选择本轮正在跑的 test persona。
+- `--amount` 必须替换成当前 `PRICING_VERSION` 对应的 OC 金额；少付/多付 case 用同一命令改金额制造。
+- `--nonce` 必须使用该 sender 在测试 lane 中未用过的 nonce。
+- client 从 `--keys-file` 的当前 persona 段读取 `chain_private_key_hex`、`chain_public_key_hex`、`oasis_sender_account_id`，不会把私钥打印到 stdout。
+- 若本 lane 由 faucet/operator 工具托管测试入账，也可以用等价工具把同一 `TEST_OASIS_SENDER_ACCOUNT_ID -> TEST_DEPOSIT_ACCOUNT_ID` 的金额提交到链上，并保留 tx/action id。
 
 transfer submit 字段形状：
 


### PR DESCRIPTION
## Summary
- Add `oasis7_chain_transfer_submit_client` with `sign` and `submit` modes for signed main-token transfer submit requests.
- Reuse canonical `sign_main_token_runtime_action_auth` so bridge happy-path test deposits emit `octransferauth:v1:` proofs accepted by runtime auth.
- Update the OC -> LetAI bridge runbook Step D to use the repo-owned client instead of an unspecified signer/operator path.

## Verification
- `./scripts/cargo-dev.sh test -p oasis7 --bin oasis7_chain_transfer_submit_client -- --nocapture`
- `transfer-client sign` smoke with a temporary keys file, checking output JSON and that private key material is not emitted
- `cargo fmt -p oasis7`
- `./scripts/doc-governance-check.sh`
- `git diff --check`
- Public docs/code secret-pattern scan returned no generated private key or raw `token_key` hits

## Notes
- Rebased onto `origin/main` before PR creation and reran targeted verification.
- `./scripts/pm/task-closeout.sh` recorded this task as verified/done, but its final repository-wide PM lint step is currently blocked by pre-existing formatting failures in tracked task `.pm/tasks/task_455ea61e04c946469b8b1d22b700f853.execution.md`, outside this PR's touched files.
- Full local happy-path execution still requires local bridge/provider/chain services, LetAI test credentials, and a funded sender account.