### PR TITLE
Add Viewer visual design system

### DIFF
--- a/.pm/tasks/task_a25bf76359be45719edfcda1759626d1.execution.md
+++ b/.pm/tasks/task_a25bf76359be45719edfcda1759626d1.execution.md
@@ -1,0 +1,566 @@
+# task_a25bf76359be45719edfcda1759626d1 Execution Log
+
+- task_uid: task_a25bf76359be45719edfcda1759626d1
+- title: Create viewer visual design specification
+- owner_role: tpm
+- worktree_hint: /Users/scc/ccwork/worktrees/oasis7-world-simulator-viewer-visual-design-spec
+
+<!-- Append entries using:
+Example:
+  ## YYYY-MM-DD HH:MM:SS CST / role_name
+  - 完成内容: ...
+  - 遗留事项: ...
+  - Action: ...
+  - Validation Command: ...
+  - Expected Result: ...
+  - Actual Result: ...
+  - Blocker / Next Action: ...
+-->
+
+## 2026-06-05 16:05:00 CST / tpm
+- 完成内容: WORKFLOW BOOTSTRAP DECIDED
+  - Repository State Impact: changes repository docs by adding a canonical visual design specification and index links.
+  - Isolation Decision: created dedicated task worktree `/Users/scc/ccwork/worktrees/oasis7-world-simulator-viewer-visual-design-spec` on branch `task/world-simulator-viewer-visual-design-spec`.
+  - Task Truth: `.pm/tasks/task_a25bf76359be45719edfcda1759626d1.yaml`; owner role `tpm` for workflow coordination/integration only.
+  - Formal Docs: source refs include `AGENTS.md`, `doc/engineering/workflow/source-of-truth.md`, `doc/world-simulator/viewer/README.md`, and `doc/testing/manual/model-visual-review-sop-2026-05-29.manual.md`.
+  - Routed Next Phase: `repo-owned-workflow-router` -> documentation execution with required `game_visual_interaction_designer` professional slice because the output is a player-facing visual design specification.
+- 完成内容: WORKFLOW ROUTE DECIDED
+  - Selected Workflow Skills:
+    1. `default-workflow-bootstrap` - already completed for task truth.
+    2. `repo-owned-workflow-router` - selected this documentation execution path.
+    3. `bounded-brainstorming` - skipped as a separate artifact; scope is clear enough from user request and existing viewer docs, but the visual role slice must consolidate principles.
+    4. `executing-project-tasks` - create the canonical spec and link it from relevant indexes.
+    5. `verification-before-completion` - run doc/lint/diff checks before claiming completion.
+  - Specialist Skills Considered: `game_visual_interaction_designer` role slice is required; no image generation or browser visual companion is required because this task creates a written canonical specification, not a rendered UI change.
+- 完成内容: Subagent Slice Contract
+  - role: `game_visual_interaction_designer`
+  - slice type: `design_spec_authoring_guidance`
+  - intended model configuration: workflow default `gpt-5.5-medium`
+  - actual dispatched model/reasoning: requested default/inherited through available subagent tool; actual model may be `inherited/unverified` if the tool does not report runtime details.
+  - context delivery mode: full-thread/full-history fork requested; explicit context packet included as supplement.
+  - mandatory context checklist/packet:
+    - identity and authority: role card `.agents/roles/game_visual_interaction_designer.md`; TPM owner/integrator `tpm`.
+    - workflow governance: `AGENTS.md`; `doc/engineering/workflow/source-of-truth.md`; selected route above.
+    - task truth: `.pm/tasks/task_a25bf76359be45719edfcda1759626d1.yaml`; this execution log; canonical worktree `/Users/scc/ccwork/worktrees/oasis7-world-simulator-viewer-visual-design-spec`; branch `task/world-simulator-viewer-visual-design-spec`; base `HEAD`; no PR yet.
+    - user intent: user needs a complete visual design specification, not merely a fact answer; output should be canonical and repo-linked.
+    - scoped repo context: `doc/world-simulator/viewer/README.md`, `viewer-gameplay-release-experience-overhaul.prd.md`, `viewer-web-entry-visual-redesign-2026-05-12.prd.md`, `viewer-pixel-world-semantic-positioning-2026-05-26.prd.md`, `viewer-pixel-world-commercial-rendering-loop-2026-05-28.prd.md`, `doc/testing/manual/model-visual-review-sop-2026-05-29.manual.md`, `doc/ui_review_result/README.md`, `doc/engineering/doc-governance/doc-structure-standard.design.md`.
+    - collaboration boundary: subagent owns professional visual/interaction principles and acceptance rubric; TPM owns file edits, index linking, and verification; no second task/worktree/PR truth.
+  - write scope: recommendation only unless the subagent chooses to patch a clearly named doc; TPM will integrate into `doc/world-simulator/viewer/viewer-visual-design-spec-2026-06-05.design.md`, `doc/world-simulator/viewer/README.md`, and `doc/world-simulator/prd.index.md`.
+  - return contract: provide concise canonical spec outline, non-negotiable visual principles, tokens/language, interaction states, pixel-world layer priorities, responsive/accessibility expectations, visual review gates, evidence paths, and residual risks.
+  - formal sink / writeback surface: this execution log is mandatory; final doc must attribute content to the role slice.
+  - integration owner/order: TPM records slice result, drafts/edits docs, then verifies.
+- 遗留事项: Await `game_visual_interaction_designer` slice result, then integrate the canonical spec and links.
+- Action: Dispatch `game_visual_interaction_designer` bounded slice.
+- Validation Command: N/A before dispatch.
+- Expected Result: Role-owned content guidance suitable for a complete visual design spec.
+- Actual Result: Pending.
+- Blocker / Next Action: wait for role guidance while TPM prepares doc placement/index context.
+
+## 2026-06-05 19:47:19 CST / game_visual_interaction_designer
+- 完成内容: Bounded professional slice result for the canonical Viewer/player-facing visual design specification.
+- 遗留事项: TPM must integrate the role-owned visual direction into the canonical spec and repo links; no role blocker remains.
+- Action: Reviewed scoped viewer/testing/doc-governance evidence and returned canonical visual design specification guidance.
+- Validation Command: Role slice file reads listed below under `Validation Command`.
+- Expected Result: Existing visual/topic docs provide enough evidence to consolidate a canonical Viewer visual design specification without adding implementation code.
+- Actual Result: Pass; recommended canonical path, structure, visual principles, tokens/language, hierarchy, interaction states, pixel-world priorities, responsive/accessibility rules, gates, non-goals, and residual risks.
+- Blocker / Next Action: No blocker for TPM doc authoring; TPM should write/link the spec and run doc governance checks.
+- Role / Slice Type: `game_visual_interaction_designer` / `design_spec_authoring_guidance`.
+- Context / Evidence Reviewed:
+  - `.agents/roles/game_visual_interaction_designer.md`
+  - `doc/engineering/workflow/source-of-truth.md`
+  - `doc/engineering/doc-governance/doc-structure-standard.design.md`
+  - `doc/world-simulator/viewer/README.md`
+  - `doc/world-simulator/viewer/viewer-gameplay-release-experience-overhaul.prd.md`
+  - `doc/world-simulator/viewer/viewer-web-entry-visual-redesign-2026-05-12.prd.md`
+  - `doc/world-simulator/viewer/viewer-pixel-world-semantic-positioning-2026-05-26.prd.md`
+  - `doc/world-simulator/viewer/viewer-pixel-world-commercial-rendering-loop-2026-05-28.prd.md`
+  - `doc/world-simulator/viewer/viewer-2d-visual-polish.design.md`
+  - `doc/testing/manual/model-visual-review-sop-2026-05-29.manual.md`
+  - `doc/ui_review_result/README.md`
+- Recommended Canonical Spec:
+  - Title: `Viewer Visual Design Specification`
+  - Path: `doc/world-simulator/viewer/viewer-visual-design-spec-2026-06-05.design.md`
+  - Rationale: This is a `*.design.md` surface because it defines durable visual language, information hierarchy, interaction contracts, layer priority, and review gates. It should live in `doc/world-simulator/viewer/` because it consolidates viewer/player-facing visual direction. It should be linked from `doc/world-simulator/viewer/README.md` as the first-read entry for visual design direction, and from the module index if the existing index structure accepts design/supporting entries.
+- Recommended Document Structure:
+  1. `Document Status and Scope`: identify the document as canonical for Viewer/player-facing visual direction; list covered surfaces: Viewer Web entry, Player/Director mode hierarchy, pixel-world, 2D map readability, HUDs, side panels, diagnostics, fallback surfaces, visual review evidence.
+  2. `Source Documents Consolidated`: cite the reviewed PRD/design/manual sources and state that this spec consolidates direction without replacing runtime, QA, or release gates.
+  3. `Experience Target`: "world-first playable command board"; player should understand world state, current objective, next move, blocker, and action receipt within five seconds.
+  4. `Non-Negotiable Visual Principles`: world first; player leverage before ambient activity; diagnostics demoted not deleted; data honesty; one primary action path; readable before decorative; sparse snapshots still communicate relationships; fallback must be explicit.
+  5. `Visual Language and Tokens`: palette roles, typography roles, spacing/density, surface elevation, borders, icon/status vocabulary, motion/feedback timing, state colors, and diagnostics styling.
+  6. `Information Hierarchy`: default Player hierarchy, Director/diagnostics hierarchy, HUD hierarchy, right panel hierarchy, empty/loading/error hierarchy, mobile tab hierarchy.
+  7. `Interaction States and Feedback`: hover/focus/active/selected/disabled/loading/error/success/blocker/no-receipt/accepted-intent/executing/complete states and their visual receipts.
+  8. `Pixel-World Layer Priorities`: stage summary/commercial HUD, selected callouts, agents/routes/hotspots, locations, Fragment terrain, diagnostics/raw DTO/test controls, fallback DOM.
+  9. `2D Map Rules`: high-contrast Location/Agent symbols, label LOD, flow direction arrows, mode-specific 2D overlays, and no leakage into 3D mode.
+  10. `Responsive and Accessibility Rules`: desktop/mobile priority, no horizontal scroll, target sizing, text overflow, focus visibility, contrast, reduced motion, canvas fallback and screen-readable summaries.
+  11. `Visual Review Gates`: screenshot requirements, model visual review rubric, blocking signals, escalation rules, and evidence sink expectations.
+  12. `Implementation Brief for Viewer Engineer`: stable anchors, data-source constraints, diagnostics collapse rules, tests to update, screenshot fixtures.
+  13. `Non-Goals`: no runtime protocol expansion, no new 3D workstream, no heavy art asset pack, no editor-style terrain interaction, no replacement for QA/release approval.
+  14. `Residual Risks and Follow-Ups`: facility/production semantics are still thin, derived agent positions can be misread without badges, sparse worlds need stronger art direction later, mobile command depth needs screenshot validation, tokens need implementation audit.
+- Non-Negotiable Visual Principles:
+  - World canvas is the first visual focus in Player mode. Side panels, diagnostics, and raw state must never compete as equal-weight first-screen surfaces.
+  - Player-facing surfaces answer in order: current world/selected object, current objective, blocker/next action, latest action receipt, then diagnostics.
+  - Player leverage is visually distinct from ambient simulation. A lively world cannot be presented as player progress unless accepted intent, execution cause, or world-change receipt supports it.
+  - Diagnostics are demoted, never removed. Runtime Diagnostics, Session Ladder, Hosted Action Matrix, raw DTO, renderer status, provider checks, and test controls belong in explicit Director/diagnostics surfaces.
+  - Sparse snapshots must still read as a world. If exact agent coordinates are missing, deterministic `location_derived` placement, badges, and relationship lines should preserve semantic readability without claiming runtime truth.
+  - Fallbacks must be honest and visible. Missing wasm bridge or degraded renderer state must show a clear fallback/callout, not silently imply the full renderer is active.
+  - Visual polish must serve scan speed. Decoration, color variation, terrain texture, and badges are subordinate to Agent, route, objective, blocker, and receipt readability.
+  - Player mode uses one obvious command path. The viewer may support advanced layouts, but the default path must keep "directly command Agent" or equivalent primary action one step away.
+- Visual Tokens / Language:
+  - Palette roles, not hard-coded brand colors: `world-background`, `terrain-subdued`, `agent-primary`, `route-active`, `objective-accent`, `blocker-danger`, `receipt-success`, `diagnostic-muted`, `panel-surface`, `focus-ring`.
+  - Typography roles: `world-title` for stage identity, `objective-title` for current goal, `action-label` for executable next step, `receipt-body` for result feedback, `diagnostic-caption` for engineering/status metadata. Diagnostic captions must not visually outrank objective/action text.
+  - Surfaces: main world stage is unframed or minimally framed; HUD and panels are tools, not equal dashboard cards; diagnostics use lower contrast and collapsed density by default.
+  - Status marks: selected, target, blocker, active route, accepted intent, no receipt, derived position, fallback/degraded renderer. Each mark needs a stable text or badge equivalent for data honesty.
+  - Motion/feedback: action feedback may use short emphasis for receipt/selection/route change, but must not obscure labels or replace textual state.
+- Information Hierarchy:
+  - Player desktop default: world stage > commercial HUD/objective-next-action-leverage > selected entity/action receipt > command entry > compact side panel > diagnostics.
+  - Player mobile default: `World / Targets / Command` or equivalent segmented path; mobile must preserve the same priority instead of flattening all content into a long single column.
+  - Director mode: diagnostics may be visible by default, but should remain visually labeled as Director/diagnostic context so screenshots are not mistaken for Player release surface.
+  - Empty/loading/error states: must state what is missing, what is still true, and what the next recovery action is. Empty world states should not look like successful idle gameplay.
+- Interaction States and Feedback:
+  - Hover: reveal affordance without shifting layout or hiding the world.
+  - Focus: visible keyboard focus ring on all controls, including icon-only controls and panel tabs.
+  - Selected: selected Agent/Location/route must update both canvas emphasis and textual summary.
+  - Disabled/blocker: show reason and next recovery path; disabled controls without reason are not acceptable in Player mode.
+  - Loading/degraded: visible status plus stable layout; no spinner-only first screen.
+  - Accepted intent/executing/complete: action feedback must show what the player did, what is happening, and what changed or did not change.
+  - No-receipt: explicitly state no player-facing receipt yet; do not use world activity as a substitute.
+- Pixel-World Layer Priority:
+  1. Stage identity and commercial HUD: `World Command Board`, objective, next move, player leverage, blocker.
+  2. Foreground semantic callouts: selected entity, goal/blocker/action receipt.
+  3. Primary world actors: Agents, active routes, action hotspots.
+  4. Secondary anchors: Locations and relationship lines.
+  5. Background: Fragment terrain and non-interactive world body.
+  6. Diagnostics: renderer status, runtime source, camera, raw DTO, test controls, collapsed by default.
+  7. Fallback DOM: must preserve route/agent/location readability where possible and mark degraded mode clearly.
+- Responsive / Accessibility Rules:
+  - Desktop default must allocate the largest visual area to the world stage.
+  - Mobile must provide explicit World/Targets/Command navigation and keep primary command path reachable without horizontal scroll.
+  - Text must fit containers at supported viewports; avoid clipped buttons, overlapping HUDs, and labels competing with each other.
+  - Canvas-only semantics require adjacent textual summaries for objective, blocker, selected entity, player leverage, and fallback/degraded status.
+  - All interactive controls need keyboard focus, readable labels/tooltips, and minimum practical target size.
+  - Contrast must prioritize Agent/route/action readability over terrain/detail decoration.
+  - Reduced motion should preserve feedback through text/state changes.
+- Visual Review Gates:
+  - Any visible surface change requires screenshot plus model visual review unless explicitly proven non-visible.
+  - Minimum screenshot set: desktop Player primary surface; mobile when responsive/first-screen/layout is touched; before/after for redesign; degraded/fallback when renderer paths are affected.
+  - Must-pass checks: first visual focus, hierarchy/readability, no overlap/overflow, data honesty, action feedback, responsive continuity, commercial/player-facing feel, no regression vs baseline.
+  - Pixel-world specific blockers: Agent less visible than Fragment terrain; renderer diagnostics louder than command board/receipt; Location markers dominating as main entities; no honest indication for derived/missing position; no route/readability in sparse snapshot.
+  - Escalate to `game_visual_interaction_designer` for direction, screen-flow, interaction-feel, or commercial-readiness disputes; model review can replace routine screenshot inspection but not role-owned direction.
+- Explicit Non-Goals:
+  - Do not expand runtime snapshot protocol in this visual spec.
+  - Do not define final brand identity, marketing art, or heavy asset packs.
+  - Do not restore or define a new 3D renderer workstream.
+  - Do not make Fragment blocks interactive targets in this spec.
+  - Do not replace QA release gates, GitHub required checks, or human approval where governance requires them.
+  - Do not reclassify diagnostics as Player primary content.
+- Residual Risks:
+  - Facility, production-line, inventory-flow, and long-loop economic semantics are still not rich enough in current viewer data; the spec can only require honest placeholders and player-leverage separation until runtime/viewer contracts deepen.
+  - Derived agent positioning remains a readability compromise; badges and source labels are mandatory to prevent false precision.
+  - Mobile `World / Targets / Command` needs screenshot validation after implementation because density risks cannot be fully resolved in text.
+  - Token names need implementation audit before they become enforced CSS/API constants.
+  - This slice did not perform browser screenshot review because the current task is doc/spec authoring and no rendered UI was changed.
+- TPM Proceed / Integration Recommendation:
+  - TPM can proceed to write the canonical document at `doc/world-simulator/viewer/viewer-visual-design-spec-2026-06-05.design.md`.
+  - TPM should link it from `doc/world-simulator/viewer/README.md` under "从这里开始" as the first-read entry for visual direction.
+  - TPM may additionally link it from `doc/world-simulator/prd.index.md` or an appropriate design/index surface if that file currently indexes supporting design docs.
+  - The final doc should attribute the consolidated professional visual/interaction direction to this `game_visual_interaction_designer` slice and keep runtime/QA/release authority separated.
+- Validation Command: `git diff --check && ./scripts/doc-governance-check.sh`; targeted pm-lint grep; spec link grep.
+  - `sed -n '1,240p' .agents/roles/game_visual_interaction_designer.md`
+  - `sed -n '1,220p' doc/engineering/workflow/source-of-truth.md`
+  - `sed -n '1,260p' doc/engineering/doc-governance/doc-structure-standard.design.md`
+  - `sed -n '1,220p' doc/world-simulator/viewer/README.md`
+  - `sed -n '1,240p' doc/world-simulator/viewer/viewer-gameplay-release-experience-overhaul.prd.md`
+  - `sed -n '1,260p' doc/world-simulator/viewer/viewer-web-entry-visual-redesign-2026-05-12.prd.md`
+  - `sed -n '1,260p' doc/world-simulator/viewer/viewer-pixel-world-semantic-positioning-2026-05-26.prd.md`
+  - `sed -n '1,280p' doc/world-simulator/viewer/viewer-pixel-world-commercial-rendering-loop-2026-05-28.prd.md`
+  - `sed -n '1,280p' doc/world-simulator/viewer/viewer-2d-visual-polish.design.md`
+  - `sed -n '1,260p' doc/testing/manual/model-visual-review-sop-2026-05-29.manual.md`
+  - `sed -n '1,220p' doc/ui_review_result/README.md`
+- Expected Result: Existing visual/topic docs provide enough evidence to consolidate a canonical Viewer visual design specification without adding implementation code.
+- Actual Result: Pass. The slice recommends the canonical structure and content above. No implementation code was modified.
+- Blocker / Next Action:
+  - No blocker for TPM doc authoring.
+  - `./scripts/pm/workflow-report.sh --phase start --role game_visual_interaction_designer --task-uid task_a25bf76359be45719edfcda1759626d1` was attempted and failed because the task owner role is `tpm`, not `game_visual_interaction_designer`; this is a script ownership limitation for subagent slices under TPM, not a design blocker.
+  - `./scripts/pm/workflow-report.sh --phase close --role game_visual_interaction_designer --task-uid task_a25bf76359be45719edfcda1759626d1` was attempted and failed for the same owner-role mismatch.
+- Memory Extraction Check:
+  - New durable user preference? No.
+  - New durable repo workflow rule? No; existing TPM/subagent owner mismatch is already governed by current workflow truth and script behavior.
+  - New reusable project knowledge beyond this task? No; the visual spec guidance belongs in the canonical doc TPM will author, not in memory.
+
+## 2026-06-05 20:05:00 CST / tpm
+- 完成内容: Integrated the `game_visual_interaction_designer` slice into repository documentation.
+  - Added canonical spec: `doc/world-simulator/viewer/viewer-visual-design-spec-2026-06-05.design.md`.
+  - Linked the spec from `doc/world-simulator/viewer/README.md` as the first-read entry for visual direction and review gates.
+  - Linked the spec from `doc/world-simulator/README.md` and `doc/world-simulator/prd.index.md` as an active supplemental document.
+  - The spec attributes professional visual direction to the `game_visual_interaction_designer` slice and preserves runtime/QA/release ownership boundaries.
+- 遗留事项: Full `./scripts/pm/lint.sh` still fails on unrelated pre-existing execution-log format debt in `task_202b9f812d49432a9f4360b8a66c5364` and `task_455ea61e04c946469b8b1d22b700f853`; this task has no remaining pm-lint failures.
+- Action: Wrote canonical visual design spec and index/README links; ran fresh verification.
+- Validation Command: `git diff --check && ./scripts/doc-governance-check.sh`; targeted pm-lint grep; spec link grep.
+  - `git diff --check && ./scripts/doc-governance-check.sh`
+  - `out=$(./scripts/pm/lint.sh 2>&1 || true); if printf '%s\n' "$out" | rg 'task_a25bf76359be45719edfcda1759626d1'; then exit 1; else echo 'no pm-lint failures for task_a25bf76359be45719edfcda1759626d1'; fi`
+  - `rg -n "viewer-visual-design-spec-2026-06-05.design.md" doc/world-simulator/README.md doc/world-simulator/prd.index.md doc/world-simulator/viewer/README.md doc/world-simulator/viewer/viewer-visual-design-spec-2026-06-05.design.md`
+- Expected Result: Doc governance and diff hygiene pass, the canonical spec is linked from viewer/module entrypoints, and no pm-lint failures remain for this task UID.
+- Actual Result: Pass; doc governance, diff hygiene, targeted pm-lint, and link grep passed.
+  - `git diff --check && ./scripts/doc-governance-check.sh`: pass; output `doc-governance-check: OK`.
+  - targeted pm-lint check: pass; output `no pm-lint failures for task_a25bf76359be45719edfcda1759626d1`.
+  - link grep: pass; spec referenced from `doc/world-simulator/README.md`, `doc/world-simulator/prd.index.md`, and `doc/world-simulator/viewer/README.md`.
+- Blocker / Next Action: No blocker for the requested documentation change; full PM lint remains blocked by unrelated existing tasks listed above.
+
+## 2026-06-05 20:15:10 CST / tpm
+- 完成内容: Started implementation gap review against the new Viewer visual design specification.
+  - User follow-up: inspect current implementation, identify gaps against the design spec, and fill them.
+  - Current task truth remains canonical: this task UID/worktree/branch; no new `.pm` task or worktree created.
+  - TPM preliminary fact inventory only: current Viewer already has world-first stage anchors, commercial HUD/action receipt surfaces, collapsed diagnostics, sparse pixel-world positioning, and fallback/no-receipt tests; the clearest actionable gap found so far is diagnostics discoverability in the mobile/anchor route.
+- 遗留事项: Need role-owned confirmation before finalizing implementation scope; then patch and verify.
+- Action: Record professional slice contracts for gap validation and implementation feasibility.
+- Validation Command: `rg` over Viewer anchors/diagnostics plus `sed` over viewer package scripts.
+  - `rg -n "MobileJumpRail|diagnostic-surface|Runtime Diagnostics|mobile-rail__link" crates/oasis7_viewer/software_safe_src/main.jsx crates/oasis7_viewer/software_safe_src/main.test.jsx crates/oasis7_viewer/software_safe.html`
+  - `sed -n '1,220p' crates/oasis7_viewer/package.json`
+- Expected Result: Identify concrete, scoped implementation gaps and the right commands for UI verification.
+- Actual Result: Pass for TPM fact inventory; `test:ui` and `build:software-safe` scripts exist. Professional gap/implementation judgment is pending bounded slices below.
+- Subagent Slice Contract:
+  - role: `game_visual_interaction_designer`
+  - slice type: `implementation_gap_validation`
+  - intended model configuration: workflow default inherited through available subagent tool.
+  - actual dispatched model/reasoning: inherited/unverified unless the subagent tool reports concrete runtime details.
+  - context delivery mode: full-thread/full-history fork requested; explicit context packet included as supplement.
+  - mandatory context checklist/packet:
+    - task truth: this execution log, `.pm/tasks/task_a25bf76359be45719edfcda1759626d1.yaml`, canonical worktree, branch `task/world-simulator-viewer-visual-design-spec`.
+    - role authority: `.agents/roles/game_visual_interaction_designer.md`.
+    - design truth: `doc/world-simulator/viewer/viewer-visual-design-spec-2026-06-05.design.md`.
+    - implementation surfaces: `crates/oasis7_viewer/software_safe_src/main.jsx`, `crates/oasis7_viewer/software_safe_src/main.test.jsx`, `crates/oasis7_viewer/software_safe.html`, relevant pixel-world files/tests.
+    - user intent: compare current implementation to spec and fill gaps, not broaden into unrelated redesign.
+  - write scope: no direct edits requested; return must-fix/should-defer gap list with evidence.
+  - return contract: say whether the diagnostics mobile/anchor discoverability gap is must-fix now, name any other must-fix spec gaps visible in current implementation, and list residual risks.
+  - formal sink / writeback surface: TPM will paste the result into this execution log.
+  - integration owner/order: TPM integrates result before final completion claim.
+- Subagent Slice Contract:
+  - role: `viewer_engineer`
+  - slice type: `scoped_implementation_feasibility`
+  - intended model configuration: workflow default inherited through available subagent tool.
+  - actual dispatched model/reasoning: inherited/unverified unless the subagent tool reports concrete runtime details.
+  - context delivery mode: full-thread/full-history fork requested; explicit context packet included as supplement.
+  - mandatory context checklist/packet:
+    - task truth and worktree listed above.
+    - role authority: `.agents/roles/viewer_engineer.md`.
+    - design truth: `doc/world-simulator/viewer/viewer-visual-design-spec-2026-06-05.design.md`.
+    - scoped implementation surfaces: `main.jsx`, `main.test.jsx`, `software_safe.html`; generated bundle only if the repo build script updates it.
+  - write scope: recommendation only; no direct edits requested to avoid overlapping with TPM integration patch.
+  - return contract: confirm minimal patch plan, tests/build commands, and whether generated `viewer.js` should be updated.
+  - formal sink / writeback surface: TPM will paste the result into this execution log.
+  - integration owner/order: TPM patches after receiving/while waiting if non-overlapping evidence is sufficient, then verifies.
+- Blocker / Next Action: Dispatch bounded slices and patch the diagnostics anchor/mobile discoverability gap if confirmed or if no broader must-fix emerges.
+
+## 2026-06-05 20:19:23 CST / game_visual_interaction_designer
+- 完成内容: Bounded implementation gap validation completed.
+- 遗留事项: Screenshot-level visual review remains required before final completion because this slice performed source/test inspection only.
+- Action: Checked current Viewer implementation against `doc/world-simulator/viewer/viewer-visual-design-spec-2026-06-05.design.md`.
+- Validation Command: Role slice inspected the design spec and Viewer implementation/test/style surfaces with `sed` and `rg`.
+  - `sed -n '1,260p' doc/world-simulator/viewer/viewer-visual-design-spec-2026-06-05.design.md`
+  - `sed` / `rg` over `crates/oasis7_viewer/software_safe_src/main.jsx`, `main.test.jsx`, `pixel_world_host.jsx`, `pixel_world_host.test.jsx`, and `crates/oasis7_viewer/software_safe.html`
+- Expected Result: Identify must-fix visual implementation gaps.
+- Actual Result: Pass; no must-fix visual gaps remain after the diagnostics anchor/mobile entry patch.
+  - Must-fix gaps: none remaining after the diagnostics anchor/mobile entry patch.
+  - Confirmed evidence: `MobileJumpRail` contains a demoted `Diagnostics` link to `#viewer-diagnostics-panel`; Runtime Diagnostics has a stable collapsed `<details>` anchor; CSS demotes the diagnostics link; tests cover the anchor and collapsed diagnostics state.
+  - Should-defer gaps: final brand book, full asset/icon system, final token audit, and screenshot-level validation.
+  - Residual risks: no browser screenshot was run by the slice; pixel-world evidence looked aligned, but final visual review still needs rendered proof.
+- Blocker / Next Action: TPM to run build/tests/browser verification and record final evidence.
+
+## 2026-06-05 20:19:23 CST / viewer_engineer
+- 完成内容: Bounded scoped implementation feasibility review completed.
+- 遗留事项: Need generated bundle update and final verification.
+- Action: Reviewed current diff and implementation surfaces for minimal patch plan.
+- Validation Command: Role slice read `main.jsx`, `main.test.jsx`, `software_safe.html`, and viewer build/test scripts.
+  - Read `crates/oasis7_viewer/software_safe_src/main.jsx`
+  - Read `crates/oasis7_viewer/software_safe_src/main.test.jsx`
+  - Read `crates/oasis7_viewer/software_safe.html`
+  - Checked `crates/oasis7_viewer/package.json` build/test scripts
+- Expected Result: Confirm exact implementation scope, test commands, and generated bundle requirement.
+- Actual Result: Pass; current patch scope and generated bundle update requirement were confirmed.
+  - Recommended patch scope matches current TPM edits: add demoted `Diagnostics` rail link, add `id="viewer-diagnostics-panel"` to collapsed diagnostics details, add low-contrast diagnostics link style, and test the anchor/default collapsed state.
+  - Recommended commands: `npm --prefix crates/oasis7_viewer run test:ui -- software_safe_src/main.test.jsx`, `npm --prefix crates/oasis7_viewer run build:software-safe`, and `git diff --check`.
+  - Generated bundle: update `crates/oasis7_viewer/viewer.js`; current bundle did not yet contain the new diagnostics anchor/classes.
+  - Residual risk: the patch does not auto-expand collapsed diagnostics on anchor navigation; current spec reads as discoverable-but-demoted, so no broader interaction patch is recommended.
+- Blocker / Next Action: TPM to build bundle and run verification.
+
+## 2026-06-05 20:34:36 CST / tpm
+- 完成内容: Filled current implementation gaps against the new Viewer visual design specification.
+  - Added a demoted mobile `Diagnostics` rail entry that links to `#viewer-diagnostics-panel`.
+  - Added the stable diagnostics anchor to the collapsed Runtime Diagnostics `<details>`.
+  - Added low-contrast diagnostics rail styling so diagnostics remain discoverable but do not compete with `World / Targets / Command`.
+  - Fixed the responsive grid area so the mobile rail appears at the top of the first viewport instead of being auto-placed after the stage/targets/details panels.
+  - Updated UI tests for the diagnostics anchor and default collapsed diagnostics state.
+  - Rebuilt checked-in `crates/oasis7_viewer/viewer.js`.
+- 遗留事项: Full brand book/token/icon/asset system and broader screenshot matrix remain deferred; npm dependency audit still reports pre-existing `1 moderate, 1 high` vulnerability after `npm ci`; full PM lint may still include unrelated historical task debt, but this task UID is clean.
+- Action: Patched Viewer UI/CSS/tests/bundle and ran fresh verification including browser-rendered mobile/desktop checks.
+- Validation Command: Fresh checks: `npm --prefix crates/oasis7_viewer run test:ui -- software_safe_src/main.test.jsx`; `npm --prefix crates/oasis7_viewer run build:software-safe`; `git diff --check`; `./scripts/doc-governance-check.sh`; targeted `./scripts/pm/lint.sh` grep for this task UID; `rg` bundle keyword check; in-app browser DOM/screenshot checks at 390x844 and 1280x720.
+- Expected Result: UI tests/build/doc/diff/task checks pass, generated bundle contains the new diagnostics anchor/classes, mobile rail is first-viewport visible with no horizontal overflow, diagnostics remains collapsed/demoted, and desktop rail remains hidden.
+- Actual Result: Pass.
+  - UI test: `1 passed`, `11 passed`.
+  - Build: `software_safe build finalized: .../crates/oasis7_viewer/viewer.js`.
+  - Diff hygiene: `git diff --check` exited 0.
+  - Doc governance: `doc-governance-check: OK`.
+  - Targeted PM lint: `no pm-lint failures for task_a25bf76359be45719edfcda1759626d1`.
+  - Bundle check: `viewer.js` contains `viewer-diagnostics-panel` and `mobile-rail__link--diagnostics`; `software_safe.html` contains `grid-area: rail`.
+  - Mobile browser check at 390x844: rail display `flex`; rail rect y=14; stage y=102; Diagnostics href `#viewer-diagnostics-panel`; diagnostics panel open=false; horizontalOverflow=false.
+  - Desktop browser check at 1280x720: rail display `none`; diagnostics panel open=false; horizontalOverflow=false; page console error list was empty.
+- Blocker / Next Action: No blocker for the requested gap fill; task remains uncommitted because user did not ask for commit/PR.
+
+## 2026-06-05 21:01:12 CST / tpm
+- 完成内容: Started a deeper second-pass implementation audit at user request.
+  - Scope: re-check current Viewer implementation against the canonical visual spec beyond the just-fixed diagnostics anchor.
+  - Audit surfaces: Viewer source, CSS, tests, generated bundle, pixel-world host/fallback behavior, mobile/desktop browser-rendered layout, and expanded verification commands.
+  - Current task/worktree remains canonical; no new `.pm` task or worktree created.
+- 遗留事项: Need role cross-checks, local spec-to-implementation matrix, any must-fix patches, and expanded verification evidence.
+- Action: Record second-pass audit contracts and start cross-role review.
+- Validation Command: N/A before second-pass dispatch; this entry records scope and contracts.
+- Expected Result: Identify any remaining must-fix visual/design-spec gaps or confirm none remain with stronger evidence.
+- Actual Result: Pending second-pass audit.
+- Subagent Slice Contract:
+  - role: `game_visual_interaction_designer`
+  - slice type: `second_pass_visual_gap_audit`
+  - intended model configuration: workflow default inherited through available subagent tool.
+  - actual dispatched model/reasoning: inherited/unverified unless the subagent tool reports concrete runtime details.
+  - context delivery mode: full-thread/full-history fork requested; explicit context packet included as supplement.
+  - mandatory context checklist/packet:
+    - task truth: this execution log and task YAML, canonical worktree, branch `task/world-simulator-viewer-visual-design-spec`.
+    - design truth: `doc/world-simulator/viewer/viewer-visual-design-spec-2026-06-05.design.md`.
+    - implementation surfaces: `crates/oasis7_viewer/software_safe_src/main.jsx`, `pixel_world_host.jsx`, related tests, `software_safe.html`, generated `viewer.js`.
+    - user intent: "还要仔细排查一遍" means look for remaining must-fix gaps, not broaden into a new redesign or brand-book project.
+  - write scope: no direct edits requested; return a must-fix / should-defer / no-finding verdict with evidence.
+  - formal sink / writeback surface: TPM will paste the result into this execution log.
+- Subagent Slice Contract:
+  - role: `qa_engineer`
+  - slice type: `second_pass_visual_verification_audit`
+  - intended model configuration: workflow default inherited through available subagent tool.
+  - actual dispatched model/reasoning: inherited/unverified unless the subagent tool reports concrete runtime details.
+  - context delivery mode: full-thread/full-history fork requested; explicit context packet included as supplement.
+  - mandatory context checklist/packet:
+    - task truth and canonical worktree listed above.
+    - design truth and role review results already recorded above.
+    - verification surfaces: viewer package scripts, UI tests, pixel-world tests/smoke scripts, browser-rendered mobile/desktop layout evidence, generated bundle consistency.
+  - write scope: no direct edits requested; return missing verification gaps, recommended commands, and any blocking QA findings.
+- Blocker / Next Action: Dispatch role slices while TPM builds a local spec-to-implementation checklist and reruns expanded verification.
+
+## 2026-06-05 21:21:26 CST / game_visual_interaction_designer
+- 完成内容: Second-pass visual gap audit completed.
+- 遗留事项: Final brand book/token/icon/asset system remains a should-defer project; final visual gate should still keep screenshot evidence.
+- Action: Re-checked current Viewer implementation against the canonical visual spec after the diagnostics/mobile fixes.
+- Validation Command: Role slice inspected the visual spec, Viewer source/style/tests, pixel-world host/tests, and generated bundle evidence.
+- Expected Result: Find remaining must-fix visible design gaps or confirm none remain.
+- Actual Result: Pass; no new must-fix visible design gaps found.
+  - Confirmed mobile path: `World / Targets / Command / Diagnostics`, with Diagnostics demoted.
+  - Confirmed Runtime Diagnostics stable anchor/default collapsed behavior.
+  - Confirmed command/right-panel raw diagnostics remain collapsed and secondary.
+  - Confirmed pixel-world command board/action receipt/canvas/renderer diagnostics ordering, no-receipt honesty, `location_derived` honesty, and explicit fallback messaging.
+  - Should-defer: final brand book, icon set, complete token governance, dense/CJK screenshot matrix.
+- Blocker / Next Action: No visual role blocker; TPM to finish QA/browser/visual-smoke verification and record final evidence.
+
+## 2026-06-05 21:21:26 CST / qa_engineer
+- 完成内容: Second-pass QA verification audit completed.
+- 遗留事项: Full `npm --prefix crates/oasis7_viewer run test:ui` and pixel-world visual smoke were recommended before PR/readiness; TPM ran them after this slice.
+- Action: Reviewed tests, CSS, source, bundle, task log, and scoped verification evidence.
+- Validation Command: Role slice ran/read `main.test.jsx`, `pixel_world_host.test.jsx`, `git diff --check`, targeted PM lint, doc governance, and source/bundle greps.
+- Expected Result: Identify blocking QA gaps or missing verification evidence.
+- Actual Result: Pass; no blocking QA gap found.
+  - QA judged mobile Diagnostics entry, Runtime Diagnostics anchor, mobile rail first-viewport ordering, UI tests, bundle consistency, browser mobile/desktop checks, and doc/task lint sufficient for the scoped patch.
+  - Non-blocking risk: visual smoke screenshot evidence should be recorded before PR/readiness.
+  - Recommended commands included full `test:ui`, `build:software-safe`, `test:pixel-world:visual`, diff hygiene, and doc governance.
+- Blocker / Next Action: TPM to run recommended expanded commands and record screenshot evidence paths.
+
+## 2026-06-05 21:21:26 CST / tpm
+- 完成内容: Completed the deeper second-pass audit and filled two additional implementation/test-quality gaps.
+  - Added explicit `:focus-visible` ring styling for links, buttons, canvas, details summaries, inputs, textareas, and selects.
+  - Included `canvas` in the focus-ring selector after browser probing showed canvas could receive focus but was not covered by the first focus-ring patch.
+  - Stabilized two hosted backend reauth tests with `15000` ms per-test budgets after reproducing a 5000 ms timeout in the expanded UI test run.
+  - Ran pixel-world visual smoke and recorded screenshot artifact paths under ignored `output/playwright/...`.
+  - Rebuilt checked-in `crates/oasis7_viewer/viewer.js`.
+- 遗留事项: Browser keyboard Tab simulation in the in-app browser stayed on `BODY`, so focus-ring visual proof is source/CSS plus broader browser layout/console evidence rather than a successful keyboard focus screenshot. Full brand book/token/icon/asset work remains deferred by both role slices.
+- Action: Applied second-pass scoped fixes, reran expanded verification, and checked generated/ignored artifact state.
+- Validation Command: Fresh commands: failing hosted reauth single-test reproduction; hosted reauth single-test rerun; `npm --prefix crates/oasis7_viewer run test:ui -- software_safe_src/main.test.jsx software_safe_src/pixel_world_host.test.jsx`; `npm --prefix crates/oasis7_viewer run test:ui`; `npm --prefix crates/oasis7_viewer run build:software-safe`; `npm --prefix crates/oasis7_viewer run test:pixel-world:visual`; `git diff --check`; `./scripts/doc-governance-check.sh`; targeted `./scripts/pm/lint.sh` grep for this task UID; source/bundle grep; mobile/desktop browser DOM checks.
+- Expected Result: Expanded tests and visual smoke pass, generated bundle is up to date, browser layout remains stable, no task/doc/diff hygiene failures remain, and any second-pass gaps are either fixed or explicitly deferred.
+- Actual Result: Pass.
+  - Reproduced failure: `main.test.jsx -t "marks hosted backend reauth as available"` timed out at 5000 ms before the test-budget patch.
+  - Targeted rerun after patch: passed, `1 passed | 10 skipped`.
+  - Expanded two-file UI run: passed, `2 passed`, `20 passed`.
+  - Full viewer UI run: passed, `4 passed`, `27 passed`.
+  - Build: `software_safe build finalized: .../crates/oasis7_viewer/viewer.js`.
+  - Pixel-world visual smoke: passed; summary `output/playwright/pixel-world-fragment-visual/2026-06-05T13-16-35-011Z/summary.json`; screenshots `fragment-fallback-visual.png`, `action-receipt-visual.png`, `mobile-action-receipt-visual.png` in the same directory.
+  - Diff hygiene: `git diff --check` exited 0.
+  - Doc governance: `doc-governance-check: OK`.
+  - Targeted PM lint: `no pm-lint failures for task_a25bf76359be45719edfcda1759626d1`.
+  - Browser mobile check retained first-viewport rail and no horizontal overflow; desktop check retained hidden mobile rail and no horizontal overflow; browser error logs were empty in the earlier rendered check.
+  - Output artifacts are ignored by repo status (`!! output/`) and were not added to the diff.
+- Blocker / Next Action: No blocker remains for the requested careful re-audit; task remains uncommitted because user has not requested commit/PR.
+
+## 2026-06-05 21:26:33 CST / tpm
+- 完成内容: Expanded scope at user request to include the previously deferred large visual-system items.
+  - User request: "大项也都做了".
+  - Scope now includes: final Viewer brand book, full token naming/governance, icon/status vocabulary, asset-language rules, and denser screenshot/visual evidence matrix including mobile, fallback, action receipt, and CJK/long-text risk.
+  - Current task/worktree remains canonical; no new `.pm` task or worktree created.
+- 遗留事项: Need role boundary confirmation, then update docs/implementation hooks and run expanded verification.
+- Action: Record expanded scope and prepare visual/QA role slices.
+- Validation Command: N/A before expanded-scope dispatch.
+- Expected Result: Convert deferred large items into repo-owned, enforceable guidance and evidence without inventing unrelated runtime features.
+- Actual Result: Pending role slices and implementation.
+- Subagent Slice Contract:
+  - role: `game_visual_interaction_designer`
+  - slice type: `brand_token_icon_asset_system_guidance`
+  - intended model configuration: workflow default inherited through available subagent tool.
+  - actual dispatched model/reasoning: inherited/unverified unless the subagent tool reports concrete runtime details.
+  - context delivery mode: full-thread/full-history fork requested; explicit context packet included as supplement.
+  - mandatory context checklist/packet:
+    - task truth: this execution log/task YAML, worktree, branch.
+    - design truth: `doc/world-simulator/viewer/viewer-visual-design-spec-2026-06-05.design.md`.
+    - implementation surfaces: `crates/oasis7_viewer/software_safe.html`, `main.jsx`, `pixel_world_host.jsx`, tests, visual smoke artifacts.
+    - user intent: finish previously deferred large visual design-system items now, while staying scoped to Viewer/player-facing visual system.
+  - write scope: recommendation only; TPM integrates docs/code.
+  - return contract: concrete brand book additions, token taxonomy, icon/status vocabulary, asset rules, screenshot matrix, and any must-implement code hooks.
+- Subagent Slice Contract:
+  - role: `qa_engineer`
+  - slice type: `expanded_visual_system_verification_matrix`
+  - intended model configuration: workflow default inherited through available subagent tool.
+  - actual dispatched model/reasoning: inherited/unverified unless the subagent tool reports concrete runtime details.
+  - context delivery mode: full-thread/full-history fork requested; explicit context packet included as supplement.
+  - mandatory context checklist/packet:
+    - task truth and design/implementation surfaces listed above.
+    - verification surfaces: viewer UI tests, pixel-world visual smoke, browser DOM/screenshot evidence, doc governance, task lint, generated bundle consistency.
+  - write scope: recommendation only; TPM integrates docs/code.
+  - return contract: required screenshot matrix, commands, artifact paths, and blocking criteria for claiming the large items are done.
+- Blocker / Next Action: Dispatch role slices and begin local design-system/doc/code audit.
+
+## 2026-06-05 21:50:26 CST / game_visual_interaction_designer
+- 完成内容: Expanded large-item visual-system slice completed.
+- 遗留事项: No external art pack or runtime feature is required; future richer live data may need additional dense-state screenshots.
+- Action: Reviewed the brand-system companion direction and specified required large-item completion scope.
+- Validation Command: Role slice inspected `viewer-brand-system-2026-06-05.design.md`, `software_safe.html`, Viewer source, pixel-world host, tests, and current screenshot evidence.
+- Expected Result: Define what "大项也都做了" means for Viewer visual design without inventing unrelated art/runtime scope.
+- Actual Result: Pass.
+  - Required design-system scope: brand book, token taxonomy/governance, icon/status vocabulary, asset-language rules, screenshot matrix.
+  - Required code hooks: semantic CSS token aliases; `data-viewer-surface` for stage/targets/command/diagnostics; stable fallback hook `data-renderer-state="fallback"`; tests for these hooks.
+  - Direction: current text-badge/shape/data-hook vocabulary is acceptable; no icon pack needed now.
+  - Documentation: brand-system companion must be directly linked from Viewer README, world-simulator README, and `prd.index.md`.
+- Blocker / Next Action: TPM to integrate doc links, token aliases, DOM hooks, tests, screenshots, and review card.
+
+## 2026-06-05 21:50:26 CST / qa_engineer
+- 完成内容: Expanded visual-system QA matrix slice completed.
+- 遗留事项: QA initially blocked a completion claim until missing formal links, screenshot artifacts, visual review card, and final sink evidence were added.
+- Action: Defined required verification matrix, artifact expectations, blocking criteria, and exact commands for large-item completion.
+- Validation Command: Role slice reviewed task log, visual spec, brand-system doc, viewer scripts/tests, visual smoke evidence, and doc links.
+- Expected Result: Identify what evidence is missing before TPM can claim all large items are done.
+- Actual Result: Pass; QA matrix required:
+  - direct links from module entrypoints to `viewer-brand-system-2026-06-05.design.md`;
+  - token/hook greps recorded;
+  - desktop first screen, mobile first screen, diagnostics demotion, CJK/long text, focus evidence, fallback/action receipt/dense pixel-world evidence;
+  - model visual review card in a formal sink;
+  - full `test:ui`, `build:software-safe`, `test:pixel-world:visual`, diff/doc/task lint, and relevant greps.
+- Blocker / Next Action: TPM to satisfy the matrix before final completion claim.
+
+## 2026-06-05 21:50:26 CST / tpm
+- 完成内容: Completed the large visual-system items requested by the user.
+  - Added `doc/world-simulator/viewer/viewer-brand-system-2026-06-05.design.md` covering brand book, token taxonomy/governance, icon/status vocabulary, asset language, screenshot matrix, implementation hooks, and done criteria.
+  - Linked the brand-system companion from `doc/world-simulator/viewer/README.md`, `doc/world-simulator/README.md`, `doc/world-simulator/prd.index.md`, and the parent visual spec.
+  - Added `doc/world-simulator/viewer/viewer-visual-system-review-card-2026-06-05.design.md` as the formal module sink for the visual review card.
+  - Added semantic CSS token aliases and changed the focus ring to use `--color-focus-ring`.
+  - Added stable `data-viewer-surface="targets|stage|command|diagnostics"` hooks.
+  - Added stable `data-renderer-state="fallback"` hook for fallback renderer callout.
+  - Added tests for the visual-system hooks.
+  - Rebuilt `crates/oasis7_viewer/viewer.js`.
+  - Captured the expanded screenshot/probe matrix and ran the latest pixel-world visual smoke.
+- 遗留事项: No blocking large-item gap remains. Remaining future risk is richer live/dense data that may require additional screenshots when runtime provides more complex snapshots; public marketing identity and external art production remain out of scope by role verdict.
+- Action: Integrated docs/code/tests, captured screenshots/probes, wrote formal review card, and ran final verification.
+- Validation Command: Fresh commands: `npm --prefix crates/oasis7_viewer run test:ui -- software_safe_src/main.test.jsx software_safe_src/pixel_world_host.test.jsx`; `npm --prefix crates/oasis7_viewer run build:software-safe`; `npm --prefix crates/oasis7_viewer run test:ui`; `npm --prefix crates/oasis7_viewer run test:pixel-world:visual`; `git diff --check`; `./scripts/doc-governance-check.sh`; targeted `./scripts/pm/lint.sh` grep; brand-system link grep; hook/token grep; screenshot capture through in-app browser.
+- Expected Result: All large-item docs are linked, hooks are test-covered, screenshot/review evidence exists, generated bundle is updated, and all required checks pass.
+- Actual Result: Pass.
+  - Two-file UI run: `2 passed`, `20 passed`.
+  - Full UI run: `4 passed`, `27 passed`.
+  - Build: `software_safe build finalized: .../crates/oasis7_viewer/viewer.js`.
+  - Latest pixel-world visual smoke: passed; `output/playwright/pixel-world-fragment-visual/2026-06-05T13-43-42-359Z/summary.json`, `fragment-fallback-visual.png`, `action-receipt-visual.png`, `mobile-action-receipt-visual.png`.
+  - Visual-system screenshot/probe matrix: `output/playwright/viewer-visual-system/2026-06-05T13-26-33Z/desktop-player-first-screen.png`, `mobile-player-first-screen.png`, `diagnostics-demotion-collapsed.png`, `cjk-long-text-mobile.png`, `focus-keyboard-visible-probe.json`, `fallback-renderer-hook-probe.json`.
+  - Model visual review card: `doc/world-simulator/viewer/viewer-visual-system-review-card-2026-06-05.design.md`; verdict `pass`, confidence `high`, human escalation `no`.
+  - Brand-system link grep: pass across module README, viewer README, `prd.index.md`, and parent visual spec.
+  - Hook/token grep: pass for `--color-focus-ring`, `--color-world-background`, `:focus-visible`, `data-viewer-surface`, `data-renderer-state="fallback"`, `viewer-diagnostics-panel`, `mobile-rail__link--diagnostics`, and `grid-area: rail`.
+  - Diff hygiene: `git diff --check` exited 0.
+  - Doc governance: `doc-governance-check: OK`.
+  - Targeted PM lint: `no pm-lint failures for task_a25bf76359be45719edfcda1759626d1`.
+  - Output screenshots/probes remain ignored under `output/`; formal review card records their paths.
+- Blocker / Next Action: No blocker remains for the user-requested large visual-system completion; task remains uncommitted because user has not requested commit/PR.
+
+## 2026-06-05 22:19:00 CST / tpm
+- 完成内容: User requested merge flow; task closeout passed and implementation was committed locally as `Add Viewer visual design system`.
+- 遗留事项: Pre-PR local role review, PR creation, PR checks/comment watch, merge, and worktree cleanup remain.
+- Action: Prepare required pre-PR local role review slices before PR creation.
+- Validation Command: `./scripts/pm/task-closeout.sh --role tpm --task-uid task_a25bf76359be45719edfcda1759626d1 --no-lint --verify-command 'npm --prefix crates/oasis7_viewer run test:ui && npm --prefix crates/oasis7_viewer run build:software-safe && npm --prefix crates/oasis7_viewer run test:pixel-world:visual && git diff --check && ./scripts/doc-governance-check.sh && out=$(./scripts/pm/lint.sh 2>&1 || true); if printf "%s\n" "$out" | rg "task_a25bf76359be45719edfcda1759626d1"; then exit 1; else echo "no pm-lint failures for task_a25bf76359be45719edfcda1759626d1"; fi'`
+- Expected Result: Closeout records task completion with fresh verification before PR preparation.
+- Actual Result: Pass; `final_status: done`, `claim_verification_status: verified`, `claim_type: task_complete`; full PM lint intentionally skipped due unrelated existing task-log failures, with targeted lint grep confirming this task has no PM-lint failures.
+- Blocker / Next Action: Dispatch pre-PR role review slices.
+
+## 2026-06-05 22:20:00 CST / tpm
+- 完成内容: Pre-PR Local Role Review dispatch contracts defined.
+- 遗留事项: Await role findings/no-findings and integrate results before PR creation.
+- Action: Dispatch bounded local review slices:
+  - role: `game_visual_interaction_designer`
+    - slice type: `pre_pr_visual_design_system_review`
+    - intended model configuration: workflow default inherited through available subagent tool.
+    - actual dispatched model/reasoning: inherited/unverified unless the subagent tool reports concrete runtime details.
+    - context delivery mode: full-thread/full-history fork requested.
+    - mandatory context checklist/packet: task truth, committed diff against `origin/main`, visual spec, brand-system companion, visual review card, Viewer docs, UI screenshots/probes paths, semantic token/hooks/tests.
+    - write scope: review only; no file edits.
+    - return contract: findings/no_findings, severity, evidence paths, residual risk, PR readiness verdict.
+  - role: `viewer_engineer`
+    - slice type: `pre_pr_viewer_implementation_review`
+    - intended model configuration: workflow default inherited through available subagent tool.
+    - actual dispatched model/reasoning: inherited/unverified unless the subagent tool reports concrete runtime details.
+    - context delivery mode: full-thread/full-history fork requested.
+    - mandatory context checklist/packet: committed diff against `origin/main`, `software_safe.html`, `software_safe_src/main.jsx`, `pixel_world_host.jsx`, updated tests, generated `viewer.js`, build/test commands.
+    - write scope: review only; no file edits.
+    - return contract: findings/no_findings, severity, evidence paths, generated bundle/test risk, residual risk, PR readiness verdict.
+  - role: `qa_engineer`
+    - slice type: `pre_pr_verification_gate_review`
+    - intended model configuration: workflow default inherited through available subagent tool.
+    - actual dispatched model/reasoning: inherited/unverified unless the subagent tool reports concrete runtime details.
+    - context delivery mode: full-thread/full-history fork requested.
+    - mandatory context checklist/packet: task closeout result, verification commands/results, doc-governance result, targeted PM lint result, ignored screenshot/probe evidence, PR gate requirements.
+    - write scope: review only; no file edits.
+    - return contract: findings/no_findings, missing verification if any, residual risk, PR readiness verdict.
+- Validation Command: Subagent dispatch via `multi_agent_v1.spawn_agent` with `fork_context: true`.
+- Expected Result: Independent role review results are available and any actionable findings are handled before PR creation.
+- Actual Result: Pending.
+- Blocker / Next Action: Spawn role slices and wait for completion.
+
+## 2026-06-05 22:27:00 CST / tpm
+- 完成内容: Pre-PR Local Role Review completed and passed.
+- 遗留事项: Proceed to PR creation, PR checks/comment watch, merge, and cleanup.
+- Action: Integrated three bounded local role review results:
+  - `game_visual_interaction_designer`: verdict `pass`; findings `no_findings`; PR readiness `ready`.
+    - residual risk: future richer live data may need additional dense screenshots; focus proof is CSS/probe based; public marketing identity/external art remain out of scope.
+  - `viewer_engineer`: verdict `pass`; findings `no_findings`; PR readiness `ready`.
+    - residual risk: review slice did not rerun build to avoid rewriting bundle, but verified compiled hooks/anchors in generated bundle; screenshot quality is covered by review artifacts/docs rather than unit assertions.
+  - `qa_engineer`: verdict `pass`; findings `no_findings`; PR readiness `ready`.
+    - residual risk: full repo-wide PM lint remains dirty due unrelated historical task-log failures; targeted lint for this task is clean; screenshot/probe binaries remain ignored under `output/` with paths recorded in formal sinks; focus proof is CSS/probe based.
+- Validation Command: `multi_agent_v1.wait_agent` for `game_visual_interaction_designer`, `viewer_engineer`, and `qa_engineer` pre-PR review slices.
+- Expected Result: All required local role review slices return no blocking findings before PR creation.
+- Actual Result: Pass; all three roles returned `pass`, `no_findings`, and `pr_readiness: ready`.
+- Blocker / Next Action: `Pre-PR Local Role Review: passed`; run `./scripts/prepare-task-pr.sh --create` after committing this evidence packet.
+
+## 2026-06-05 22:29:00 CST / tpm
+- 完成内容: Source-bound pre-PR local role review packet recorded for `prepare-task-pr.sh`.
+- 遗留事项: PR creation, PR checks/comment watch, merge, and cleanup remain.
+- Action: Record script-readable review packet after fresh local role review slices.
+- Validation Command: `./scripts/prepare-task-pr.sh --create --title "Add Viewer visual design system"` preflight gate requirements inspected after initial marker miss.
+- Expected Result: PR helper can validate exact task, source worktree, source branch, source head, comparison ref, role selection, evidence, finding disposition, and residual risk.
+- Actual Result: Pass.
+- Pre-PR Local Role Review: passed
+- Task UID: task_a25bf76359be45719edfcda1759626d1
+- Source Worktree: /Users/scc/ccwork/worktrees/oasis7-world-simulator-viewer-visual-design-spec
+- Source Branch: task/world-simulator-viewer-visual-design-spec
+- Source Head: e742c3e361b15c8146f947931d3b71b88ea706b4
+- Comparison Ref: refs/remotes/origin/main
+- Reviewed Changed Paths: .pm/tasks/task_a25bf76359be45719edfcda1759626d1.execution.md,.pm/tasks/task_a25bf76359be45719edfcda1759626d1.yaml,crates/oasis7_viewer/software_safe.html,crates/oasis7_viewer/software_safe_src/main.jsx,crates/oasis7_viewer/software_safe_src/main.test.jsx,crates/oasis7_viewer/software_safe_src/pixel_world_host.jsx,crates/oasis7_viewer/software_safe_src/pixel_world_host.test.jsx,crates/oasis7_viewer/viewer.js,doc/world-simulator/README.md,doc/world-simulator/prd.index.md,doc/world-simulator/viewer/README.md,doc/world-simulator/viewer/viewer-brand-system-2026-06-05.design.md,doc/world-simulator/viewer/viewer-visual-design-spec-2026-06-05.design.md,doc/world-simulator/viewer/viewer-visual-system-review-card-2026-06-05.design.md
+- Role Selection Basis: changed paths cover Viewer visual design docs, Viewer UI implementation, generated Viewer bundle, and verification tests; selected game_visual_interaction_designer, viewer_engineer, and qa_engineer.
+- Review Roles: game_visual_interaction_designer,viewer_engineer,qa_engineer
+- Review Evidence: game_visual_interaction_designer 2026-06-05 22:24 CST pass no_findings ready; viewer_engineer 2026-06-05 22:26 CST pass no_findings ready; qa_engineer 2026-06-05 22:25 CST pass no_findings ready.
+- Review Findings Disposition: no_findings
+- Finding Disposition Evidence: All three role slices returned no findings; no code/doc changes required after role review except this source-bound evidence packet.
+- Residual Risk: Future richer live data may need additional dense screenshots; full repo-wide PM lint remains dirty only due unrelated historical task-log failures while this task's targeted lint is clean; screenshot/probe binaries remain ignored under output with paths recorded in review card/task log; focus proof is CSS/probe based.
+- Blocker / Next Action: No pre-PR local role review blocker remains; rerun `./scripts/prepare-task-pr.sh --create --title "Add Viewer visual design system"`.

