### PR TITLE
Add manual testnet package workflow

### DIFF
--- a/.github/workflows/testnet-packages.yml
+++ b/.github/workflows/testnet-packages.yml
@@ -1,0 +1,316 @@
+name: Testnet Packages
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref_or_sha:
+        description: "Branch, tag, or commit SHA to package. Empty uses the selected workflow ref."
+        required: false
+        default: ""
+        type: string
+      build_profile:
+        description: "Cargo profile for package binaries"
+        required: true
+        default: release
+        type: choice
+        options:
+          - release
+          - dev
+      package_scope:
+        description: "Platform package set"
+        required: true
+        default: linux_only
+        type: choice
+        options:
+          - linux_only
+          - linux_macos_x64
+          - all_existing
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+  CARGO_NET_RETRY: 10
+  CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
+  CARGO_PROFILE_DEV_DEBUG: 0
+  CARGO_PROFILE_TEST_DEBUG: 0
+  RUST_TOOLCHAIN: 1.96.0
+
+jobs:
+  plan:
+    name: plan-testnet-package-scope
+    runs-on: ubuntu-24.04
+    outputs:
+      ref: ${{ steps.plan.outputs.ref }}
+      matrix: ${{ steps.plan.outputs.matrix }}
+    steps:
+      - id: plan
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          ref="${{ inputs.ref_or_sha }}"
+          if [[ -z "${ref}" ]]; then
+            ref="${GITHUB_REF}"
+          fi
+
+          case "${{ inputs.package_scope }}" in
+            linux_only)
+              matrix='{"include":[{"os":"ubuntu-24.04","platform":"linux-x64","asset_name":"oasis7-linux-x86_64.AppImage","target_triple":"native"}]}'
+              ;;
+            linux_macos_x64)
+              matrix='{"include":[{"os":"ubuntu-24.04","platform":"linux-x64","asset_name":"oasis7-linux-x86_64.AppImage","target_triple":"native"},{"os":"macos-14","platform":"macos-x64","asset_name":"oasis7-macos-x64.dmg","target_triple":"x86_64-apple-darwin"}]}'
+              ;;
+            all_existing)
+              matrix='{"include":[{"os":"ubuntu-24.04","platform":"linux-x64","asset_name":"oasis7-linux-x86_64.AppImage","target_triple":"native"},{"os":"macos-14","platform":"macos-x64","asset_name":"oasis7-macos-x64.dmg","target_triple":"x86_64-apple-darwin"},{"os":"windows-2022","platform":"windows-x64","asset_name":"oasis7-windows-x64.exe","target_triple":"native"}]}'
+              ;;
+            *)
+              echo "error: unsupported package_scope=${{ inputs.package_scope }}" >&2
+              exit 1
+              ;;
+          esac
+
+          echo "ref=${ref}" >> "${GITHUB_OUTPUT}"
+          echo "matrix=${matrix}" >> "${GITHUB_OUTPUT}"
+
+  build-web-dist:
+    name: build-web-dist
+    needs: plan
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.plan.outputs.ref }}
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+      - name: Install viewer web dependencies
+        run: npm ci --prefix crates/oasis7_viewer
+      - name: Install pinned Rust toolchain
+        run: |
+          rustup toolchain install "${RUST_TOOLCHAIN}" --profile default
+          rustup target add wasm32-unknown-unknown --toolchain "${RUST_TOOLCHAIN}"
+          rustup default "${RUST_TOOLCHAIN}"
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: testnet-packages-web-wasm-v1
+          cache-on-failure: true
+      - name: Install trunk
+        run: cargo install trunk --locked
+      - name: Build web dists
+        run: |
+          mkdir -p output/testnet-packages/web-dist output/testnet-packages/web-launcher-dist
+          (
+            ./scripts/build-viewer-software-safe.sh
+            ./scripts/copy-viewer-web-dist.sh --dist-dir output/testnet-packages/web-dist
+          )
+          (
+            cd crates/oasis7_client_launcher
+            env -u NO_COLOR trunk build --release --dist ../../output/testnet-packages/web-launcher-dist
+          )
+      - name: Upload web dist artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: testnet-web-dists
+          path: |
+            output/testnet-packages/web-dist
+            output/testnet-packages/web-launcher-dist
+          if-no-files-found: error
+
+  package-native:
+    name: package-${{ matrix.platform }}
+    needs:
+      - plan
+      - build-web-dist
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.plan.outputs.matrix) }}
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.plan.outputs.ref }}
+      - name: Install pinned Rust toolchain
+        shell: bash
+        run: |
+          rustup toolchain install "${RUST_TOOLCHAIN}" --profile default
+          rustup default "${RUST_TOOLCHAIN}"
+          if [[ "${{ matrix.target_triple }}" != "native" ]]; then
+            rustup target add "${{ matrix.target_triple }}" --toolchain "${RUST_TOOLCHAIN}"
+          fi
+      - name: Install Linux system dependencies
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            pkg-config \
+            libwayland-dev \
+            wayland-protocols \
+            libxkbcommon-dev \
+            libx11-dev \
+            libxi-dev \
+            libxcursor-dev \
+            libxrandr-dev \
+            libxinerama-dev \
+            libasound2-dev \
+            libudev-dev
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: testnet-packages-${{ runner.os }}-${{ matrix.target_triple }}-v1
+          cache-on-failure: true
+      - name: Ensure Linux AppImage tooling
+        if: matrix.platform == 'linux-x64'
+        shell: bash
+        run: |
+          set -euo pipefail
+          APPIMAGETOOL_VERSION="1.9.1"
+          APPIMAGETOOL_FILENAME="appimagetool-x86_64.AppImage"
+          APPIMAGETOOL_URL="https://github.com/AppImage/appimagetool/releases/download/${APPIMAGETOOL_VERSION}/${APPIMAGETOOL_FILENAME}"
+          APPIMAGETOOL_SHA256="ed4ce84f0d9caff66f50bcca6ff6f35aae54ce8135408b3fa33abfc3cb384eb0"
+
+          mkdir -p "${RUNNER_TEMP}/appimagetool"
+          curl -fsSL "${APPIMAGETOOL_URL}" \
+            -o "${RUNNER_TEMP}/appimagetool/${APPIMAGETOOL_FILENAME}"
+          printf '%s  %s\n' \
+            "${APPIMAGETOOL_SHA256}" \
+            "${RUNNER_TEMP}/appimagetool/${APPIMAGETOOL_FILENAME}" | sha256sum -c -
+          chmod +x "${RUNNER_TEMP}/appimagetool/${APPIMAGETOOL_FILENAME}"
+          ln -sf \
+            "${RUNNER_TEMP}/appimagetool/${APPIMAGETOOL_FILENAME}" \
+            "${RUNNER_TEMP}/appimagetool/appimagetool"
+          echo "${RUNNER_TEMP}/appimagetool" >> "${GITHUB_PATH}"
+      - name: Download web dist artifacts
+        uses: actions/download-artifact@v6
+        with:
+          name: testnet-web-dists
+          path: output/testnet-packages
+      - name: Ensure Windows packaging dependencies
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $missing = @()
+          if (-not (Get-Command makensis -ErrorAction SilentlyContinue)) {
+            $missing += "nsis"
+          }
+          if ($missing.Count -eq 0) {
+            exit 0
+          }
+          choco install $missing -y --no-progress
+      - name: Resolve package version
+        id: package_version
+        shell: bash
+        run: |
+          set -euo pipefail
+          short_sha="$(git rev-parse --short=12 HEAD)"
+          version="0.0.0+testnet.${GITHUB_RUN_NUMBER}.${short_sha}"
+          echo "value=${version}" >> "${GITHUB_OUTPUT}"
+      - name: Build launcher bundle
+        shell: bash
+        run: |
+          ./scripts/release-prepare-bundle.sh \
+            --platform "${{ matrix.platform }}" \
+            --target-triple "${{ matrix.target_triple }}" \
+            --web-dist output/testnet-packages/web-dist \
+            --web-launcher-dist output/testnet-packages/web-launcher-dist \
+            --out-dir output/testnet-packages/assets \
+            --profile "${{ inputs.build_profile }}"
+      - name: Validate bundle entrypoints
+        shell: bash
+        run: |
+          ./scripts/validate-release-platform-entrypoints.sh \
+            --platform "${{ matrix.platform }}" \
+            --bundle-dir "output/testnet-packages/assets/oasis7-${{ matrix.platform }}" \
+            | tee "output/testnet-packages/assets/${{ matrix.platform }}-entrypoint-validation.log"
+      - name: Stage bundle manifest
+        shell: bash
+        run: |
+          cp \
+            "output/testnet-packages/assets/oasis7-${{ matrix.platform }}/.oasis7-bundle-manifest.json" \
+            "output/testnet-packages/assets/${{ matrix.platform }}-bundle-manifest.json"
+      - name: Package native installer
+        shell: bash
+        run: |
+          ./scripts/package-native-installer.sh \
+            --platform "${{ matrix.platform }}" \
+            --bundle-dir "output/testnet-packages/assets/oasis7-${{ matrix.platform }}" \
+            --out-dir output/testnet-packages/assets \
+            --asset-name "${{ matrix.asset_name }}" \
+            --version "${{ steps.package_version.outputs.value }}"
+      - name: Package secondary Linux .deb
+        if: matrix.platform == 'linux-x64'
+        shell: bash
+        run: |
+          ./scripts/package-native-installer.sh \
+            --platform "${{ matrix.platform }}" \
+            --bundle-dir "output/testnet-packages/assets/oasis7-${{ matrix.platform }}" \
+            --out-dir output/testnet-packages/assets \
+            --asset-name "oasis7-linux-x64.deb" \
+            --version "${{ steps.package_version.outputs.value }}"
+      - name: Archive raw Linux bundle
+        if: matrix.platform == 'linux-x64'
+        shell: bash
+        run: |
+          tar -C output/testnet-packages/assets \
+            -czf output/testnet-packages/assets/oasis7-linux-x64-bundle.tar.gz \
+            oasis7-linux-x64
+      - name: Write BUILDINFO
+        shell: bash
+        run: |
+          {
+            echo "workflow=Testnet Packages"
+            echo "run_id=${GITHUB_RUN_ID}"
+            echo "run_number=${GITHUB_RUN_NUMBER}"
+            echo "repository=${GITHUB_REPOSITORY}"
+            echo "requested_ref=${{ needs.plan.outputs.ref }}"
+            echo "commit=$(git rev-parse HEAD)"
+            echo "build_profile=${{ inputs.build_profile }}"
+            echo "package_scope=${{ inputs.package_scope }}"
+            echo "platform=${{ matrix.platform }}"
+            echo "target_triple=${{ matrix.target_triple }}"
+            echo "runner_os=${RUNNER_OS}"
+            echo "package_version=${{ steps.package_version.outputs.value }}"
+            echo "published=false"
+          } > "output/testnet-packages/assets/${{ matrix.platform }}-BUILDINFO"
+      - name: Generate checksums
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd output/testnet-packages/assets
+
+          checksum() {
+            if command -v sha256sum >/dev/null 2>&1; then
+              sha256sum "$@"
+            else
+              shasum -a 256 "$@"
+            fi
+          }
+
+          files=(
+            "${{ matrix.asset_name }}"
+            "${{ matrix.platform }}-BUILDINFO"
+            "${{ matrix.platform }}-bundle-manifest.json"
+            "${{ matrix.platform }}-entrypoint-validation.log"
+          )
+          if [[ "${{ matrix.platform }}" == "linux-x64" ]]; then
+            files+=(
+              "oasis7-linux-x64.deb"
+              "oasis7-linux-x64-bundle.tar.gz"
+            )
+          fi
+
+          for file in "${files[@]}"; do
+            [[ -f "${file}" ]] || { echo "error: missing package artifact ${file}" >&2; exit 1; }
+          done
+          checksum "${files[@]}" > "${{ matrix.platform }}-SHA256SUMS"
+      - name: Upload testnet package artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: testnet-package-${{ matrix.platform }}-${{ steps.package_version.outputs.value }}
+          path: |
+            output/testnet-packages/assets/${{ matrix.asset_name }}
+            output/testnet-packages/assets/${{ matrix.platform }}-BUILDINFO
+            output/testnet-packages/assets/${{ matrix.platform }}-SHA256SUMS
+            output/testnet-packages/assets/${{ matrix.platform }}-bundle-manifest.json
+            output/testnet-packages/assets/${{ matrix.platform }}-entrypoint-validation.log
+            output/testnet-packages/assets/oasis7-linux-x64.deb
+            output/testnet-packages/assets/oasis7-linux-x64-bundle.tar.gz
+          if-no-files-found: warn

