### PR TITLE
Package governance registry ops tools

### DIFF
--- a/scripts/build-game-launcher-bundle.sh
+++ b/scripts/build-game-launcher-bundle.sh
@@ -20,6 +20,8 @@ Build a distributable launcher bundle:
 - bin/oasis7_web_launcher
 - bin/oasis7_viewer_live
 - bin/oasis7_chain_runtime
+- bin/oasis7_governance_registry_import
+- bin/oasis7_governance_registry_audit
 - web/ (prebuilt viewer static assets)
 - web-launcher/ (prebuilt launcher web static assets)
 - run-client.sh (desktop client launcher entry)
@@ -217,6 +219,8 @@ LAUNCHER_BIN_NAME="$(resolve_binary_name oasis7_game_launcher "$TARGET_TRIPLE")"
 WEB_LAUNCHER_BIN_NAME="$(resolve_binary_name oasis7_web_launcher "$TARGET_TRIPLE")"
 LIVE_BIN_NAME="$(resolve_binary_name oasis7_viewer_live "$TARGET_TRIPLE")"
 CHAIN_BIN_NAME="$(resolve_binary_name oasis7_chain_runtime "$TARGET_TRIPLE")"
+GOVERNANCE_REGISTRY_IMPORT_BIN_NAME="$(resolve_binary_name oasis7_governance_registry_import "$TARGET_TRIPLE")"
+GOVERNANCE_REGISTRY_AUDIT_BIN_NAME="$(resolve_binary_name oasis7_governance_registry_audit "$TARGET_TRIPLE")"
 CLIENT_LAUNCHER_BIN_NAME="$(resolve_binary_name oasis7_client_launcher "$TARGET_TRIPLE")"
 TARGET_SUBDIR="$PROFILE"
 if [[ "$PROFILE" == "dev" ]]; then
@@ -238,15 +242,19 @@ run mkdir -p "$BUNDLE_BIN_DIR" "$BUNDLE_WEB_DIR" "$BUNDLE_WEB_LAUNCHER_DIR"
 
 # 1) Build native binaries for launcher/live/client launcher.
 BUNDLE_NATIVE_BUILD_ARGS=(
-  "${CARGO_TARGET_ARGS[@]}"
   -p oasis7
   -p oasis7_client_launcher
   --bin oasis7_game_launcher
   --bin oasis7_web_launcher
   --bin oasis7_viewer_live
   --bin oasis7_chain_runtime
+  --bin oasis7_governance_registry_import
+  --bin oasis7_governance_registry_audit
   --bin oasis7_client_launcher
 )