--- a/.pm/tasks/task_a25bf76359be45719edfcda1759626d1.execution.md
+++ b/.pm/tasks/task_a25bf76359be45719edfcda1759626d1.execution.md
@@ -554,7 +554,7 @@ Example:
 - Task UID: task_a25bf76359be45719edfcda1759626d1
 - Source Worktree: /Users/scc/ccwork/worktrees/oasis7-world-simulator-viewer-visual-design-spec
 - Source Branch: task/world-simulator-viewer-visual-design-spec
-- Source Head: e742c3e361b15c8146f947931d3b71b88ea706b4
+- Source Head: 209bd8de4dcfd83692e5e9a7dd23c2bf0aebdf77
 - Comparison Ref: refs/remotes/origin/main
 - Reviewed Changed Paths: .pm/tasks/task_a25bf76359be45719edfcda1759626d1.execution.md,.pm/tasks/task_a25bf76359be45719edfcda1759626d1.yaml,crates/oasis7_viewer/software_safe.html,crates/oasis7_viewer/software_safe_src/main.jsx,crates/oasis7_viewer/software_safe_src/main.test.jsx,crates/oasis7_viewer/software_safe_src/pixel_world_host.jsx,crates/oasis7_viewer/software_safe_src/pixel_world_host.test.jsx,crates/oasis7_viewer/viewer.js,doc/world-simulator/README.md,doc/world-simulator/prd.index.md,doc/world-simulator/viewer/README.md,doc/world-simulator/viewer/viewer-brand-system-2026-06-05.design.md,doc/world-simulator/viewer/viewer-visual-design-spec-2026-06-05.design.md,doc/world-simulator/viewer/viewer-visual-system-review-card-2026-06-05.design.md
 - Role Selection Basis: changed paths cover Viewer visual design docs, Viewer UI implementation, generated Viewer bundle, and verification tests; selected game_visual_interaction_designer, viewer_engineer, and qa_engineer.

