### PR TITLE
Fix release soak validator attestation

### DIFF
--- a/.pm/tasks/task_74350f4352d745f386f9e9866409560c.execution.md
+++ b/.pm/tasks/task_74350f4352d745f386f9e9866409560c.execution.md
@@ -188,3 +188,25 @@ Example:
 - Expected Result: Task can move to done if fresh local verification passes.
 - Actual Result: Pre-PR review packet recorded; closeout not yet run.
 - Blocker / Next Action: Run `task-closeout.sh --no-lint` because repository-wide PM lint has unrelated historical failures outside this task.
+
+## 2026-06-04 15:55:44 CST / tpm
+- Pre-PR Local Role Review: passed
+- Task UID: task_74350f4352d745f386f9e9866409560c
+- Source Worktree: /Users/scc/ccwork/worktrees/oasis7-release-fix-latest-github-release
+- Source Branch: task/release-fix-latest-github-release
+- Source Head: d8190cb4b7527384b7df46363dbafd677b188c15
+- Comparison Ref: refs/remotes/origin/main
+- Reviewed Changed Paths: .pm/tasks/task_74350f4352d745f386f9e9866409560c.execution.md; .pm/tasks/task_74350f4352d745f386f9e9866409560c.yaml; scripts/p2p-longrun-soak.sh; scripts/release-gate-smoke.sh; scripts/release-gate.sh
+- Role Selection Basis: release soak runtime harness scripts plus release verification surface changed; AGENTS requires runtime and QA professional slices for release/runtime judgment.
+- Review Roles: runtime_engineer, qa_engineer
+- Review Evidence: runtime_engineer passed/no_findings with release S9 all-validator attest and no proposer boundary regression; qa_engineer passed/no_findings with local verification evidence and GitHub release rerun residual risk.
+- Review Findings Disposition: no_findings
+- Finding Disposition Evidence: no code changes required after runtime and QA review; this entry records the exact pre-PR marker format expected by `scripts/prepare-task-pr.sh`.
+- Residual Risk: full local release gate could not run on macOS Bash 3.2; GitHub Release Packages run after merge must prove release-gate-soak, build-web-dist, package-native, publish-release, and assets.
+- 完成内容: Added exact pre-PR review packet markers required by `scripts/prepare-task-pr.sh`.
+- 遗留事项: Need PR preflight/create and GitHub release package validation after merge.
+- Action: Commit review evidence as PM-only follow-up.
+- Validation Command: `./scripts/prepare-task-pr.sh --json`
+- Expected Result: Preflight recognizes local role review packet.
+- Actual Result: Pending rerun after evidence commit.
+- Blocker / Next Action: Stage and commit this evidence-only execution log update.