--- a/.pm/roles/tpm/backlog/committed.yaml
+++ b/.pm/roles/tpm/backlog/committed.yaml
@@ -1,14 +1,4 @@
 version: 1
 role: tpm
 status: committed
-tasks:
-  - task_uid: task_202b9f812d49432a9f4360b8a66c5364
-    title: "expand testnet to fourth local node"
-    priority: P2
-    source_signal: null
-    related_prd: []
-    acceptance:
-      - "Start one additional local public testnet node and verify four-node topology evidence."
-    handoff_to: []
-    status: committed
-    task_path: .pm/tasks/task_202b9f812d49432a9f4360b8a66c5364.yaml
+tasks: []

--- a/.pm/roles/tpm/backlog/committed.yaml
+++ b/.pm/roles/tpm/backlog/committed.yaml
@@ -1,4 +1,14 @@
 version: 1
 role: tpm
 status: committed
-tasks: []
+tasks:
+  - task_uid: task_202b9f812d49432a9f4360b8a66c5364
+    title: "expand testnet to fourth local node"
+    priority: P2
+    source_signal: null
+    related_prd: []
+    acceptance:
+      - "Start one additional local public testnet node and verify four-node topology evidence."
+    handoff_to: []
+    status: committed
+    task_path: .pm/tasks/task_202b9f812d49432a9f4360b8a66c5364.yaml