--- a/.pm/tasks/task_a25bf76359be45719edfcda1759626d1.yaml
+++ b/.pm/tasks/task_a25bf76359be45719edfcda1759626d1.yaml
@@ -1,0 +1,26 @@
+task_uid: task_a25bf76359be45719edfcda1759626d1
+title: "Create viewer visual design specification"
+owner_role: tpm
+worktree_hint: /Users/scc/ccwork/worktrees/oasis7-world-simulator-viewer-visual-design-spec
+execution_log_path: .pm/tasks/task_a25bf76359be45719edfcda1759626d1.execution.md
+status: done
+priority: P2
+source_signal: null
+source_refs:
+  - AGENTS.md
+  - doc/engineering/workflow/source-of-truth.md
+  - doc/world-simulator/viewer/README.md
+  - doc/testing/manual/model-visual-review-sop-2026-05-29.manual.md
+doc_refs: []
+related_prd: []
+acceptance:
+  - "Add a canonical complete visual design specification for viewer/player-facing surfaces and link it from relevant indexes."
+handoff_to: []
+updated_at: 2026-06-05T22:17:26+08:00
+last_started_at: 2026-06-05T19:42:19+08:00
+last_claim_type: task_complete
+last_verify_command: "npm --prefix crates/oasis7_viewer run test:ui && npm --prefix crates/oasis7_viewer run build:software-safe && npm --prefix crates/oasis7_viewer run test:pixel-world:visual && git diff --check && ./scripts/doc-governance-check.sh && out=$(./scripts/pm/lint.sh 2>&1 || true); if printf \"%s\\n\" \"$out\" | rg \"task_a25bf76359be45719edfcda1759626d1\"; then exit 1; else echo \"no pm-lint failures for task_a25bf76359be45719edfcda1759626d1\"; fi"
+last_verified_at: 2026-06-05T22:17:24+08:00
+last_verification_exit_code: 0
+last_verification_status: verified
+last_closed_at: 2026-06-05T22:17:26+08:00

--- a/crates/oasis7_viewer/software_safe.html
+++ b/crates/oasis7_viewer/software_safe.html
@@ -26,6 +26,33 @@
         --font-body: "IBM Plex Sans", "Avenir Next", "Segoe UI", sans-serif;
         --font-display: "Iowan Old Style", "Palatino Linotype", "Book Antiqua", Georgia, serif;
         --font-mono: "SFMono-Regular", "SF Mono", Menlo, Consolas, monospace;
+        --color-world-background: var(--bg);
+        --color-world-depth: var(--bg-deep);
+        --color-panel-surface: var(--panel);
+        --color-panel-strong: var(--panel-strong);
+        --color-stage-surface: var(--panel-stage);
+        --color-border-subtle: var(--border);
+        --color-border-stage: var(--border-strong);
+        --color-text-primary: var(--text);
+        --color-text-muted: var(--muted);
+        --color-agent-primary: var(--accent);
+        --color-objective-accent: var(--accent-strong);
+        --color-route-active: var(--accent);
+        --color-receipt-success: var(--good);
+        --color-blocker-danger: var(--bad);
+        --color-warning: var(--warn);
+        --color-diagnostic-muted: var(--muted);
+        --color-focus-ring: var(--accent-strong);
+        --font-viewer-body: var(--font-body);
+        --font-viewer-display: var(--font-display);
+        --font-viewer-mono: var(--font-mono);
+        --space-panel-gap: 18px;
+        --space-stack-gap: 16px;
+        --space-control-gap: 8px;
+        --radius-tool: 12px;
+        --radius-stage: 18px;
+        --radius-panel: 20px;
+        --motion-feedback-fast: 140ms;
       }
 
       * { box-sizing: border-box; }
@@ -186,6 +213,11 @@
         transform: translateY(-1px);
       }
       button:disabled { opacity: 0.5; cursor: not-allowed; }