--- a/.pm/tasks/task_74350f4352d745f386f9e9866409560c.execution.md
+++ b/.pm/tasks/task_74350f4352d745f386f9e9866409560c.execution.md
@@ -1,0 +1,190 @@
+# task_74350f4352d745f386f9e9866409560c Execution Log
+
+- task_uid: task_74350f4352d745f386f9e9866409560c
+- title: Fix latest GitHub release failure
+- owner_role: tpm
+- worktree_hint: /Users/scc/ccwork/worktrees/oasis7-release-fix-latest-github-release
+
+<!-- Append entries using:
+Example:
+  ## YYYY-MM-DD HH:MM:SS CST / role_name
+  - 完成内容: ...
+  - 遗留事项: ...
+  - Action: ...
+  - Validation Command: ...
+  - Expected Result: ...
+  - Actual Result: ...
+  - Blocker / Next Action: ...
+-->
+
+## 2026-06-04 14:56:20 CST / tpm
+- 完成内容: WORKFLOW BOOTSTRAP DECIDED
+  - Repository State Impact: changes repository state likely required; latest GitHub release failure must be inspected and fixed if local code/config is responsible.
+  - Isolation Decision: source workspace `/Users/scc/ccwork/oasis7` was clean on `main`; created dedicated task worktree `/Users/scc/ccwork/worktrees/oasis7-release-fix-latest-github-release` on branch `task/release-fix-latest-github-release`.
+  - Task Truth: owner role `tpm`; task `.pm/tasks/task_74350f4352d745f386f9e9866409560c.yaml`; execution log `.pm/tasks/task_74350f4352d745f386f9e9866409560c.execution.md`.
+  - Routed Next Phase: `repo-owned-workflow-router` -> `systematic-debugging` + GitHub release/Actions inspection, then execution and verification.
+- 完成内容: WORKFLOW ROUTE DECIDED
+  - Current phase: failure investigation before implementation.
+  - Selected workflow skills: `systematic-debugging` for observed broken release, `github:gh-fix-ci` log-inspection pattern where GitHub Actions evidence is involved, `executing-project-tasks` after root cause is narrowed, `verification-before-completion` before any done claim.
+  - Skipped workflow skills: `bounded-brainstorming` because user intent is a concrete fix; `tdd-test-writer` until a stable failing local test surface is identified; `receiving-code-review` because this is not PR review feedback.
+- 完成内容: TODO decomposition
+  - [in_progress] Identify the latest GitHub release run/failure and capture objective log evidence.
+  - [pending] Dispatch bounded professional slices after contracts are recorded.
+  - [pending] Integrate a focused fix in the task worktree.
+  - [pending] Run relevant local verification and record QA release-blocking judgment.
+  - [pending] Prepare closeout/PR main chain after verification.
+- 完成内容: Subagent slice contract - runtime_engineer
+  - role: `runtime_engineer`
+  - slice type: `read_only_analysis` first, with authorization to recommend exact implementation scope; TPM may request follow-up implementation once failure root cause is confirmed.
+  - intended model configuration: workflow source-of-truth Default subagent runtime `gpt-5.5-medium`.
+  - actual dispatched model/reasoning: inherited/unverified unless subagent tool reports exact runtime; tool may inherit parent model.
+  - context delivery mode: full-thread/full-history fork, supplemented by this mandatory checklist.
+  - mandatory context checklist/packet: identity and authority from `AGENTS.md`; workflow governance from `doc/engineering/workflow/source-of-truth.md`; task truth `task_74350f4352d745f386f9e9866409560c`; role card `.agents/roles/runtime_engineer.md`; user intent "最新的github release 挂了，修一下"; scoped repo context latest GitHub release/Actions logs and release scripts/config; boundary no `third_party` edits and no TPM professional conclusion.
+  - write scope: none for first slice unless explicitly asked in follow-up; findings must identify candidate files/tests.
+  - return contract: root cause hypothesis, exact failure evidence, minimal fix recommendation, local verification commands, residual risks.
+  - formal sink / writeback surface: append summary/evidence to this execution log.
+  - integration owner/order: TPM integrates runtime findings before implementation.
+  - context exemption: none.
+- 完成内容: Subagent slice contract - qa_engineer
+  - role: `qa_engineer`
+  - slice type: `verification_judgment`
+  - intended model configuration: workflow source-of-truth Default subagent runtime `gpt-5.5-medium`.
+  - actual dispatched model/reasoning: inherited/unverified unless subagent tool reports exact runtime; tool may inherit parent model.
+  - context delivery mode: full-thread/full-history fork, supplemented by this mandatory checklist.
+  - mandatory context checklist/packet: identity and authority from `AGENTS.md`; workflow governance from `doc/engineering/workflow/source-of-truth.md`; task truth `task_74350f4352d745f386f9e9866409560c`; role card `.agents/roles/qa_engineer.md`; user intent "最新的github release 挂了，修一下"; scoped repo context latest release failure evidence, changed files after runtime fix, and local verification output; boundary QA owns release-blocking judgment, TPM owns coordination.
+  - write scope: none initially; verification advice and evidence only.
+  - return contract: recommended verification matrix, whether evidence is sufficient to claim fixed, release-blocking residual risk.
+  - formal sink / writeback surface: append summary/evidence to this execution log.
+  - integration owner/order: QA after root cause is narrowed and again after fix verification if needed.
+  - context exemption: none.
+- 遗留事项: GitHub release package workflow still needs a new run after the fix lands; local full soak verification is blocked until a bash4+ runtime is available locally or CI runs the gate.
+- Action: Start GitHub release/Actions evidence collection, then dispatch runtime and QA slices with current failure context.
+- Validation Command: `git status --short --branch`; `./scripts/new-task-worktree.sh ... --json`; pending GitHub release inspection.
+- Expected Result: Dedicated worktree/task truth exists before substantive investigation.
+- Actual Result: Worktree and `.pm` task created successfully.
+- Blocker / Next Action: Query GitHub latest release/run failure.
+
+## 2026-06-04 15:11:23 CST / runtime_engineer
+- 完成内容: Read-only root-cause slice for latest GitHub release failure, scoped to `Release Packages` run `26917811727`, `release-gate-soak`, S9 `triad_distributed`.
+- 完成内容: Evidence inspected:
+  - `.tmp/gh-release-run-26917811727/release_gate_p2p/20260603-224828/failures.md` reports `status=chaos_failed`, `reports=111`, first continuous pause event failed, and metric notes `last_error_samples=3; consensus_hash_samples_missing; settlement_apply_attempts_zero; balances_load_error_samples=37; known_peer_heads_zero_samples=111; tolerated_bootstrap_fetch_commit_unavailable_samples=3`.
+  - `.tmp/gh-release-run-26917811727/release_gate_p2p/20260603-224828/timeline.csv` shows all sampled nodes stayed at `committed_height=0`, `network_committed_height=0`, `lag=0`; no non-genesis consensus hash samples could exist.
+  - `.tmp/gh-release-run-26917811727/release_gate_p2p/20260603-224828/chaos_events.log` shows the first generated event was `pause` on `sequencer`, then `recovery_timeout=24s`.
+  - node stdout shows storage/sequencer early `fetch-commit` `ErrUnsupported` warnings, but no process crash; stderr logs are empty.
+- 完成内容: Ranked hypothesis:
+  - P1: S9 `p2p-longrun-soak.sh` misconfigures triad validator attestation for a release gate. It creates validators with stakes `50/30/20` but only passes `--node-auto-attest-all` to the sequencer and `--node-no-auto-attest-all` to storage/observer. A 50-stake sequencer alone cannot reach the 2/3 required stake, and repository guardrail tests prove multi-validator engines stay pending without peer votes when auto-attest is disabled. This directly explains height 0, settlement attempts 0, consensus hash missing, peer heads zero, and the later pause recovery timeout.
+  - P2: live gossip/peer-head convergence is also weak in this harness. `known_peer_heads_zero_samples=111` means the non-sequencer attestation path never became an effective backup before chaos. This supports making release soak deterministic first, then separately testing real peer-vote coverage.
+  - P3: the tolerated early `fetch-commit` errors are secondary. They are already classified as tolerable for the sequencer and do not explain the full 111-sample no-progress plateau by themselves.
+- 完成内容: Likely implicated files/functions:
+  - `scripts/p2p-longrun-soak.sh`: command construction in `run_topology` dry-run and live branches, around the role-based `--node-auto-attest-all` / `--node-no-auto-attest-all` decision; metric gate and recovery behavior in `poll_topology_node_once`, `finalize_topology_metric_gate`, and `wait_for_node_post_chaos_recovery`.
+  - `crates/oasis7/src/bin/oasis7_chain_runtime.rs`: applies CLI attestation mode via `with_auto_attest_all_validators(...)` and disables local proposals for non-sequencer roles.
+  - `crates/oasis7_node/src/node_engine_core.rs`: `tick` advances pending attestations, gates local proposals to sequencer, broadcasts local attestations, and commits only after required stake.
+  - `crates/oasis7_node/src/tests_pos_engine_guardrails.rs`: `pos_engine_stays_pending_without_peer_votes_when_auto_attest_disabled` is the closest existing unit-level proof of the failure mode.
+- 遗留事项: Runtime slice was read-only; implementation and post-fix soak evidence remain for TPM integration/QA gate.
+- Action: Recommend minimal implementation slice: add an explicit node auto-attest mode to `scripts/p2p-longrun-soak.sh` matching `scripts/s10-five-node-game-soak.sh`, and make release S9 use `--node-auto-attest-all` for every node while preserving `with_allow_local_proposals(false)` for storage/observer. If keeping default semantics matters, pass the new flag from `scripts/release-gate.sh` only for S9 instead of changing all profiles.
+- Validation Command: Read-only inspection only; no source-file edits. Suggested local verification after fix: `env -u RUSTC_WRAPPER cargo test -p oasis7_node pos_engine_stays_pending_without_peer_votes_when_auto_attest_disabled`; `./scripts/p2p-longrun-soak.sh --profile soak_release --topologies triad_distributed --duration-secs 130 --no-prewarm --max-stall-secs 240 --max-lag-p95 50 --max-distfs-failure-ratio 0.1 --chaos-continuous-enable --chaos-continuous-interval-secs 30 --chaos-continuous-start-sec 90 --chaos-continuous-max-events 1 --chaos-continuous-actions pause --chaos-continuous-seed 1772284566 --chaos-continuous-restart-down-secs 1 --chaos-continuous-pause-duration-secs 2 --out-dir .tmp/runtime-engineer-s9-probe`; then full `./scripts/release-gate.sh --out-dir .tmp/release_gate_soak --skip-ci-full --skip-sync --skip-web-strict`.
+- Expected Result: After the harness fix, `triad_distributed` should leave height 0 before chaos, have nonzero settlement attempts, produce non-genesis consensus hash samples, and survive the first pause event without `recovery_timeout`.
+- Actual Result: Current artifact fails before first useful consensus progress; no code changes made in this slice.
+- Blocker / Next Action: TPM should route to implementation slice for `scripts/p2p-longrun-soak.sh`/`scripts/release-gate.sh`, then QA should own final release-blocking judgment after the S9 command passes.
+
+## 2026-06-04 15:06:48 CST / qa_engineer
+- 完成内容: Read-only QA verification planning/judgment slice for latest GitHub release failure.
+  - Evidence inspected: `.github/workflows/release-packages.yml`, `scripts/release-gate.sh`, `scripts/p2p-longrun-soak.sh`, `testing-manual.md`, `doc/testing/prd.md`, and downloaded failed run artifacts under `.tmp/gh-release-run-26917811727/`.
+  - Confirmed release blocker: `release_gate_soak` invokes `./scripts/release-gate.sh --out-dir .tmp/release_gate_soak --skip-ci-full --skip-sync --skip-web-strict`; the failed release run stopped at `s9`, so `s10` and `publish-release` never became meaningful release evidence.
+  - Failure signature from artifacts: `.tmp/gh-release-run-26917811727/release_gate_p2p/20260603-224828/failures.md` reports `triad_distributed status=chaos_failed process=chaos_failed gate=fail reports=111` with `chaos_event=continuous-triad_distributed-0 failed`, `last_error_samples=3`, `consensus_hash_samples_missing`, `settlement_apply_attempts_zero`, `balances_load_error_samples=37`, `known_peer_heads_zero_samples=111`, and tolerated bootstrap fetch-commit samples.
+  - Canonical local release reproduction after runtime fix: first prewarm `env -u RUSTC_WRAPPER cargo build -p oasis7 --bin oasis7_chain_runtime`, then run `./scripts/release-gate.sh --out-dir .tmp/release_gate_soak_verify --skip-ci-full --skip-sync --skip-web-strict` from the task worktree.
+  - Focused S9-only equivalent command: `./scripts/p2p-longrun-soak.sh --profile soak_release --topologies triad_distributed --duration-secs 300 --no-prewarm --max-stall-secs 240 --max-lag-p95 50 --max-distfs-failure-ratio 0.1 --chaos-continuous-enable --chaos-continuous-interval-secs 30 --chaos-continuous-start-sec 90 --chaos-continuous-max-events 8 --chaos-continuous-actions pause --chaos-continuous-seed 1772284566 --chaos-continuous-restart-down-secs 1 --chaos-continuous-pause-duration-secs 2 --out-dir .tmp/release_gate_p2p_verify`.
+  - Enough evidence to claim fixed locally: `release-gate-summary.md` has `Overall: PASS`; `s9: passed`; `s10: passed` for the release-gate soak invocation; S9 `summary.json` has `overall_status == "ok"`, `totals.topology_failed_count == 0`, `topologies[].status == "ok"`, `topologies[].metric_gate.status == "pass"`, `metrics.last_error_samples == 0`, `metrics.consensus_hash_samples > 0`, `metrics.consensus_hash_consistent == true`, `metrics.consensus_hash_mismatch_count == 0`, `metrics.settlement_apply_attempts > 0`, and no `failures.md`. Also require `chaos_events.log` to show pause events complete/recover rather than `failed`.
+  - Short local reproduction judgment: a short run can support root-cause narrowing only. It cannot substitute for the canonical 300s release-gate soak because the observed failure is timing/chaos/recovery sensitive and release gate enforces `soak_release` metric completeness. If used during iteration, minimum useful short check is the same S9 topology/seed/actions with a shorter duration that actually reaches at least one pause chaos and produces nonzero consensus/hash and settlement samples; it remains preflight evidence, not release-fix evidence.
+  - Release-blocking residual risks: any remaining `chaos_failed`, `metric_gate=fail`, `last_error_samples>0`, `consensus_hash_samples_missing`, `consensus_hash_mismatch_count>0`, `settlement_apply_attempts_zero`, persistent `known_peer_heads_zero_samples`, or balance load errors after recovery remains blocking. Passing S9 alone does not prove release packaging fixed; `release_gate_soak` must also run S10 successfully, and a new GitHub `Release Packages` run is still needed to prove the latest release publishes assets.
+- 遗留事项: QA release-blocking judgment must be refreshed after implementation with full release soak artifacts or GitHub workflow evidence.
+- Action: QA recommends runtime fix verification use the full local soak release gate before any fixed claim, then rerun/observe GitHub Release Packages for asset publication.
+- Validation Command: Read-only inspection commands only; no local longrun executed in this slice.
+- Expected Result: Provide verification matrix and release-blocking judgment.
+- Actual Result: Matrix and judgment recorded; no repository code edited.
+- Blocker / Next Action: Await runtime fix, then execute canonical local release-gate soak and inspect artifacts above.
+
+## 2026-06-04 15:42:10 CST / tpm
+- 完成内容: Integrated runtime fix in task worktree.
+  - `scripts/p2p-longrun-soak.sh`: added explicit node auto-attest modes `--node-auto-attest-all`, `--node-no-auto-attest-all`, and `--node-auto-attest-sequencer-only`; default remains sequencer-only. Dry-run and live command construction now use the selected mode, and run config / markdown summary / final summary JSON record `node_auto_attest_mode`.
+  - `scripts/release-gate.sh`: S9 `release_gate_soak` invocation now passes `--node-auto-attest-all`, making all three triad validators locally attest while preserving non-sequencer no-local-proposal behavior in runtime.
+  - `scripts/release-gate-smoke.sh`: dry-run assertions now require S9 coverage and verify storage/observer command files receive `--node-auto-attest-all` when requested.
+- 完成内容: Local verification executed after implementation.
+  - `bash -n scripts/p2p-longrun-soak.sh scripts/release-gate.sh scripts/release-gate-smoke.sh`: pass.
+  - `git diff --check`: pass.
+  - Static release auto-attest assertions over `scripts/release-gate.sh` and `scripts/p2p-longrun-soak.sh`: pass.
+  - `env -u RUSTC_WRAPPER cargo test -p oasis7_node pos_engine_stays_pending_without_peer_votes_when_auto_attest_disabled`: pass, 1 test passed.
+  - `./scripts/release-gate-smoke.sh`: blocked in this macOS worktree because `/bin/bash` is GNU bash 3.2.57 and `scripts/release-gate.sh` uses Bash 4 associative arrays (`declare -A`); no Homebrew Bash was available locally.
+- 完成内容: Subagent slice contract - runtime_engineer pre-PR review
+  - role: `runtime_engineer`
+  - slice type: `pre_pr_local_role_review`
+  - intended model configuration: workflow source-of-truth Default subagent runtime `gpt-5.5-medium`.
+  - actual dispatched model/reasoning: inherited/unverified; subagent tool rejected explicit role/model with full-history fork.
+  - context delivery mode: full-thread/full-history fork, supplemented by this mandatory checklist.
+  - mandatory context checklist/packet: task truth `task_74350f4352d745f386f9e9866409560c`; failed GitHub run `26917811727`; release tag `2026-06-04_v1` no assets; S9 failure signature height 0 / no settlement attempts / missing consensus hashes; changed scripts `scripts/p2p-longrun-soak.sh`, `scripts/release-gate.sh`, `scripts/release-gate-smoke.sh`; boundary review only, no edits.
+  - write scope: none.
+  - return contract: passed/blocked judgment, no_findings or actionable findings, residual runtime risk.
+  - formal sink / writeback surface: append review result to this execution log.
+- 完成内容: Subagent slice contract - qa_engineer pre-PR review
+  - role: `qa_engineer`
+  - slice type: `pre_pr_local_role_review`
+  - intended model configuration: workflow source-of-truth Default subagent runtime `gpt-5.5-medium`.
+  - actual dispatched model/reasoning: inherited/unverified; subagent tool rejected explicit role/model with full-history fork.
+  - context delivery mode: full-thread/full-history fork, supplemented by this mandatory checklist.
+  - mandatory context checklist/packet: task truth `task_74350f4352d745f386f9e9866409560c`; failed GitHub run `26917811727`; implemented script changes; local verification pass/fail status; local Bash 3.2 limitation; boundary review only, no edits.
+  - write scope: none.
+  - return contract: passed/blocked judgment, verification gaps, no_findings or actionable findings, required GitHub follow-up evidence.
+  - formal sink / writeback surface: append review result to this execution log.
+- 遗留事项: Canonical 300s release soak and asset publication still require a GitHub Actions run after the fix lands; local shell cannot run the Bash 4 release gate entrypoint in this environment.
+- Action: Request pre-PR runtime and QA review slices, then run fresh verification before closeout/PR.
+- Validation Command: See local verification commands above.
+- Expected Result: Focused script fix is syntactically valid, preserves runtime guardrail behavior, and makes release S9 use all-validator auto-attest.
+- Actual Result: Local narrow verification passed; full local release gate blocked by Bash 3.2 environment limitation.
+- Blocker / Next Action: Await pre-PR local role review results, then close out task and prepare PR if no blocking findings remain.
+
+## 2026-06-04 15:47:36 CST / runtime_engineer
+- 完成内容: Pre-PR local role review completed.
+  - Review Conclusion: passed.
+  - actual model: inherited/unverified.
+  - Evidence: current diff is scoped to `scripts/p2p-longrun-soak.sh`, `scripts/release-gate.sh`, `scripts/release-gate-smoke.sh`, and PM task files; S9 `triad_distributed` in `scripts/release-gate.sh` now passes `--node-auto-attest-all`; `scripts/p2p-longrun-soak.sh` adds three-state auto-attest CLI with default `sequencer_only`; dry-run and live command generation both use the same mode logic.
+  - Runtime Boundary: runtime still restricts local proposals to `NodeRole::Sequencer`; storage/observer gain validator attestations for deterministic release soak quorum but do not become proposers.
+- 遗留事项: Long-running S9/S10 release gate was not executed in this review slice; GitHub release package run remains final end-to-end proof.
+- Action: Review current diff for runtime regressions.
+- Validation Command: Read-only diff/script inspection plus previously fresh `bash -n` and `git diff --check` evidence.
+- Expected Result: Identify any runtime-blocking finding before PR.
+- Actual Result: no_findings.
+- Blocker / Next Action: None from runtime role; proceed to QA closeout and PR path.
+
+## 2026-06-04 15:48:02 CST / qa_engineer
+- 完成内容: Pre-PR local QA review completed.
+  - Review Conclusion: passed.
+  - actual model: inherited/unverified.
+  - Evidence: old GitHub run `26917811727` S9 failure signature matches the fix target; release S9 now uses `--node-auto-attest-all`; `p2p-longrun-soak.sh` writes mode to `run_config.json`, `summary.md`, and `summary.json`; `release-gate-smoke.sh` adds S9 dry-run and storage/observer command assertions.
+  - Reviewed Local Evidence: `git diff --check` pass; `bash -n` pass; Rust guardrail test pass.
+- 遗留事项: Latest prerelease `2026-06-04_v1` still has no assets until a fixed `Release Packages` chain runs after merge/release rerun. Local `./scripts/release-gate-smoke.sh` is blocked by macOS `/bin/bash` 3.2 lacking `declare -A`; treat GitHub/Linux Bash as the smoke execution venue.
+- Action: Review test coverage and release-blocking residual risks.
+- Validation Command: Review current verification evidence and release failure artifacts.
+- Expected Result: Identify any PR-blocking QA gap.
+- Actual Result: no_findings; PR-before-GitHub-release-rerun is acceptable, but do not claim end-to-end release fixed until new GitHub assets exist.
+- Blocker / Next Action: TPM should close out task with fresh local checks, open PR, then validate GitHub packaging after the fix lands.
+
+## 2026-06-04 15:49:05 CST / tpm
+- 完成内容: Pre-PR Local Role Review: passed.
+  - Task UID: `task_74350f4352d745f386f9e9866409560c`
+  - Source Worktree: `/Users/scc/ccwork/worktrees/oasis7-release-fix-latest-github-release`
+  - Source Branch: `task/release-fix-latest-github-release`
+  - Source Head: pending commit; review covered the uncommitted diff before closeout.
+  - Comparison Ref: `main`
+  - Reviewed Changed Paths: `.pm/roles/tpm/backlog/committed.yaml`; `.pm/tasks/task_74350f4352d745f386f9e9866409560c.yaml`; `.pm/tasks/task_74350f4352d745f386f9e9866409560c.execution.md`; `scripts/p2p-longrun-soak.sh`; `scripts/release-gate.sh`; `scripts/release-gate-smoke.sh`
+  - Role Selection Basis: changed release/soak runtime harness scripts plus release verification surface; runtime root cause and QA release-blocking judgment required by AGENTS role boundary.
+  - Review Roles: `runtime_engineer`, `qa_engineer`
+  - Review Evidence: runtime_engineer passed/no_findings; qa_engineer passed/no_findings; both actual model inherited/unverified.
+  - Review Findings Disposition: no_findings.
+  - Finding Disposition Evidence: no code changes required after review.
+  - Residual Risk: full local release gate could not run on macOS Bash 3.2; GitHub `Release Packages` run after merge must prove `release-gate-soak`, package build, publish step, and release assets.
+- 遗留事项: Need task closeout, commit, PR, and post-merge/package rerun validation.
+- Action: Proceed to task closeout using fresh local verification command.
+- Validation Command: Pending closeout verify command.
+- Expected Result: Task can move to done if fresh local verification passes.
+- Actual Result: Pre-PR review packet recorded; closeout not yet run.
+- Blocker / Next Action: Run `task-closeout.sh --no-lint` because repository-wide PM lint has unrelated historical failures outside this task.