--- a/.pm/tasks/task_3434e82349934071aba4f35354a67786.execution.md
+++ b/.pm/tasks/task_3434e82349934071aba4f35354a67786.execution.md
@@ -144,3 +144,21 @@ Example:
 - Expected Result: GitHub PR opens against `eng-cc/oasis7:main`.
 - Actual Result: Draft PR created: https://github.com/eng-cc/oasis7/pull/351
 - Blocker / Next Action: Run GitHub Actions package workflow from PR branch when ready, then move PR out of draft after review/CI expectations are satisfied.
+
+## 2026-06-04 09:20:00 CST / tpm
+- 完成内容: Addressed Copilot review comment on PR #351.
+- 遗留事项: Thread not resolved on GitHub; user asked to inspect and solve comments, not to resolve/reply on GitHub.
+- Action: Restored `.pm/roles/tpm/backlog/committed.yaml` to the regenerated empty view so the PR no longer commits a local backlog view change with an unrelated task entry.
+- Validation Command: `gh api repos/eng-cc/oasis7/pulls/351/comments --paginate --jq '.[] | {id, path, line, side, body, user: .user.login, html_url}'`
+- Expected Result: Identify actionable inline review comments.
+- Actual Result: One actionable Copilot comment found on `.pm/roles/tpm/backlog/committed.yaml`, requesting the file be reverted/dropped from the PR because it is a git-ignored regenerated view.
+- Blocker / Next Action: Run fresh verification, commit, and push the review fix.
+
+## 2026-06-04 09:23:00 CST / tpm
+- 完成内容: Verified review fix locally.
+- 遗留事项: Need to push fix commit to PR branch and re-check PR diff/comments.
+- Action: Ran workflow structural checks, doc governance, and diff whitespace check after reverting backlog view.
+- Validation Command: `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/testnet-packages.yml"); puts "yaml ok"' && python3 <matrix-json-check> && ./scripts/doc-governance-check.sh && git diff --check`
+- Expected Result: Workflow remains structurally valid, doc governance passes, and diff has no whitespace errors.
+- Actual Result: YAML parse passed, matrix JSON check passed, `doc-governance-check: OK`, and `git diff --check` exited 0.
+- Blocker / Next Action: Commit and push review fix.