+      :where(a, button, canvas, summary, input, textarea, select):focus-visible {
+        outline: 2px solid var(--color-focus-ring);
+        outline-offset: 3px;
+        box-shadow: 0 0 0 4px rgba(208, 168, 91, 0.16);
+      }
       input[type="email"], input[type="number"], input[type="search"], input[type="text"], textarea {
         width: 100%;
         border-radius: 12px;
@@ -548,6 +580,7 @@
       }
       .mobile-rail {
         display: none;
+        grid-area: rail;
       }
       .mobile-rail__link {
         color: var(--text);
@@ -561,6 +594,11 @@
         border: 1px solid rgba(208, 168, 91, 0.26);
         background: rgba(255, 255, 255, 0.04);
         font-size: 13px;
+      }
+      .mobile-rail__link--diagnostics {
+        color: var(--muted);
+        border-color: rgba(152, 177, 150, 0.14);
+        background: rgba(255, 255, 255, 0.02);
       }
       .pixel-world-canvas {
         position: relative;
@@ -766,6 +804,7 @@
         .shell {
           grid-template-columns: 1fr;
           grid-template-areas:
+            "rail"
             "stage"
             "targets"
             "details";

--- a/crates/oasis7_viewer/software_safe_src/main.jsx
+++ b/crates/oasis7_viewer/software_safe_src/main.jsx
@@ -602,6 +602,9 @@ function MobileJumpRail() {
       <a class="mobile-rail__link" href="#viewer-stage-panel">{tr(locale(), "世界", "World")}</a>
       <a class="mobile-rail__link" href="#viewer-targets-panel">{tr(locale(), "目标", "Targets")}</a>
       <a class="mobile-rail__link" href="#viewer-details-panel">{tr(locale(), "指挥", "Command")}</a>
+      <a class="mobile-rail__link mobile-rail__link--diagnostics" href="#viewer-diagnostics-panel">
+        {tr(locale(), "诊断", "Diagnostics")}
+      </a>
     </nav>
   );
 }
@@ -1054,7 +1057,7 @@ function WorldSummaryPanel() {
           </Show>
         </PanelSection>
       </Show>
-      <details class="panel diagnostic-surface">
+      <details id="viewer-diagnostics-panel" class="panel diagnostic-surface" data-viewer-surface="diagnostics">
         <summary class="panel__header diagnostic-surface__summary">
           <div class="diagnostic-surface__title">
             <div class="panel__title">{tr(locale(), "运行诊断", "Runtime Diagnostics")}</div>
@@ -1856,7 +1859,7 @@ function AppShell() {
     <>
       <MobileJumpRail />
       <HostedLoginGate />
-      <section class="panel panel--targets" id="viewer-targets-panel">
+      <section class="panel panel--targets" id="viewer-targets-panel" data-viewer-surface="targets">
         <div class="panel__header panel__header--stack">
           <div class="panel__eyebrow">{tr(locale(), "导航", "Navigate")}</div>
           <div class="panel__title">{tr(locale(), "目标", "Targets")}</div>
@@ -1868,7 +1871,7 @@ function AppShell() {
           <TargetsPanel />
         </div>
       </section>
-      <section class="panel panel--stage" id="viewer-stage-panel">
+      <section class="panel panel--stage" id="viewer-stage-panel" data-viewer-surface="stage">
         <div class="panel__body panel__body--stage">
           <div class="stack">
             <WorldStageHero />
@@ -1877,7 +1880,7 @@ function AppShell() {
           </div>
         </div>
       </section>
-      <section class="panel panel--details" id="viewer-details-panel">
+      <section class="panel panel--details" id="viewer-details-panel" data-viewer-surface="command">
         <div class="panel__header panel__header--stack">
           <div class="panel__eyebrow">{tr(locale(), "指挥与核查", "Command and Inspect")}</div>
           <div class="panel__title">{tr(locale(), "交互与明细", "Interact and Inspect")}</div>

--- a/crates/oasis7_viewer/software_safe_src/main.test.jsx
+++ b/crates/oasis7_viewer/software_safe_src/main.test.jsx
@@ -181,14 +181,24 @@ describe("viewer web ui automation baseline", () => {
     expect(within(nav).getByRole("link", { name: "World" })).toHaveAttribute("href", "#viewer-stage-panel");
     expect(within(nav).getByRole("link", { name: "Targets" })).toHaveAttribute("href", "#viewer-targets-panel");
     expect(within(nav).getByRole("link", { name: "Command" })).toHaveAttribute("href", "#viewer-details-panel");
+    expect(within(nav).getByRole("link", { name: "Diagnostics" })).toHaveAttribute(
+      "href",
+      "#viewer-diagnostics-panel",
+    );
 
     const targetsPanel = container.querySelector("#viewer-targets-panel");
     const stagePanel = container.querySelector("#viewer-stage-panel");
     const detailsPanel = container.querySelector("#viewer-details-panel");
+    const diagnosticsPanel = container.querySelector("#viewer-diagnostics-panel");
 
     expect(targetsPanel).toBeTruthy();
     expect(stagePanel).toBeTruthy();
     expect(detailsPanel).toBeTruthy();
+    expect(diagnosticsPanel).toBeTruthy();
+    expect(targetsPanel).toHaveAttribute("data-viewer-surface", "targets");
+    expect(stagePanel).toHaveAttribute("data-viewer-surface", "stage");
+    expect(detailsPanel).toHaveAttribute("data-viewer-surface", "command");
+    expect(diagnosticsPanel).toHaveAttribute("data-viewer-surface", "diagnostics");
     expect(within(targetsPanel).getByText("Targets")).toBeInTheDocument();
     expect(within(stagePanel).getByText("Industrial World Command Desk")).toBeInTheDocument();
     expect(within(stagePanel).getAllByText("Recover sustainable capability").length).toBeGreaterThan(0);
@@ -235,6 +245,10 @@ describe("viewer web ui automation baseline", () => {
     const summary = screen.getByText("Runtime Diagnostics").closest("summary");
     expect(summary).toBeTruthy();
     expect(summary).toHaveClass("diagnostic-surface__summary");
+    const diagnosticsPanel = container.querySelector("#viewer-diagnostics-panel");
+    expect(diagnosticsPanel).toBeTruthy();
+    expect(diagnosticsPanel).toHaveClass("diagnostic-surface");
+    expect(diagnosticsPanel).not.toHaveAttribute("open");
 
     const stagePanel = container.querySelector("#viewer-stage-panel");
     expect(stagePanel).toBeTruthy();
@@ -416,7 +430,7 @@ describe("viewer web ui automation baseline", () => {
       within(assetLane).getAllByText(/main_token_transfer remains blocked until a higher-trust hosted strong-auth lane exists/i).length,
     ).toBeGreaterThan(0);
     expect(screen.queryByText("not_implemented")).not.toBeInTheDocument();
-  });
+  }, 15000);
 
   it("keeps hosted backend reauth pending until runtime registration finishes", async () => {
     await renderViewerApp({
@@ -444,5 +458,5 @@ describe("viewer web ui automation baseline", () => {
         "hosted preview backend reauth stays pending until the browser device-session-backed player_session finishes runtime registration",
       ),
     ).toBeInTheDocument();
-  });
+  }, 15000);
 });

--- a/crates/oasis7_viewer/software_safe_src/pixel_world_host.jsx
+++ b/crates/oasis7_viewer/software_safe_src/pixel_world_host.jsx
@@ -1228,7 +1228,7 @@ export function PixelWorldHost(props) {
         />
       </Show>
       <Show when={rendererStatus() === "fallback"}>
-        <div class="callout callout--warn">
+        <div class="callout callout--warn" data-renderer-state="fallback">
           <div class="callout__header">
             <div class="callout__title">{tr(locale(), "Renderer 未接管", "Renderer Not Attached")}</div>
           </div>

--- a/crates/oasis7_viewer/software_safe_src/pixel_world_host.test.jsx
+++ b/crates/oasis7_viewer/software_safe_src/pixel_world_host.test.jsx
@@ -430,6 +430,7 @@ describe("pixel world host", () => {
     expect(screen.getByText("Action Receipt")).toBeInTheDocument();
     expect(screen.getByText("Action blocked")).toBeInTheDocument();
     expect(screen.getByText("Smelter build request reached factory-0; iron shortage blocks construction.")).toBeInTheDocument();
+    expect(document.querySelector('[data-renderer-state="fallback"]')).toHaveTextContent("Renderer Not Attached");
     const receipt = document.querySelector(".pixel-world-action-receipt");
     expect(receipt).toHaveAttribute("data-receipt-present", "true");
     expect(receipt).toHaveAttribute("data-receipt-state", "blocked");

--- a/crates/oasis7_viewer/viewer.js
+++ b/crates/oasis7_viewer/viewer.js
@@ -4958,7 +4958,7 @@ async function createPixelWorldRuntimeBridge({
     fatal
   };
 }
-var _tmpl$$1 = /* @__PURE__ */ template(`<div class="pixel-world-canvas__callout pixel-world-canvas__callout--goal">`), _tmpl$2$1 = /* @__PURE__ */ template(`<div class="pixel-world-canvas__callout pixel-world-canvas__callout--blocker">`), _tmpl$3$1 = /* @__PURE__ */ template(`<div class=pixel-world-canvas__selection>`), _tmpl$4$1 = /* @__PURE__ */ template(`<div class="pixel-world-canvas pixel-world-canvas--rendered"data-renderer-ready=true><canvas id=pixel-world-embedded-runtime-canvas class=pixel-world-canvas__surface width=960 height=540></canvas><div class=pixel-world-canvas__overlay>`), _tmpl$5$1 = /* @__PURE__ */ template(`<div class=pixel-world-command-cell__detail>`), _tmpl$6$1 = /* @__PURE__ */ template(`<div class=pixel-world-command-strip><div class="pixel-world-command-cell pixel-world-command-cell--objective"><div class=pixel-world-command-cell__label></div><div class=pixel-world-command-cell__value></div><div class=pixel-world-command-cell__detail></div></div><div class="pixel-world-command-cell pixel-world-command-cell--next"><div class=pixel-world-command-cell__label></div><div class=pixel-world-command-cell__value></div></div><div class="pixel-world-command-cell pixel-world-command-cell--leverage"><div class=pixel-world-command-cell__label></div><div class=pixel-world-command-cell__value></div><div class=pixel-world-command-cell__detail>`), _tmpl$7$1 = /* @__PURE__ */ template(`<div class=pixel-world-action-receipt__detail>`), _tmpl$8$1 = /* @__PURE__ */ template(`<span>`), _tmpl$9$1 = /* @__PURE__ */ template(`<div class=pixel-world-action-receipt><div class=pixel-world-action-receipt__label></div><div class=pixel-world-action-receipt__body><div class=pixel-world-action-receipt__title></div><div class=pixel-world-action-receipt__summary></div></div><div class=pixel-world-action-receipt__meta><span>`), _tmpl$0$1 = /* @__PURE__ */ template(`<span class="badge badge--warn">`), _tmpl$1$1 = /* @__PURE__ */ template(`<div class="pixel-world-readout badge-row"><span class="badge badge--accent"></span><span class=badge></span><span class=badge></span><span class=badge>`), _tmpl$10$1 = /* @__PURE__ */ template(`<div class=pixel-world-canvas><div class=pixel-world-canvas__grid></div><div class=pixel-world-canvas__overlay>`), _tmpl$11$1 = /* @__PURE__ */ template(`<div class=pixel-world-fragment-terrain>`), _tmpl$12$1 = /* @__PURE__ */ template(`<div class=pixel-world-route>`), _tmpl$13$1 = /* @__PURE__ */ template(`<button class="pixel-world-entity pixel-world-entity--location"><span>`), _tmpl$14$1 = /* @__PURE__ */ template(`<button class="pixel-world-entity pixel-world-entity--agent"><span>`), _tmpl$15$1 = /* @__PURE__ */ template(`<div class=feedback-detail>`), _tmpl$16$1 = /* @__PURE__ */ template(`<div class="callout callout--warn"><div class=callout__header><div class=callout__title></div></div><div class=callout__body><div class=feedback-summary>`), _tmpl$17$1 = /* @__PURE__ */ template(`<span class=badge>`), _tmpl$18$1 = /* @__PURE__ */ template(`<div class=stack style=margin-top:10px><pre class=json>`), _tmpl$19$1 = /* @__PURE__ */ template(`<div class="pixel-world-host stack"><div class=pixel-world-host__summary><div class=pixel-world-host__headline></div><div class=feedback-detail></div></div><details class="diagnostic pixel-world-render-diagnostics"><summary></summary><div class="pixel-world-host__toolbar badge-row"><span class="badge badge--accent"></span><span class="badge badge--accent"></span><span class="badge badge--accent"></span><span class=badge></span><span class=badge></span><span class=badge></span><span class=badge></span><span class=badge></span><span class=badge></span><button type=button></button><button type=button></button><button type=button></button><div class=feedback-detail></div></div></details><details class=diagnostic><summary>`);
+var _tmpl$$1 = /* @__PURE__ */ template(`<div class="pixel-world-canvas__callout pixel-world-canvas__callout--goal">`), _tmpl$2$1 = /* @__PURE__ */ template(`<div class="pixel-world-canvas__callout pixel-world-canvas__callout--blocker">`), _tmpl$3$1 = /* @__PURE__ */ template(`<div class=pixel-world-canvas__selection>`), _tmpl$4$1 = /* @__PURE__ */ template(`<div class="pixel-world-canvas pixel-world-canvas--rendered"data-renderer-ready=true><canvas id=pixel-world-embedded-runtime-canvas class=pixel-world-canvas__surface width=960 height=540></canvas><div class=pixel-world-canvas__overlay>`), _tmpl$5$1 = /* @__PURE__ */ template(`<div class=pixel-world-command-cell__detail>`), _tmpl$6$1 = /* @__PURE__ */ template(`<div class=pixel-world-command-strip><div class="pixel-world-command-cell pixel-world-command-cell--objective"><div class=pixel-world-command-cell__label></div><div class=pixel-world-command-cell__value></div><div class=pixel-world-command-cell__detail></div></div><div class="pixel-world-command-cell pixel-world-command-cell--next"><div class=pixel-world-command-cell__label></div><div class=pixel-world-command-cell__value></div></div><div class="pixel-world-command-cell pixel-world-command-cell--leverage"><div class=pixel-world-command-cell__label></div><div class=pixel-world-command-cell__value></div><div class=pixel-world-command-cell__detail>`), _tmpl$7$1 = /* @__PURE__ */ template(`<div class=pixel-world-action-receipt__detail>`), _tmpl$8$1 = /* @__PURE__ */ template(`<span>`), _tmpl$9$1 = /* @__PURE__ */ template(`<div class=pixel-world-action-receipt><div class=pixel-world-action-receipt__label></div><div class=pixel-world-action-receipt__body><div class=pixel-world-action-receipt__title></div><div class=pixel-world-action-receipt__summary></div></div><div class=pixel-world-action-receipt__meta><span>`), _tmpl$0$1 = /* @__PURE__ */ template(`<span class="badge badge--warn">`), _tmpl$1$1 = /* @__PURE__ */ template(`<div class="pixel-world-readout badge-row"><span class="badge badge--accent"></span><span class=badge></span><span class=badge></span><span class=badge>`), _tmpl$10$1 = /* @__PURE__ */ template(`<div class=pixel-world-canvas><div class=pixel-world-canvas__grid></div><div class=pixel-world-canvas__overlay>`), _tmpl$11$1 = /* @__PURE__ */ template(`<div class=pixel-world-fragment-terrain>`), _tmpl$12$1 = /* @__PURE__ */ template(`<div class=pixel-world-route>`), _tmpl$13$1 = /* @__PURE__ */ template(`<button class="pixel-world-entity pixel-world-entity--location"><span>`), _tmpl$14$1 = /* @__PURE__ */ template(`<button class="pixel-world-entity pixel-world-entity--agent"><span>`), _tmpl$15$1 = /* @__PURE__ */ template(`<div class=feedback-detail>`), _tmpl$16$1 = /* @__PURE__ */ template(`<div class="callout callout--warn"data-renderer-state=fallback><div class=callout__header><div class=callout__title></div></div><div class=callout__body><div class=feedback-summary>`), _tmpl$17$1 = /* @__PURE__ */ template(`<span class=badge>`), _tmpl$18$1 = /* @__PURE__ */ template(`<div class=stack style=margin-top:10px><pre class=json>`), _tmpl$19$1 = /* @__PURE__ */ template(`<div class="pixel-world-host stack"><div class=pixel-world-host__summary><div class=pixel-world-host__headline></div><div class=feedback-detail></div></div><details class="diagnostic pixel-world-render-diagnostics"><summary></summary><div class="pixel-world-host__toolbar badge-row"><span class="badge badge--accent"></span><span class="badge badge--accent"></span><span class="badge badge--accent"></span><span class=badge></span><span class=badge></span><span class=badge></span><span class=badge></span><span class=badge></span><span class=badge></span><button type=button></button><button type=button></button><button type=button></button><div class=feedback-detail></div></div></details><details class=diagnostic><summary>`);
 function tr$1(locale, zh, en) {
   return isLocaleZh(locale) ? zh : en;
 }
@@ -6220,7 +6220,7 @@ function PixelWorldHost(props) {
   })();
 }
 delegateEvents(["click"]);
-var _tmpl$ = /* @__PURE__ */ template(`<span>`), _tmpl$2 = /* @__PURE__ */ template(`<div class=empty>`), _tmpl$3 = /* @__PURE__ */ template(`<pre class=json>`), _tmpl$4 = /* @__PURE__ */ template(`<div class=feedback-detail>`), _tmpl$5 = /* @__PURE__ */ template(`<details class=diagnostic><summary></summary><div class=stack style=margin-top:10px>`), _tmpl$6 = /* @__PURE__ */ template(`<div class=feedback-card><div class=badge-row></div><div class=feedback-summary>`), _tmpl$7 = /* @__PURE__ */ template(`<div class=feedback-detail style=margin-top:8px>`), _tmpl$8 = /* @__PURE__ */ template(`<div class=badge-row style=margin-top:8px>`), _tmpl$9 = /* @__PURE__ */ template(`<div class=metric><div class=metric__label></div><div class=metric__value>`), _tmpl$0 = /* @__PURE__ */ template(`<div class=event-card__meta>`), _tmpl$1 = /* @__PURE__ */ template(`<div><div class=event-card__title><span>`), _tmpl$10 = /* @__PURE__ */ template(`<div class=panel__eyebrow>`), _tmpl$11 = /* @__PURE__ */ template(`<div class=panel__meta-copy>`), _tmpl$12 = /* @__PURE__ */ template(`<div><div class=panel__header><div class=stack style=gap:4px><div class=panel__title></div></div></div><div class="panel__body stack">`), _tmpl$13 = /* @__PURE__ */ template(`<div><div class=callout__header><div class=callout__title></div></div><div class=callout__body>`), _tmpl$14 = /* @__PURE__ */ template(`<div class=badge-row>`), _tmpl$15 = /* @__PURE__ */ template(`<div class=field><label></label><input type=text autocomplete=off>`), _tmpl$16 = /* @__PURE__ */ template(`<div class=toolbar><button data-auth-action=complete-login>`), _tmpl$17 = /* @__PURE__ */ template(`<div class=stack>`), _tmpl$18 = /* @__PURE__ */ template(`<div class=stack><div class=control-grid><div class=field><label></label><input type=email autocomplete=email></div></div><div class=toolbar><button data-auth-action=start-login>`), _tmpl$19 = /* @__PURE__ */ template(`<div class=auth-gate role=dialog aria-modal=true aria-labelledby=hosted-login-gate-title tabindex=-1><div class=auth-gate__dialog><div class=auth-gate__header><div><div class=panel__eyebrow></div><h1 id=hosted-login-gate-title class=auth-gate__title></h1></div></div><div class=feedback-summary>`), _tmpl$20 = /* @__PURE__ */ template(`<div class=feedback-summary>`), _tmpl$21 = /* @__PURE__ */ template(`<details class=entry-menu><summary class=entry-menu__toggle></summary><div class="entry-menu__panel stack"><div><div class=panel__title style=margin-bottom:10px></div><div class=feedback-detail></div></div><div class=toolbar><button data-locale=zh>中文</button><button data-locale=en>English</button></div><div class=badge-row></div><div class=feedback-detail>`), _tmpl$22 = /* @__PURE__ */ template(`<div class=stage-hero><div class=stage-hero__topline><div class=stack style=gap:10px><div class=stage-hero__eyebrow></div><div class=stage-hero__title></div><div class=stage-hero__lede></div></div></div><div class=hero-focus-grid><div class=hero-focus-card><div class=hero-focus-card__label></div><div></div><div class=hero-focus-card__detail></div></div><div class=hero-focus-card><div class=hero-focus-card__label></div><div class="hero-focus-card__value hero-focus-card__value--body"></div><div class=hero-focus-card__detail></div></div><div class=hero-focus-card><div class=hero-focus-card__label></div><div class="hero-focus-card__value hero-focus-card__value--body">`), _tmpl$23 = /* @__PURE__ */ template(`<nav class=mobile-rail><a class=mobile-rail__link href=#viewer-stage-panel></a><a class=mobile-rail__link href=#viewer-targets-panel></a><a class=mobile-rail__link href=#viewer-details-panel>`), _tmpl$24 = /* @__PURE__ */ template(`<div class=stack><div class=field><label for=entity-search></label><input id=entity-search type=search></div><div><div class=panel__title style=margin-bottom:10px></div><div class=list></div></div><div><div class=panel__title style=margin-bottom:10px></div><div class=list>`), _tmpl$25 = /* @__PURE__ */ template(`<button class=list-item data-select-kind=agent><div class=list-item__title></div><div class=list-item__meta>`), _tmpl$26 = /* @__PURE__ */ template(`<button class=list-item data-select-kind=location><div class=list-item__title></div><div class=list-item__meta>`), _tmpl$27 = /* @__PURE__ */ template(`<div class=toolbar><button data-auth-action=logout>`), _tmpl$28 = /* @__PURE__ */ template(`<button data-auth-action=logout>`), _tmpl$29 = /* @__PURE__ */ template(`<div class=event-list>`), _tmpl$30 = /* @__PURE__ */ template(`<div class=stack><details class="panel diagnostic-surface"><summary class="panel__header diagnostic-surface__summary"><div class=diagnostic-surface__title><div class=panel__title></div><div class=diagnostic-surface__meta></div></div><div class=badge-row></div></summary><div class="panel__body stack"><div class=badge-row></div><div class=badge-row></div><div class=toolbar></div><div class=summary-grid></div><div><div class=panel__title style=margin-bottom:10px></div><div class=event-list>`), _tmpl$31 = /* @__PURE__ */ template(`<div class=badge-row style=margin-top:10px>`), _tmpl$32 = /* @__PURE__ */ template(`<div class=summary-grid>`), _tmpl$33 = /* @__PURE__ */ template(`<div><div class=panel__title style=margin-bottom:10px></div><div class=action-grid>`), _tmpl$34 = /* @__PURE__ */ template(`<div class=toolbar><button>`), _tmpl$35 = /* @__PURE__ */ template(`<div class=field><label for=agent-chat-message></label><textarea id=agent-chat-message rows=4>`), _tmpl$36 = /* @__PURE__ */ template(`<div class=toolbar><button data-chat-send=1>`), _tmpl$37 = /* @__PURE__ */ template(`<div><div class=panel__title style=margin-bottom:10px></div><div class=event-list>`), _tmpl$38 = /* @__PURE__ */ template(`<div class=toolbar><button data-prompt-visibility-toggle=1>`), _tmpl$39 = /* @__PURE__ */ template(`<div class=field><label for=strong-auth-approval-code></label><input id=strong-auth-approval-code type=password autocomplete=off>`), _tmpl$40 = /* @__PURE__ */ template(`<div class=field><label for=prompt-system></label><textarea id=prompt-system rows=4>`), _tmpl$41 = /* @__PURE__ */ template(`<div class=field><label for=prompt-short></label><textarea id=prompt-short rows=3>`), _tmpl$42 = /* @__PURE__ */ template(`<div class=field><label for=prompt-long></label><textarea id=prompt-long rows=3>`), _tmpl$43 = /* @__PURE__ */ template(`<div class=toolbar><button data-prompt-action=preview></button><button data-prompt-action=apply>`), _tmpl$44 = /* @__PURE__ */ template(`<div class=toolbar><div class=field style=margin:0;min-width:180px;flex:1><label for=prompt-rollback-version></label><input id=prompt-rollback-version type=number min=0 step=1></div><button data-prompt-action=rollback>`), _tmpl$45 = /* @__PURE__ */ template(`<div class=toolbar><button disabled>`), _tmpl$46 = /* @__PURE__ */ template(`<div class=stack><div class=badge-row></div><div class=badge-row>`), _tmpl$47 = /* @__PURE__ */ template(`<div><div class=panel__title style=margin-bottom:10px;color:var(--bad)></div><pre class=json>`), _tmpl$48 = /* @__PURE__ */ template(`<div class=stack><div class=badge-row></div><div><div class=panel__title style=margin-bottom:10px></div><div class=badge-row></div><div class=stack style=margin-top:10px><div class=feedback-detail></div><div class=feedback-detail></div><div><div class=panel__title style=margin-bottom:10px></div><div class=event-list>`), _tmpl$49 = /* @__PURE__ */ template(`<div class=feedback-detail>=`), _tmpl$50 = /* @__PURE__ */ template(`<section class="panel panel--targets"id=viewer-targets-panel><div class="panel__header panel__header--stack"><div class=panel__eyebrow></div><div class=panel__title></div><div class=panel__meta-copy></div></div><div class=panel__body>`), _tmpl$51 = /* @__PURE__ */ template(`<section class="panel panel--stage"id=viewer-stage-panel><div class="panel__body panel__body--stage"><div class=stack>`), _tmpl$52 = /* @__PURE__ */ template(`<section class="panel panel--details"id=viewer-details-panel><div class="panel__header panel__header--stack"><div class=panel__eyebrow></div><div class=panel__title></div><div class=panel__meta-copy></div></div><div class=panel__body>`);
+var _tmpl$ = /* @__PURE__ */ template(`<span>`), _tmpl$2 = /* @__PURE__ */ template(`<div class=empty>`), _tmpl$3 = /* @__PURE__ */ template(`<pre class=json>`), _tmpl$4 = /* @__PURE__ */ template(`<div class=feedback-detail>`), _tmpl$5 = /* @__PURE__ */ template(`<details class=diagnostic><summary></summary><div class=stack style=margin-top:10px>`), _tmpl$6 = /* @__PURE__ */ template(`<div class=feedback-card><div class=badge-row></div><div class=feedback-summary>`), _tmpl$7 = /* @__PURE__ */ template(`<div class=feedback-detail style=margin-top:8px>`), _tmpl$8 = /* @__PURE__ */ template(`<div class=badge-row style=margin-top:8px>`), _tmpl$9 = /* @__PURE__ */ template(`<div class=metric><div class=metric__label></div><div class=metric__value>`), _tmpl$0 = /* @__PURE__ */ template(`<div class=event-card__meta>`), _tmpl$1 = /* @__PURE__ */ template(`<div><div class=event-card__title><span>`), _tmpl$10 = /* @__PURE__ */ template(`<div class=panel__eyebrow>`), _tmpl$11 = /* @__PURE__ */ template(`<div class=panel__meta-copy>`), _tmpl$12 = /* @__PURE__ */ template(`<div><div class=panel__header><div class=stack style=gap:4px><div class=panel__title></div></div></div><div class="panel__body stack">`), _tmpl$13 = /* @__PURE__ */ template(`<div><div class=callout__header><div class=callout__title></div></div><div class=callout__body>`), _tmpl$14 = /* @__PURE__ */ template(`<div class=badge-row>`), _tmpl$15 = /* @__PURE__ */ template(`<div class=field><label></label><input type=text autocomplete=off>`), _tmpl$16 = /* @__PURE__ */ template(`<div class=toolbar><button data-auth-action=complete-login>`), _tmpl$17 = /* @__PURE__ */ template(`<div class=stack>`), _tmpl$18 = /* @__PURE__ */ template(`<div class=stack><div class=control-grid><div class=field><label></label><input type=email autocomplete=email></div></div><div class=toolbar><button data-auth-action=start-login>`), _tmpl$19 = /* @__PURE__ */ template(`<div class=auth-gate role=dialog aria-modal=true aria-labelledby=hosted-login-gate-title tabindex=-1><div class=auth-gate__dialog><div class=auth-gate__header><div><div class=panel__eyebrow></div><h1 id=hosted-login-gate-title class=auth-gate__title></h1></div></div><div class=feedback-summary>`), _tmpl$20 = /* @__PURE__ */ template(`<div class=feedback-summary>`), _tmpl$21 = /* @__PURE__ */ template(`<details class=entry-menu><summary class=entry-menu__toggle></summary><div class="entry-menu__panel stack"><div><div class=panel__title style=margin-bottom:10px></div><div class=feedback-detail></div></div><div class=toolbar><button data-locale=zh>中文</button><button data-locale=en>English</button></div><div class=badge-row></div><div class=feedback-detail>`), _tmpl$22 = /* @__PURE__ */ template(`<div class=stage-hero><div class=stage-hero__topline><div class=stack style=gap:10px><div class=stage-hero__eyebrow></div><div class=stage-hero__title></div><div class=stage-hero__lede></div></div></div><div class=hero-focus-grid><div class=hero-focus-card><div class=hero-focus-card__label></div><div></div><div class=hero-focus-card__detail></div></div><div class=hero-focus-card><div class=hero-focus-card__label></div><div class="hero-focus-card__value hero-focus-card__value--body"></div><div class=hero-focus-card__detail></div></div><div class=hero-focus-card><div class=hero-focus-card__label></div><div class="hero-focus-card__value hero-focus-card__value--body">`), _tmpl$23 = /* @__PURE__ */ template(`<nav class=mobile-rail><a class=mobile-rail__link href=#viewer-stage-panel></a><a class=mobile-rail__link href=#viewer-targets-panel></a><a class=mobile-rail__link href=#viewer-details-panel></a><a class="mobile-rail__link mobile-rail__link--diagnostics"href=#viewer-diagnostics-panel>`), _tmpl$24 = /* @__PURE__ */ template(`<div class=stack><div class=field><label for=entity-search></label><input id=entity-search type=search></div><div><div class=panel__title style=margin-bottom:10px></div><div class=list></div></div><div><div class=panel__title style=margin-bottom:10px></div><div class=list>`), _tmpl$25 = /* @__PURE__ */ template(`<button class=list-item data-select-kind=agent><div class=list-item__title></div><div class=list-item__meta>`), _tmpl$26 = /* @__PURE__ */ template(`<button class=list-item data-select-kind=location><div class=list-item__title></div><div class=list-item__meta>`), _tmpl$27 = /* @__PURE__ */ template(`<div class=toolbar><button data-auth-action=logout>`), _tmpl$28 = /* @__PURE__ */ template(`<button data-auth-action=logout>`), _tmpl$29 = /* @__PURE__ */ template(`<div class=event-list>`), _tmpl$30 = /* @__PURE__ */ template(`<div class=stack><details id=viewer-diagnostics-panel class="panel diagnostic-surface"data-viewer-surface=diagnostics><summary class="panel__header diagnostic-surface__summary"><div class=diagnostic-surface__title><div class=panel__title></div><div class=diagnostic-surface__meta></div></div><div class=badge-row></div></summary><div class="panel__body stack"><div class=badge-row></div><div class=badge-row></div><div class=toolbar></div><div class=summary-grid></div><div><div class=panel__title style=margin-bottom:10px></div><div class=event-list>`), _tmpl$31 = /* @__PURE__ */ template(`<div class=badge-row style=margin-top:10px>`), _tmpl$32 = /* @__PURE__ */ template(`<div class=summary-grid>`), _tmpl$33 = /* @__PURE__ */ template(`<div><div class=panel__title style=margin-bottom:10px></div><div class=action-grid>`), _tmpl$34 = /* @__PURE__ */ template(`<div class=toolbar><button>`), _tmpl$35 = /* @__PURE__ */ template(`<div class=field><label for=agent-chat-message></label><textarea id=agent-chat-message rows=4>`), _tmpl$36 = /* @__PURE__ */ template(`<div class=toolbar><button data-chat-send=1>`), _tmpl$37 = /* @__PURE__ */ template(`<div><div class=panel__title style=margin-bottom:10px></div><div class=event-list>`), _tmpl$38 = /* @__PURE__ */ template(`<div class=toolbar><button data-prompt-visibility-toggle=1>`), _tmpl$39 = /* @__PURE__ */ template(`<div class=field><label for=strong-auth-approval-code></label><input id=strong-auth-approval-code type=password autocomplete=off>`), _tmpl$40 = /* @__PURE__ */ template(`<div class=field><label for=prompt-system></label><textarea id=prompt-system rows=4>`), _tmpl$41 = /* @__PURE__ */ template(`<div class=field><label for=prompt-short></label><textarea id=prompt-short rows=3>`), _tmpl$42 = /* @__PURE__ */ template(`<div class=field><label for=prompt-long></label><textarea id=prompt-long rows=3>`), _tmpl$43 = /* @__PURE__ */ template(`<div class=toolbar><button data-prompt-action=preview></button><button data-prompt-action=apply>`), _tmpl$44 = /* @__PURE__ */ template(`<div class=toolbar><div class=field style=margin:0;min-width:180px;flex:1><label for=prompt-rollback-version></label><input id=prompt-rollback-version type=number min=0 step=1></div><button data-prompt-action=rollback>`), _tmpl$45 = /* @__PURE__ */ template(`<div class=toolbar><button disabled>`), _tmpl$46 = /* @__PURE__ */ template(`<div class=stack><div class=badge-row></div><div class=badge-row>`), _tmpl$47 = /* @__PURE__ */ template(`<div><div class=panel__title style=margin-bottom:10px;color:var(--bad)></div><pre class=json>`), _tmpl$48 = /* @__PURE__ */ template(`<div class=stack><div class=badge-row></div><div><div class=panel__title style=margin-bottom:10px></div><div class=badge-row></div><div class=stack style=margin-top:10px><div class=feedback-detail></div><div class=feedback-detail></div><div><div class=panel__title style=margin-bottom:10px></div><div class=event-list>`), _tmpl$49 = /* @__PURE__ */ template(`<div class=feedback-detail>=`), _tmpl$50 = /* @__PURE__ */ template(`<section class="panel panel--targets"id=viewer-targets-panel data-viewer-surface=targets><div class="panel__header panel__header--stack"><div class=panel__eyebrow></div><div class=panel__title></div><div class=panel__meta-copy></div></div><div class=panel__body>`), _tmpl$51 = /* @__PURE__ */ template(`<section class="panel panel--stage"id=viewer-stage-panel data-viewer-surface=stage><div class="panel__body panel__body--stage"><div class=stack>`), _tmpl$52 = /* @__PURE__ */ template(`<section class="panel panel--details"id=viewer-details-panel data-viewer-surface=command><div class="panel__header panel__header--stack"><div class=panel__eyebrow></div><div class=panel__title></div><div class=panel__meta-copy></div></div><div class=panel__body>`);
 function uiLocale() {
   return state.uiLocale;
 }
@@ -6876,10 +6876,11 @@ function WorldStageHero() {
 function MobileJumpRail() {
   const locale = () => uiLocale();
   return (() => {
-    var _el$88 = _tmpl$23(), _el$89 = _el$88.firstChild, _el$90 = _el$89.nextSibling, _el$91 = _el$90.nextSibling;
+    var _el$88 = _tmpl$23(), _el$89 = _el$88.firstChild, _el$90 = _el$89.nextSibling, _el$91 = _el$90.nextSibling, _el$92 = _el$91.nextSibling;
     insert(_el$89, () => tr(locale(), "世界", "World"));
     insert(_el$90, () => tr(locale(), "目标", "Targets"));
     insert(_el$91, () => tr(locale(), "指挥", "Command"));
+    insert(_el$92, () => tr(locale(), "诊断", "Diagnostics"));
     createRenderEffect(() => setAttribute(_el$88, "aria-label", tr(locale(), "主入口分区导航", "Primary entry section navigation")));
     return _el$88;
   })();
@@ -6889,36 +6890,36 @@ function TargetsPanel() {
   const locale = () => uiLocale();
   const selectedLabel = () => state.selectedKind && state.selectedId ? `${state.selectedKind}:${state.selectedId}` : null;
   return (() => {
-    var _el$92 = _tmpl$24(), _el$93 = _el$92.firstChild, _el$94 = _el$93.firstChild, _el$95 = _el$94.nextSibling, _el$96 = _el$93.nextSibling, _el$97 = _el$96.firstChild, _el$98 = _el$97.nextSibling, _el$99 = _el$96.nextSibling, _el$100 = _el$99.firstChild, _el$101 = _el$100.nextSibling;
-    insert(_el$92, createComponent(Show, {
+    var _el$93 = _tmpl$24(), _el$94 = _el$93.firstChild, _el$95 = _el$94.firstChild, _el$96 = _el$95.nextSibling, _el$97 = _el$94.nextSibling, _el$98 = _el$97.firstChild, _el$99 = _el$98.nextSibling, _el$100 = _el$97.nextSibling, _el$101 = _el$100.firstChild, _el$102 = _el$101.nextSibling;
+    insert(_el$93, createComponent(Show, {
       get when() {
         return selectedLabel();
       },
       children: (selected) => (() => {
-        var _el$102 = _tmpl$14();
-        insert(_el$102, createComponent(Badge, {
+        var _el$103 = _tmpl$14();
+        insert(_el$103, createComponent(Badge, {
           "class": "badge badge--accent",
           get children() {
             return tr(locale(), "已锁定目标", "Locked Target");
           }
         }), null);
-        insert(_el$102, createComponent(Badge, {
+        insert(_el$103, createComponent(Badge, {
           get children() {
             return selected();
           }
         }), null);
-        return _el$102;
+        return _el$103;
       })()
-    }), _el$93);
-    insert(_el$92, createComponent(EmptyState, {
+    }), _el$94);
+    insert(_el$93, createComponent(EmptyState, {
       get children() {
         return tr(locale(), "先从这里锁定一个 Agent 或地点。中间读局势，右侧只处理你当前选中的目标。", "Lock onto an agent or location here first. Read the world in the middle, then use the right column only for the selected target.");
       }
-    }), _el$93);
-    insert(_el$94, () => tr(locale(), "筛选目标", "Filter targets"));
-    _el$95.$$input = (event) => setSelectedSearch(event.currentTarget.value);
-    insert(_el$97, () => tr(locale(), "Agents", "Agents"));
-    insert(_el$98, createComponent(Show, {
+    }), _el$94);
+    insert(_el$95, () => tr(locale(), "筛选目标", "Filter targets"));
+    _el$96.$$input = (event) => setSelectedSearch(event.currentTarget.value);
+    insert(_el$98, () => tr(locale(), "Agents", "Agents"));
+    insert(_el$99, createComponent(Show, {
       get when() {
         return lists().agents.length > 0;
       },
@@ -6935,29 +6936,29 @@ function TargetsPanel() {
             return lists().agents;
           },
           children: (agent) => (() => {
-            var _el$103 = _tmpl$25(), _el$104 = _el$103.firstChild, _el$105 = _el$104.nextSibling;
-            _el$103.$$click = () => applySelection({
+            var _el$104 = _tmpl$25(), _el$105 = _el$104.firstChild, _el$106 = _el$105.nextSibling;
+            _el$104.$$click = () => applySelection({
               kind: "agent",
               id: agent.id
             });
-            insert(_el$104, () => agent.id);
-            insert(_el$105, () => `${tr(locale(), "地点", "location")}=${agent.location_id} · ${tr(locale(), "资源", "resources")}=${renderResourceSummary(agent.resources)}`);
+            insert(_el$105, () => agent.id);
+            insert(_el$106, () => `${tr(locale(), "地点", "location")}=${agent.location_id} · ${tr(locale(), "资源", "resources")}=${renderResourceSummary(agent.resources)}`);
             createRenderEffect((_p$) => {
               var _v$8 = agent.id, _v$9 = state.selectedKind === "agent" && state.selectedId === agent.id;
-              _v$8 !== _p$.e && setAttribute(_el$103, "data-select-id", _p$.e = _v$8);
-              _v$9 !== _p$.t && setAttribute(_el$103, "data-selected", _p$.t = _v$9);
+              _v$8 !== _p$.e && setAttribute(_el$104, "data-select-id", _p$.e = _v$8);
+              _v$9 !== _p$.t && setAttribute(_el$104, "data-selected", _p$.t = _v$9);
               return _p$;
             }, {
               e: void 0,
               t: void 0
             });
-            return _el$103;
+            return _el$104;
           })()
         });
       }
     }));
-    insert(_el$100, () => tr(locale(), "地点", "Locations"));
-    insert(_el$101, createComponent(Show, {
+    insert(_el$101, () => tr(locale(), "地点", "Locations"));
+    insert(_el$102, createComponent(Show, {
       get when() {
         return lists().locations.length > 0;
       },
@@ -6974,30 +6975,30 @@ function TargetsPanel() {
             return lists().locations;
           },
           children: (location) => (() => {
-            var _el$106 = _tmpl$26(), _el$107 = _el$106.firstChild, _el$108 = _el$107.nextSibling;
-            _el$106.$$click = () => applySelection({
+            var _el$107 = _tmpl$26(), _el$108 = _el$107.firstChild, _el$109 = _el$108.nextSibling;
+            _el$107.$$click = () => applySelection({
               kind: "location",
               id: location.id
             });
-            insert(_el$107, () => location.name || location.id);
-            insert(_el$108, () => `id=${location.id} · ${tr(locale(), "半径", "radius")}=${formatPhysicalDistanceCm(location.profile?.radius_cm, locale()) || "-"} · ${tr(locale(), "资源", "resources")}=${renderResourceSummary(location.resources)}`);
+            insert(_el$108, () => location.name || location.id);
+            insert(_el$109, () => `id=${location.id} · ${tr(locale(), "半径", "radius")}=${formatPhysicalDistanceCm(location.profile?.radius_cm, locale()) || "-"} · ${tr(locale(), "资源", "resources")}=${renderResourceSummary(location.resources)}`);
             createRenderEffect((_p$) => {
               var _v$0 = location.id, _v$1 = state.selectedKind === "location" && state.selectedId === location.id;
-              _v$0 !== _p$.e && setAttribute(_el$106, "data-select-id", _p$.e = _v$0);
-              _v$1 !== _p$.t && setAttribute(_el$106, "data-selected", _p$.t = _v$1);
+              _v$0 !== _p$.e && setAttribute(_el$107, "data-select-id", _p$.e = _v$0);
+              _v$1 !== _p$.t && setAttribute(_el$107, "data-selected", _p$.t = _v$1);
               return _p$;
             }, {
               e: void 0,
               t: void 0
             });
-            return _el$106;
+            return _el$107;
           })()
         });
       }
     }));
-    createRenderEffect(() => setAttribute(_el$95, "placeholder", tr(locale(), "搜索 Agent 或地点", "Search agents or locations")));
-    createRenderEffect(() => _el$95.value = getSelectedSearch());
-    return _el$92;
+    createRenderEffect(() => setAttribute(_el$96, "placeholder", tr(locale(), "搜索 Agent 或地点", "Search agents or locations")));
+    createRenderEffect(() => _el$96.value = getSelectedSearch());
+    return _el$93;
   })();
 }
 function WorldSummaryPanel() {
@@ -7019,8 +7020,8 @@ function WorldSummaryPanel() {
   const showPlayerSessionSurface = () => !!hostedRecoveryHint() || !state$1.auth.available && String(state$1.hostedAccess?.deployment_mode || "").trim() === "hosted_public_join" || showRebindNotice();
   const diagnosticsSummaryBadges = () => [`debugViewer=${state$1.debugViewerMode}:${state$1.debugViewerStatus}`, `auth=${state$1.auth.available ? state$1.auth.registrationStatus || "ready" : "missing"}`, `events=${state$1.recentEvents.length}`];
   return (() => {
-    var _el$109 = _tmpl$30(), _el$113 = _el$109.firstChild, _el$114 = _el$113.firstChild, _el$115 = _el$114.firstChild, _el$116 = _el$115.firstChild, _el$117 = _el$116.nextSibling, _el$118 = _el$115.nextSibling, _el$119 = _el$114.nextSibling, _el$120 = _el$119.firstChild, _el$122 = _el$120.nextSibling, _el$123 = _el$122.nextSibling, _el$131 = _el$123.nextSibling, _el$132 = _el$131.nextSibling, _el$133 = _el$132.firstChild, _el$134 = _el$133.nextSibling;
-    insert(_el$109, createComponent(PanelSection, {
+    var _el$110 = _tmpl$30(), _el$114 = _el$110.firstChild, _el$115 = _el$114.firstChild, _el$116 = _el$115.firstChild, _el$117 = _el$116.firstChild, _el$118 = _el$117.nextSibling, _el$119 = _el$116.nextSibling, _el$120 = _el$115.nextSibling, _el$121 = _el$120.firstChild, _el$123 = _el$121.nextSibling, _el$124 = _el$123.nextSibling, _el$132 = _el$124.nextSibling, _el$133 = _el$132.nextSibling, _el$134 = _el$133.firstChild, _el$135 = _el$134.nextSibling;
+    insert(_el$110, createComponent(PanelSection, {
       get title() {
         return tr(locale(), "正式玩法摘要", "Formal Gameplay Summary");
       },
@@ -7043,8 +7044,8 @@ function WorldSummaryPanel() {
             });
           },
           children: (gameplay) => [(() => {
-            var _el$135 = _tmpl$14();
-            insert(_el$135, createComponent(Badge, {
+            var _el$136 = _tmpl$14();
+            insert(_el$136, createComponent(Badge, {
               get ["class"]() {
                 return gameplayStatusBadgeClass(gameplay().stageStatus);
               },
@@ -7052,13 +7053,13 @@ function WorldSummaryPanel() {
                 return gameplayStageLabel(gameplay().stageStatus, locale());
               }
             }), null);
-            insert(_el$135, createComponent(Badge, {
+            insert(_el$136, createComponent(Badge, {
               "class": "badge badge--accent",
               get children() {
                 return gameplayProgressLabel(gameplay().progressPercent, locale());
               }
             }), null);
-            return _el$135;
+            return _el$136;
           })(), createComponent(EventCard, {
             get title() {
               return tr(locale(), "已接受意图", "Accepted Intent");
@@ -7074,30 +7075,30 @@ function WorldSummaryPanel() {
             },
             get children() {
               return [(() => {
-                var _el$136 = _tmpl$20();
-                insert(_el$136, () => gameplay().acceptedIntentSummary);
-                return _el$136;
-              })(), (() => {
-                var _el$137 = _tmpl$4();
-                insert(_el$137, () => gameplay().acceptedIntentDetail);
+                var _el$137 = _tmpl$20();
+                insert(_el$137, () => gameplay().acceptedIntentSummary);
                 return _el$137;
+              })(), (() => {
+                var _el$138 = _tmpl$4();
+                insert(_el$138, () => gameplay().acceptedIntentDetail);
+                return _el$138;
               })(), createComponent(Show, {
                 get when() {
                   return gameplay().resumeAnchor;
                 },
                 get children() {
                   return [(() => {
-                    var _el$138 = _tmpl$14();
-                    insert(_el$138, createComponent(Badge, {
+                    var _el$139 = _tmpl$14();
+                    insert(_el$139, createComponent(Badge, {
                       get children() {
                         return tr(locale(), "续玩锚点", "Resume Anchor");
                       }
                     }));
-                    return _el$138;
-                  })(), (() => {
-                    var _el$139 = _tmpl$4();
-                    insert(_el$139, () => gameplay().resumeAnchor);
                     return _el$139;
+                  })(), (() => {
+                    var _el$140 = _tmpl$4();
+                    insert(_el$140, () => gameplay().resumeAnchor);
+                    return _el$140;
                   })()];
                 }
               })];
@@ -7117,8 +7118,8 @@ function WorldSummaryPanel() {
             },
             get children() {
               return [(() => {
-                var _el$140 = _tmpl$14();
-                insert(_el$140, createComponent(For, {
+                var _el$141 = _tmpl$14();
+                insert(_el$141, createComponent(For, {
                   get each() {
                     return gameplay().executionStateMachine || [];
                   },
@@ -7131,32 +7132,32 @@ function WorldSummaryPanel() {
                     }
                   })
                 }));
-                return _el$140;
-              })(), (() => {
-                var _el$141 = _tmpl$20();
-                insert(_el$141, () => gameplay().executionSummary || tr(locale(), "等待目标执行状态更新。", "Waiting for goal execution state updates."));
                 return _el$141;
+              })(), (() => {
+                var _el$142 = _tmpl$20();
+                insert(_el$142, () => gameplay().executionSummary || tr(locale(), "等待目标执行状态更新。", "Waiting for goal execution state updates."));
+                return _el$142;
               })(), createComponent(Show, {
                 get when() {
                   return gameplay().executionCauseLabel;
                 },
                 get children() {
-                  var _el$142 = _tmpl$14();
-                  insert(_el$142, createComponent(Badge, {
+                  var _el$143 = _tmpl$14();
+                  insert(_el$143, createComponent(Badge, {
                     get children() {
                       return gameplay().executionCauseLabel;
                     }
                   }));
-                  return _el$142;
+                  return _el$143;
                 }
               }), createComponent(Show, {
                 get when() {
                   return gameplay().executionCauseDetail;
                 },
                 get children() {
-                  var _el$143 = _tmpl$4();
-                  insert(_el$143, () => gameplay().executionCauseDetail);
-                  return _el$143;
+                  var _el$144 = _tmpl$4();
+                  insert(_el$144, () => gameplay().executionCauseDetail);
+                  return _el$144;
                 }
               })];
             }
@@ -7177,9 +7178,9 @@ function WorldSummaryPanel() {
                   return gameplay().progressDetail;
                 },
                 get children() {
-                  var _el$144 = _tmpl$4();
-                  insert(_el$144, () => gameplay().progressDetail);
-                  return _el$144;
+                  var _el$145 = _tmpl$4();
+                  insert(_el$145, () => gameplay().progressDetail);
+                  return _el$145;
                 }
               }), createComponent(Show, {
                 get when() {
@@ -7187,18 +7188,18 @@ function WorldSummaryPanel() {
                 },
                 get children() {
                   return [(() => {
-                    var _el$145 = _tmpl$31();
-                    insert(_el$145, createComponent(Badge, {
+                    var _el$146 = _tmpl$31();
+                    insert(_el$146, createComponent(Badge, {
                       "class": "badge badge--warn",
                       get children() {
                         return gameplay().blockerLabel || gameplay().blockerKind || tr(locale(), "当前阻塞", "Current Blocker");
                       }
                     }));
-                    return _el$145;
-                  })(), (() => {
-                    var _el$146 = _tmpl$4();
-                    insert(_el$146, () => gameplay().narrativeBlockerDetail || tr(locale(), "当前玩法被阻塞，需要显式恢复。", "Gameplay is blocked and needs explicit recovery."));
                     return _el$146;
+                  })(), (() => {
+                    var _el$147 = _tmpl$4();
+                    insert(_el$147, () => gameplay().narrativeBlockerDetail || tr(locale(), "当前玩法被阻塞，需要显式恢复。", "Gameplay is blocked and needs explicit recovery."));
+                    return _el$147;
                   })()];
                 }
               }), createComponent(Show, {
@@ -7206,49 +7207,49 @@ function WorldSummaryPanel() {
                   return gameplay().blockerSupplementalDetail;
                 },
                 get children() {
-                  var _el$147 = _tmpl$4();
-                  insert(_el$147, () => gameplay().blockerSupplementalDetail);
-                  return _el$147;
+                  var _el$148 = _tmpl$4();
+                  insert(_el$148, () => gameplay().blockerSupplementalDetail);
+                  return _el$148;
                 }
               }), (() => {
-                var _el$148 = _tmpl$31();
-                insert(_el$148, createComponent(Badge, {
+                var _el$149 = _tmpl$31();
+                insert(_el$149, createComponent(Badge, {
                   "class": "badge badge--accent",
                   get children() {
                     return tr(locale(), "下一步", "Next Step");
                   }
                 }));
-                return _el$148;
-              })(), (() => {
-                var _el$149 = _tmpl$20();
-                insert(_el$149, () => gameplay().narrativeNextStep || tr(locale(), "等待下一次 runtime 指引更新。", "Wait for the next runtime guidance update."));
                 return _el$149;
+              })(), (() => {
+                var _el$150 = _tmpl$20();
+                insert(_el$150, () => gameplay().narrativeNextStep || tr(locale(), "等待下一次 runtime 指引更新。", "Wait for the next runtime guidance update."));
+                return _el$150;
               })(), createComponent(Show, {
                 get when() {
                   return gameplay().branchHint;
                 },
                 get children() {
-                  var _el$150 = _tmpl$4();
-                  insert(_el$150, () => gameplay().branchHint);
-                  return _el$150;
+                  var _el$151 = _tmpl$4();
+                  insert(_el$151, () => gameplay().branchHint);
+                  return _el$151;
                 }
               }), createComponent(Show, {
                 get when() {
                   return gameplay().entityCounts;
                 },
                 get children() {
-                  var _el$151 = _tmpl$14();
-                  insert(_el$151, createComponent(Badge, {
+                  var _el$152 = _tmpl$14();
+                  insert(_el$152, createComponent(Badge, {
                     get children() {
                       return `agents=${gameplay().entityCounts.agents}`;
                     }
                   }), null);
-                  insert(_el$151, createComponent(Badge, {
+                  insert(_el$152, createComponent(Badge, {
                     get children() {
                       return `locations=${gameplay().entityCounts.locations}`;
                     }
                   }), null);
-                  return _el$151;
+                  return _el$152;
                 }
               })];
             }
@@ -7263,8 +7264,8 @@ function WorldSummaryPanel() {
               return tr(locale(), "把当前玩法翻译成显式的投入 / 产出 / 新用途 / 修复动作 / 下一步价值，避免工业成长继续退化成只看库存与产量。", "Translate the current loop into explicit input / output / new use / repair move / next value so industrial growth does not collapse into stockpile and throughput alone.");
             },
             get children() {
-              var _el$152 = _tmpl$32();
-              insert(_el$152, createComponent(MetricCard, {
+              var _el$153 = _tmpl$32();
+              insert(_el$153, createComponent(MetricCard, {
                 get label() {
                   return tr(locale(), "投入", "Input");
                 },
@@ -7272,7 +7273,7 @@ function WorldSummaryPanel() {
                   return gameplay().economicSurface?.input || tr(locale(), "待发布", "not published");
                 }
               }), null);
-              insert(_el$152, createComponent(MetricCard, {
+              insert(_el$153, createComponent(MetricCard, {
                 get label() {
                   return tr(locale(), "产出", "Output");
                 },
@@ -7280,7 +7281,7 @@ function WorldSummaryPanel() {
                   return gameplay().economicSurface?.output || tr(locale(), "待发布", "not published");
                 }
               }), null);
-              insert(_el$152, createComponent(MetricCard, {
+              insert(_el$153, createComponent(MetricCard, {
                 get label() {
                   return tr(locale(), "新用途", "New Use");
                 },
@@ -7288,7 +7289,7 @@ function WorldSummaryPanel() {
                   return gameplay().economicSurface?.unlockedValue || tr(locale(), "待发布", "not published");
                 }
               }), null);
-              insert(_el$152, createComponent(MetricCard, {
+              insert(_el$153, createComponent(MetricCard, {
                 get label() {
                   return tr(locale(), "修复动作", "Repair Move");
                 },
@@ -7299,7 +7300,7 @@ function WorldSummaryPanel() {
                   return memo(() => !!gameplay().economicSurface?.blockerLabel)() ? tr(locale(), `当前阻塞归类: ${gameplay().economicSurface.blockerLabel}`, `Current blocker class: ${gameplay().economicSurface.blockerLabel}`) : null;
                 }
               }), null);
-              insert(_el$152, createComponent(MetricCard, {
+              insert(_el$153, createComponent(MetricCard, {
                 get label() {
                   return tr(locale(), "下一步价值", "Next Value");
                 },
@@ -7307,7 +7308,7 @@ function WorldSummaryPanel() {
                   return gameplay().economicSurface?.nextValue || tr(locale(), "待发布", "not published");
                 }
               }), null);
-              return _el$152;
+              return _el$153;
             }
           }), createComponent(Show, {
             get when() {
@@ -7328,26 +7329,26 @@ function WorldSummaryPanel() {
               },
               get children() {
                 return [(() => {
-                  var _el$158 = _tmpl$20();
-                  insert(_el$158, () => feedback().effect || feedback().reason || tr(locale(), "最新回执已更新，但还没有新的世界级后果。", "The latest feedback is in, but there is no new world-level consequence yet."));
-                  return _el$158;
+                  var _el$159 = _tmpl$20();
+                  insert(_el$159, () => feedback().effect || feedback().reason || tr(locale(), "最新回执已更新，但还没有新的世界级后果。", "The latest feedback is in, but there is no new world-level consequence yet."));
+                  return _el$159;
                 })(), createComponent(Show, {
                   get when() {
                     return feedback().reason;
                   },
                   get children() {
-                    var _el$159 = _tmpl$4();
-                    insert(_el$159, () => feedback().reason);
-                    return _el$159;
+                    var _el$160 = _tmpl$4();
+                    insert(_el$160, () => feedback().reason);
+                    return _el$160;
                   }
                 }), createComponent(Show, {
                   get when() {
                     return feedback().hint;
                   },
                   get children() {
-                    var _el$160 = _tmpl$4();
-                    insert(_el$160, () => feedback().hint);
-                    return _el$160;
+                    var _el$161 = _tmpl$4();
+                    insert(_el$161, () => feedback().hint);
+                    return _el$161;
                   }
                 })];
               }
@@ -7378,26 +7379,26 @@ function WorldSummaryPanel() {
               badgeClass: "badge badge--good",
               get children() {
                 return [(() => {
-                  var _el$161 = _tmpl$20();
-                  insert(_el$161, () => action().label || action().actionId || tr(locale(), "当前存在一条更合适的推进动作。", "One action is currently the best next move."));
-                  return _el$161;
-                })(), (() => {
-                  var _el$162 = _tmpl$4();
-                  insert(_el$162, () => gameplay().narrativeNextStep || tr(locale(), "先执行这一步，再判断是否需要切到聊天、恢复或改道。", "Take this action first, then decide whether to chat, resume, or reprioritize."));
+                  var _el$162 = _tmpl$20();
+                  insert(_el$162, () => action().label || action().actionId || tr(locale(), "当前存在一条更合适的推进动作。", "One action is currently the best next move."));
                   return _el$162;
                 })(), (() => {
-                  var _el$163 = _tmpl$34(), _el$164 = _el$163.firstChild;
-                  _el$164.$$click = () => renderGameplayAction(action());
-                  insert(_el$164, () => gameplayActionButtonLabel(action(), locale()));
-                  createRenderEffect(() => _el$164.disabled = Boolean(action().disabledReason));
+                  var _el$163 = _tmpl$4();
+                  insert(_el$163, () => gameplay().narrativeNextStep || tr(locale(), "先执行这一步，再判断是否需要切到聊天、恢复或改道。", "Take this action first, then decide whether to chat, resume, or reprioritize."));
                   return _el$163;
+                })(), (() => {
+                  var _el$164 = _tmpl$34(), _el$165 = _el$164.firstChild;
+                  _el$165.$$click = () => renderGameplayAction(action());
+                  insert(_el$165, () => gameplayActionButtonLabel(action(), locale()));
+                  createRenderEffect(() => _el$165.disabled = Boolean(action().disabledReason));
+                  return _el$164;
                 })()];
               }
             })
           }), (() => {
-            var _el$153 = _tmpl$33(), _el$154 = _el$153.firstChild, _el$155 = _el$154.nextSibling;
-            insert(_el$154, () => tr(locale(), "可用玩法动作", "Available Gameplay Actions"));
-            insert(_el$155, createComponent(Show, {
+            var _el$154 = _tmpl$33(), _el$155 = _el$154.firstChild, _el$156 = _el$155.nextSibling;
+            insert(_el$155, () => tr(locale(), "可用玩法动作", "Available Gameplay Actions"));
+            insert(_el$156, createComponent(Show, {
               get when() {
                 return gameplay().availableActions.length > 0;
               },
@@ -7429,30 +7430,30 @@ function WorldSummaryPanel() {
                     },
                     get children() {
                       return [(() => {
-                        var _el$165 = _tmpl$4();
-                        insert(_el$165, () => action.disabledReason || tr(locale(), "无需打开 visual QA viewer，也可以直接从正式 Web 入口执行。", "Playable from the formal Web entry without opening the visual QA viewer."));
-                        return _el$165;
+                        var _el$166 = _tmpl$4();
+                        insert(_el$166, () => action.disabledReason || tr(locale(), "无需打开 visual QA viewer，也可以直接从正式 Web 入口执行。", "Playable from the formal Web entry without opening the visual QA viewer."));
+                        return _el$166;
                       })(), createComponent(Show, {
                         get when() {
                           return action.executeKind === "request_snapshot" || action.executeKind === "step" || action.executeKind === "play" || action.executeKind === "gameplay_action";
                         },
                         get children() {
-                          var _el$166 = _tmpl$34(), _el$167 = _el$166.firstChild;
-                          _el$167.$$click = () => renderGameplayAction(action);
-                          insert(_el$167, () => gameplayActionButtonLabel(action, locale()));
-                          createRenderEffect(() => _el$167.disabled = Boolean(action.disabledReason));
-                          return _el$166;
+                          var _el$167 = _tmpl$34(), _el$168 = _el$167.firstChild;
+                          _el$168.$$click = () => renderGameplayAction(action);
+                          insert(_el$168, () => gameplayActionButtonLabel(action, locale()));
+                          createRenderEffect(() => _el$168.disabled = Boolean(action.disabledReason));
+                          return _el$167;
                         }
                       }), createComponent(Show, {
                         get when() {
                           return action.executeKind === "agent_chat";
                         },
                         get children() {
-                          var _el$168 = _tmpl$34(), _el$169 = _el$168.firstChild;
-                          _el$169.$$click = () => renderGameplayAction(action);
-                          insert(_el$169, () => gameplayActionButtonLabel(action, locale()));
-                          createRenderEffect(() => _el$169.disabled = Boolean(action.disabledReason));
-                          return _el$168;
+                          var _el$169 = _tmpl$34(), _el$170 = _el$169.firstChild;
+                          _el$170.$$click = () => renderGameplayAction(action);
+                          insert(_el$170, () => gameplayActionButtonLabel(action, locale()));
+                          createRenderEffect(() => _el$170.disabled = Boolean(action.disabledReason));
+                          return _el$169;
                         }
                       })];
                     }
@@ -7460,7 +7461,7 @@ function WorldSummaryPanel() {
                 });
               }
             }));
-            return _el$153;
+            return _el$154;
           })(), createComponent(CalloutCard, {
             get title() {
               return tr(locale(), "未在此页暴露的动作", "Actions Not Exposed On This Page");
@@ -7469,20 +7470,20 @@ function WorldSummaryPanel() {
             badgeClass: "badge badge--warn",
             get children() {
               return [(() => {
-                var _el$156 = _tmpl$20();
-                insert(_el$156, () => gameplay().assetGovernanceHandoff);
-                return _el$156;
-              })(), (() => {
-                var _el$157 = _tmpl$4();
-                insert(_el$157, () => tr(locale(), "资产 / 治理相关能力请走单独 lane；这张主入口页面只保留正式玩法所需的最小动作面。", "Asset and governance actions stay on their dedicated lane; this primary entry only keeps the minimum surface needed for formal gameplay."));
+                var _el$157 = _tmpl$20();
+                insert(_el$157, () => gameplay().assetGovernanceHandoff);
                 return _el$157;
+              })(), (() => {
+                var _el$158 = _tmpl$4();
+                insert(_el$158, () => tr(locale(), "资产 / 治理相关能力请走单独 lane；这张主入口页面只保留正式玩法所需的最小动作面。", "Asset and governance actions stay on their dedicated lane; this primary entry only keeps the minimum surface needed for formal gameplay."));
+                return _el$158;
               })()];
             }
           })]
         });
       }
-    }), _el$113);
-    insert(_el$109, createComponent(Show, {
+    }), _el$114);
+    insert(_el$110, createComponent(Show, {
       get when() {
         return showPlayerSessionSurface();
       },
@@ -7499,8 +7500,8 @@ function WorldSummaryPanel() {
           },
           get children() {
             return [(() => {
-              var _el$110 = _tmpl$14();
-              insert(_el$110, createComponent(Badge, {
+              var _el$111 = _tmpl$14();
+              insert(_el$111, createComponent(Badge, {
                 get ["class"]() {
                   return state$1.auth.available ? "badge badge--good" : "badge badge--warn";
                 },
@@ -7508,23 +7509,23 @@ function WorldSummaryPanel() {
                   return `auth=${state$1.auth.available ? state$1.auth.registrationStatus || "ready" : "missing"}`;
                 }
               }), null);
-              insert(_el$110, createComponent(Badge, {
+              insert(_el$111, createComponent(Badge, {
                 "class": "badge badge--accent",
                 get children() {
                   return `tier=${authSurface().currentTier}`;
                 }
               }), null);
-              insert(_el$110, createComponent(Badge, {
+              insert(_el$111, createComponent(Badge, {
                 get children() {
                   return `player=${state$1.auth.playerId || "-"}`;
                 }
               }), null);
-              insert(_el$110, createComponent(Badge, {
+              insert(_el$111, createComponent(Badge, {
                 get children() {
                   return `boundAgent=${state$1.auth.boundAgentId || "-"}`;
                 }
               }), null);
-              return _el$110;
+              return _el$111;
             })(), createComponent(EmptyState, {
               get children() {
                 return hostedRecoveryHint()?.detail || state$1.auth.rebindNotice || authSurface().currentTierReason;
@@ -7554,21 +7555,21 @@ function WorldSummaryPanel() {
                 return memo(() => !!state$1.auth.available)() && state$1.auth.source !== "legacy_viewer_auth_bootstrap";
               },
               get children() {
-                var _el$111 = _tmpl$27(), _el$112 = _el$111.firstChild;
-                _el$112.$$click = () => {
+                var _el$112 = _tmpl$27(), _el$113 = _el$112.firstChild;
+                _el$113.$$click = () => {
                   void logoutHostedPlayerSession();
                 };
-                insert(_el$112, () => tr(locale(), "释放玩家会话", "Release Player Session"));
-                return _el$111;
+                insert(_el$113, () => tr(locale(), "释放玩家会话", "Release Player Session"));
+                return _el$112;
               }
             })];
           }
         });
       }
-    }), _el$113);
-    insert(_el$116, () => tr(locale(), "运行诊断", "Runtime Diagnostics"));
-    insert(_el$117, () => tr(locale(), "执行 lane、auth/session、托管矩阵与最近事件都收在这里，避免它们继续抢占主玩法首屏。", "Execution lanes, auth/session truth, hosted matrix, and recent events live here so they no longer dominate the primary gameplay viewport."));
-    insert(_el$118, createComponent(For, {
+    }), _el$114);
+    insert(_el$117, () => tr(locale(), "运行诊断", "Runtime Diagnostics"));
+    insert(_el$118, () => tr(locale(), "执行 lane、auth/session、托管矩阵与最近事件都收在这里，避免它们继续抢占主玩法首屏。", "Execution lanes, auth/session truth, hosted matrix, and recent events live here so they no longer dominate the primary gameplay viewport."));
+    insert(_el$119, createComponent(For, {
       get each() {
         return diagnosticsSummaryBadges();
       },
@@ -7576,53 +7577,53 @@ function WorldSummaryPanel() {
         children: label
       })
     }));
-    insert(_el$120, createComponent(Badge, {
+    insert(_el$121, createComponent(Badge, {
       get children() {
         return `ws=${state$1.wsUrl || "-"}`;
       }
     }), null);
-    insert(_el$120, createComponent(Badge, {
+    insert(_el$121, createComponent(Badge, {
       get children() {
         return `entryReason=${state$1.viewerReason || "-"}`;
       }
     }), null);
-    insert(_el$120, createComponent(Badge, {
+    insert(_el$121, createComponent(Badge, {
       get children() {
         return `renderer=${state$1.renderer || "n/a"}`;
       }
     }), null);
-    insert(_el$120, createComponent(Badge, {
+    insert(_el$121, createComponent(Badge, {
       get children() {
         return `controlProfile=${state$1.controlProfile}`;
       }
     }), null);
-    insert(_el$119, createComponent(PanelSection, {
+    insert(_el$120, createComponent(PanelSection, {
       get title() {
         return tr(locale(), "执行 Lane", "Execution Lanes");
       },
       get children() {
         return [(() => {
-          var _el$121 = _tmpl$14();
-          insert(_el$121, createComponent(Badge, {
+          var _el$122 = _tmpl$14();
+          insert(_el$122, createComponent(Badge, {
             "class": "badge badge--accent",
             children: "debug_viewer"
           }), null);
-          insert(_el$121, createComponent(Badge, {
+          insert(_el$122, createComponent(Badge, {
             get children() {
               return `status=${state$1.debugViewerStatus}`;
             }
           }), null);
-          insert(_el$121, createComponent(Badge, {
+          insert(_el$122, createComponent(Badge, {
             get children() {
               return `renderMode=${state$1.renderMode}`;
             }
           }), null);
-          insert(_el$121, createComponent(Badge, {
+          insert(_el$122, createComponent(Badge, {
             get children() {
               return `entryReason=${state$1.viewerReason || "-"}`;
             }
           }), null);
-          return _el$121;
+          return _el$122;
         })(), createComponent(EmptyState, {
           style: "margin-top:-2px;",
           get children() {
@@ -7638,99 +7639,99 @@ function WorldSummaryPanel() {
             });
           },
           children: (debug) => [(() => {
-            var _el$170 = _tmpl$14();
-            insert(_el$170, createComponent(Badge, {
+            var _el$171 = _tmpl$14();
+            insert(_el$171, createComponent(Badge, {
               "class": "badge badge--accent",
               children: "selected agent lane"
             }), null);
-            insert(_el$170, createComponent(Badge, {
+            insert(_el$171, createComponent(Badge, {
               get children() {
                 return `provider=${debug().provider_mode || "-"}`;
               }
             }), null);
-            insert(_el$170, createComponent(Badge, {
+            insert(_el$171, createComponent(Badge, {
               get children() {
                 return `mode=${debug().execution_mode || "-"}`;
               }
             }), null);
-            insert(_el$170, createComponent(Badge, {
+            insert(_el$171, createComponent(Badge, {
               get children() {
                 return `env=${debug().environment_class || "-"}`;
               }
             }), null);
-            return _el$170;
+            return _el$171;
           })(), (() => {
-            var _el$171 = _tmpl$14();
-            insert(_el$171, createComponent(Badge, {
+            var _el$172 = _tmpl$14();
+            insert(_el$172, createComponent(Badge, {
               get children() {
                 return `obs=${debug().observation_schema_version || "-"}`;
               }
             }), null);
-            insert(_el$171, createComponent(Badge, {
+            insert(_el$172, createComponent(Badge, {
               get children() {
                 return `act=${debug().action_schema_version || "-"}`;
               }
             }), null);
-            insert(_el$171, createComponent(Badge, {
+            insert(_el$172, createComponent(Badge, {
               get children() {
                 return `agentProfile=${debug().agent_profile || "-"}`;
               }
             }), null);
-            insert(_el$171, createComponent(Badge, {
+            insert(_el$172, createComponent(Badge, {
               get children() {
                 return `providerFallback=${debug().fallback_reason || "-"}`;
               }
             }), null);
-            return _el$171;
+            return _el$172;
           })(), createComponent(EmptyState, {
             style: "margin-top:-2px;",
             get children() {
               return tr(locale(), "上面的 lane badge 表示 phase-1 期望执行 contract；下面的 provider check badge 表示 runtime_live 基于 /v1/provider/info 和 /v1/provider/health 的真实探测结果。", "Lane badges show the expected phase-1 execution contract. Provider check badges below show the actual runtime_live probe against /v1/provider/info and /v1/provider/health.");
             }
           }), (() => {
-            var _el$172 = _tmpl$14();
-            insert(_el$172, createComponent(Badge, {
+            var _el$173 = _tmpl$14();
+            insert(_el$173, createComponent(Badge, {
               "class": "badge badge--accent",
               children: "provider check"
             }), null);
-            insert(_el$172, createComponent(Badge, {
+            insert(_el$173, createComponent(Badge, {
               get children() {
                 return `status=${debug().provider_check_status || "-"}`;
               }
             }), null);
-            insert(_el$172, createComponent(Badge, {
+            insert(_el$173, createComponent(Badge, {
               get children() {
                 return `source=${debug().provider_check_source || "-"}`;
               }
             }), null);
-            insert(_el$172, createComponent(Badge, {
+            insert(_el$173, createComponent(Badge, {
               get children() {
                 return `fallback=${debug().provider_check_fallback_reason || "-"}`;
               }
             }), null);
-            return _el$172;
+            return _el$173;
           })(), createComponent(Show, {
             get when() {
               return debug().provider_check_error || debug().provider_reported_capabilities?.length || debug().provider_reported_supported_action_sets?.length;
             },
             get children() {
-              var _el$173 = _tmpl$14();
-              insert(_el$173, createComponent(Badge, {
+              var _el$174 = _tmpl$14();
+              insert(_el$174, createComponent(Badge, {
                 get children() {
                   return `actualCaps=${(debug().provider_reported_capabilities || []).join(",") || "-"}`;
                 }
               }), null);
-              insert(_el$173, createComponent(Badge, {
+              insert(_el$174, createComponent(Badge, {
                 get children() {
                   return `actualActions=${(debug().provider_reported_supported_action_sets || []).join(",") || "-"}`;
                 }
               }), null);
-              insert(_el$173, createComponent(Badge, {
+              insert(_el$174, createComponent(Badge, {
                 get children() {
                   return `checkError=${debug().provider_check_error || "-"}`;
                 }
               }), null);
-              return _el$173;
+              return _el$174;
             }
           }), createComponent(JsonBlock, {
             get value() {
@@ -7739,8 +7740,8 @@ function WorldSummaryPanel() {
           })]
         })];
       }
-    }), _el$122);
-    insert(_el$122, createComponent(Badge, {
+    }), _el$123);
+    insert(_el$123, createComponent(Badge, {
       get ["class"]() {
         return state$1.auth.available ? "badge badge--good" : "badge badge--warn";
       },
@@ -7748,71 +7749,71 @@ function WorldSummaryPanel() {
         return `auth=${state$1.auth.available ? state$1.auth.registrationStatus || "ready" : "missing"}`;
       }
     }), null);
-    insert(_el$122, createComponent(Badge, {
+    insert(_el$123, createComponent(Badge, {
       "class": "badge badge--accent",
       get children() {
         return `tier=${authSurface().currentTier}`;
       }
     }), null);
-    insert(_el$122, createComponent(Badge, {
+    insert(_el$123, createComponent(Badge, {
       get children() {
         return `source=${authSurface().source}`;
       }
     }), null);
-    insert(_el$122, createComponent(Badge, {
+    insert(_el$123, createComponent(Badge, {
       get children() {
         return `deploymentHint=${authSurface().deploymentHint}`;
       }
     }), null);
-    insert(_el$122, createComponent(Badge, {
+    insert(_el$123, createComponent(Badge, {
       get children() {
         return `player=${state$1.auth.playerId || "-"}`;
       }
     }), null);
-    insert(_el$122, createComponent(Badge, {
+    insert(_el$123, createComponent(Badge, {
       get children() {
         return `pubkey=${state$1.auth.publicKey ? `${state$1.auth.publicKey.slice(0, 10)}…` : "-"}`;
       }
     }), null);
-    insert(_el$122, createComponent(Badge, {
+    insert(_el$123, createComponent(Badge, {
       get children() {
         return `epoch=${state$1.auth.sessionEpoch == null ? "-" : state$1.auth.sessionEpoch}`;
       }
     }), null);
-    insert(_el$122, createComponent(Badge, {
+    insert(_el$123, createComponent(Badge, {
       get children() {
         return `runtime=${state$1.auth.runtimeStatus || "-"}`;
       }
     }), null);
-    insert(_el$122, createComponent(Badge, {
+    insert(_el$123, createComponent(Badge, {
       get children() {
         return `boundAgent=${state$1.auth.boundAgentId || "-"}`;
       }
     }), null);
-    insert(_el$122, createComponent(Badge, {
+    insert(_el$123, createComponent(Badge, {
       get children() {
         return `requestedAgent=${state$1.auth.pendingRequestedAgentId || "-"}`;
       }
     }), null);
-    insert(_el$122, createComponent(Badge, {
+    insert(_el$123, createComponent(Badge, {
       get children() {
         return state$1.auth.pendingForceRebind ? "rebind=forcing" : "rebind=idle";
       }
     }), null);
-    insert(_el$123, createComponent(Show, {
+    insert(_el$124, createComponent(Show, {
       get when() {
         return memo(() => !!state$1.auth.available)() && state$1.auth.source !== "legacy_viewer_auth_bootstrap";
       },
       get children() {
-        var _el$124 = _tmpl$28();
-        _el$124.$$click = () => {
+        var _el$125 = _tmpl$28();
+        _el$125.$$click = () => {
           void logoutHostedPlayerSession();
         };
-        insert(_el$124, () => tr(locale(), "释放玩家会话", "Release Player Session"));
-        return _el$124;
+        insert(_el$125, () => tr(locale(), "释放玩家会话", "Release Player Session"));
+        return _el$125;
       }
     }));
-    insert(_el$119, createComponent(Show, {
+    insert(_el$120, createComponent(Show, {
       get when() {
         return hostedRecoveryHint();
       },
@@ -7821,8 +7822,8 @@ function WorldSummaryPanel() {
           return hint().detail;
         }
       })
-    }), _el$131);
-    insert(_el$119, createComponent(Show, {
+    }), _el$132);
+    insert(_el$120, createComponent(Show, {
       get when() {
         return memo(() => !!!state$1.auth.available)() && String(state$1.hostedAccess?.deployment_mode || "").trim() === "hosted_public_join";
       },
@@ -7836,124 +7837,124 @@ function WorldSummaryPanel() {
           codeId: "diag-hosted-login-code"
         });
       }
-    }), _el$131);
-    insert(_el$119, createComponent(Show, {
+    }), _el$132);
+    insert(_el$120, createComponent(Show, {
       get when() {
         return state$1.auth.recoveryErrorCode || state$1.auth.recoveryErrorMessage;
       },
       get children() {
-        var _el$125 = _tmpl$14();
-        insert(_el$125, createComponent(Badge, {
+        var _el$126 = _tmpl$14();
+        insert(_el$126, createComponent(Badge, {
           "class": "badge badge--warn",
           get children() {
             return `recoveryError=${state$1.auth.recoveryErrorCode || "-"}`;
           }
         }), null);
-        insert(_el$125, createComponent(Badge, {
+        insert(_el$126, createComponent(Badge, {
           get children() {
             return state$1.auth.recoveryErrorMessage || "-";
           }
         }), null);
-        return _el$125;
+        return _el$126;
       }
-    }), _el$131);
-    insert(_el$119, createComponent(Show, {
+    }), _el$132);
+    insert(_el$120, createComponent(Show, {
       get when() {
         return showRebindNotice();
       },
       get children() {
         return [(() => {
-          var _el$126 = _tmpl$14();
-          insert(_el$126, createComponent(Badge, {
+          var _el$127 = _tmpl$14();
+          insert(_el$127, createComponent(Badge, {
             "class": "badge badge--accent",
             children: "rebind"
           }), null);
-          insert(_el$126, createComponent(Badge, {
+          insert(_el$127, createComponent(Badge, {
             get children() {
               return `target=${state$1.auth.pendingRequestedAgentId || "-"}`;
             }
           }), null);
-          insert(_el$126, createComponent(Badge, {
+          insert(_el$127, createComponent(Badge, {
             get children() {
               return state$1.auth.pendingForceRebind ? "mode=force_rebind" : "mode=awaiting_retry";
             }
           }), null);
-          return _el$126;
+          return _el$127;
         })(), createComponent(EmptyState, {
           children: "Player session is switching to the requested agent and the current action will continue after registration succeeds."
         })];
       }
-    }), _el$131);
-    insert(_el$119, createComponent(Show, {
+    }), _el$132);
+    insert(_el$120, createComponent(Show, {
       get when() {
         return state$1.hostedAdmission;
       },
       children: (admission) => (() => {
-        var _el$174 = _tmpl$14();
-        insert(_el$174, createComponent(Badge, {
+        var _el$175 = _tmpl$14();
+        insert(_el$175, createComponent(Badge, {
           get children() {
             return `activeSlots=${admission().active_player_sessions}/${admission().max_player_sessions}`;
           }
         }), null);
-        insert(_el$174, createComponent(Badge, {
+        insert(_el$175, createComponent(Badge, {
           get children() {
             return `effectiveSlots=${admission().effective_player_sessions == null ? "-" : `${admission().effective_player_sessions}/${admission().max_player_sessions}`}`;
           }
         }), null);
-        insert(_el$174, createComponent(Badge, {
+        insert(_el$175, createComponent(Badge, {
           get children() {
             return `runtimeBound=${admission().runtime_bound_player_sessions ?? "-"}`;
           }
         }), null);
-        insert(_el$174, createComponent(Badge, {
+        insert(_el$175, createComponent(Badge, {
           get children() {
             return `runtimeOnly=${admission().runtime_only_player_sessions ?? "-"}`;
           }
         }), null);
-        insert(_el$174, createComponent(Badge, {
+        insert(_el$175, createComponent(Badge, {
           get children() {
             return `runtimeProbe=${admission().runtime_probe_status || "-"}`;
           }
         }), null);
-        insert(_el$174, createComponent(Badge, {
+        insert(_el$175, createComponent(Badge, {
           get children() {
             return `issueBudget=${admission().remaining_issue_budget}`;
           }
         }), null);
-        insert(_el$174, createComponent(Badge, {
+        insert(_el$175, createComponent(Badge, {
           get children() {
             return `leaseTTL=${admission().slot_lease_ttl_ms}`;
           }
         }), null);
-        insert(_el$174, createComponent(Badge, {
+        insert(_el$175, createComponent(Badge, {
           get children() {
             return `issued=${admission().issued_players_total}`;
           }
         }), null);
-        insert(_el$174, createComponent(Badge, {
+        insert(_el$175, createComponent(Badge, {
           get children() {
             return `released=${admission().released_players_total}`;
           }
         }), null);
-        return _el$174;
+        return _el$175;
       })()
-    }), _el$131);
-    insert(_el$119, createComponent(Show, {
+    }), _el$132);
+    insert(_el$120, createComponent(Show, {
       get when() {
         return state$1.hostedAdmission?.runtime_probe_error;
       },
       get children() {
-        var _el$127 = _tmpl$14();
-        insert(_el$127, createComponent(Badge, {
+        var _el$128 = _tmpl$14();
+        insert(_el$128, createComponent(Badge, {
           "class": "badge badge--warn",
           get children() {
             return `runtimeProbeError=${state$1.hostedAdmission.runtime_probe_error}`;
           }
         }));
-        return _el$127;
+        return _el$128;
       }
-    }), _el$131);
-    insert(_el$119, createComponent(PanelSection, {
+    }), _el$132);
+    insert(_el$120, createComponent(PanelSection, {
       title: "Session Ladder",
       get children() {
         return [createComponent(EmptyState, {
@@ -7961,8 +7962,8 @@ function WorldSummaryPanel() {
             return authSurface().currentTierReason;
           }
         }), (() => {
-          var _el$128 = _tmpl$29();
-          insert(_el$128, createComponent(For, {
+          var _el$129 = _tmpl$29();
+          insert(_el$129, createComponent(For, {
             get each() {
               return authSurface().tiers;
             },
@@ -7981,10 +7982,10 @@ function WorldSummaryPanel() {
               }
             })
           }));
-          return _el$128;
+          return _el$129;
         })(), (() => {
-          var _el$129 = _tmpl$14();
-          insert(_el$129, createComponent(Badge, {
+          var _el$130 = _tmpl$14();
+          insert(_el$130, createComponent(Badge, {
             get ["class"]() {
               return authSurface().capabilities.prompt_control.enabled ? "badge badge--good" : "badge badge--warn";
             },
@@ -7992,7 +7993,7 @@ function WorldSummaryPanel() {
               return `prompt=${authSurface().capabilities.prompt_control.enabled ? "enabled" : authSurface().capabilities.prompt_control.code}`;
             }
           }), null);
-          insert(_el$129, createComponent(Badge, {
+          insert(_el$130, createComponent(Badge, {
             get ["class"]() {
               return authSurface().capabilities.agent_chat.enabled ? "badge badge--good" : "badge badge--warn";
             },
@@ -8000,21 +8001,21 @@ function WorldSummaryPanel() {
               return `chat=${authSurface().capabilities.agent_chat.enabled ? "enabled" : authSurface().capabilities.agent_chat.code}`;
             }
           }), null);
-          insert(_el$129, createComponent(Badge, {
+          insert(_el$130, createComponent(Badge, {
             "class": "badge badge--warn",
             get children() {
               return `mainToken=${authSurface().capabilities.main_token_transfer.code}`;
             }
           }), null);
-          return _el$129;
+          return _el$130;
         })(), createComponent(EmptyState, {
           get children() {
             return authSurface().reconnect;
           }
         })];
       }
-    }), _el$131);
-    insert(_el$119, createComponent(Show, {
+    }), _el$132);
+    insert(_el$120, createComponent(Show, {
       get when() {
         return hostedActionMatrixView().length > 0;
       },
@@ -8029,8 +8030,8 @@ function WorldSummaryPanel() {
                 return tr(locale(), "这里是 launcher 导出的 hosted public-join 真值面。QA 应该直接读取这些 action id，而不是只靠按钮状态推断。", "This is the hosted public-join truth surface exported by the launcher. QA should read these action ids directly instead of inferring from button state alone.");
               }
             }), (() => {
-              var _el$130 = _tmpl$29();
-              insert(_el$130, createComponent(For, {
+              var _el$131 = _tmpl$29();
+              insert(_el$131, createComponent(For, {
                 get each() {
                   return hostedActionMatrixView();
                 },
@@ -8067,13 +8068,13 @@ function WorldSummaryPanel() {
                   }
                 })
               }));
-              return _el$130;
+              return _el$131;
             })()];
           }
         });
       }
-    }), _el$131);
-    insert(_el$131, createComponent(MetricCard, {
+    }), _el$132);
+    insert(_el$132, createComponent(MetricCard, {
       get label() {
         return tr(locale(), "Prompt 反馈", "Prompt Feedback");
       },
@@ -8098,7 +8099,7 @@ function WorldSummaryPanel() {
         });
       }
     }), null);
-    insert(_el$131, createComponent(MetricCard, {
+    insert(_el$132, createComponent(MetricCard, {
       get label() {
         return tr(locale(), "聊天反馈", "Chat Feedback");
       },
@@ -8123,8 +8124,8 @@ function WorldSummaryPanel() {
         });
       }
     }), null);
-    insert(_el$133, () => tr(locale(), "最近事件", "Recent Events"));
-    insert(_el$134, createComponent(Show, {
+    insert(_el$134, () => tr(locale(), "最近事件", "Recent Events"));
+    insert(_el$135, createComponent(Show, {
       get when() {
         return state$1.recentEvents.length > 0;
       },
@@ -8161,7 +8162,7 @@ function WorldSummaryPanel() {
         });
       }
     }));
-    return _el$109;
+    return _el$110;
   })();
 }
 function InteractionPanel() {
@@ -8203,19 +8204,19 @@ function InteractionPanel() {
     });
   }
   return (() => {
-    var _el$175 = _tmpl$46(), _el$176 = _el$175.firstChild, _el$178 = _el$176.nextSibling;
-    insert(_el$176, createComponent(Badge, {
+    var _el$176 = _tmpl$46(), _el$177 = _el$176.firstChild, _el$179 = _el$177.nextSibling;
+    insert(_el$177, createComponent(Badge, {
       "class": "badge badge--accent",
       get children() {
         return tr(locale(), "当前交互目标", "Current Target");
       }
     }), null);
-    insert(_el$176, createComponent(Badge, {
+    insert(_el$177, createComponent(Badge, {
       get children() {
         return `agent=${agentId()}`;
       }
     }), null);
-    insert(_el$176, createComponent(Badge, {
+    insert(_el$177, createComponent(Badge, {
       get ["class"]() {
         return chatCapability().enabled ? "badge badge--good" : "badge badge--warn";
       },
@@ -8223,7 +8224,7 @@ function InteractionPanel() {
         return memo(() => !!chatCapability().enabled)() ? tr(locale(), "聊天可用", "Chat Ready") : tr(locale(), "聊天受限", "Chat Limited");
       }
     }), null);
-    insert(_el$175, createComponent(Show, {
+    insert(_el$176, createComponent(Show, {
       get when() {
         return debugContext()?.provider_mode === "provider_loopback_http";
       },
@@ -8234,8 +8235,8 @@ function InteractionPanel() {
           }
         });
       }
-    }), _el$178);
-    insert(_el$175, createComponent(Show, {
+    }), _el$179);
+    insert(_el$176, createComponent(Show, {
       get when() {
         return debugContext()?.provider_mode !== "provider_loopback_http";
       },
@@ -8253,24 +8254,24 @@ function InteractionPanel() {
           },
           get children() {
             return [(() => {
-              var _el$177 = _tmpl$14();
-              insert(_el$177, createComponent(Badge, {
+              var _el$178 = _tmpl$14();
+              insert(_el$178, createComponent(Badge, {
                 "class": "badge badge--good",
                 get children() {
                   return authSurface().currentTier;
                 }
               }), null);
-              insert(_el$177, createComponent(Badge, {
+              insert(_el$178, createComponent(Badge, {
                 get children() {
                   return `player=${state.auth.playerId}`;
                 }
               }), null);
-              insert(_el$177, createComponent(Badge, {
+              insert(_el$178, createComponent(Badge, {
                 get children() {
                   return `source=${authSurface().source}`;
                 }
               }), null);
-              return _el$177;
+              return _el$178;
             })(), createComponent(EmptyState, {
               get children() {
                 return promptCapability().reason;
@@ -8279,18 +8280,18 @@ function InteractionPanel() {
           }
         });
       }
-    }), _el$178);
-    insert(_el$178, createComponent(Badge, {
+    }), _el$179);
+    insert(_el$179, createComponent(Badge, {
       get children() {
         return `boundPlayer=${binding()?.playerId || "-"}`;
       }
     }), null);
-    insert(_el$178, createComponent(Badge, {
+    insert(_el$179, createComponent(Badge, {
       get children() {
         return `boundKey=${binding()?.publicKey ? `${binding().publicKey.slice(0, 10)}…` : "-"}`;
       }
     }), null);
-    insert(_el$178, createComponent(Badge, {
+    insert(_el$179, createComponent(Badge, {
       get ["class"]() {
         return promptCapability().enabled ? "badge badge--good" : "badge badge--warn";
       },
@@ -8298,7 +8299,7 @@ function InteractionPanel() {
         return `prompt=${promptCapability().enabled ? "enabled" : promptCapability().code}`;
       }
     }), null);
-    insert(_el$178, createComponent(Badge, {
+    insert(_el$179, createComponent(Badge, {
       get ["class"]() {
         return chatCapability().enabled ? "badge badge--good" : "badge badge--warn";
       },
@@ -8306,7 +8307,7 @@ function InteractionPanel() {
         return `chat=${chatCapability().enabled ? "enabled" : chatCapability().code}`;
       }
     }), null);
-    insert(_el$178, createComponent(Badge, {
+    insert(_el$179, createComponent(Badge, {
       get ["class"]() {
         return mainTokenTransferCapability().enabled ? "badge badge--good" : "badge badge--warn";
       },
@@ -8314,12 +8315,12 @@ function InteractionPanel() {
         return `mainToken=${assetLaneStatusText()}`;
       }
     }), null);
-    insert(_el$175, createComponent(EmptyState, {
+    insert(_el$176, createComponent(EmptyState, {
       get children() {
         return assetLaneDetail();
       }
     }), null);
-    insert(_el$175, createComponent(PanelSection, {
+    insert(_el$176, createComponent(PanelSection, {
       get title() {
         return tr(locale(), "Agent 聊天", "Agent Chat");
       },
@@ -8331,29 +8332,29 @@ function InteractionPanel() {
       },
       get children() {
         return [(() => {
-          var _el$179 = _tmpl$35(), _el$180 = _el$179.firstChild, _el$181 = _el$180.nextSibling;
-          insert(_el$180, () => tr(locale(), "消息", "Message"));
-          _el$181.$$input = (event) => {
+          var _el$180 = _tmpl$35(), _el$181 = _el$180.firstChild, _el$182 = _el$181.nextSibling;
+          insert(_el$181, () => tr(locale(), "消息", "Message"));
+          _el$182.$$input = (event) => {
             state.chatDraft.message = String(event.currentTarget.value || "");
             state.chatDraft.dirty = true;
           };
           createRenderEffect((_p$) => {
             var _v$10 = tr(locale(), "给当前选中的 Agent 发一条消息", "Send a message to the selected agent"), _v$11 = !chatCapability().enabled;
-            _v$10 !== _p$.e && setAttribute(_el$181, "placeholder", _p$.e = _v$10);
-            _v$11 !== _p$.t && (_el$181.disabled = _p$.t = _v$11);
+            _v$10 !== _p$.e && setAttribute(_el$182, "placeholder", _p$.e = _v$10);
+            _v$11 !== _p$.t && (_el$182.disabled = _p$.t = _v$11);
             return _p$;
           }, {
             e: void 0,
             t: void 0
           });
-          createRenderEffect(() => _el$181.value = state.chatDraft.message);
-          return _el$179;
+          createRenderEffect(() => _el$182.value = state.chatDraft.message);
+          return _el$180;
         })(), (() => {
-          var _el$182 = _tmpl$36(), _el$183 = _el$182.firstChild;
-          _el$183.$$click = () => sendAgentChat(agentId(), state.chatDraft.message);
-          insert(_el$183, () => tr(locale(), "发送聊天", "Send Chat"));
-          createRenderEffect(() => _el$183.disabled = !chatCapability().enabled);
-          return _el$182;
+          var _el$183 = _tmpl$36(), _el$184 = _el$183.firstChild;
+          _el$184.$$click = () => sendAgentChat(agentId(), state.chatDraft.message);
+          insert(_el$184, () => tr(locale(), "发送聊天", "Send Chat"));
+          createRenderEffect(() => _el$184.disabled = !chatCapability().enabled);
+          return _el$183;
         })(), createComponent(Show, {
           get when() {
             return chatFeedback();
@@ -8374,9 +8375,9 @@ function InteractionPanel() {
             }
           })
         }), (() => {
-          var _el$184 = _tmpl$37(), _el$185 = _el$184.firstChild, _el$186 = _el$185.nextSibling;
-          insert(_el$185, () => tr(locale(), "消息流", "Message Flow"));
-          insert(_el$186, createComponent(Show, {
+          var _el$185 = _tmpl$37(), _el$186 = _el$185.firstChild, _el$187 = _el$186.nextSibling;
+          insert(_el$186, () => tr(locale(), "消息流", "Message Flow"));
+          insert(_el$187, createComponent(Show, {
             get when() {
               return chatHistory().length > 0;
             },
@@ -8411,11 +8412,11 @@ function InteractionPanel() {
               });
             }
           }));
-          return _el$184;
+          return _el$185;
         })()];
       }
     }), null);
-    insert(_el$175, createComponent(PanelSection, {
+    insert(_el$176, createComponent(PanelSection, {
       get title() {
         return tr(locale(), "高级 Prompt 设置", "Advanced Prompt Settings");
       },
@@ -8427,18 +8428,18 @@ function InteractionPanel() {
       },
       get children() {
         return [(() => {
-          var _el$187 = _tmpl$14();
-          insert(_el$187, createComponent(Badge, {
+          var _el$188 = _tmpl$14();
+          insert(_el$188, createComponent(Badge, {
             get children() {
               return `activePrompt=v${promptVersionState().currentVersion}`;
             }
           }), null);
-          insert(_el$187, createComponent(Badge, {
+          insert(_el$188, createComponent(Badge, {
             get children() {
               return `nextRollback=v${promptVersionState().nextRollbackTargetVersion}`;
             }
           }), null);
-          insert(_el$187, createComponent(Show, {
+          insert(_el$188, createComponent(Show, {
             get when() {
               return promptVersionState().restoredFromVersion != null;
             },
@@ -8450,7 +8451,7 @@ function InteractionPanel() {
               });
             }
           }), null);
-          insert(_el$187, createComponent(Badge, {
+          insert(_el$188, createComponent(Badge, {
             get ["class"]() {
               return promptOverridesVisible() ? "badge badge--good" : "badge";
             },
@@ -8458,25 +8459,25 @@ function InteractionPanel() {
               return memo(() => !!promptOverridesVisible())() ? tr(locale(), "状态=已展开", "state=expanded") : tr(locale(), "状态=默认收起", "state=hidden_by_default");
             }
           }), null);
-          insert(_el$187, createComponent(Badge, {
+          insert(_el$188, createComponent(Badge, {
             get children() {
               return tr(locale(), "本地设置持久化", "locally persisted");
             }
           }), null);
-          return _el$187;
+          return _el$188;
         })(), createComponent(EmptyState, {
           get children() {
             return promptSettingsSummary();
           }
         }), (() => {
-          var _el$188 = _tmpl$38(), _el$189 = _el$188.firstChild;
-          _el$189.$$click = () => togglePromptOverridesVisible();
-          insert(_el$189, promptSettingsButtonLabel);
-          return _el$188;
+          var _el$189 = _tmpl$38(), _el$190 = _el$189.firstChild;
+          _el$190.$$click = () => togglePromptOverridesVisible();
+          insert(_el$190, promptSettingsButtonLabel);
+          return _el$189;
         })()];
       }
     }), null);
-    insert(_el$175, createComponent(Show, {
+    insert(_el$176, createComponent(Show, {
       get when() {
         return promptOverridesVisible();
       },
@@ -8485,97 +8486,97 @@ function InteractionPanel() {
           title: "Prompt Overrides",
           get children() {
             return [(() => {
-              var _el$190 = _tmpl$4();
-              insert(_el$190, () => promptVersionState().summary);
-              return _el$190;
-            })(), (() => {
               var _el$191 = _tmpl$4();
-              insert(_el$191, () => promptVersionState().detail);
+              insert(_el$191, () => promptVersionState().summary);
               return _el$191;
+            })(), (() => {
+              var _el$192 = _tmpl$4();
+              insert(_el$192, () => promptVersionState().detail);
+              return _el$192;
             })(), createComponent(Show, {
               get when() {
                 return memo(() => !!authSurface().capabilities.prompt_control.enabled)() && String(state.hostedAccess?.deployment_mode || "").trim() === "hosted_public_join";
               },
               get children() {
-                var _el$192 = _tmpl$39(), _el$193 = _el$192.firstChild, _el$194 = _el$193.nextSibling;
-                insert(_el$193, () => tr(locale(), "后端审批码", "Backend Approval Code"));
-                _el$194.$$input = (event) => {
+                var _el$193 = _tmpl$39(), _el$194 = _el$193.firstChild, _el$195 = _el$194.nextSibling;
+                insert(_el$194, () => tr(locale(), "后端审批码", "Backend Approval Code"));
+                _el$195.$$input = (event) => {
                   state.strongAuth.approvalCode = String(event.currentTarget.value || "");
                 };
-                createRenderEffect(() => _el$194.value = state.strongAuth.approvalCode || "");
-                return _el$192;
+                createRenderEffect(() => _el$195.value = state.strongAuth.approvalCode || "");
+                return _el$193;
               }
             }), (() => {
-              var _el$195 = _tmpl$40(), _el$196 = _el$195.firstChild, _el$197 = _el$196.nextSibling;
-              insert(_el$196, () => tr(locale(), "System Prompt 覆盖", "System Prompt Override"));
-              _el$197.$$input = (event) => {
+              var _el$196 = _tmpl$40(), _el$197 = _el$196.firstChild, _el$198 = _el$197.nextSibling;
+              insert(_el$197, () => tr(locale(), "System Prompt 覆盖", "System Prompt Override"));
+              _el$198.$$input = (event) => {
                 state.promptDraft.systemPrompt = String(event.currentTarget.value || "");
                 state.promptDraft.dirty = true;
               };
-              createRenderEffect(() => _el$197.disabled = !promptCapability().enabled);
-              createRenderEffect(() => _el$197.value = state.promptDraft.systemPrompt);
-              return _el$195;
+              createRenderEffect(() => _el$198.disabled = !promptCapability().enabled);
+              createRenderEffect(() => _el$198.value = state.promptDraft.systemPrompt);
+              return _el$196;
             })(), (() => {
-              var _el$198 = _tmpl$41(), _el$199 = _el$198.firstChild, _el$200 = _el$199.nextSibling;
-              insert(_el$199, () => tr(locale(), "短期目标覆盖", "Short-Term Goal Override"));
-              _el$200.$$input = (event) => {
+              var _el$199 = _tmpl$41(), _el$200 = _el$199.firstChild, _el$201 = _el$200.nextSibling;
+              insert(_el$200, () => tr(locale(), "短期目标覆盖", "Short-Term Goal Override"));
+              _el$201.$$input = (event) => {
                 state.promptDraft.shortTermGoal = String(event.currentTarget.value || "");
                 state.promptDraft.dirty = true;
               };
-              createRenderEffect(() => _el$200.disabled = !promptCapability().enabled);
-              createRenderEffect(() => _el$200.value = state.promptDraft.shortTermGoal);
-              return _el$198;
+              createRenderEffect(() => _el$201.disabled = !promptCapability().enabled);
+              createRenderEffect(() => _el$201.value = state.promptDraft.shortTermGoal);
+              return _el$199;
             })(), (() => {
-              var _el$201 = _tmpl$42(), _el$202 = _el$201.firstChild, _el$203 = _el$202.nextSibling;
-              insert(_el$202, () => tr(locale(), "长期目标覆盖", "Long-Term Goal Override"));
-              _el$203.$$input = (event) => {
+              var _el$202 = _tmpl$42(), _el$203 = _el$202.firstChild, _el$204 = _el$203.nextSibling;
+              insert(_el$203, () => tr(locale(), "长期目标覆盖", "Long-Term Goal Override"));
+              _el$204.$$input = (event) => {
                 state.promptDraft.longTermGoal = String(event.currentTarget.value || "");
                 state.promptDraft.dirty = true;
               };
-              createRenderEffect(() => _el$203.disabled = !promptCapability().enabled);
-              createRenderEffect(() => _el$203.value = state.promptDraft.longTermGoal);
-              return _el$201;
+              createRenderEffect(() => _el$204.disabled = !promptCapability().enabled);
+              createRenderEffect(() => _el$204.value = state.promptDraft.longTermGoal);
+              return _el$202;
             })(), (() => {
-              var _el$204 = _tmpl$43(), _el$205 = _el$204.firstChild, _el$206 = _el$205.nextSibling;
-              _el$205.$$click = () => sendPromptControl("preview", null);
-              insert(_el$205, () => tr(locale(), "预览 Prompt", "Preview Prompt"));
-              _el$206.$$click = () => sendPromptControl("apply", null);
-              insert(_el$206, () => tr(locale(), "应用 Prompt", "Apply Prompt"));
+              var _el$205 = _tmpl$43(), _el$206 = _el$205.firstChild, _el$207 = _el$206.nextSibling;
+              _el$206.$$click = () => sendPromptControl("preview", null);
+              insert(_el$206, () => tr(locale(), "预览 Prompt", "Preview Prompt"));
+              _el$207.$$click = () => sendPromptControl("apply", null);
+              insert(_el$207, () => tr(locale(), "应用 Prompt", "Apply Prompt"));
               createRenderEffect((_p$) => {
                 var _v$12 = !promptCapability().enabled, _v$13 = !promptCapability().enabled;
-                _v$12 !== _p$.e && (_el$205.disabled = _p$.e = _v$12);
-                _v$13 !== _p$.t && (_el$206.disabled = _p$.t = _v$13);
+                _v$12 !== _p$.e && (_el$206.disabled = _p$.e = _v$12);
+                _v$13 !== _p$.t && (_el$207.disabled = _p$.t = _v$13);
                 return _p$;
               }, {
                 e: void 0,
                 t: void 0
               });
-              return _el$204;
+              return _el$205;
             })(), (() => {
-              var _el$207 = _tmpl$44(), _el$208 = _el$207.firstChild, _el$209 = _el$208.firstChild, _el$210 = _el$209.nextSibling, _el$211 = _el$208.nextSibling;
-              insert(_el$209, () => tr(locale(), "下一次回滚目标版本", "Next Rollback Target Version"));
-              _el$210.$$input = (event) => {
+              var _el$208 = _tmpl$44(), _el$209 = _el$208.firstChild, _el$210 = _el$209.firstChild, _el$211 = _el$210.nextSibling, _el$212 = _el$209.nextSibling;
+              insert(_el$210, () => tr(locale(), "下一次回滚目标版本", "Next Rollback Target Version"));
+              _el$211.$$input = (event) => {
                 const nextValue = Number(event.currentTarget.value || 0);
                 state.promptDraft.rollbackTargetVersion = Math.max(0, Math.floor(nextValue || 0));
                 requestRender();
               };
-              _el$211.$$click = () => {
+              _el$212.$$click = () => {
                 sendPromptControl("rollback", {
                   toVersion: Number(state.promptDraft.rollbackTargetVersion || 0)
                 });
               };
-              insert(_el$211, () => tr(locale(), "回滚 Prompt", "Rollback Prompt"));
+              insert(_el$212, () => tr(locale(), "回滚 Prompt", "Rollback Prompt"));
               createRenderEffect((_p$) => {
                 var _v$14 = !promptCapability().enabled, _v$15 = !promptCapability().enabled;
-                _v$14 !== _p$.e && (_el$210.disabled = _p$.e = _v$14);
-                _v$15 !== _p$.t && (_el$211.disabled = _p$.t = _v$15);
+                _v$14 !== _p$.e && (_el$211.disabled = _p$.e = _v$14);
+                _v$15 !== _p$.t && (_el$212.disabled = _p$.t = _v$15);
                 return _p$;
               }, {
                 e: void 0,
                 t: void 0
               });
-              createRenderEffect(() => _el$210.value = Number(state.promptDraft.rollbackTargetVersion || 0));
-              return _el$207;
+              createRenderEffect(() => _el$211.value = Number(state.promptDraft.rollbackTargetVersion || 0));
+              return _el$208;
             })(), createComponent(Show, {
               get when() {
                 return promptFeedback();
@@ -8623,7 +8624,7 @@ function InteractionPanel() {
         });
       }
     }), null);
-    insert(_el$175, createComponent(PanelSection, {
+    insert(_el$176, createComponent(PanelSection, {
       get title() {
         return tr(locale(), "资产 / 治理 Lane", "Asset / Governance Lane");
       },
@@ -8635,8 +8636,8 @@ function InteractionPanel() {
       },
       get children() {
         return [(() => {
-          var _el$212 = _tmpl$14();
-          insert(_el$212, createComponent(Badge, {
+          var _el$213 = _tmpl$14();
+          insert(_el$213, createComponent(Badge, {
             get ["class"]() {
               return mainTokenTransferCapability().enabled ? "badge badge--good" : "badge badge--warn";
             },
@@ -8644,17 +8645,17 @@ function InteractionPanel() {
               return `main_token_transfer=${assetLaneStatusText()}`;
             }
           }), null);
-          insert(_el$212, createComponent(Badge, {
+          insert(_el$213, createComponent(Badge, {
             get children() {
               return `required_auth=${mainTokenTransferPolicy()?.required_auth || "-"}`;
             }
           }), null);
-          insert(_el$212, createComponent(Badge, {
+          insert(_el$213, createComponent(Badge, {
             get children() {
               return `availability=${mainTokenTransferPolicy()?.availability || "-"}`;
             }
           }), null);
-          return _el$212;
+          return _el$213;
         })(), createComponent(EmptyState, {
           get children() {
             return assetLaneDetail();
@@ -8664,13 +8665,13 @@ function InteractionPanel() {
             return mainTokenTransferPolicy()?.reason || tr(locale(), "当前 lane 没有 main_token_transfer 的 hosted action policy。", "No hosted action policy is available for main_token_transfer on this lane.");
           }
         }), (() => {
-          var _el$213 = _tmpl$45(), _el$214 = _el$213.firstChild;
-          insert(_el$214, () => tr(locale(), "主代币转账（这里暂未开放）", "Main Token Transfer (Not Exposed Here Yet)"));
-          return _el$213;
+          var _el$214 = _tmpl$45(), _el$215 = _el$214.firstChild;
+          insert(_el$215, () => tr(locale(), "主代币转账（这里暂未开放）", "Main Token Transfer (Not Exposed Here Yet)"));
+          return _el$214;
         })()];
       }
     }), null);
-    return _el$175;
+    return _el$176;
   })();
 }
 function DetailsPanel() {
@@ -8697,20 +8698,20 @@ function DetailsPanel() {
   });
   const hasSnapshotDiagnostics = () => !!state.snapshot || !!state.metrics || !!state.hostedAccess;
   return (() => {
-    var _el$215 = _tmpl$48(), _el$216 = _el$215.firstChild, _el$217 = _el$216.nextSibling, _el$218 = _el$217.firstChild, _el$219 = _el$218.nextSibling, _el$220 = _el$219.nextSibling, _el$221 = _el$220.firstChild, _el$222 = _el$221.nextSibling, _el$223 = _el$222.nextSibling, _el$224 = _el$223.firstChild, _el$225 = _el$224.nextSibling;
-    insert(_el$216, createComponent(Badge, {
+    var _el$216 = _tmpl$48(), _el$217 = _el$216.firstChild, _el$218 = _el$217.nextSibling, _el$219 = _el$218.firstChild, _el$220 = _el$219.nextSibling, _el$221 = _el$220.nextSibling, _el$222 = _el$221.firstChild, _el$223 = _el$222.nextSibling, _el$224 = _el$223.nextSibling, _el$225 = _el$224.firstChild, _el$226 = _el$225.nextSibling;
+    insert(_el$217, createComponent(Badge, {
       "class": "badge badge--accent",
       get children() {
         return tr(locale(), "当前命令目标", "Current Command Target");
       }
     }), null);
-    insert(_el$216, createComponent(Badge, {
+    insert(_el$217, createComponent(Badge, {
       get children() {
         return selectedLabel();
       }
     }), null);
-    insert(_el$215, createComponent(InteractionPanel, {}), _el$217);
-    insert(_el$215, createComponent(Show, {
+    insert(_el$216, createComponent(InteractionPanel, {}), _el$218);
+    insert(_el$216, createComponent(Show, {
       get when() {
         return state.selectedObject;
       },
@@ -8741,29 +8742,29 @@ function DetailsPanel() {
         },
         value: () => clone(selected())
       })
-    }), _el$217);
-    insert(_el$218, () => tr(locale(), "世界规模", "World Scale"));
-    insert(_el$219, createComponent(Badge, {
+    }), _el$218);
+    insert(_el$219, () => tr(locale(), "世界规模", "World Scale"));
+    insert(_el$220, createComponent(Badge, {
       get children() {
         return `agents=${snapshotCounts().agents}`;
       }
     }), null);
-    insert(_el$219, createComponent(Badge, {
+    insert(_el$220, createComponent(Badge, {
       get children() {
         return `locations=${snapshotCounts().locations}`;
       }
     }), null);
-    insert(_el$219, createComponent(Badge, {
+    insert(_el$220, createComponent(Badge, {
       get children() {
         return `promptProfiles=${snapshotCounts().promptProfiles}`;
       }
     }), null);
-    insert(_el$219, createComponent(Badge, {
+    insert(_el$220, createComponent(Badge, {
       get children() {
         return `debugContexts=${snapshotCounts().executionDebugContexts}`;
       }
     }), null);
-    insert(_el$220, createComponent(MetricCard, {
+    insert(_el$221, createComponent(MetricCard, {
       get label() {
         return tr(locale(), "物理真值单位", "Canonical Physical Unit");
       },
@@ -8777,9 +8778,9 @@ function DetailsPanel() {
           }
         });
       }
-    }), _el$221);
-    insert(_el$221, () => worldScaleSurface().physicalTruth.canonicalUnitDetail);
-    insert(_el$220, createComponent(MetricCard, {
+    }), _el$222);
+    insert(_el$222, () => worldScaleSurface().physicalTruth.canonicalUnitDetail);
+    insert(_el$221, createComponent(MetricCard, {
       get label() {
         return tr(locale(), "世界边界", "World Bounds");
       },
@@ -8793,9 +8794,9 @@ function DetailsPanel() {
           }
         });
       }
-    }), _el$222);
-    insert(_el$222, () => worldScaleSurface().physicalTruth.worldBoundsDetail);
-    insert(_el$220, createComponent(Show, {
+    }), _el$223);
+    insert(_el$223, () => worldScaleSurface().physicalTruth.worldBoundsDetail);
+    insert(_el$221, createComponent(Show, {
       get when() {
         return worldScaleSurface().physicalTruth.anchor;
       },
@@ -8812,25 +8813,25 @@ function DetailsPanel() {
         },
         get children() {
           return [(() => {
-            var _el$232 = _tmpl$20();
-            insert(_el$232, () => anchor().positionLabel || tr(locale(), "缺少可读坐标。", "Missing readable coordinates."));
-            return _el$232;
+            var _el$233 = _tmpl$20();
+            insert(_el$233, () => anchor().positionLabel || tr(locale(), "缺少可读坐标。", "Missing readable coordinates."));
+            return _el$233;
           })(), createComponent(Show, {
             get when() {
               return anchor().radiusLabel;
             },
             get children() {
-              var _el$233 = _tmpl$49(), _el$234 = _el$233.firstChild;
-              insert(_el$233, () => tr(locale(), "地点半径真值", "Location radius truth"), _el$234);
-              insert(_el$233, () => anchor().radiusLabel, null);
-              return _el$233;
+              var _el$234 = _tmpl$49(), _el$235 = _el$234.firstChild;
+              insert(_el$234, () => tr(locale(), "地点半径真值", "Location radius truth"), _el$235);
+              insert(_el$234, () => anchor().radiusLabel, null);
+              return _el$234;
             }
           })];
         }
       })
-    }), _el$223);
-    insert(_el$224, () => tr(locale(), "最近距离样本", "Nearest Distance Samples"));
-    insert(_el$225, createComponent(Show, {
+    }), _el$224);
+    insert(_el$225, () => tr(locale(), "最近距离样本", "Nearest Distance Samples"));
+    insert(_el$226, createComponent(Show, {
       get when() {
         return worldScaleSurface().physicalTruth.nearestLocations.length > 0;
       },
@@ -8859,19 +8860,19 @@ function DetailsPanel() {
             },
             get children() {
               return [(() => {
-                var _el$235 = _tmpl$49(), _el$236 = _el$235.firstChild;
-                insert(_el$235, () => tr(locale(), "真实距离", "Physical distance"), _el$236);
-                insert(_el$235, () => location.distanceLabel || "-", null);
-                return _el$235;
+                var _el$236 = _tmpl$49(), _el$237 = _el$236.firstChild;
+                insert(_el$236, () => tr(locale(), "真实距离", "Physical distance"), _el$237);
+                insert(_el$236, () => location.distanceLabel || "-", null);
+                return _el$236;
               })(), createComponent(Show, {
                 get when() {
                   return location.radiusLabel;
                 },
                 get children() {
-                  var _el$237 = _tmpl$49(), _el$238 = _el$237.firstChild;
-                  insert(_el$237, () => tr(locale(), "地点半径", "Location radius"), _el$238);
-                  insert(_el$237, () => location.radiusLabel, null);
-                  return _el$237;
+                  var _el$238 = _tmpl$49(), _el$239 = _el$238.firstChild;
+                  insert(_el$238, () => tr(locale(), "地点半径", "Location radius"), _el$239);
+                  insert(_el$238, () => location.radiusLabel, null);
+                  return _el$238;
                 }
               })];
             }
@@ -8879,7 +8880,7 @@ function DetailsPanel() {
         });
       }
     }));
-    insert(_el$220, createComponent(EventCard, {
+    insert(_el$221, createComponent(EventCard, {
       get title() {
         return tr(locale(), "表现层说明", "Presentation Notes");
       },
@@ -8889,26 +8890,26 @@ function DetailsPanel() {
       badgeClass: "badge badge--warn",
       get children() {
         return [(() => {
-          var _el$226 = _tmpl$20();
-          insert(_el$226, () => worldScaleSurface().presentationScale.markerTruthNote);
-          return _el$226;
-        })(), (() => {
-          var _el$227 = _tmpl$4();
-          insert(_el$227, () => worldScaleSurface().presentationScale.zoomTruthNote);
+          var _el$227 = _tmpl$20();
+          insert(_el$227, () => worldScaleSurface().presentationScale.markerTruthNote);
           return _el$227;
         })(), (() => {
           var _el$228 = _tmpl$4();
-          insert(_el$228, () => worldScaleSurface().presentationScale.softwareSafeNote);
+          insert(_el$228, () => worldScaleSurface().presentationScale.zoomTruthNote);
           return _el$228;
+        })(), (() => {
+          var _el$229 = _tmpl$4();
+          insert(_el$229, () => worldScaleSurface().presentationScale.softwareSafeNote);
+          return _el$229;
         })()];
       }
     }), null);
-    insert(_el$220, createComponent(EmptyState, {
+    insert(_el$221, createComponent(EmptyState, {
       get children() {
         return tr(locale(), "主状态已经在中间的“世界摘要”里展示；这里现在专门保留“厘米真值 vs 表现层夸张”的读图锚点，原始快照仍按需展开。", "The main runtime state already lives in World Summary; this section now reserves the reading anchors for centimeter truth vs presentation exaggeration, while raw snapshots stay collapsible.");
       }
     }), null);
-    insert(_el$217, createComponent(Show, {
+    insert(_el$218, createComponent(Show, {
       get when() {
         return hasSnapshotDiagnostics();
       },
@@ -8927,46 +8928,46 @@ function DetailsPanel() {
         });
       }
     }), null);
-    insert(_el$215, createComponent(Show, {
+    insert(_el$216, createComponent(Show, {
       get when() {
         return state.lastError;
       },
       get children() {
-        var _el$229 = _tmpl$47(), _el$230 = _el$229.firstChild, _el$231 = _el$230.nextSibling;
-        insert(_el$230, () => tr(locale(), "最近错误", "Last Error"));
-        insert(_el$231, () => state.lastError);
-        return _el$229;
+        var _el$230 = _tmpl$47(), _el$231 = _el$230.firstChild, _el$232 = _el$231.nextSibling;
+        insert(_el$231, () => tr(locale(), "最近错误", "Last Error"));
+        insert(_el$232, () => state.lastError);
+        return _el$230;
       }
     }), null);
-    return _el$215;
+    return _el$216;
   })();
 }
 function AppShell() {
   const locale = () => uiLocale();
   return [createComponent(MobileJumpRail, {}), createComponent(HostedLoginGate, {}), (() => {
-    var _el$239 = _tmpl$50(), _el$240 = _el$239.firstChild, _el$241 = _el$240.firstChild, _el$242 = _el$241.nextSibling, _el$243 = _el$242.nextSibling, _el$244 = _el$240.nextSibling;
-    insert(_el$241, () => tr(locale(), "导航", "Navigate"));
-    insert(_el$242, () => tr(locale(), "目标", "Targets"));
-    insert(_el$243, () => tr(locale(), "先锁定对象，再进入世界舞台或右侧命令面。", "Lock onto a target first, then move into the stage or command surface."));
-    insert(_el$244, createComponent(TargetsPanel, {}));
-    return _el$239;
+    var _el$240 = _tmpl$50(), _el$241 = _el$240.firstChild, _el$242 = _el$241.firstChild, _el$243 = _el$242.nextSibling, _el$244 = _el$243.nextSibling, _el$245 = _el$241.nextSibling;
+    insert(_el$242, () => tr(locale(), "导航", "Navigate"));
+    insert(_el$243, () => tr(locale(), "目标", "Targets"));
+    insert(_el$244, () => tr(locale(), "先锁定对象，再进入世界舞台或右侧命令面。", "Lock onto a target first, then move into the stage or command surface."));
+    insert(_el$245, createComponent(TargetsPanel, {}));
+    return _el$240;
   })(), (() => {
-    var _el$245 = _tmpl$51(), _el$246 = _el$245.firstChild, _el$247 = _el$246.firstChild;
-    insert(_el$247, createComponent(WorldStageHero, {}), null);
-    insert(_el$247, createComponent(PixelWorldHost, {
+    var _el$246 = _tmpl$51(), _el$247 = _el$246.firstChild, _el$248 = _el$247.firstChild;
+    insert(_el$248, createComponent(WorldStageHero, {}), null);
+    insert(_el$248, createComponent(PixelWorldHost, {
       get locale() {
         return locale();
       }
     }), null);
-    insert(_el$247, createComponent(WorldSummaryPanel, {}), null);
-    return _el$245;
+    insert(_el$248, createComponent(WorldSummaryPanel, {}), null);
+    return _el$246;
   })(), (() => {
-    var _el$248 = _tmpl$52(), _el$249 = _el$248.firstChild, _el$250 = _el$249.firstChild, _el$251 = _el$250.nextSibling, _el$252 = _el$251.nextSibling, _el$253 = _el$249.nextSibling;
-    insert(_el$250, () => tr(locale(), "指挥与核查", "Command and Inspect"));
-    insert(_el$251, () => tr(locale(), "交互与明细", "Interact and Inspect"));
-    insert(_el$252, () => tr(locale(), "只有锁定目标后才进入这里。聊天优先，Prompt 与对象核查继续后置。", "Enter this column only after locking a target. Chat comes first; prompt controls and raw inspection stay behind it."));
-    insert(_el$253, createComponent(DetailsPanel, {}));
-    return _el$248;
+    var _el$249 = _tmpl$52(), _el$250 = _el$249.firstChild, _el$251 = _el$250.firstChild, _el$252 = _el$251.nextSibling, _el$253 = _el$252.nextSibling, _el$254 = _el$250.nextSibling;
+    insert(_el$251, () => tr(locale(), "指挥与核查", "Command and Inspect"));
+    insert(_el$252, () => tr(locale(), "交互与明细", "Interact and Inspect"));
+    insert(_el$253, () => tr(locale(), "只有锁定目标后才进入这里。聊天优先，Prompt 与对象核查继续后置。", "Enter this column only after locking a target. Chat comes first; prompt controls and raw inspection stay behind it."));
+    insert(_el$254, createComponent(DetailsPanel, {}));
+    return _el$249;
   })()];
 }
 function mountViewerApp(root = document.getElementById("app")) {

--- a/doc/world-simulator/README.md
+++ b/doc/world-simulator/README.md
@@ -5,6 +5,7 @@
 ## 从这里开始
 - 想先回答 world-simulator 在做什么、覆盖哪些边界：`doc/world-simulator/prd.md`
 - 想看当前执行任务、负责人、测试层级与最新完成态：`doc/world-simulator/project.md`
+- 想确认 Viewer / player-facing surface 的统一视觉设计规范：`doc/world-simulator/viewer/viewer-visual-design-spec-2026-06-05.design.md`；涉及 brand book、token、icon/status、资产准入和截图矩阵时读 `doc/world-simulator/viewer/viewer-brand-system-2026-06-05.design.md`
 - 想先进入 Viewer 热点子域，而不是在接近 300 份 Viewer 文档里盲扫：`doc/world-simulator/viewer/README.md`
 - 想执行 Viewer、走 Web 闭环或查操作步骤：`doc/world-simulator/viewer/viewer-manual.manual.md`
 - 想按子域或文件名继续下钻，而不是从长表里逐行找：`doc/world-simulator/prd.index.md`
@@ -22,6 +23,8 @@
 - `project.md` 是执行台账，适合确认当前活跃任务、测试层级、阻断与最新完成项。
 - `prd.index.md` 是定向检索索引，适合已经知道主题后按文件名查找，不是新读者的首读入口。
 - `viewer/README.md` 是 `viewer/` 热点子域的 landing page，负责把近 300 份 Viewer 文档按问题分流。
+- `viewer/viewer-visual-design-spec-2026-06-05.design.md` 是 Viewer / player-facing surface 的 canonical 视觉设计规范，负责视觉方向、层级、pixel-world 可读性与视觉评审 gate。
+- `viewer/viewer-brand-system-2026-06-05.design.md` 是 Viewer 视觉规范的 brand-system companion，负责 brand book、语义 token、icon/status vocabulary、资产语言与扩展截图矩阵。
 - `viewer/viewer-manual.manual.md` 是仓库内 canonical 操作手册；静态 `site/doc/**/viewer-manual.html` 仅作为公开只读镜像，不反向替代仓库权威源。
 
 ## 活跃阅读面边界

--- a/doc/world-simulator/prd.index.md
+++ b/doc/world-simulator/prd.index.md
@@ -22,6 +22,9 @@
 
 ## 活跃补充文档
 - `doc/world-simulator/viewer/README.md`：`viewer/` 热点子域 landing page，适合先做簇级分流，再决定进入 `manual`、`software_safe` 或 runtime live 专题。
+- `doc/world-simulator/viewer/viewer-visual-design-spec-2026-06-05.design.md`：Viewer / player-facing surface 的 canonical 视觉设计规范，覆盖视觉方向、层级、pixel-world 可读性、响应式/可访问性与视觉 review gate。
+- `doc/world-simulator/viewer/viewer-brand-system-2026-06-05.design.md`：Viewer 视觉规范 companion，覆盖 brand book、语义 token、icon/status vocabulary、资产语言、稳定 DOM hook 与扩展截图矩阵。
+- `doc/world-simulator/viewer/viewer-visual-system-review-card-2026-06-05.design.md`：本轮 Viewer 视觉系统大项的模型视觉 review card，引用 desktop/mobile/CJK/diagnostics/pixel-world 截图矩阵与 verdict。
 - `doc/world-simulator/viewer/viewer-manual.manual.md`：Viewer / Web 闭环 / operator 手册，不在下方 PRD 三件套长表中展开。
 - `doc/world-simulator/viewer/viewer-pixel-world-player-leverage-production-readability-2026-05-28.brainstorm.md`：pixel-world 商业化下一轮 bounded brainstorming，聚焦玩家因果、行动反馈、生产可读性与后续 runtime/viewer 协议候选。
 - `doc/world-simulator/llm/llm-provider-agent-direct-connect-review-2026-04-06.md`：`provider agent direct connect` 的正式 review，适合在判断双模式产品完整性、实施差距和后续 remediation 时定向进入。

--- a/doc/world-simulator/viewer/README.md
+++ b/doc/world-simulator/viewer/README.md
@@ -3,6 +3,7 @@
 更新时间: 2026-05-29
 
 ## 从这里开始
+- 想确认 Viewer / player-facing surface 的整体视觉方向、层级、pixel-world 可读性与视觉评审 gate：先读 `viewer-visual-design-spec-2026-06-05.design.md`；涉及 brand book、token、icon/status、资产准入和截图矩阵时继续读 `viewer-brand-system-2026-06-05.design.md`
 - 想执行 Viewer、走 Web 闭环、看命令或手工步骤：先读 `viewer-manual.manual.md`
 - 想确认正式浏览器主入口、`viewer` / `software_safe` 兼容边界或弱机/CI 默认路径：先读 `viewer-web-software-safe-mode-2026-03-16.prd.md`
 - 想确认 `legacy_core.js` 拆分边界、`viewer.js` / `software_safe.js` canonical/compat 关系，或 `pixel-world-bridge` generated runtime 真值：先读 `viewer-web-single-source-build-truth-2026-05-19.prd.md`
@@ -37,7 +38,19 @@
   - `viewer` canonical 入口、`software_safe` alias / bilingual URL / test API 怎么使用
 - 说明: 如果你是来“操作”而不是“做治理判断”，这里通常是第一入口。
 
-### 2. `viewer` 与正式 Web 主入口
+### 2. 视觉方向与评审 gate
+- 首读入口:
+  - `viewer-visual-design-spec-2026-06-05.design.md`
+  - `viewer-brand-system-2026-06-05.design.md`
+  - `viewer-visual-system-review-card-2026-06-05.design.md`
+- 适合问题:
+  - Viewer / player-facing surface 的统一视觉方向是什么
+  - 世界、目标、Agent、路径、回执、诊断的视觉层级怎么排
+  - pixel-world、2D 地图、移动端和视觉 review gate 应该按什么标准验收
+  - brand book、语义 token、icon/status vocabulary、资产语言和截图矩阵如何执行
+  - 本轮视觉系统大项的截图矩阵与模型视觉 review verdict 是什么
+
+### 3. `viewer` 与正式 Web 主入口
 - 首读入口:
   - `viewer-web-software-safe-mode-2026-03-16.prd.md`
   - `viewer-web-runtime-fatal-surfacing-2026-03-12.prd.md`
@@ -47,7 +60,7 @@
   - 弱机 / CI / 无 GPU 环境下的 canonical 路径是什么
   - 浏览器 fatal、语义测试接口、正式主入口怎么对齐
 
-### 3. runtime live / event-driven / control
+### 4. runtime live / event-driven / control
 - 首读入口:
   - `viewer-live-full-event-driven-phase10-2026-02-27.prd.md`
   - `viewer-live-runtime-world-migration-phase1-2026-03-04.prd.md`
@@ -58,7 +71,7 @@
   - step/control/live playback 的现行边界是什么
 - 说明: `phase8/9` 已物理合并到主文档，当前不应再从旧阶段文件倒推现行口径。
 
-### 4. chat / prompt / right panel
+### 5. chat / prompt / right panel
 - 首读入口:
   - `viewer-chat-right-panel-polish.prd.md`
   - `viewer-egui-right-panel.prd.md`
@@ -67,7 +80,7 @@
   - 聊天入口、右侧面板、Prompt profile 现在怎样组织
   - 输入法、回车发送、预设编辑这些问题该去哪里看
 
-### 5. release / 体验收口
+### 6. release / 体验收口
 - 首读入口:
   - `viewer-gameplay-release-experience-overhaul.prd.md`
 - 适合问题:
@@ -81,5 +94,7 @@
 
 ## 维护约定
 - 新增 Viewer 专题后，若改变了默认首读路径，应同步更新本页。
+- 任何改变 Viewer 默认视觉方向、player-facing screen flow、pixel-world 层级或视觉评审 gate 的任务，必须同步评估是否更新 `viewer-visual-design-spec-2026-06-05.design.md`。
+- 任何改变 Viewer brand book、语义 token、icon/status vocabulary、资产语言或截图矩阵的任务，必须同步评估是否更新 `viewer-brand-system-2026-06-05.design.md`。
 - 本页只维护簇级入口，不维护完整文件清单。
 - 若未来 `viewer/` 内部继续分裂出更高密度簇，再另开簇内治理专题，而不是把本页扩写成长表。

--- a/doc/world-simulator/viewer/viewer-brand-system-2026-06-05.design.md
+++ b/doc/world-simulator/viewer/viewer-brand-system-2026-06-05.design.md
@@ -1,0 +1,216 @@
+# Viewer Brand System Specification (2026-06-05)
+
+- Professional owner: `game_visual_interaction_designer`
+- Integration owner: `tpm`
+- Source task: `.pm/tasks/task_a25bf76359be45719edfcda1759626d1.yaml`
+- Parent visual spec: `viewer-visual-design-spec-2026-06-05.design.md`
+
+## 1. Purpose
+This document is the executable brand-system companion for Viewer visual work.
+It completes the brand book, token taxonomy, icon/status vocabulary, asset
+language, and screenshot matrix that the parent visual spec requires.
+
+The system is scoped to Viewer and player-facing world-simulator surfaces. It
+does not define public marketing identity, launcher branding, runtime protocol,
+or a new art-production pipeline.
+
+## 2. Brand Book
+### 2.1 Brand Position
+Viewer is an industrial world command table. It should feel precise, playable,
+and causally honest.
+
+The brand is:
+- world-first;
+- command-oriented;
+- technically credible;
+- calm under failure;
+- explicit about player agency.
+
+The brand is not:
+- a generic observability dashboard;
+- a marketing landing page;
+- a sci-fi decoration layer;
+- a raw DTO inspector as the first experience;
+- a single-color dark admin console.
+
+### 2.2 First Five Seconds
+Every Viewer first screen must answer:
+1. Which world/stage is this?
+2. Which objective, blocker, route, or actor matters?
+3. What is the next player move?
+4. Is there a player-facing action receipt?
+5. Where are diagnostics if needed?
+
+If a screenshot cannot answer these, the brand system has failed even when the
+colors are correct.
+
+### 2.3 Voice and Labels
+Player-facing copy uses action verbs and concrete state. Diagnostics may use
+technical labels, but they must be visually demoted and grouped under explicit
+diagnostic surfaces.
+
+Preferred label forms:
+- `Objective`, not `Goal DTO`.
+- `Next Move`, not `Pending Handler`.
+- `Action Receipt`, not `Latest Event`.
+- `Renderer Not Attached`, not silent fallback.
+- `position=location_derived`, not hidden inferred coordinate.
+
+## 3. Token Taxonomy
+Tokens are semantic roles. Implementation variables may alias existing CSS
+values, but new work must refer to these roles in docs, review notes, and
+acceptance criteria.
+
+### 3.1 Color Tokens
+| Token | Role | Current Viewer alias |
+| --- | --- | --- |
+| `--color-world-background` | page/stage base | `--bg` |
+| `--color-world-depth` | deepest stage background | `--bg-deep` |
+| `--color-panel-surface` | command/context panels | `--panel` |
+| `--color-panel-strong` | panel headers and raised tools | `--panel-strong` |
+| `--color-stage-surface` | primary world stage | `--panel-stage` |
+| `--color-border-subtle` | default low-emphasis border | `--border` |
+| `--color-border-stage` | world/stage emphasis | `--border-strong` |
+| `--color-text-primary` | primary readable text | `--text` |
+| `--color-text-muted` | diagnostic/context detail | `--muted` |
+| `--color-agent-primary` | active player-relevant actor | `--accent` |
+| `--color-objective-accent` | objective and next move | `--accent-strong` |
+| `--color-route-active` | active relationship/path | `--accent` |
+| `--color-receipt-success` | completed/applied result | `--good` |
+| `--color-blocker-danger` | blocked/error/missing requirement | `--bad` |
+| `--color-warning` | recoverable warning/blocker | `--warn` |
+| `--color-diagnostic-muted` | QA/runtime metadata | `--muted` |
+| `--color-focus-ring` | keyboard/selection focus | `--accent-strong` |
+
+### 3.2 Typography Tokens
+| Token | Role | Current implementation |
+| --- | --- | --- |
+| `--font-viewer-body` | all normal UI text | `--font-body` |
+| `--font-viewer-display` | stage/hero identity | `--font-display` |
+| `--font-viewer-mono` | JSON and technical values | `--font-mono` |
+| `--type-world-title` | true stage title | `.stage-hero__title` |
+| `--type-objective-title` | objective/selected subject | `.pixel-world-command-cell__value` |
+| `--type-action-label` | next executable move | `.pixel-world-command-cell__value` |
+| `--type-receipt-body` | result/cause/effect | `.pixel-world-action-receipt__summary` |
+| `--type-diagnostic-caption` | runtime/provider metadata | `.diagnostic-surface__meta` |
+
+### 3.3 Space, Radius, and Motion Tokens
+| Token | Role | Current value |
+| --- | --- | --- |
+| `--space-panel-gap` | desktop shell/panel gap | `18px` |
+| `--space-stack-gap` | internal vertical rhythm | `16px` |
+| `--space-control-gap` | badge/toolbar gap | `8px` |
+| `--radius-tool` | buttons, inputs, compact tools | `12px` |
+| `--radius-stage` | primary stage/pixel-world frame | `18px` |
+| `--radius-panel` | section panels | `20px` |
+| `--motion-feedback-fast` | hover/focus/status emphasis | `140ms` |
+
+### 3.4 Governance Rules
+- Do not add new hard-coded colors without mapping them to this table.
+- If a task needs a new semantic state, add the token and status vocabulary
+  first, then use it in CSS/JS/tests.
+- Token aliases may evolve, but token meanings must not drift without updating
+  this document and the parent visual spec.
+- Any CSS token change requires at least one desktop screenshot and mobile
+  screenshot when responsive or first-screen surfaces are affected.
+
+## 4. Icon and Status Vocabulary
+Viewer currently uses text/badge status marks rather than a shipped icon pack.
+That remains valid: stable text, shape, placement, and data attributes are the
+canonical icon vocabulary until an icon library is adopted.
+
+### 4.1 Required Status Marks
+| Status | Visual mark | Text equivalent | Data/test hook |
+| --- | --- | --- | --- |
+| selected | accent border or selected callout | `Selected` / `Current Selection` | `data-selected`, selection callout |
+| target | accent badge and target panel | `Current Target` | `data-select-kind` |
+| blocker | warn/danger badge or receipt state | `Blocker`, `World Constraint` | `data-receipt-state=blocked` |
+| active route | route line between agent/location | route kind label | `data-route-kind` |
+| accepted intent | command-stage card | `Accepted Intent` | stable text |
+| executing | progress/action copy | `Executing` or explicit stage | future `data-action-state` |
+| completed | success badge/receipt | `completed` / receipt summary | `data-receipt-state=completed` |
+| no receipt | muted receipt state | `No action receipt yet` | `data-receipt-present=false` |
+| derived position | badge/source label | `position=location_derived` | `data-position-source` |
+| fallback renderer | visible callout | `Renderer Not Attached` | `renderer=fallback` text |
+| diagnostics | muted collapsed surface | `Runtime Diagnostics` | `#viewer-diagnostics-panel` |
+
+### 4.2 Icon Pack Rule
+If a future task introduces an icon library, it must map icons to the table
+above and preserve text equivalents. Icons may reinforce state, but they must
+not be the only state signal.
+
+## 5. Asset Language
+### 5.1 Current Asset Scope
+The current Viewer brand system relies on CSS, DOM shapes, text badges, canvas
+fallback surfaces, and generated pixel-world screenshots. No new bitmap art pack
+is required for this task.
+
+### 5.2 Allowed Asset Types
+- screenshots and visual smoke artifacts under ignored `output/playwright/`;
+- favicon and existing static Viewer assets;
+- future small symbol/icon assets only when they map to the status vocabulary;
+- generated bitmap references only when a task needs marketing or illustrative
+  material outside the software-safe product surface.
+
+### 5.3 Asset Acceptance
+An asset is acceptable only if it:
+- makes agent, route, objective, blocker, receipt, or fallback state easier to
+  read;
+- does not compete with the world stage;
+- has a text or semantic equivalent;
+- works in desktop and mobile screenshots;
+- has an owner and evidence path in the task log.
+
+Assets that are purely atmospheric, ornamental, blurred, or unrelated to the
+actual world state are not valid for Viewer product surfaces.
+
+## 6. Screenshot and Visual Evidence Matrix
+Any visible change must choose the smallest row set that covers its risk. A
+large visual-system change must run all required rows.
+
+| Row | Viewport/state | Required for | Evidence |
+| --- | --- | --- | --- |
+| desktop player first screen | 1280x720 or wider | all stage/layout/token changes | screenshot or browser DOM+visual smoke |
+| mobile player first screen | 390x844 or equivalent | navigation, first screen, text density | screenshot or browser DOM+visual smoke |
+| diagnostics demotion | Runtime Diagnostics collapsed | diagnostics, routing, QA surfaces | DOM/test assertion plus screenshot when visual |
+| fallback renderer | host fallback visible | renderer/fallback/pixel-world work | `test:pixel-world:visual` screenshot |
+| action receipt | present receipt | command/receipt/action work | `action-receipt-visual.png` or equivalent |
+| no receipt | no player-caused receipt | causality/data honesty work | UI test or targeted screenshot |
+| dense pixel-world | agent/location/route/terrain together | layer priority changes | pixel-world visual smoke |
+| CJK/long text | `locale=zh` and long labels where touched | typography/density/localization changes | screenshot or targeted DOM overflow probe |
+| focus/keyboard | focusable controls/canvas where touched | accessibility changes | CSS/test/browser evidence |
+
+Blocking findings:
+- horizontal overflow on supported mobile width;
+- clipped primary command or unreadable receipt/blocker;
+- diagnostics louder than command/world surfaces;
+- fallback without explicit fallback label;
+- derived position without source label;
+- color-only critical state;
+- focusable product control with no visible focus style.
+
+## 7. Current Implementation Hooks
+Current implementation anchors for this brand system:
+- `#viewer-stage-panel`: world/stage surface.
+- `#viewer-targets-panel`: target selection surface.
+- `#viewer-details-panel`: command/context surface.
+- `#viewer-diagnostics-panel`: demoted diagnostics surface.
+- `.mobile-rail`: mobile route.
+- `.pixel-world-command-strip`: objective/next move/player leverage.
+- `.pixel-world-action-receipt`: player-facing receipt state.
+- `.pixel-world-canvas`: world surface and fallback DOM.
+- `.pixel-world-render-diagnostics`: renderer diagnostics.
+
+These hooks are part of the visual-system contract. Rename or remove them only
+with test and documentation updates.
+
+## 8. Done Criteria for Visual-System Changes
+A visual-system task is done only when:
+- this document and the parent visual spec stay in sync;
+- CSS/DOM hooks use semantic tokens or documented aliases;
+- status marks include text equivalents and stable hooks;
+- relevant screenshots or visual smoke artifacts are recorded;
+- `npm --prefix crates/oasis7_viewer run test:ui` passes;
+- `npm --prefix crates/oasis7_viewer run build:software-safe` passes;
+- `git diff --check` and `./scripts/doc-governance-check.sh` pass;
+- task execution log records role verdicts and evidence paths.

--- a/doc/world-simulator/viewer/viewer-visual-design-spec-2026-06-05.design.md
+++ b/doc/world-simulator/viewer/viewer-visual-design-spec-2026-06-05.design.md
@@ -1,0 +1,399 @@
+# Viewer Visual Design Specification (2026-06-05)
+
+- Professional owner: `game_visual_interaction_designer`
+- Integration owner: `tpm`
+- Source task: `.pm/tasks/task_a25bf76359be45719edfcda1759626d1.yaml`
+- Related entrypoints:
+  - `doc/world-simulator/viewer/viewer-brand-system-2026-06-05.design.md`
+  - `doc/world-simulator/viewer/viewer-gameplay-release-experience-overhaul.prd.md`
+  - `doc/world-simulator/viewer/viewer-web-entry-visual-redesign-2026-05-12.prd.md`
+  - `doc/world-simulator/viewer/viewer-pixel-world-commercial-rendering-loop-2026-05-28.prd.md`
+  - `doc/testing/manual/model-visual-review-sop-2026-05-29.manual.md`
+
+## 1. Purpose
+This document is the canonical visual design specification for Viewer and
+player-facing world-simulator screens. It consolidates the current visual
+direction that was previously spread across release experience, Viewer Web,
+pixel-world, 2D readability, and visual review SOP documents.
+
+The professional visual direction in this document is owned by the
+`game_visual_interaction_designer` slice recorded in
+`.pm/tasks/task_a25bf76359be45719edfcda1759626d1.execution.md`. TPM integrated
+that slice into the repository docs and does not replace the professional role's
+visual judgment.
+
+The specification answers:
+- what a player should notice first;
+- how world, agent, action, diagnostics, and command surfaces are layered;
+- which visual rules are non-negotiable for new Viewer work;
+- what evidence is required before a visual change can be considered ready.
+
+For executable brand-system details, token taxonomy, icon/status vocabulary,
+asset-language rules, and the expanded screenshot matrix, use
+`viewer-brand-system-2026-06-05.design.md` as the companion specification.
+
+## 2. Scope
+In scope:
+- Viewer Web and `software_safe` player-facing screens.
+- Pixel-world stage, fallback DOM world surfaces, 2D map/readability overlays,
+  right-side command surfaces, chat/prompt panels, receipts, blockers, empty
+  states, loading states, and diagnostics disclosure.
+- Site or documentation screenshots only when they represent the current Viewer
+  experience.
+
+Out of scope:
+- Runtime rules, economy balance, networking, auth, chain state, or WASM ABI
+  semantics.
+- New large art packs, marketing campaign visuals, launcher/explorer redesigns,
+  or public brand identity outside Viewer. Viewer-specific brand-system rules
+  are in `viewer-brand-system-2026-06-05.design.md`.
+- Real-player retention claims, external messaging, release approval, or
+  GitHub required review.
+
+## 3. Source Documents Consolidated
+This specification consolidates and does not replace:
+- `viewer-gameplay-release-experience-overhaul.prd.md`: Player mode,
+  Director mode, world-first release experience, and command discoverability.
+- `viewer-web-entry-visual-redesign-2026-05-12.prd.md`: industrial world
+  command table direction, stage-first layout, diagnostics demotion, and
+  `World / Targets / Command` mobile route.
+- `viewer-pixel-world-semantic-positioning-2026-05-26.prd.md`: sparse snapshot
+  semantic positioning, `location_derived` honesty, and relationship-line
+  readability.
+- `viewer-pixel-world-commercial-rendering-loop-2026-05-28.prd.md`:
+  commercial HUD, player leverage, route readability, and diagnostics collapse.
+- `viewer-2d-visual-polish.design.md`: 2D symbol layer, label LOD, and flow
+  overlay readability.
+- `doc/testing/manual/model-visual-review-sop-2026-05-29.manual.md`:
+  screenshot-based visual review gate, model review rubric, and escalation
+  boundaries.
+
+Runtime, QA, release, LiveOps, and GitHub governance authority remains with the
+corresponding role/process. This document defines visual direction and review
+expectations.
+
+## 4. Product Visual North Star
+The Viewer must feel like an industrial world command table, not a generic dark
+diagnostics dashboard.
+
+The player should read the screen in this order:
+1. What world or stage am I looking at?
+2. Which agent, location, objective, blocker, or route matters now?
+3. What can I do next?
+4. What happened because of the latest player or agent action?
+5. Where can I open deeper diagnostics if I need them?
+
+This order is more important than any single color, card shape, or layout
+variant. When space is constrained, preserve the reading order and remove
+secondary detail before shrinking the main subject.
+
+## 5. Non-Negotiable Principles
+### 5.1 World First
+- The world stage is the primary visual surface in Player mode.
+- Diagnostics, raw JSON, renderer badges, provider checks, and governance labels
+  must never compete with the world stage on first load.
+- If a renderer is degraded or missing, the fallback surface must still show an
+  honest world summary and the reason for degraded mode.
+
+### 5.2 Player Leverage Before Ambient Activity
+- The UI must distinguish player-caused progress from ambient simulation
+  movement.
+- A busy world is not automatically a successful player action.
+- Receipts must answer: what was attempted, what changed, what is blocked, and
+  what the next step is.
+
+### 5.3 Diagnostics Are Available, Not Dominant
+- Director and QA capabilities remain reachable.
+- In Player mode, advanced controls and diagnostics are demoted to drawers,
+  collapsible panels, secondary tabs, or explicit mode switches.
+- Hiding diagnostics is acceptable only when the route back to them remains
+  discoverable and scriptable.
+
+### 5.4 Data Honesty
+- Derived visual positions, fallback states, inferred routes, and missing
+  runtime fields must be labelled or visually scoped so they cannot be mistaken
+  for authoritative runtime truth.
+- Visual hierarchy must not imply progress, causality, health, or ownership
+  that the DTO/state does not support.
+
+### 5.5 One Obvious Command Path
+- Player mode must keep the primary command route one explicit step away from
+  the world stage.
+- Advanced layouts, debug presets, and secondary prompt tools may exist, but
+  they must not hide the first command path.
+- If the primary command is disabled, blocked, or waiting on data, the reason
+  and recovery path must be visible.
+
+### 5.6 Sparse Worlds Still Communicate Relationships
+- Sparse snapshots must still read as a world, not as isolated dots.
+- Agent-location links, route lines, hotspots, semantic badges, and textual
+  summaries are mandatory tools for sparse-state readability.
+- Fallback DOM views should preserve relationships whenever canvas/wasm surfaces
+  are degraded.
+
+### 5.7 Readability Beats Decorative Density
+- Avoid adding decorative panels, badges, grids, particles, or status chips when
+  they reduce scan speed.
+- Fragment terrain, location anchors, and background world texture support the
+  active agent/action read; they do not become the first visual subject unless a
+  task specifically makes them the subject.
+
+## 6. Visual Language
+The durable brand-system companion for this section is
+`viewer-brand-system-2026-06-05.design.md`. New visible Viewer work must use the
+token taxonomy, icon/status vocabulary, asset-language rules, and screenshot
+matrix defined there.
+
+### 6.1 Tone
+- Industrial, precise, command-oriented, and playable.
+- The interface can feel technical, but it should not feel like an internal log
+  viewer by default.
+- Avoid one-note dark dashboard language where every surface has the same weight.
+
+### 6.2 Surface Hierarchy
+Use four surface levels:
+
+| Level | Purpose | Examples | Default prominence |
+| --- | --- | --- | --- |
+| Stage | Primary world comprehension | Pixel-world canvas, 2D map, selected target overlay | Highest |
+| Command | Player decision and action | objective, next action, chat command, action receipt | High |
+| Context | Helpful state and explanation | target details, recent events, route counts, lightweight summaries | Medium |
+| Diagnostics | Engineering and QA visibility | renderer status, raw DTO, provider checks, governance lanes | Low / collapsed |
+
+### 6.3 Color Semantics
+Color is semantic, not ornamental:
+- `world-background`: low-distraction stage base.
+- `terrain-subdued`: background Fragment and world-body detail.
+- `agent-primary`: player-relevant active actor.
+- `route-active`: current or selected relationship/action path.
+- `objective-accent`: current goal and recommended next step.
+- `blocker-danger`: blocked/error/missing requirement.
+- `receipt-success`: applied/completed feedback.
+- `diagnostic-muted`: technical or QA-only metadata.
+- `panel-surface`: command/context tool surfaces.
+- `focus-ring`: keyboard and selection focus.
+
+Do not encode critical state only by color; pair color with label, icon, shape,
+or placement.
+
+### 6.4 Typography and Copy Density
+- `world-title`: stage identity.
+- `objective-title`: current goal.
+- `action-label`: executable or recommended next step.
+- `receipt-body`: result feedback and cause/effect text.
+- `diagnostic-caption`: engineering/status metadata.
+
+- Player-facing headings should be short and action-oriented.
+- Compact panels should use compact headings; reserve large type for true stage
+  or route-level focus.
+- Diagnostic labels may be terse, but player receipts and blockers must be
+  understandable without reading raw state names.
+- CJK text must remain readable and must not fallback to missing glyph boxes.
+
+### 6.5 Shape and Layout
+- Use strong alignment, consistent spacing, and clear grouping instead of nested
+  card walls.
+- Cards are for repeated items, modal-like surfaces, or true framed tools, not
+  for wrapping every page section.
+- Stable stage, toolbar, grid, and panel dimensions are required so hover,
+  status text, labels, and loading states do not shift the layout.
+
+### 6.6 Status Vocabulary
+The following states need stable visual and text equivalents:
+- selected;
+- target;
+- blocker;
+- active route;
+- accepted intent;
+- executing;
+- completed;
+- no receipt;
+- derived position;
+- fallback or degraded renderer.
+
+## 7. Information Architecture
+### 7.1 Player Mode Default
+Player mode must show:
+- world/stage;
+- current objective or selected target;
+- next action or blocker;
+- latest receipt or current action feedback;
+- a clear route into command/chat.
+
+Player mode must demote:
+- raw runtime JSON;
+- renderer implementation status;
+- provider/auth/governance detail;
+- test controls;
+- long event lists.
+
+### 7.2 Director Mode
+Director mode may expose denser diagnostics, but it still follows data honesty
+and hierarchy rules. Director mode is not permission to make every surface equal.
+
+### 7.3 HUD and Side Panel Hierarchy
+- HUD: objective, next action, player leverage, blocker, receipt.
+- Right/side panel: selected target, command/chat, recent context, then
+  diagnostics.
+- Diagnostics panel: runtime status, renderer status, provider/auth/governance,
+  raw DTO, test controls.
+
+### 7.4 Empty, Loading, Error, and Fallback Hierarchy
+- First: state name and whether player action is possible.
+- Second: reason or missing dependency.
+- Third: recovery path or next observable signal.
+- Fourth: diagnostic detail, collapsed unless it is the recovery path.
+
+### 7.5 Mobile and Narrow Screens
+Mobile must preserve the same conceptual route as desktop:
+- `World`
+- `Targets`
+- `Command`
+- optional `Diagnostics`
+
+Do not rely on one long single-column stack when that makes the player scroll
+past the world before finding the command path.
+
+## 8. Pixel-World Layering
+Pixel-world surfaces use this priority order:
+1. World Command Board: objective, next action, player leverage.
+2. Action Receipt / Blocker: latest meaningful feedback.
+3. Active Agent and selected target.
+4. Routes, relationships, hotspots, and goal callouts.
+5. Locations and logical anchors.
+6. Fragment terrain and ambient background.
+7. Renderer diagnostics and raw DTO controls.
+
+Fragment terrain should make the world feel physically present, but the active
+agent, route, objective, and receipt must remain easier to identify.
+
+When exact coordinates are missing:
+- derived positions may be used for readability;
+- the source must remain inspectable as `location_derived`, fallback, or
+  equivalent;
+- derived visuals must not claim runtime authority.
+
+## 9. 2D Map Rules
+- 2D mode may introduce high-contrast Location and Agent symbols that are not
+  shown in 3D mode.
+- Label LOD must prioritize selected/active Agent, current objective, blocker,
+  and route labels before ambient Location labels.
+- Flow overlays should use direction arrows or equivalent marks when they
+  clarify current movement, logistics, or command effect.
+- 2D overlays must not leak into 3D mode after camera mode changes.
+- Dense map labels should degrade by hiding secondary labels, not by shrinking
+  all text below readability.
+
+## 10. Interaction and Feedback
+### 10.1 Selection
+- Selecting an entity must produce a visible focus state and a readable details
+  surface.
+- Selection should not hide the current objective or next step.
+- If an entity is decorative/background-only, do not make it look selectable.
+
+### 10.2 Command
+- The command route must be visible within one player-facing step from the main
+  stage.
+- Chat/prompt controls must not be buried behind diagnostics.
+- Disabled or unavailable commands require a clear reason.
+
+### 10.3 Receipt
+Every action feedback surface should answer:
+- action: what was attempted;
+- result: what changed or did not change;
+- reason: why it succeeded, stalled, or failed;
+- next: what the player can do now.
+
+### 10.4 Loading, Empty, Error, and Fallback States
+- Loading states must reserve layout space and avoid stage jumps.
+- Empty states must explain whether the world is empty, still loading, filtered,
+  or degraded.
+- Error states must distinguish player-fixable blockers from system failures.
+- Fallback rendering must be explicit; silent renderer substitution is not a
+  valid player-facing state.
+
+## 11. Accessibility and Robustness
+- Critical text must remain readable on desktop and mobile viewports.
+- Primary controls must be keyboard reachable where the surface supports DOM
+  interaction.
+- Focus states must be visible.
+- Color contrast must be sufficient for objective, blocker, receipt, and command
+  labels.
+- Motion and animation should clarify cause/effect; do not depend on motion as
+  the only indicator of progress.
+- Avoid horizontal overflow, clipped button text, overlapping labels, and hidden
+  main actions.
+
+## 12. Visual Review Gate
+Any change that affects visible output must trigger screenshot-based visual
+review under `doc/testing/manual/model-visual-review-sop-2026-05-29.manual.md`.
+
+Minimum evidence:
+- desktop screenshot of the target surface;
+- mobile screenshot when the change touches first screen, responsive behavior,
+  navigation, stage layout, command route, or text density;
+- automated summary such as DOM/UI tests, console/state probe, visual smoke, or
+  explicit reason when an automated check is not available;
+- expected visual contract for the change.
+
+For visual-system or large surface changes, also apply the expanded matrix in
+`viewer-brand-system-2026-06-05.design.md#6-screenshot-and-visual-evidence-matrix`.
+
+Must-pass checks:
+- first visual focus matches the task goal;
+- stage, objective, command, receipt, and diagnostics are ordered correctly;
+- no blocking overlap, clipping, horizontal overflow, or illegible text;
+- UI does not imply unsupported causality or progress;
+- mobile preserves the same main route as desktop;
+- diagnostics do not dominate Player mode.
+
+Escalate to human or owner review when:
+- visual direction, interaction feel, or player screen flow is disputed;
+- model confidence is low;
+- screenshot evidence lacks a key viewport;
+- the verdict affects release notes, public claims, or user promises;
+- the same issue remains `watch` after two rounds.
+
+Pixel-world specific blockers:
+- Agent is less visible than Fragment terrain.
+- Renderer diagnostics are louder than the command board or action receipt.
+- Location markers dominate as main entities when the task is agent/action
+  focused.
+- Derived or missing positions lack an honest source marker.
+- Sparse snapshots do not show relationships, route, or readable fallback.
+
+## 13. Implementation Brief for Viewer Work
+Viewer implementation tasks that change visible surfaces should include:
+- target mode: Player, Director, or both;
+- primary first-read subject;
+- affected stage/command/context/diagnostics level;
+- expected receipt/blocker/empty/fallback behavior;
+- desktop and mobile screenshot plan;
+- DOM or semantic test anchors that must remain stable;
+- explicit non-goals, especially protocol, runtime, and art-pipeline boundaries.
+
+## 14. Acceptance Criteria for Future Visual Changes
+- The change preserves world-first reading order.
+- Player leverage is more prominent than ambient simulation activity.
+- Diagnostics remain reachable but demoted.
+- Visual states map honestly to current DTO/runtime truth.
+- Pixel-world layers follow the priority order in this spec.
+- Responsive layouts preserve `World / Targets / Command`.
+- Screenshot review and automated evidence are attached before completion claims.
+
+## 15. Governance
+- This document is the canonical visual design specification for Viewer and
+  player-facing world-simulator surfaces.
+- Topic-specific PRDs may add stricter rules for their own scope, but they should
+  not weaken this document's hierarchy, data honesty, or review-gate rules.
+- If a future task changes the default visual direction, update this document and
+  link the decision from `doc/world-simulator/viewer/README.md`.
+
+## 16. Residual Risks
+- The final Viewer brand book, token taxonomy, icon/status vocabulary,
+  asset-language rules, and expanded screenshot matrix now live in
+  `viewer-brand-system-2026-06-05.design.md`.
+- The brand-system companion does not create a new runtime feature, public
+  marketing identity, or external art-production pipeline.
+- It does not replace `viewer_engineer` feasibility judgment, `qa_engineer`
+  release-blocking judgment, or `liveops_community` public messaging ownership.

--- a/doc/world-simulator/viewer/viewer-visual-system-review-card-2026-06-05.design.md
+++ b/doc/world-simulator/viewer/viewer-visual-system-review-card-2026-06-05.design.md
@@ -1,0 +1,85 @@
+# Viewer Visual System Review Card (2026-06-05 21:26:33 CST)
+
+- task_uid: `task_a25bf76359be45719edfcda1759626d1`
+- branch: `task/world-simulator-viewer-visual-design-spec`
+- reviewer: Codex model visual review using repository screenshots
+- surface: Viewer `software_safe` player-facing visual system
+- locale: `en`, `zh`
+- viewport set: desktop 1280x720, mobile 390x844
+
+## Inputs
+- Change goal: complete the Viewer visual-system large items: brand book,
+  token governance, icon/status vocabulary, asset-language rules, stable visual
+  DOM hooks, and expanded screenshot evidence.
+- Expected visual contract: Viewer remains an industrial world command table:
+  world and command path first, diagnostics demoted, fallback honest, action
+  receipts clear, sparse pixel-world layers readable, and CJK/mobile text not
+  clipped.
+- Screenshots:
+  - `output/playwright/viewer-visual-system/2026-06-05T13-26-33Z/desktop-player-first-screen.png`
+  - `output/playwright/viewer-visual-system/2026-06-05T13-26-33Z/mobile-player-first-screen.png`
+  - `output/playwright/viewer-visual-system/2026-06-05T13-26-33Z/diagnostics-demotion-collapsed.png`
+  - `output/playwright/viewer-visual-system/2026-06-05T13-26-33Z/cjk-long-text-mobile.png`
+  - `output/playwright/pixel-world-fragment-visual/2026-06-05T13-43-42-359Z/fragment-fallback-visual.png`
+  - `output/playwright/pixel-world-fragment-visual/2026-06-05T13-43-42-359Z/action-receipt-visual.png`
+  - `output/playwright/pixel-world-fragment-visual/2026-06-05T13-43-42-359Z/mobile-action-receipt-visual.png`
+- Automated evidence:
+  - `output/playwright/viewer-visual-system/2026-06-05T13-26-33Z/focus-keyboard-visible-probe.json`
+  - `output/playwright/viewer-visual-system/2026-06-05T13-26-33Z/fallback-renderer-hook-probe.json`
+  - `output/playwright/pixel-world-fragment-visual/2026-06-05T13-43-42-359Z/summary.json`
+- Known out of scope: public marketing identity, external art production,
+  runtime protocol, launcher/explorer redesign, and GitHub approval.
+
+## Verdict
+- verdict: `pass`
+- confidence: `high`
+- human escalation needed: `no`
+- owner action: Keep the brand-system companion linked from module entrypoints
+  and require the screenshot matrix for future large visual-system changes.
+
+## Must-Pass Checks
+| Check | Result | Evidence / Note |
+| --- | --- | --- |
+| First visual focus matches the task goal | pass | Desktop and mobile first screens lead with the world command desk and next-step cards. |
+| Main subject remains readable | pass | World, objective, accepted intent, and next step are readable at 1280x720 and 390x844. |
+| No major overlap, crop, or horizontal overflow | pass | Mobile screenshot has no horizontal rail overflow; probe reports `horizontalOverflow=false`. |
+| UI state is honest against supplied state / DTO evidence | pass | Empty/sync state is presented as waiting; fallback and derived state hooks are explicit. |
+| Action feedback / blocker / next step is visible when required | pass | Visual smoke covers action receipt and mobile action receipt screenshots. |
+| Diagnostics or debug panels do not dominate the primary player path | pass | Diagnostics screenshot shows Runtime Diagnostics after the player path summary and as a collapsed summary surface. |
+| Desktop and mobile preserve the same priority order | pass | Desktop three-column layout and mobile rail keep World/Targets/Command/Diagnostics ordering. |
+
+## Findings
+1. No blocking visual findings.
+2. Brand-system governance is represented as a separate companion spec, which is
+   easier to enforce than expanding the parent visual spec indefinitely.
+3. Focus evidence is CSS/probe based rather than a successful keyboard
+   screenshot because the in-app browser keypress probe did not advance focus
+   reliably; the CSS rule covers `a`, `button`, `canvas`, `summary`, `input`,
+   `textarea`, and `select` with a semantic `--color-focus-ring` token.
+
+## Pixel-World Addendum
+- agent_readability: pass; visual smoke keeps world command board and action
+  receipt above renderer diagnostics.
+- fragment_background_role: pass; visual smoke and tests keep Fragment terrain
+  as background behind routes/anchors/agents.
+- location_logic_anchor_role: pass; locations are treated as logic anchors.
+- action_receipt_clarity: pass; action receipt screenshots show player-facing
+  feedback.
+- no_receipt_honesty: pass by automated UI test coverage; no-receipt remains
+  `data-receipt-present=false` and `confidence=none`.
+
+## What This Review Does Not Prove
+- It does not validate public marketing identity or future external artwork.
+- It does not prove real player comprehension.
+- It does not replace runtime, security, auth, or GitHub approval gates.
+
+## Residual Risk
+- Dense live data with many real agents/locations may still need a future
+  screenshot matrix once runtime provides richer snapshots.
+- The focus proof is CSS/probe based; a future browser harness with reliable
+  keyboard focus screenshots would make this evidence stronger.
+
+## Escalation Notes
+- escalation_reason: none
+- requested_human_owner: none
+- decision_needed_by: N/A


### PR DESCRIPTION
## Summary
- add the canonical Viewer visual design spec, brand-system companion, and formal visual review card
- align Viewer implementation with semantic visual tokens, mobile diagnostics demotion, and stable visual-system DOM hooks
- add tests for visual-system hooks and rebuild the checked-in Viewer bundle

## Verification
- npm --prefix crates/oasis7_viewer run test:ui
- npm --prefix crates/oasis7_viewer run build:software-safe
- npm --prefix crates/oasis7_viewer run test:pixel-world:visual
- git diff --check
- ./scripts/doc-governance-check.sh
- targeted ./scripts/pm/lint.sh check for task_a25bf76359be45719edfcda1759626d1

## Pre-PR local role review
- game_visual_interaction_designer: pass, no_findings, ready
- viewer_engineer: pass, no_findings, ready
- qa_engineer: pass, no_findings, ready