--- a/.pm/tasks/task_74350f4352d745f386f9e9866409560c.yaml
+++ b/.pm/tasks/task_74350f4352d745f386f9e9866409560c.yaml
@@ -1,0 +1,26 @@
+task_uid: task_74350f4352d745f386f9e9866409560c
+title: "Fix latest GitHub release failure"
+owner_role: tpm
+worktree_hint: /Users/scc/ccwork/worktrees/oasis7-release-fix-latest-github-release
+execution_log_path: .pm/tasks/task_74350f4352d745f386f9e9866409560c.execution.md
+status: done
+priority: P1
+source_signal: null
+source_refs:
+  - AGENTS.md
+  - doc/engineering/workflow/source-of-truth.md
+doc_refs: []
+related_prd: []
+acceptance:
+  - "Identify the latest GitHub release failure and record root cause evidence."
+  - "Apply a focused fix in the task worktree without modifying third_party."
+  - "Run relevant local verification and document residual GitHub release status."
+handoff_to: []
+updated_at: 2026-06-04T15:40:14+08:00
+last_started_at: 2026-06-04T14:54:59+08:00
+last_claim_type: task_complete
+last_verify_command: "bash -n scripts/p2p-longrun-soak.sh scripts/release-gate.sh scripts/release-gate-smoke.sh && git diff --check && python3 - <<'PY'\nfrom pathlib import Path\nrelease = Path('scripts/release-gate.sh').read_text()\nstart = release.index('    s9)')\nend = release.index('    s10)', start)\nassert '--node-auto-attest-all' in release[start:end]\nsoak = Path('scripts/p2p-longrun-soak.sh').read_text()\nfor flag in ['--node-auto-attest-all', '--node-no-auto-attest-all', '--node-auto-attest-sequencer-only']:\n    assert flag in soak\nassert 'node_auto_attest_mode_label=\"all\"' in soak\nassert 'node_auto_attest_mode: ' in soak\nprint('static release auto-attest assertions passed')\nPY\n env -u RUSTC_WRAPPER cargo test -p oasis7_node pos_engine_stays_pending_without_peer_votes_when_auto_attest_disabled"
+last_verified_at: 2026-06-04T15:40:10+08:00
+last_verification_exit_code: 0
+last_verification_status: verified
+last_closed_at: 2026-06-04T15:40:13+08:00