--- a/.pm/tasks/task_3434e82349934071aba4f35354a67786.execution.md
+++ b/.pm/tasks/task_3434e82349934071aba4f35354a67786.execution.md
@@ -1,0 +1,146 @@
+# task_3434e82349934071aba4f35354a67786 Execution Log
+
+- task_uid: task_3434e82349934071aba4f35354a67786
+- title: testnet deployment and CI packaging advice
+- owner_role: tpm
+- worktree_hint: /Users/scc/ccwork/worktrees/oasis7-engineering-testnet-ci-packaging-advice
+
+<!-- Append entries using:
+Example:
+  ## YYYY-MM-DD HH:MM:SS CST / role_name
+  - 完成内容: ...
+  - 遗留事项: ...
+  - Action: ...
+  - Validation Command: ...
+  - Expected Result: ...
+  - Actual Result: ...
+  - Blocker / Next Action: ...
+-->
+
+## 2026-06-03 22:46:30 CST / tpm
+- 完成内容: WORKFLOW BOOTSTRAP DECIDED. Created standard task worktree for a read-only professional/domain question about deploying a four-node testnet and whether to add manual PR CI packaging.
+- 遗留事项: Need professional role conclusions before answering user.
+- Repository State Impact: Creates workflow/task truth only; no product/runtime/CI implementation changes yet.
+- Isolation Decision: Source worktree was `main` and clean; created `/Users/scc/ccwork/worktrees/oasis7-engineering-testnet-ci-packaging-advice` on branch `task/engineering-testnet-ci-packaging-advice`.
+- Task Truth: owner role `tpm`; `.pm` task `task_3434e82349934071aba4f35354a67786`; execution log `.pm/tasks/task_3434e82349934071aba4f35354a67786.execution.md`.
+- Routed Next Phase: repo-owned workflow router, read-only professional/domain judgment.
+- Required Writeback: `.pm` execution log mandatory; no PRD/project change required unless a later implementation task is opened.
+- Action: `./scripts/new-task-worktree.sh engineering testnet-ci-packaging-advice --pm-owner-role tpm --pm-title "testnet deployment and CI packaging advice" --pm-source-ref AGENTS.md --pm-doc-ref doc/engineering/workflow/source-of-truth.md --pm-acceptance "Answer whether to add a manual PR CI build for multi-platform packages before deploying a four-node testnet" --json`
+- Validation Command: command exited 0 and returned task/worktree JSON.
+- Expected Result: Standard task worktree with linked target cache and committed `.pm` task.
+- Actual Result: Created worktree and task as expected.
+- Blocker / Next Action: Record route and dispatch professional read-only slices.
+
+## 2026-06-03 22:47:00 CST / tpm
+- 完成内容: WORKFLOW ROUTE DECIDED.
+- 遗留事项: Await runtime_engineer and qa_engineer bounded read-only analysis slices.
+- Task Phase: Read-only professional/domain judgment.
+- Selected Workflow Skills: `repo-owned-workflow-router` after bootstrap; professional bounded slices required because answer depends on runtime/deployment package shape and QA/CI release evidence.
+- Skipped Workflow Skills: `bounded-brainstorming` skipped because the immediate decision is narrow; `tdd-test-writer`, `executing-project-tasks`, `verification-before-completion`, and `finishing-a-development-branch` skipped because no implementation or completion claim is being made.
+- Specialist Skills Considered: `runtime_engineer` for deployment/runtime package implications; `qa_engineer` for CI/manual trigger and release-blocking judgment.
+- TPM TODO decomposition: (1) gather objective repo CI/build context, (2) dispatch runtime_engineer read-only analysis, (3) dispatch qa_engineer read-only analysis, (4) integrate role-tagged answer to user.
+- Subagent Slice Plan 1:
+  - role: `runtime_engineer`
+  - slice type: `read_only_analysis`
+  - intended model configuration: workflow source-of-truth default subagent runtime `gpt-5.5-medium`
+  - actual dispatched model/reasoning: to be recorded after dispatch; expected inherited/unverified if tool cannot verify
+  - context delivery mode: full-thread/full-history fork requested
+  - mandatory context checklist/packet: AGENTS.md; `.agents/roles/runtime_engineer.md`; `doc/engineering/workflow/source-of-truth.md`; task yaml/log; canonical worktree/branch; user question; third_party read-only and Rust cargo wrapper constraints; relevant CI/build files found by repo search
+  - write scope: read-only; append final conclusion/evidence to this execution log only if directly available, otherwise TPM records returned result
+  - return contract: concise recommendation on package/platform/deployment implications for local + three Ubuntu nodes, evidence paths/commands, uncertainty, and whether repo writeback is recommended
+  - formal sink / writeback surface: `.pm/tasks/task_3434e82349934071aba4f35354a67786.execution.md`
+  - integration owner/order: TPM integrates after QA slice
+- Subagent Slice Plan 2:
+  - role: `qa_engineer`
+  - slice type: `verification_judgment`
+  - intended model configuration: workflow source-of-truth default subagent runtime `gpt-5.5-medium`
+  - actual dispatched model/reasoning: to be recorded after dispatch; expected inherited/unverified if tool cannot verify
+  - context delivery mode: full-thread/full-history fork requested
+  - mandatory context checklist/packet: AGENTS.md; `.agents/roles/qa_engineer.md`; `doc/engineering/workflow/source-of-truth.md`; task yaml/log; canonical worktree/branch; user question; relevant CI/workflow/package files found by repo search
+  - write scope: read-only; append final conclusion/evidence to this execution log only if directly available, otherwise TPM records returned result
+  - return contract: concise recommendation on adding manual PR CI builds for cross-platform packages, suggested trigger/artifact matrix, release-blocking expectations, uncertainty, and whether repo writeback is recommended
+  - formal sink / writeback surface: `.pm/tasks/task_3434e82349934071aba4f35354a67786.execution.md`
+  - integration owner/order: TPM integrates after runtime slice
+- Action: Route recorded before delegated professional work.
+- Validation Command: `sed -n '1,220p' .agents/skills/repo-owned-workflow-router/SKILL.md`
+- Expected Result: Router requires professional slices for read-only domain judgments.
+- Actual Result: Router instructions confirm read-only professional/domain judgments require matching bounded role slices and `.pm` sink.
+- Blocker / Next Action: Gather objective repo context and dispatch slices.
+
+## 2026-06-03 22:49:00 CST / tpm
+- 完成内容: Dispatched professional read-only slices.
+- 遗留事项: Await returned role conclusions and integrate user-facing answer.
+- Action: Spawned full-history fork subagents for `runtime_engineer` and `qa_engineer`.
+- Validation Command: `multi_agent_v1.spawn_agent` returned agent ids.
+- Expected Result: Two bounded read-only professional slices running with full-thread context.
+- Actual Result: `runtime_engineer` slice agent `019e8df3-70e0-7ac1-bf9b-0b3625fda582` (`Raman`) and `qa_engineer` slice agent `019e8df3-b3b0-7083-954d-be3da1786166` (`Faraday`) started. Tool limitation prevented verified model/reasoning selection with full-history fork; actual dispatched model/reasoning recorded as `inherited/unverified`.
+- Blocker / Next Action: Read objective CI/package evidence while slices run.
+
+## 2026-06-03 22:57:30 CST / runtime_engineer
+- 完成内容: Read-only runtime/deployment package analysis returned by subagent `019e8df3-70e0-7ac1-bf9b-0b3625fda582` (`Raman`).
+- 遗留事项: Await QA release/CI judgment before user-facing synthesis.
+- Professional Conclusion: Add a manual, PR/ref-selectable, artifact-only package build entry for testnet candidates; do not add this to automatic PR required CI.
+- Evidence: `.github/workflows/rust.yml` currently has manual `full_regression` / `newapi_bridge_package` modes but no oasis7 testnet package mode; `.github/workflows/release-packages.yml` has Linux/macOS/Windows packaging but is release/tag and publish oriented; `scripts/build-game-launcher-bundle.sh` includes `oasis7_chain_runtime` and launcher binaries; `scripts/package-native-installer.sh` supports Linux `.deb`/`.AppImage`; `scripts/network-tier-manifest-smoke.sh` contains a `target-validator-count 4` public-testnet smoke lane.
+- Recommended Artifacts: Linux x64 `.deb` or raw tar bundle for the three Ubuntu nodes; local machine package depends on local architecture, with `macos-arm64` uncertain if the local machine is Apple Silicon; Windows is optional for this deployment.
+- Uncertainty: Ubuntu CPU architecture, local machine architecture, validator vs observer topology, and whether deployment should consume PR-head artifacts or only merged/tagged artifacts.
+- Writeback Recommendation: Follow-up implementation PR recommended to add `workflow_dispatch` package-only path with `ref`/PR head input, skip publish, upload artifacts, and preferably include raw Linux tar bundle.
+- Action: Integrated returned role conclusion into execution log.
+- Validation Command: `multi_agent_v1.wait_agent` returned completed runtime slice.
+- Expected Result: Role-tagged professional conclusion recorded in `.pm` sink.
+- Actual Result: Conclusion recorded; actual model/reasoning `inherited/unverified`.
+- Blocker / Next Action: Await `qa_engineer` slice.
+
+## 2026-06-03 22:59:30 CST / qa_engineer
+- 完成内容: Read-only QA verification judgment returned by subagent `019e8df3-b3b0-7083-954d-be3da1786166` (`Faraday`).
+- 遗留事项: Integrate runtime + QA conclusions into user-facing answer.
+- Professional Conclusion: Add a manual PR/branch packaging workflow, but do not put it into default required PR CI. Before a four-node controlled testnet, CI should produce same-commit Linux x64 deployable packages plus checksums to avoid per-node build drift.
+- Evidence: `.github/workflows/rust.yml` has manual dispatch but only packages NewAPI bridge; `.github/workflows/release-packages.yml` has manual release packaging matrix for `linux-x64 / macos-x64 / windows-x64`; Linux release package includes AppImage and `.deb`; `scripts/validate-release-platform-entrypoints.sh` validates `run-chain-runtime.sh` and `oasis7_chain_runtime`; `testing-manual.md` says `public_testnet` is still skeleton/readiness-gated rather than live by package build alone.
+- Recommended Workflow Shape: `workflow_dispatch` inputs `ref_or_sha`, `build_profile=release|dev`, `package_scope=linux_only|local_plus_linux|all`, `publish=false`.
+- Recommended Artifacts: Linux `.deb` or tarball/AppImage, `SHA256SUMS`, `BUILDINFO`, bundle manifest, and entrypoint validation log.
+- Release-Blocking Recommendation: For controlled four-node testnet, block on Linux x64 package build, entrypoint validation, checksum/BUILDINFO, and fixed candidate commit/bundle. For public claims, also require readiness lanes: `shared_devnet_pass`, `public_rpc_ready`, `explorer_public_ready`, `faucet_guard_ready`, `reset_policy_announced`, `runtime_bootstrap`, `claims_boundary_review`.
+- Uncertainty: Local machine architecture is unknown; existing release matrix does not cover native `macos-arm64`.
+- Writeback Recommendation: Follow-up implementation task recommended to add manual PR/branch testnet package workflow.
+- Action: Integrated returned role conclusion into execution log.
+- Validation Command: subagent notification returned completed QA slice.
+- Expected Result: Role-tagged QA conclusion recorded in `.pm` sink.
+- Actual Result: Conclusion recorded; actual model/reasoning `inherited/unverified`.
+- Blocker / Next Action: Send integrated user-facing answer.
+
+## 2026-06-03 23:03:30 CST / tpm
+- 完成内容: User requested implementation: "加".
+- 遗留事项: Implement manual package-only workflow and verify workflow structure.
+- Route Update: Continue from read-only professional judgment into `executing-project-tasks` for a narrow CI workflow implementation.
+- Plan-Gap Review: Acceptance maps to adding a manual PR/branch package workflow; existing evidence identifies release package scripts to reuse and warns not to alter default required PR CI or publish release behavior.
+- Implementation Plan: (1) add a separate package-only workflow, (2) support manual ref/profile/scope inputs, (3) build web dist once, (4) package Linux required and macOS/Windows optional existing platforms, (5) upload packages plus SHA256SUMS/BUILDINFO/entrypoint logs, (6) validate YAML/diff.
+- Action: Record implementation route before editing files.
+- Validation Command: `sed -n '1,220p' .agents/skills/executing-project-tasks/SKILL.md`
+- Expected Result: Execution skill requires plan-gap review and atomic step evidence.
+- Actual Result: Requirements confirmed.
+- Blocker / Next Action: Edit `.github/workflows/testnet-packages.yml`.
+
+## 2026-06-03 23:08:30 CST / tpm
+- 完成内容: Added manual package-only GitHub Actions workflow for testnet candidate artifacts.
+- 遗留事项: GitHub-hosted workflow has not been executed yet; first run should use `package_scope=linux_only` against the intended PR branch/ref.
+- Action: Created `.github/workflows/testnet-packages.yml` with `workflow_dispatch` inputs `ref_or_sha`, `build_profile`, and `package_scope`; added package scopes `linux_only`, `linux_macos_x64`, and `all_existing`; reused existing web dist, release bundle, native installer, and entrypoint validator scripts; uploaded package artifacts, BUILDINFO, SHA256SUMS, bundle manifest, and entrypoint validation logs without publishing a GitHub Release.
+- Validation Command: `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/testnet-packages.yml"); puts "yaml ok"'`
+- Expected Result: New workflow YAML parses.
+- Actual Result: `yaml ok`.
+- Blocker / Next Action: Run structural matrix validation and completion verification.
+
+## 2026-06-03 23:10:00 CST / tpm
+- 完成内容: Ran fresh verification for the workflow implementation.
+- 遗留事项: `actionlint`/Go are not installed locally, so GitHub Actions semantic lint was not run; `./scripts/pm/lint.sh` has pre-existing failures in unrelated task logs `task_202b9f812d49432a9f4360b8a66c5364` and `task_455ea61e04c946469b8b1d22b700f853`.
+- Action: Verified YAML parsing, package matrix JSON shape, doc governance, and whitespace for the untracked workflow file.
+- Validation Command: `./scripts/pm/claim-ready.sh --claim-type task_complete --verify-command "<ruby YAML parse && python matrix JSON validation && ./scripts/doc-governance-check.sh>"` plus `bash -lc 'set +e; out=$(git diff --check --no-index /dev/null .github/workflows/testnet-packages.yml 2>&1); status=$?; set -e; if [[ $status -gt 1 ]]; then printf "%s\n" "$out"; exit $status; fi; if [[ -n "$out" ]]; then printf "%s\n" "$out"; exit 1; fi; echo "new workflow diff check ok"'`
+- Expected Result: Structural checks pass and claim-ready allows task completion; new workflow has no whitespace errors.
+- Actual Result: `claim-ready` exited 0 with `status: verified` and `allowed_to_claim: true`; no-index diff check printed `new workflow diff check ok`.
+- Blocker / Next Action: User can run the manual `Testnet Packages` workflow from GitHub Actions after this branch is pushed/PR is opened.
+
+## 2026-06-03 23:35:00 CST / tpm
+- 完成内容: Created draft PR for the task branch.
+- 遗留事项: GitHub-hosted `Testnet Packages` workflow has not been manually run yet; PR remains draft.
+- Action: Pushed `task/engineering-testnet-ci-packaging-advice` and created draft PR with title `Add manual testnet package workflow`.
+- Validation Command: `gh pr create --draft --base main --head task/engineering-testnet-ci-packaging-advice --title "Add manual testnet package workflow" --body-file <tmp>`
+- Expected Result: GitHub PR opens against `eng-cc/oasis7:main`.
+- Actual Result: Draft PR created: https://github.com/eng-cc/oasis7/pull/351
+- Blocker / Next Action: Run GitHub Actions package workflow from PR branch when ready, then move PR out of draft after review/CI expectations are satisfied.