+if (( ${#CARGO_TARGET_ARGS[@]} > 0 )); then
+  BUNDLE_NATIVE_BUILD_ARGS=("${CARGO_TARGET_ARGS[@]}" "${BUNDLE_NATIVE_BUILD_ARGS[@]}")
+fi
 if [[ "$PROFILE" == "release" ]]; then
   run env -u RUSTC_WRAPPER cargo build --release "${BUNDLE_NATIVE_BUILD_ARGS[@]}"
 else
@@ -257,6 +265,8 @@ LAUNCHER_SRC="$ROOT_DIR/target/$TARGET_OUTPUT_SUBDIR/$LAUNCHER_BIN_NAME"
 WEB_LAUNCHER_SRC="$ROOT_DIR/target/$TARGET_OUTPUT_SUBDIR/$WEB_LAUNCHER_BIN_NAME"
 LIVE_SRC="$ROOT_DIR/target/$TARGET_OUTPUT_SUBDIR/$LIVE_BIN_NAME"
 CHAIN_SRC="$ROOT_DIR/target/$TARGET_OUTPUT_SUBDIR/$CHAIN_BIN_NAME"
+GOVERNANCE_REGISTRY_IMPORT_SRC="$ROOT_DIR/target/$TARGET_OUTPUT_SUBDIR/$GOVERNANCE_REGISTRY_IMPORT_BIN_NAME"
+GOVERNANCE_REGISTRY_AUDIT_SRC="$ROOT_DIR/target/$TARGET_OUTPUT_SUBDIR/$GOVERNANCE_REGISTRY_AUDIT_BIN_NAME"
 CLIENT_LAUNCHER_SRC="$ROOT_DIR/target/$TARGET_OUTPUT_SUBDIR/$CLIENT_LAUNCHER_BIN_NAME"
 
 if [[ "$DRY_RUN" != "1" ]]; then
@@ -264,6 +274,8 @@ if [[ "$DRY_RUN" != "1" ]]; then
   [[ -f "$WEB_LAUNCHER_SRC" ]] || { echo "error: web launcher binary not found: $WEB_LAUNCHER_SRC" >&2; exit 1; }
   [[ -f "$LIVE_SRC" ]] || { echo "error: oasis7_viewer_live binary not found: $LIVE_SRC" >&2; exit 1; }
   [[ -f "$CHAIN_SRC" ]] || { echo "error: oasis7_chain_runtime binary not found: $CHAIN_SRC" >&2; exit 1; }
+  [[ -f "$GOVERNANCE_REGISTRY_IMPORT_SRC" ]] || { echo "error: oasis7_governance_registry_import binary not found: $GOVERNANCE_REGISTRY_IMPORT_SRC" >&2; exit 1; }
+  [[ -f "$GOVERNANCE_REGISTRY_AUDIT_SRC" ]] || { echo "error: oasis7_governance_registry_audit binary not found: $GOVERNANCE_REGISTRY_AUDIT_SRC" >&2; exit 1; }
   [[ -f "$CLIENT_LAUNCHER_SRC" ]] || { echo "error: client launcher binary not found: $CLIENT_LAUNCHER_SRC" >&2; exit 1; }
 fi
 
@@ -271,6 +283,8 @@ replace_file "$LAUNCHER_SRC" "$BUNDLE_BIN_DIR/$LAUNCHER_BIN_NAME"
 replace_file "$WEB_LAUNCHER_SRC" "$BUNDLE_BIN_DIR/$WEB_LAUNCHER_BIN_NAME"
 replace_file "$LIVE_SRC" "$BUNDLE_BIN_DIR/$LIVE_BIN_NAME"
 replace_file "$CHAIN_SRC" "$BUNDLE_BIN_DIR/$CHAIN_BIN_NAME"
+replace_file "$GOVERNANCE_REGISTRY_IMPORT_SRC" "$BUNDLE_BIN_DIR/$GOVERNANCE_REGISTRY_IMPORT_BIN_NAME"
+replace_file "$GOVERNANCE_REGISTRY_AUDIT_SRC" "$BUNDLE_BIN_DIR/$GOVERNANCE_REGISTRY_AUDIT_BIN_NAME"
 replace_file "$CLIENT_LAUNCHER_SRC" "$BUNDLE_BIN_DIR/$CLIENT_LAUNCHER_BIN_NAME"
 
 # 2) Prepare viewer web dist (software_safe static bundle by default).

--- a/scripts/bundle-freshness-lib.sh
+++ b/scripts/bundle-freshness-lib.sh
@@ -30,6 +30,8 @@ scope = [
     "crates/oasis7/src/bin/oasis7_game_launcher",
     "crates/oasis7/src/bin/oasis7_web_launcher.rs",
     "crates/oasis7/src/bin/oasis7_web_launcher",
+    "crates/oasis7/src/bin/oasis7_governance_registry_import.rs",
+    "crates/oasis7/src/bin/oasis7_governance_registry_audit.rs",
     "crates/oasis7_proto/Cargo.toml",
     "crates/oasis7_proto/src",
     "crates/oasis7_viewer/software_safe.html",

--- a/scripts/validate-release-platform-entrypoints.sh
+++ b/scripts/validate-release-platform-entrypoints.sh
@@ -129,6 +129,8 @@ case "$PLATFORM" in
     require_path "$BUNDLE_DIR/bin/oasis7_web_launcher" executable
     require_path "$BUNDLE_DIR/bin/oasis7_viewer_live" executable
     require_path "$BUNDLE_DIR/bin/oasis7_chain_runtime" executable
+    require_path "$BUNDLE_DIR/bin/oasis7_governance_registry_import" executable
+    require_path "$BUNDLE_DIR/bin/oasis7_governance_registry_audit" executable
     ;;
   macos-x64)
     require_path "$BUNDLE_DIR/run-client.sh" executable
@@ -140,6 +142,8 @@ case "$PLATFORM" in
     require_path "$BUNDLE_DIR/bin/oasis7_web_launcher" executable
     require_path "$BUNDLE_DIR/bin/oasis7_viewer_live" executable
     require_path "$BUNDLE_DIR/bin/oasis7_chain_runtime" executable
+    require_path "$BUNDLE_DIR/bin/oasis7_governance_registry_import" executable
+    require_path "$BUNDLE_DIR/bin/oasis7_governance_registry_audit" executable
     require_path "$BUNDLE_DIR/oasis7 Client Launcher.app/Contents/Info.plist" file
     require_path "$BUNDLE_DIR/oasis7 Client Launcher.app/Contents/MacOS/oasis7-client-launcher" executable
     ;;
@@ -149,6 +153,8 @@ case "$PLATFORM" in
     require_path "$BUNDLE_DIR/bin/oasis7_web_launcher.exe" file
     require_path "$BUNDLE_DIR/bin/oasis7_viewer_live.exe" file
     require_path "$BUNDLE_DIR/bin/oasis7_chain_runtime.exe" file
+    require_path "$BUNDLE_DIR/bin/oasis7_governance_registry_import.exe" file
+    require_path "$BUNDLE_DIR/bin/oasis7_governance_registry_audit.exe" file
     require_path "$BUNDLE_DIR/run-client.cmd" file
     require_path "$BUNDLE_DIR/run-web-launcher.cmd" file
     require_path "$BUNDLE_DIR/run-game.cmd" file


### PR DESCRIPTION
## Summary
- include `oasis7_governance_registry_import` and `oasis7_governance_registry_audit` in native release/testnet bundles
- validate those binaries for Linux, macOS, and Windows bundle entrypoints
- fix native bundle build arg assembly so empty target args do not trip nounset on macOS bash

## Verification
- `bash -n scripts/build-game-launcher-bundle.sh scripts/validate-release-platform-entrypoints.sh`
- `./scripts/build-game-launcher-bundle.sh --dry-run --profile dev --out-dir .tmp/bundle-dry-run` (verified native cargo/copy steps include both registry tools; existing dry-run stops later when manifest output dir is not actually created)