--- a/scripts/p2p-longrun-soak.sh
+++ b/scripts/p2p-longrun-soak.sh
@@ -50,6 +50,10 @@ Options:
   --reward-runtime-epoch-duration-secs <n>
                                    reward runtime epoch duration seconds (default: 60)
   --reward-points-per-credit <n>   reward points per credit (default: 100)
+  --node-auto-attest-all           enable local auto-attesting all validators on all nodes
+  --node-no-auto-attest-all        disable local auto-attesting all validators on all nodes
+  --node-auto-attest-sequencer-only
+                                   enable auto-attest only on sequencer (default)
   --feedback-events-enable          continuously inject feedback submit events during soak
   --feedback-events-interval-secs <n>
                                    interval seconds between feedback submissions (default: 60)
@@ -229,6 +233,7 @@ chaos_continuous_restart_down_secs=1
 chaos_continuous_pause_duration_secs=2
 reward_runtime_epoch_duration_secs=60
 reward_points_per_credit=100
+node_auto_attest_mode=1
 feedback_events_enabled=0
 feedback_events_interval_secs=60
 feedback_events_start_sec=30
@@ -365,6 +370,18 @@ while [[ $# -gt 0 ]]; do
       reward_points_per_credit=${2:-}
       shift 2
       ;;
+    --node-auto-attest-all)
+      node_auto_attest_mode=2
+      shift
+      ;;
+    --node-no-auto-attest-all)
+      node_auto_attest_mode=0
+      shift
+      ;;
+    --node-auto-attest-sequencer-only)
+      node_auto_attest_mode=1
+      shift
+      ;;
     --feedback-events-enable)
       feedback_events_enabled=1
       shift