--- a/.pm/tasks/task_3434e82349934071aba4f35354a67786.yaml
+++ b/.pm/tasks/task_3434e82349934071aba4f35354a67786.yaml
@@ -1,0 +1,24 @@
+task_uid: task_3434e82349934071aba4f35354a67786
+title: "testnet deployment and CI packaging advice"
+owner_role: tpm
+worktree_hint: /Users/scc/ccwork/worktrees/oasis7-engineering-testnet-ci-packaging-advice
+execution_log_path: .pm/tasks/task_3434e82349934071aba4f35354a67786.execution.md
+status: done
+priority: P2
+source_signal: null
+source_refs:
+  - AGENTS.md
+doc_refs:
+  - doc/engineering/workflow/source-of-truth.md
+related_prd: []
+acceptance:
+  - "Answer whether to add a manual PR CI build for multi-platform packages before deploying a four-node testnet"
+handoff_to: []
+updated_at: 2026-06-03T23:29:08+08:00
+last_started_at: 2026-06-03T22:45:00+08:00
+last_claim_type: task_complete
+last_verify_command: "ruby -e 'require \"yaml\"; YAML.load_file(\".github/workflows/testnet-packages.yml\")' && python3 - <<'PY'\nimport json\nfor matrix in [\n    '{\"include\":[{\"os\":\"ubuntu-24.04\",\"platform\":\"linux-x64\",\"asset_name\":\"oasis7-linux-x86_64.AppImage\",\"target_triple\":\"native\"}]}',\n    '{\"include\":[{\"os\":\"ubuntu-24.04\",\"platform\":\"linux-x64\",\"asset_name\":\"oasis7-linux-x86_64.AppImage\",\"target_triple\":\"native\"},{\"os\":\"macos-14\",\"platform\":\"macos-x64\",\"asset_name\":\"oasis7-macos-x64.dmg\",\"target_triple\":\"x86_64-apple-darwin\"}]}',\n    '{\"include\":[{\"os\":\"ubuntu-24.04\",\"platform\":\"linux-x64\",\"asset_name\":\"oasis7-linux-x86_64.AppImage\",\"target_triple\":\"native\"},{\"os\":\"macos-14\",\"platform\":\"macos-x64\",\"asset_name\":\"oasis7-macos-x64.dmg\",\"target_triple\":\"x86_64-apple-darwin\"},{\"os\":\"windows-2022\",\"platform\":\"windows-x64\",\"asset_name\":\"oasis7-windows-x64.exe\",\"target_triple\":\"native\"}]}'\n]:\n    data=json.loads(matrix)\n    assert data.get('include')\nprint('workflow structural checks ok')\nPY\n./scripts/doc-governance-check.sh"
+last_verified_at: 2026-06-03T23:29:07+08:00
+last_verification_exit_code: 0
+last_verification_status: verified
+last_closed_at: 2026-06-03T23:29:08+08:00


### PR DESCRIPTION
## Summary
- Add a manual `Testnet Packages` GitHub Actions workflow for PR/branch/ref-selected package builds.
- Default to `linux_only` for controlled testnet deployment, with optional `linux_macos_x64` and `all_existing` scopes.
- Upload package artifacts, `BUILDINFO`, `SHA256SUMS`, bundle manifest, and entrypoint validation logs without publishing a GitHub Release.

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/testnet-packages.yml")'`
- Matrix JSON structural validation for all package scopes
- `./scripts/doc-governance-check.sh`
- `./scripts/pm/claim-ready.sh --claim-type task_complete --verify-command "<YAML parse && matrix validation && doc-governance-check>"`
- `git diff --check --no-index /dev/null .github/workflows/testnet-packages.yml`

Note: `./scripts/pm/lint.sh` currently fails on pre-existing unrelated task execution logs (`task_202b9f812d49432a9f4360b8a66c5364`, `task_455ea61e04c946469b8b1d22b700f853`), so task closeout was run with `--no-lint` after fresh workflow verification passed.