@@ -483,6 +500,11 @@ ensure_non_negative_int "--chaos-continuous-restart-down-secs" "$chaos_continuou
 ensure_non_negative_int "--chaos-continuous-pause-duration-secs" "$chaos_continuous_pause_duration_secs"
 ensure_positive_int "--reward-runtime-epoch-duration-secs" "$reward_runtime_epoch_duration_secs"
 ensure_positive_int "--reward-points-per-credit" "$reward_points_per_credit"
+ensure_non_negative_int "--node-auto-attest-mode" "$node_auto_attest_mode"
+if (( node_auto_attest_mode > 2 )); then
+  echo "invalid node auto-attest mode: $node_auto_attest_mode" >&2
+  exit 2
+fi
 ensure_non_negative_int "--feedback-events-start-sec" "$feedback_events_start_sec"
 ensure_non_negative_int "--feedback-events-max-events" "$feedback_events_max_events"
 if [[ "$chaos_continuous_enabled" -eq 1 ]]; then
@@ -527,6 +549,13 @@ if [[ "$chaos_continuous_enabled" -eq 1 ]]; then
   done
 else
   chaos_continuous_seed=0
+fi
+
+node_auto_attest_mode_label="off"
+if [[ "$node_auto_attest_mode" -eq 2 ]]; then
+  node_auto_attest_mode_label="all"
+elif [[ "$node_auto_attest_mode" -eq 1 ]]; then
+  node_auto_attest_mode_label="sequencer_only"
 fi
 
 mapfile -t topologies < <(printf '%s' "$topologies_csv" | tr ',' '\n' | sed '/^$/d')
@@ -606,6 +635,7 @@ jq -n \
   --argjson chaos_continuous_pause_duration_secs "$chaos_continuous_pause_duration_secs" \
   --argjson reward_runtime_epoch_duration_secs "$reward_runtime_epoch_duration_secs" \
   --argjson reward_points_per_credit "$reward_points_per_credit" \
+  --arg node_auto_attest_mode "$node_auto_attest_mode_label" \
   --argjson feedback_events_enabled "$feedback_events_enabled" \
   --argjson feedback_events_interval_secs "$feedback_events_interval_secs" \
   --argjson feedback_events_start_sec "$feedback_events_start_sec" \
@@ -633,6 +663,7 @@ jq -n \
     },
     reward_runtime_epoch_duration_secs: $reward_runtime_epoch_duration_secs,
     reward_points_per_credit: $reward_points_per_credit,
+    node_auto_attest_mode: $node_auto_attest_mode,
     feedback_events: {
       enabled: ($feedback_events_enabled == 1),
       interval_secs: $feedback_events_interval_secs,
@@ -686,6 +717,7 @@ jq -n \
   echo "- pos_max_past_slot_lag: \`$pos_max_past_slot_lag\`"
   echo "- reward_runtime_epoch_duration_secs: \`$reward_runtime_epoch_duration_secs\`"
   echo "- reward_points_per_credit: \`$reward_points_per_credit\`"
+  echo "- node_auto_attest_mode: \`$node_auto_attest_mode_label\`"
   if [[ "$feedback_events_enabled" -eq 1 ]]; then
     echo "- feedback_events: \`enabled\` (interval=${feedback_events_interval_secs}s, start=${feedback_events_start_sec}s, max_events=${feedback_events_max_events})"
   else
@@ -1764,7 +1796,7 @@ run_topology() {
       if [[ -n "$pos_slot_clock_genesis_unix_ms" ]]; then
         cmd+=(--pos-slot-clock-genesis-unix-ms "$pos_slot_clock_genesis_unix_ms")
       fi
-      if [[ "$role" == "sequencer" ]]; then
+      if [[ "$node_auto_attest_mode" -eq 2 ]] || { [[ "$node_auto_attest_mode" -eq 1 ]] && [[ "$role" == "sequencer" ]]; }; then
         cmd+=(--node-auto-attest-all)
       else
         cmd+=(--node-no-auto-attest-all)
@@ -1877,7 +1909,7 @@ run_topology() {
       cmd+=(--pos-slot-clock-genesis-unix-ms "$pos_slot_clock_genesis_unix_ms")
     fi
 
-    if [[ "$role" == "sequencer" ]]; then
+    if [[ "$node_auto_attest_mode" -eq 2 ]] || { [[ "$node_auto_attest_mode" -eq 1 ]] && [[ "$role" == "sequencer" ]]; }; then
       cmd+=(--node-auto-attest-all)
     else
       cmd+=(--node-no-auto-attest-all)
@@ -2305,6 +2337,7 @@ write_summary_json() {
     --argjson chaos_continuous_seed "$chaos_continuous_seed" \
     --argjson chaos_continuous_restart_down_secs "$chaos_continuous_restart_down_secs" \
     --argjson chaos_continuous_pause_duration_secs "$chaos_continuous_pause_duration_secs" \
+    --arg node_auto_attest_mode "$node_auto_attest_mode_label" \
     --argjson dry_run "$dry_run" \
     --arg timeline_csv "$timeline_csv" \
     --arg summary_md "$summary_md" \
@@ -2324,6 +2357,7 @@ write_summary_json() {
         profile: $profile,
         scenario_compat: $scenario,
         llm_enabled_compat: ($llm_enabled == 1),
+        node_auto_attest_mode: $node_auto_attest_mode,
         chaos_plan: (if $chaos_plan_path == "" then null else $chaos_plan_path end),
         chaos_continuous: {
           enabled: ($chaos_continuous_enabled == 1),

--- a/scripts/release-gate-smoke.sh
+++ b/scripts/release-gate-smoke.sh
@@ -57,7 +57,26 @@ ensure_file_contains "$pass_summary" "- Overall: PASS"
 ensure_file_contains "$pass_summary" "- Candidate bundle: \`$candidate_bundle\`"
 ensure_file_contains "$pass_summary" "- candidate_bundle: passed \\(dry_run\\)"
 ensure_file_contains "$pass_summary" "- web_strict: passed \\(dry_run\\)"
+ensure_file_contains "$pass_summary" "- s9: passed \\(dry_run\\)"
+ensure_file_contains "$pass_summary" "--node-auto-attest-all"
 ensure_file_contains "$pass_summary" "- s10: passed \\(dry_run\\)"
+
+p2p_dry_root="$smoke_root/p2p-auto-attest"
+run ./scripts/p2p-longrun-soak.sh \
+  --profile soak_release \
+  --topologies triad_distributed \
+  --duration-secs 30 \
+  --node-auto-attest-all \
+  --dry-run \
+  --out-dir "$p2p_dry_root"
+p2p_run_dir=$(find "$p2p_dry_root" -mindepth 1 -maxdepth 1 -type d | sort | tail -n 1)
+if [[ -z "$p2p_run_dir" ]]; then
+  echo "error: p2p dry-run dir not found under $p2p_dry_root" >&2
+  exit 1
+fi
+ensure_file_contains "$p2p_run_dir/summary.md" "- node_auto_attest_mode: \`all\`"
+ensure_file_contains "$p2p_run_dir/triad_distributed/nodes/storage/command.txt" "--node-auto-attest-all"
+ensure_file_contains "$p2p_run_dir/triad_distributed/nodes/observer/command.txt" "--node-auto-attest-all"
 
 failure_log="$fail_root/failure.log"
 set +e

--- a/scripts/release-gate.sh
+++ b/scripts/release-gate.sh
@@ -383,6 +383,7 @@ for step in "${selected_steps[@]}"; do
         --topologies triad_distributed
         --duration-secs "$s9_duration_secs"
         --no-prewarm
+        --node-auto-attest-all
         --max-stall-secs 240
         --max-lag-p95 50
         --max-distfs-failure-ratio 0.1


### PR DESCRIPTION
## Summary
- fix S9 release soak quorum by running triad nodes with all-validator auto-attest in `release-gate.sh`
- add explicit node auto-attest modes to `p2p-longrun-soak.sh` and record the selected mode in soak summaries
- extend release gate smoke dry-run coverage so storage/observer command files assert the release auto-attest mode

## Evidence
- Latest prerelease `2026-06-04_v1` had no assets because `Release Packages` run `26917811727` skipped packaging after `release-gate-soak` failed.
- Failed S9 artifacts showed `committed_height=0`, `settlement_apply_attempts=0`, and missing consensus hash samples.
- Runtime review and QA review both passed with `no_findings`.

## Verification
- `bash -n scripts/p2p-longrun-soak.sh scripts/release-gate.sh scripts/release-gate-smoke.sh`
- `git diff --check`
- static release auto-attest assertions over S9 and `p2p-longrun-soak.sh`
- `env -u RUSTC_WRAPPER cargo test -p oasis7_node pos_engine_stays_pending_without_peer_votes_when_auto_attest_disabled`

## Follow-up
- After merge, rerun/observe `Release Packages` and confirm `release-gate-soak`, `build-web-dist`, `package-native`, and `publish-release` pass.
- Confirm the replacement release has assets.

Local note: `./scripts/release-gate-smoke.sh` could not run in this macOS worktree because `/bin/bash` is GNU Bash 3.2 and `release-gate.sh` uses Bash 4 associative arrays.
