### PR TITLE
Add dedicated mainnet package workflow

### DIFF
--- a/.github/workflows/mainnet-packages.yml
+++ b/.github/workflows/mainnet-packages.yml
@@ -1,0 +1,638 @@
+name: Mainnet Packages
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Mainnet release tag, e.g. v0.1.0 or 2026-06-03_v1"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: mainnet-packages-${{ github.event.inputs.tag }}
+  cancel-in-progress: false
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+  CARGO_NET_RETRY: 10
+  CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
+  CARGO_PROFILE_DEV_DEBUG: 0
+  CARGO_PROFILE_TEST_DEBUG: 0
+  RUST_TOOLCHAIN: 1.96.0
+  BUILTIN_WASM_TOOLCHAIN: nightly-2025-12-11
+  BUILTIN_WASM_TARGET: wasm32-unknown-unknown
+
+jobs:
+  plan:
+    name: plan-mainnet-package
+    runs-on: ubuntu-24.04
+    outputs:
+      ref: ${{ steps.plan.outputs.ref }}
+      version: ${{ steps.plan.outputs.version }}
+      matrix: ${{ steps.plan.outputs.matrix }}
+    steps:
+      - id: plan
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          tag="${{ inputs.tag }}"
+          if [[ -z "${tag}" ]]; then
+            echo "error: mainnet package tag is required" >&2
+            exit 1
+          fi
+          if [[ ! "${tag}" =~ ^v[0-9].* && ! "${tag}" =~ ^20[0-9]{2}-[0-9]{2}-[0-9]{2}_v[0-9]+$ ]]; then
+            echo "error: tag must be semver-like (v*) or daily date tag (YYYY-MM-DD_vN): ${tag}" >&2
+            exit 1
+          fi
+
+          version="${tag#v}"
+          matrix='{"include":[{"os":"ubuntu-24.04","platform":"linux-x64","asset_name":"oasis7-linux-x86_64.AppImage","target_triple":"native"},{"os":"macos-14","platform":"macos-x64","asset_name":"oasis7-macos-x64.dmg","target_triple":"x86_64-apple-darwin"},{"os":"windows-2022","platform":"windows-x64","asset_name":"oasis7-windows-x64.exe","target_triple":"native"}]}'
+
+          echo "ref=${tag}" >> "${GITHUB_OUTPUT}"
+          echo "version=${version}" >> "${GITHUB_OUTPUT}"
+          echo "matrix=${matrix}" >> "${GITHUB_OUTPUT}"
+
+  release_gate_runtime_core:
+    name: release-gate-runtime-core
+    needs: plan
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.plan.outputs.ref }}
+      - name: Install pinned Rust toolchain
+        run: |
+          rustup toolchain install "${RUST_TOOLCHAIN}" --profile default
+          rustup default "${RUST_TOOLCHAIN}"
+      - name: Install Linux system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            jq \
+            netcat-openbsd \
+            pkg-config \
+            libwayland-dev \
+            wayland-protocols \
+            libxkbcommon-dev \
+            libx11-dev \
+            libxi-dev \
+            libxcursor-dev \
+            libxrandr-dev \
+            libxinerama-dev \
+            libasound2-dev \
+            libudev-dev
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: mainnet-packages-release-gate-runtime-core-v1
+          cache-on-failure: true
+      - name: Run runtime core release gate
+        run: |
+          mkdir -p .tmp/release_gate_runtime_core
+          ./scripts/ci-tests.sh full-core | tee .tmp/release_gate_runtime_core/ci-tests-full-core.log
+      - name: Upload runtime core gate summary
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: mainnet-release-gate-runtime-core-summary
+          path: .tmp/release_gate_runtime_core
+          if-no-files-found: warn
+
+  release_gate_runtime_support:
+    name: release-gate-runtime-support
+    needs: plan
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.plan.outputs.ref }}
+      - name: Install pinned Rust toolchain
+        run: |
+          rustup toolchain install "${RUST_TOOLCHAIN}" --profile default
+          rustup default "${RUST_TOOLCHAIN}"
+      - name: Install Linux system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            pkg-config \
+            libwayland-dev \
+            wayland-protocols \
+            libxkbcommon-dev \
+            libx11-dev \
+            libxi-dev \
+            libxcursor-dev \
+            libxrandr-dev \
+            libxinerama-dev \
+            libasound2-dev \
+            libudev-dev
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: mainnet-packages-release-gate-runtime-support-v1
+          cache-on-failure: true
+      - name: Run runtime support release gate
+        run: |
+          mkdir -p .tmp/release_gate_runtime_support
+          ./scripts/ci-tests.sh full-support | tee .tmp/release_gate_runtime_support/ci-tests-full-support.log
+      - name: Upload runtime support gate summary
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: mainnet-release-gate-runtime-support-summary
+          path: .tmp/release_gate_runtime_support
+          if-no-files-found: warn
+
+  release_gate_runtime_sync:
+    name: release-gate-runtime-sync
+    needs: plan
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.plan.outputs.ref }}
+      - name: Install pinned Rust toolchain
+        run: |
+          rustup toolchain install "${RUST_TOOLCHAIN}" --profile default
+          rustup default "${RUST_TOOLCHAIN}"
+      - name: Install Linux system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            jq \
+            pkg-config \
+            libwayland-dev \
+            wayland-protocols \
+            libxkbcommon-dev \
+            libx11-dev \
+            libxi-dev \
+            libxcursor-dev \
+            libxrandr-dev \
+            libxinerama-dev \
+            libasound2-dev \
+            libudev-dev
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: mainnet-packages-release-gate-runtime-sync-v1
+          cache-on-failure: true
+      - name: Install canonical builtin wasm toolchain
+        run: |
+          rustup toolchain install "${BUILTIN_WASM_TOOLCHAIN}" --profile minimal --component rust-src
+          rustup target add "${BUILTIN_WASM_TARGET}" --toolchain "${BUILTIN_WASM_TOOLCHAIN}"
+      - name: Run runtime sync release gate
+        run: |
+          mkdir -p .tmp/release_gate_runtime_sync
+          {
+            echo "+ ./scripts/sync-m1-builtin-wasm-artifacts.sh --check"
+            ./scripts/sync-m1-builtin-wasm-artifacts.sh --check
+            echo "+ ./scripts/sync-m4-builtin-wasm-artifacts.sh --check"
+            ./scripts/sync-m4-builtin-wasm-artifacts.sh --check
+            echo "+ ./scripts/sync-m5-builtin-wasm-artifacts.sh --check"
+            ./scripts/sync-m5-builtin-wasm-artifacts.sh --check
+          } | tee .tmp/release_gate_runtime_sync/runtime-sync-checks.log
+      - name: Upload runtime sync gate summary
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: mainnet-release-gate-runtime-sync-summary
+          path: .tmp/release_gate_runtime_sync
+          if-no-files-found: warn
+
+  release_gate_web:
+    name: release-gate-web
+    needs: plan
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.plan.outputs.ref }}
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+      - name: Install viewer web dependencies
+        run: npm ci --prefix crates/oasis7_viewer
+      - name: Install pinned Rust toolchain
+        run: |
+          rustup toolchain install "${RUST_TOOLCHAIN}" --profile default
+          rustup target add wasm32-unknown-unknown --toolchain "${RUST_TOOLCHAIN}"
+          rustup default "${RUST_TOOLCHAIN}"
+      - name: Install Linux system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            netcat-openbsd \
+            pkg-config \
+            xvfb \
+            xauth \
+            libwayland-dev \
+            wayland-protocols \
+            libxkbcommon-dev \
+            libx11-dev \
+            libxi-dev \
+            libxcursor-dev \
+            libxrandr-dev \
+            libxinerama-dev \
+            libasound2-dev \
+            libudev-dev
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: mainnet-packages-web-wasm-v1
+          cache-on-failure: true
+      - name: Run web strict release gate
+        run: |
+          xvfb-run -a ./scripts/release-gate.sh \
+            --out-dir .tmp/release_gate_web \
+            --skip-ci-full \
+            --skip-sync \
+            --skip-s9 \
+            --skip-s10 \
+            --web-headed
+      - name: Upload web gate summary
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: mainnet-release-gate-web-summary
+          path: .tmp/release_gate_web
+          if-no-files-found: warn
+
+  release_gate_soak:
+    name: release-gate-soak
+    needs: plan
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.plan.outputs.ref }}
+      - name: Install pinned Rust toolchain
+        run: |
+          rustup toolchain install "${RUST_TOOLCHAIN}" --profile default
+          rustup default "${RUST_TOOLCHAIN}"
+      - name: Install Linux system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            jq \
+            pkg-config \
+            libwayland-dev \
+            wayland-protocols \
+            libxkbcommon-dev \
+            libx11-dev \
+            libxi-dev \
+            libxcursor-dev \
+            libxrandr-dev \
+            libxinerama-dev \
+            libasound2-dev \
+            libudev-dev
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: mainnet-packages-release-gate-soak-v1
+          cache-on-failure: true
+      - name: Prewarm soak runtime binary
+        run: env -u RUSTC_WRAPPER cargo build -p oasis7 --bin oasis7_chain_runtime
+      - name: Run soak release gate
+        run: |
+          ./scripts/release-gate.sh \
+            --out-dir .tmp/release_gate_soak \
+            --skip-ci-full \
+            --skip-sync \
+            --skip-web-strict
+      - name: Upload soak gate summary
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: mainnet-release-gate-soak-summary
+          path: |
+            .tmp/release_gate_soak
+            .tmp/release_gate_p2p
+            .tmp/release_gate_s10
+          if-no-files-found: warn
+
+  release_gate:
+    name: release-gate
+    if: always()
+    needs:
+      - release_gate_runtime_core
+      - release_gate_runtime_support
+      - release_gate_runtime_sync
+      - release_gate_web
+      - release_gate_soak
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Assert all release gates passed
+        env:
+          RUNTIME_CORE_RESULT: ${{ needs.release_gate_runtime_core.result }}
+          RUNTIME_SUPPORT_RESULT: ${{ needs.release_gate_runtime_support.result }}
+          RUNTIME_SYNC_RESULT: ${{ needs.release_gate_runtime_sync.result }}
+          WEB_RESULT: ${{ needs.release_gate_web.result }}
+          SOAK_RESULT: ${{ needs.release_gate_soak.result }}
+        run: |
+          failed=0
+          for gate in runtime_core runtime_support runtime_sync web soak; do
+            upper_name=$(printf '%s' "$gate" | tr '[:lower:]' '[:upper:]')
+            result_var="${upper_name}_RESULT"
+            result=${!result_var}
+            echo "${gate}: ${result}"
+            if [[ "$result" != "success" ]]; then
+              failed=1
+            fi
+          done
+          if [[ "$failed" -ne 0 ]]; then
+            echo "error: one or more release sub-gates failed" >&2
+            exit 1
+          fi
+
+  build-web-dist:
+    name: build-web-dist
+    needs:
+      - plan
+      - release_gate
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.plan.outputs.ref }}
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+      - name: Install viewer web dependencies
+        run: npm ci --prefix crates/oasis7_viewer
+      - name: Install pinned Rust toolchain
+        run: |
+          rustup toolchain install "${RUST_TOOLCHAIN}" --profile default
+          rustup target add wasm32-unknown-unknown --toolchain "${RUST_TOOLCHAIN}"
+          rustup default "${RUST_TOOLCHAIN}"
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: mainnet-packages-web-wasm-v1
+          cache-on-failure: true
+      - name: Install trunk
+        run: cargo install trunk --locked
+      - name: Build web dists
+        run: |
+          mkdir -p output/mainnet-packages/web-dist output/mainnet-packages/web-launcher-dist
+          (
+            ./scripts/build-viewer-software-safe.sh
+            ./scripts/copy-viewer-web-dist.sh --dist-dir output/mainnet-packages/web-dist
+          )
+          (
+            cd crates/oasis7_client_launcher
+            env -u NO_COLOR trunk build --release --dist ../../output/mainnet-packages/web-launcher-dist
+          )
+      - name: Upload web dist artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: mainnet-web-dists
+          path: |
+            output/mainnet-packages/web-dist
+            output/mainnet-packages/web-launcher-dist
+          if-no-files-found: error
+
+  package-native:
+    name: package-${{ matrix.platform }}
+    needs:
+      - plan
+      - build-web-dist
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.plan.outputs.matrix) }}
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.plan.outputs.ref }}
+      - name: Install pinned Rust toolchain
+        shell: bash
+        run: |
+          rustup toolchain install "${RUST_TOOLCHAIN}" --profile default
+          rustup default "${RUST_TOOLCHAIN}"
+          if [[ "${{ matrix.target_triple }}" != "native" ]]; then
+            rustup target add "${{ matrix.target_triple }}" --toolchain "${RUST_TOOLCHAIN}"
+          fi
+      - name: Install Linux system dependencies
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            pkg-config \
+            libwayland-dev \
+            wayland-protocols \
+            libxkbcommon-dev \
+            libx11-dev \
+            libxi-dev \
+            libxcursor-dev \
+            libxrandr-dev \
+            libxinerama-dev \
+            libasound2-dev \
+            libudev-dev
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: mainnet-packages-${{ runner.os }}-${{ matrix.target_triple }}-v1
+          cache-on-failure: true
+      - name: Ensure Linux AppImage tooling
+        if: matrix.platform == 'linux-x64'
+        shell: bash
+        run: |
+          set -euo pipefail
+          APPIMAGETOOL_VERSION="1.9.1"
+          APPIMAGETOOL_FILENAME="appimagetool-x86_64.AppImage"
+          APPIMAGETOOL_URL="https://github.com/AppImage/appimagetool/releases/download/${APPIMAGETOOL_VERSION}/${APPIMAGETOOL_FILENAME}"
+          APPIMAGETOOL_SHA256="ed4ce84f0d9caff66f50bcca6ff6f35aae54ce8135408b3fa33abfc3cb384eb0"
+
+          mkdir -p "${RUNNER_TEMP}/appimagetool"
+          curl -fsSL "${APPIMAGETOOL_URL}" \
+            -o "${RUNNER_TEMP}/appimagetool/${APPIMAGETOOL_FILENAME}"
+          printf '%s  %s\n' \
+            "${APPIMAGETOOL_SHA256}" \
+            "${RUNNER_TEMP}/appimagetool/${APPIMAGETOOL_FILENAME}" | sha256sum -c -
+          chmod +x "${RUNNER_TEMP}/appimagetool/${APPIMAGETOOL_FILENAME}"
+          ln -sf \
+            "${RUNNER_TEMP}/appimagetool/${APPIMAGETOOL_FILENAME}" \
+            "${RUNNER_TEMP}/appimagetool/appimagetool"
+          echo "${RUNNER_TEMP}/appimagetool" >> "${GITHUB_PATH}"
+      - name: Download web dist artifacts
+        uses: actions/download-artifact@v6
+        with:
+          name: mainnet-web-dists
+          path: output/mainnet-packages
+      - name: Ensure Windows packaging dependencies
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $missing = @()
+          if (-not (Get-Command makensis -ErrorAction SilentlyContinue)) {
+            $missing += "nsis"
+          }
+          if ($missing.Count -eq 0) {
+            exit 0
+          }
+          choco install $missing -y --no-progress
+      - name: Build launcher bundle
+        shell: bash
+        run: |
+          ./scripts/release-prepare-bundle.sh \
+            --platform "${{ matrix.platform }}" \
+            --target-triple "${{ matrix.target_triple }}" \
+            --web-dist output/mainnet-packages/web-dist \
+            --web-launcher-dist output/mainnet-packages/web-launcher-dist \
+            --out-dir output/mainnet-packages/assets \
+            --profile release
+      - name: Validate bundle entrypoints
+        shell: bash
+        run: |
+          ./scripts/validate-release-platform-entrypoints.sh \
+            --platform "${{ matrix.platform }}" \
+            --bundle-dir "output/mainnet-packages/assets/oasis7-${{ matrix.platform }}" \
+            | tee "output/mainnet-packages/assets/${{ matrix.platform }}-entrypoint-validation.log"
+      - name: Stage bundle manifest
+        shell: bash
+        run: |
+          cp \
+            "output/mainnet-packages/assets/oasis7-${{ matrix.platform }}/.oasis7-bundle-manifest.json" \
+            "output/mainnet-packages/assets/${{ matrix.platform }}-bundle-manifest.json"
+      - name: Package native installer
+        shell: bash
+        run: |
+          ./scripts/package-native-installer.sh \
+            --platform "${{ matrix.platform }}" \
+            --bundle-dir "output/mainnet-packages/assets/oasis7-${{ matrix.platform }}" \
+            --out-dir output/mainnet-packages/assets \
+            --asset-name "${{ matrix.asset_name }}" \
+            --version "${{ needs.plan.outputs.version }}"
+      - name: Package secondary Linux .deb
+        if: matrix.platform == 'linux-x64'
+        shell: bash
+        run: |
+          ./scripts/package-native-installer.sh \
+            --platform "${{ matrix.platform }}" \
+            --bundle-dir "output/mainnet-packages/assets/oasis7-${{ matrix.platform }}" \
+            --out-dir output/mainnet-packages/assets \
+            --asset-name "oasis7-linux-x64.deb" \
+            --version "${{ needs.plan.outputs.version }}"
+      - name: Archive raw Linux bundle
+        if: matrix.platform == 'linux-x64'
+        shell: bash
+        run: |
+          tar -C output/mainnet-packages/assets \
+            -czf output/mainnet-packages/assets/oasis7-linux-x64-bundle.tar.gz \
+            oasis7-linux-x64
+      - name: Write BUILDINFO
+        shell: bash
+        run: |
+          {
+            echo "workflow=Mainnet Packages"
+            echo "network_tier=mainnet"
+            echo "run_id=${GITHUB_RUN_ID}"
+            echo "run_number=${GITHUB_RUN_NUMBER}"
+            echo "repository=${GITHUB_REPOSITORY}"
+            echo "release_tag=${{ needs.plan.outputs.ref }}"
+            echo "commit=$(git rev-parse HEAD)"
+            echo "build_profile=release"
+            echo "package_scope=all_existing"
+            echo "platform=${{ matrix.platform }}"
+            echo "target_triple=${{ matrix.target_triple }}"
+            echo "runner_os=${RUNNER_OS}"
+            echo "package_version=${{ needs.plan.outputs.version }}"
+            echo "published=false"
+          } > "output/mainnet-packages/assets/${{ matrix.platform }}-BUILDINFO"
+      - name: Generate checksums
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd output/mainnet-packages/assets
+
+          checksum() {
+            if command -v sha256sum >/dev/null 2>&1; then
+              sha256sum "$@"
+            else
+              shasum -a 256 "$@"
+            fi
+          }
+
+          files=(
+            "${{ matrix.asset_name }}"
+            "${{ matrix.platform }}-BUILDINFO"
+            "${{ matrix.platform }}-bundle-manifest.json"
+            "${{ matrix.platform }}-entrypoint-validation.log"
+          )
+          if [[ "${{ matrix.platform }}" == "linux-x64" ]]; then
+            files+=(
+              "oasis7-linux-x64.deb"
+              "oasis7-linux-x64-bundle.tar.gz"
+            )
+          fi
+
+          for file in "${files[@]}"; do
+            [[ -f "${file}" ]] || { echo "error: missing mainnet package artifact ${file}" >&2; exit 1; }
+          done
+          checksum "${files[@]}" > "${{ matrix.platform }}-SHA256SUMS"
+      - name: Stage upload directory
+        shell: bash
+        run: |
+          set -euo pipefail
+          upload_dir="output/mainnet-packages/upload/${{ matrix.platform }}"
+          mkdir -p "${upload_dir}"
+          cp "output/mainnet-packages/assets/${{ matrix.asset_name }}" "${upload_dir}/"
+          cp "output/mainnet-packages/assets/${{ matrix.platform }}-BUILDINFO" "${upload_dir}/"
+          cp "output/mainnet-packages/assets/${{ matrix.platform }}-SHA256SUMS" "${upload_dir}/"
+          cp "output/mainnet-packages/assets/${{ matrix.platform }}-bundle-manifest.json" "${upload_dir}/"
+          cp "output/mainnet-packages/assets/${{ matrix.platform }}-entrypoint-validation.log" "${upload_dir}/"
+          if [[ "${{ matrix.platform }}" == "linux-x64" ]]; then
+            cp "output/mainnet-packages/assets/oasis7-linux-x64.deb" "${upload_dir}/"
+            cp "output/mainnet-packages/assets/oasis7-linux-x64-bundle.tar.gz" "${upload_dir}/"
+          fi
+      - name: Upload mainnet package artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: mainnet-package-${{ matrix.platform }}-${{ needs.plan.outputs.version }}
+          path: output/mainnet-packages/upload/${{ matrix.platform }}
+          if-no-files-found: error
+
+  package-index:
+    name: package-index
+    needs:
+      - plan
+      - package-native
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Download mainnet package artifacts
+        uses: actions/download-artifact@v6
+        with:
+          pattern: mainnet-package-*
+          path: output/mainnet-packages/index
+          merge-multiple: true
+      - name: Generate aggregate checksums
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd output/mainnet-packages/index
+
+          for file in \
+            oasis7-linux-x86_64.AppImage \
+            oasis7-linux-x64.deb \
+            oasis7-linux-x64-bundle.tar.gz \
+            oasis7-macos-x64.dmg \
+            oasis7-windows-x64.exe
+          do
+            [[ -f "${file}" ]] || { echo "error: missing mainnet package artifact ${file}" >&2; exit 1; }
+          done
+
+          sha256sum \
+            oasis7-linux-x86_64.AppImage \
+            oasis7-linux-x64.deb \
+            oasis7-linux-x64-bundle.tar.gz \
+            oasis7-macos-x64.dmg \
+            oasis7-windows-x64.exe \
+            > oasis7-mainnet-checksums.txt
+      - name: Upload aggregate mainnet package index
+        uses: actions/upload-artifact@v7
+        with:
+          name: mainnet-package-index-${{ needs.plan.outputs.version }}
+          path: |
+            output/mainnet-packages/index/oasis7-mainnet-checksums.txt
+            output/mainnet-packages/index/*-BUILDINFO
+            output/mainnet-packages/index/*-SHA256SUMS
+            output/mainnet-packages/index/*-bundle-manifest.json
+            output/mainnet-packages/index/*-entrypoint-validation.log
+          if-no-files-found: error

--- a/.pm/tasks/task_031e846e8bef41179637ec9ba8c487aa.execution.md
+++ b/.pm/tasks/task_031e846e8bef41179637ec9ba8c487aa.execution.md
@@ -1,0 +1,120 @@
+# task_031e846e8bef41179637ec9ba8c487aa Execution Log
+
+- task_uid: task_031e846e8bef41179637ec9ba8c487aa
+- title: Assess testnet package artifact mainnet deployability
+- owner_role: tpm
+- worktree_hint: /Users/scc/ccwork/worktrees/oasis7-engineering-ci-artifact-mainnet-compat
+
+<!-- Append entries using:
+Example:
+  ## YYYY-MM-DD HH:MM:SS CST / role_name
+  - 完成内容: ...
+  - 遗留事项: ...
+  - Action: ...
+  - Validation Command: ...
+  - Expected Result: ...
+  - Actual Result: ...
+  - Blocker / Next Action: ...
+-->
+
+## 2026-06-06 17:04:02 CST / tpm
+- 完成内容: WORKFLOW BOOTSTRAP DECIDED
+  - Repository State Impact: read-only professional judgment requested; repository state changed only by required `.pm` task/worktree truth creation.
+  - Isolation Decision: source worktree `/Users/scc/ccwork/oasis7` was on `main` and clean; created canonical task worktree `/Users/scc/ccwork/worktrees/oasis7-engineering-ci-artifact-mainnet-compat` on branch `task/engineering-ci-artifact-mainnet-compat`.
+  - Task Truth: owner role `tpm`; `.pm` task `task_031e846e8bef41179637ec9ba8c487aa`; source refs `AGENTS.md`, `.github/workflows`; doc ref `doc/engineering/workflow/source-of-truth.md`.
+  - Routed Next Phase: read-only release/deployment compatibility assessment.
+  - Required Writeback: this execution log is the mandatory sink; no PRD/project edits needed for read-only answer.
+  - Next Action: inspect testnet packaging workflow, release packaging workflow, bundle scripts, and environment/mainnet gate docs.
+- 完成内容: WORKFLOW ROUTE DECIDED
+  - Current phase: read-only professional/domain judgment after bootstrap.
+  - Selected workflow surface: repo-owned read-only evidence collection plus external summary to user.
+  - Specialist need considered: deployment/release judgment overlaps runtime/QA/liveops boundaries; current `multi_agent_v1.spawn_agent` tool explicitly allows subagents only when user explicitly asks for delegation, so no subagent was dispatched. The answer must not be represented as a specialist-role-owned verdict.
+  - Subagent Slice Plan: intended roles `runtime_engineer`, `qa_engineer`, `liveops_community`; slice type read-only assessment; intended model default repo runtime; actual dispatched model/reasoning `not dispatched due current tool authorization boundary`; context delivery mode would be full-thread/full-history fork; mandatory context checklist would include AGENTS.md, source-of-truth, this `.pm` task, user question, `.github/workflows/testnet-packages.yml`, `.github/workflows/release-packages.yml`, release bundle scripts, and environment lane docs.
+  - Integration owner/order: `tpm` integrates repo evidence and labels conclusion boundary.
+- 完成内容: Evidence inspected
+  - `.github/workflows/testnet-packages.yml`: workflow is manual-only; accepts arbitrary `ref_or_sha`; permits `build_profile` `release` or `dev`; permits reduced `package_scope`; builds web dists and native packages under `output/testnet-packages`; version is forced to `0.0.0+testnet.${GITHUB_RUN_NUMBER}.${short_sha}`; `BUILDINFO` writes `workflow=Testnet Packages` and `published=false`; uploads GitHub Actions artifacts only.
+  - `.github/workflows/release-packages.yml`: release workflow runs on release tags/manual tag; has release gates before packaging (`full-core`, `full-support`, builtin wasm sync checks, web strict gate, soak gate); packages all existing platforms with `--profile release`; publishes a GitHub Release with checksums.
+  - `scripts/release-prepare-bundle.sh` and `scripts/build-game-launcher-bundle.sh`: testnet and release workflows both invoke the same bundle construction path; bundle manifest records source fingerprint, viewer protocol version, and asset hashes, not a network-tier/mainnet authorization field.
+  - `scripts/validate-release-platform-entrypoints.sh`: validates bundle entrypoints and static assets; this is packaging shape validation, not mainnet readiness validation.
+  - `doc/engineering/governance/environment-lanes-and-inventory-2026-05-29.md`: states `public_testnet` is not `mainnet`; `mainnet` requires genesis, bootstrap, public RPC/explorer, claims boundary, custody/signing, rollback/incident runbook gates; CI packaging row distinguishes test lane as PR artifact/test deploy/regression smoke and prod lane as release artifact/prod deploy/rollback point.
+- 完成内容: TPM integrated finding
+  - The testnet package artifact may be mechanically runnable/deployable to a host if built with `build_profile=release`, because it uses the same bundle and native installer scripts as the release packaging path.
+  - It should not be treated as a mainnet deploy/release artifact under current repo truth: it lacks release workflow gates, can be built from arbitrary ref and reduced scope, carries testnet version/build metadata, is uploaded as an unpublished Actions artifact, and is not tied to mainnet manifest/custody/signing/claims gates.
+  - Safe wording: "testnet package artifacts are suitable for testnet/staging/operator validation; promote to mainnet only by rebuilding through the release/mainnet lane and attaching mainnet gate evidence."
+- 遗留事项: A true specialist-owned verdict would require authorized subagent slices or a follow-up task explicitly permitting delegation to `runtime_engineer`, `qa_engineer`, and `liveops_community`.
+- Action: read-only answer to user.
+- Validation Command: `nl -ba .github/workflows/testnet-packages.yml | sed -n '1,340p'`; `nl -ba .github/workflows/release-packages.yml | sed -n '1,540p'`; `nl -ba scripts/bundle-freshness-lib.sh | sed -n '1,240p'`; `nl -ba doc/engineering/governance/environment-lanes-and-inventory-2026-05-29.md | sed -n '1,260p'`; `rg -n "mainnet_live|public_testnet|network_tier|allowed|denied|release gate|claims boundary|deploy|promotion|promote|go/no-go|mainnet" doc/testing/templates doc/engineering/governance scripts/network-tier* -S`
+- Expected Result: CI/package and environment-lane evidence distinguishes testnet package artifacts from mainnet release/deploy readiness.
+- Actual Result: Evidence supports "mechanically similar package, not mainnet-authorized artifact".
+- Blocker / Next Action: none for read-only answer; follow-up could add a `mainnet-packages`/`prod deploy` lane if desired.
+
+## 2026-06-06 17:10:09 CST / tpm
+- 完成内容: Follow-up design recommendation recorded.
+  - User question: whether to modify current testnet packaging config to emit both testnet and mainnet packages, or add a dedicated mainnet packaging workflow.
+  - Recommendation: keep the low-level bundle/package scripts shared, but add a dedicated mainnet/release packaging lane instead of making `testnet-packages.yml` emit mainnet artifacts.
+  - Rationale: current testnet workflow intentionally allows arbitrary ref, dev profile, reduced package scope, testnet version metadata, and unpublished Actions artifacts; mainnet needs stricter trigger/tag policy, release-only profile, full platform matrix, release gates/mainnet gate evidence, production metadata, permissions/environment approval, and publish/deploy/rollback semantics.
+  - Acceptable implementation shape: extract duplicated build/package steps into reusable workflow or composite script/action; keep separate workflow entrypoints such as `testnet-packages.yml` and `mainnet-packages.yml`/`release-packages.yml`.
+  - If a single workflow is used, it must have an explicit `network_tier`/`lane` input with hard validation, but this is less clear and easier to mis-trigger than separate workflows.
+- 遗留事项: Any code change should be owned by a follow-up implementation task and, if allowed, specialist review slices for release/QA/liveops.
+- Action: answer user with recommended CI shape.
+- Validation Command: reused prior evidence from `.github/workflows/testnet-packages.yml`, `.github/workflows/release-packages.yml`, and `doc/engineering/governance/environment-lanes-and-inventory-2026-05-29.md`.
+- Expected Result: Recommendation separates testnet artifact generation from mainnet authorization/publish path while preserving shared packaging implementation.
+- Actual Result: Recommendation ready.
+- Blocker / Next Action: none for advisory response.
+
+## 2026-06-06 17:15:04 CST / tpm
+- 完成内容: Implemented dedicated mainnet package workflow.
+  - Added `.github/workflows/mainnet-packages.yml`.
+  - Workflow is manual-only via `workflow_dispatch` and requires a tag matching semver-like `v*` or daily `YYYY-MM-DD_vN`.
+  - Added `plan-mainnet-package` job that resolves `ref`, release `version`, and a fixed all-existing platform matrix.
+  - Added release-gate jobs mirroring the release packaging path: runtime core, runtime support, runtime sync with canonical builtin wasm checks, web strict, and soak.
+  - Added package flow that reuses `scripts/release-prepare-bundle.sh`, `scripts/validate-release-platform-entrypoints.sh`, and `scripts/package-native-installer.sh` with `--profile release`.
+  - Added mainnet package metadata: `workflow=Mainnet Packages`, `network_tier=mainnet`, `build_profile=release`, `package_scope=all_existing`, release tag, commit, platform, target triple, and version.
+  - Added per-platform artifacts plus aggregate `oasis7-mainnet-checksums.txt`.
+- 遗留事项: No specialist subagent review dispatched because current subagent tool authorization allows delegation only when the user explicitly requests subagents. A future PR-closeout pass should collect repo-owned involved-role review before PR creation per workflow policy.
+- Action: New workflow file added; no existing testnet/release workflow modified.
+- Validation Command: `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/mainnet-packages.yml"); puts "yaml ok"'`
+- Expected Result: New workflow YAML parses.
+- Actual Result: `yaml ok`.
+- Blocker / Next Action: none.
+
+## 2026-06-06 17:15:04 CST / tpm
+- 完成内容: Ran implementation checks.
+- 遗留事项: `actionlint` is not installed in this local environment, so GitHub Actions expression linting could not be run directly.
+- Action: Checked whitespace, workflow references, repository PM lint, and doc governance.
+- Validation Command: `out=$(git diff --check --no-index /dev/null .github/workflows/mainnet-packages.yml || true); if [[ -n "$out" ]]; then printf '%s\n' "$out"; exit 1; fi; echo 'diff check ok for mainnet-packages.yml'`
+- Expected Result: No whitespace/check errors in the new workflow file.
+- Actual Result: `diff check ok for mainnet-packages.yml`.
+- Blocker / Next Action: none.
+
+## 2026-06-06 17:15:04 CST / tpm
+- 完成内容: Ran repo governance checks.
+- 遗留事项: `./scripts/pm/lint.sh` fails on pre-existing execution-log format issues in `.pm/tasks/task_202b9f812d49432a9f4360b8a66c5364.execution.md` and `.pm/tasks/task_455ea61e04c946469b8b1d22b700f853.execution.md`; the reported paths are unrelated to this new workflow and existed outside this task scope.
+- Action: Captured verification status for final report.
+- Validation Command: `./scripts/pm/lint.sh`
+- Expected Result: PM lint passes or reports unrelated pre-existing issues.
+- Actual Result: failed with missing execution-log fields and invalid headings in the two existing task logs listed above; no failure was reported for `task_031e846e8bef41179637ec9ba8c487aa`.
+- Blocker / Next Action: no blocker for this workflow change; leave unrelated `.pm` task cleanup untouched.
+
+## 2026-06-06 17:15:04 CST / tpm
+- 完成内容: Ran doc governance check.
+- 遗留事项: none.
+- Action: Captured verification status for final report.
+- Validation Command: `./scripts/doc-governance-check.sh`
+- Expected Result: doc governance passes.
+- Actual Result: `doc-governance-check: OK`.
+- Blocker / Next Action: none.
+
+## 2026-06-06 17:45:13 CST / tpm
+- 完成内容: Started merge flow after user request.
+  - Committed task slice with commit `fc6c8f9c26ef62d53b4ac6a607cba4e53f9963e5` using message `Add dedicated mainnet package workflow`.
+  - Ran `./scripts/prepare-task-pr.sh --title "Add dedicated mainnet package workflow"` preflight.
+  - Preflight reported branch ahead of `origin/main` by 1 and behind by 0; branch sync suggested no; unpushed commits 1.
+  - Preflight reported local required validation scope `full` because `.github/workflows/mainnet-packages.yml` is `unclassified_code_or_ci`.
+  - Preflight reported missing pre-PR local role review packet: `Pre-PR Local Role Review: passed`.
+- 遗留事项: Cannot continue to PR creation under `prepare-task-pr.sh --create` until pre-PR local role review packet exists. Current subagent tool policy only permits subagent dispatch when the user explicitly asks for subagents/delegation.
+- Action: Ran required validation before attempting PR creation.
+- Validation Command: `OASIS7_CI_RUN_OASIS7_REQUIRED_TESTS=true OASIS7_CI_RUN_CONSENSUS_TESTS=true OASIS7_CI_RUN_DISTFS_TESTS=true OASIS7_CI_RUN_OASIS7_NODE_TESTS=true OASIS7_CI_RUN_OASIS7_NET_TESTS=true OASIS7_CI_RUN_OASIS7_NET_LIBP2P_TESTS=true OASIS7_CI_RUN_VIEWER_CONTRACT_TESTS=true OASIS7_CI_RUN_VIEWER_WASM_CHECK=true OASIS7_CI_RUN_LAUNCHER_WEB_BUILD=true ./scripts/ci-tests.sh required`
+- Expected Result: required validation passes.
+- Actual Result: first full run failed in `tests::write_http_response_uses_upstream_status_texts` with `Connection reset by peer`; targeted rerun `env -u RUSTC_WRAPPER cargo test -p oasis7 --bin oasis7_newapi_bridge_service write_http_response_uses_upstream_status_texts -- --nocapture` passed; second full run passed the formerly failing test but was terminated by SIGTERM during `cargo test -p oasis7 --tests --features test_tier_required` with exit code 143.
+- Blocker / Next Action: blocked from merge until full required validation completes successfully and user explicitly authorizes repo-owned subagent review, or provides an instruction that changes the review path.

--- a/.pm/tasks/task_031e846e8bef41179637ec9ba8c487aa.execution.md
+++ b/.pm/tasks/task_031e846e8bef41179637ec9ba8c487aa.execution.md
@@ -153,3 +153,16 @@ Example:
 - Review Findings Disposition: no_findings
 - Finding Disposition Evidence: no code changes required by review.
 - Residual Risk: GitHub Actions has not executed the new workflow; local actionlint unavailable; full local required validation needs a successful uninterrupted rerun; mainnet package artifacts do not by themselves authorize mainnet-live deployment or public claims.
+
+## 2026-06-06 18:01:28 CST / tpm
+- 完成内容: Continued required validation after pre-PR role review.
+  - Reran full local required validation.
+  - The run passed doc governance, Windows path checks, release script executable bit checks, cargo dev lib tests, scope planner tests, provider remote HTTPS CLI/contract smokes, NewAPI bridge service tests, file-size check, cargo fmt, and `cargo test -p oasis7 --tests --features test_tier_required`.
+  - The run then failed in `cargo test -p oasis7_node --lib` at `libp2p_replication_network::tests::libp2p_replication_network_request_retries_next_peer_when_remote_handler_fails`.
+  - Targeted rerun of the exact failing test passed.
+- 遗留事项: No successful uninterrupted full required run yet; failures observed so far both passed targeted reruns and look like local flaky/network-concurrency test behavior, but this is not proof of green required validation.
+- Action: Keep PR creation path moving after role-review pass, with GitHub required checks and heartbeat watch as the authoritative merge gate.
+- Validation Command: `OASIS7_CI_RUN_OASIS7_REQUIRED_TESTS=true OASIS7_CI_RUN_CONSENSUS_TESTS=true OASIS7_CI_RUN_DISTFS_TESTS=true OASIS7_CI_RUN_OASIS7_NODE_TESTS=true OASIS7_CI_RUN_OASIS7_NET_TESTS=true OASIS7_CI_RUN_OASIS7_NET_LIBP2P_TESTS=true OASIS7_CI_RUN_VIEWER_CONTRACT_TESTS=true OASIS7_CI_RUN_VIEWER_WASM_CHECK=true OASIS7_CI_RUN_LAUNCHER_WEB_BUILD=true ./scripts/ci-tests.sh required`; targeted rerun `env -u RUSTC_WRAPPER cargo test -p oasis7_node --lib libp2p_replication_network::tests::libp2p_replication_network_request_retries_next_peer_when_remote_handler_fails -- --nocapture`
+- Expected Result: full required passes, or failure is narrowed by targeted rerun.
+- Actual Result: full required failed at one `oasis7_node` libp2p retry test; targeted rerun passed (`1 passed; 0 failed`).
+- Blocker / Next Action: proceed to PR creation and use GitHub CI plus heartbeat watch before merge.

--- a/.pm/tasks/task_031e846e8bef41179637ec9ba8c487aa.execution.md
+++ b/.pm/tasks/task_031e846e8bef41179637ec9ba8c487aa.execution.md
@@ -166,3 +166,15 @@ Example:
 - Expected Result: full required passes, or failure is narrowed by targeted rerun.
 - Actual Result: full required failed at one `oasis7_node` libp2p retry test; targeted rerun passed (`1 passed; 0 failed`).
 - Blocker / Next Action: proceed to PR creation and use GitHub CI plus heartbeat watch before merge.
+
+## 2026-06-06 18:02:35 CST / tpm
+- 完成内容: Created GitHub PR and recorded PR purpose decision.
+  - PR: `https://github.com/eng-cc/oasis7/pull/362`
+  - PR purpose decision: `normal_pr_ci_watch`
+  - Reason: this is an ordinary CI workflow addition, not a manual packaging/release CI hold; continue watching required checks, mergeability, PR comments, and review threads through merge.
+- 遗留事项: GitHub checks/comments/mergeability pending. Full local required validation did not complete uninterrupted, so GitHub required checks are the active merge gate.
+- Action: Push PR evidence commit and watch PR.
+- Validation Command: `./scripts/prepare-task-pr.sh --create --title "Add dedicated mainnet package workflow" --body-file /tmp/oasis7-mainnet-packages-pr-body.md`
+- Expected Result: PR is created after local role review packet passes.
+- Actual Result: PR #362 created.
+- Blocker / Next Action: watch GitHub checks/comments/review threads and fix if needed.

--- a/.pm/tasks/task_031e846e8bef41179637ec9ba8c487aa.execution.md
+++ b/.pm/tasks/task_031e846e8bef41179637ec9ba8c487aa.execution.md
@@ -118,3 +118,38 @@ Example:
 - Expected Result: required validation passes.
 - Actual Result: first full run failed in `tests::write_http_response_uses_upstream_status_texts` with `Connection reset by peer`; targeted rerun `env -u RUSTC_WRAPPER cargo test -p oasis7 --bin oasis7_newapi_bridge_service write_http_response_uses_upstream_status_texts -- --nocapture` passed; second full run passed the formerly failing test but was terminated by SIGTERM during `cargo test -p oasis7 --tests --features test_tier_required` with exit code 143.
 - Blocker / Next Action: blocked from merge until full required validation completes successfully and user explicitly authorizes repo-owned subagent review, or provides an instruction that changes the review path.
+
+## 2026-06-06 17:48:39 CST / tpm
+- Review Trigger: pre-PR local role review
+- Review Scope: `.github/workflows/mainnet-packages.yml`; `.pm/tasks/task_031e846e8bef41179637ec9ba8c487aa.yaml`; `.pm/tasks/task_031e846e8bef41179637ec9ba8c487aa.execution.md`
+- Review Roles: `runtime_engineer`, `qa_engineer`, `liveops_community`
+- Review Question: confirm the dedicated mainnet package workflow is safe to take to PR: release/mainnet gates are not weakened, workflow metadata and artifact behavior do not overclaim deploy readiness, and verification/CI risks are accurately represented.
+- Evidence Available: commit `ed35548c3dec0d3f0711afcbfbc4b5de7eb809ea`; YAML parse passed; new-file diff check passed; `doc-governance-check: OK`; task closeout verification passed; full required validation has not completed because one run had an intermittent NewAPI bridge test failure followed by targeted pass and one rerun was SIGTERM during `cargo test -p oasis7 --tests --features test_tier_required`.
+- Expected Return Contract: `findings` or `no_findings`, plus `residual_risk`.
+- Formal Sink: `.pm/tasks/task_031e846e8bef41179637ec9ba8c487aa.execution.md`
+
+## 2026-06-06 17:56:00 CST / tpm
+- 完成内容: Integrated pre-PR local role review results.
+  - `runtime_engineer` review: `no_findings`. Residual risk: workflow mirrors release/runtime gates and canonical builtin wasm sync checks, but unpublished `network_tier=mainnet` artifacts do not satisfy broader mainnet deployment authorization gates.
+  - `qa_engineer` review: `no_findings`. Residual risk: workflow is PR-ready from QA review, but GitHub Actions has not executed it, local `actionlint` is unavailable, and full local required validation remains incomplete due one intermittent NewAPI bridge failure followed by targeted pass and one SIGTERM during `cargo test -p oasis7 --tests --features test_tier_required`.
+  - `liveops_community` review: `no_findings`. Residual risk: downstream PR/release notes must continue to say this is package generation, not proof of mainnet deployment/readiness; mainnet-live claims still require separate genesis/bootstrap/RPC/explorer/claims/custody/rollback/incident evidence.
+- 遗留事项: Full local required validation still needs a successful uninterrupted run; GitHub Actions validation still pending PR.
+- Action: Record passed pre-PR local role review packet.
+- Validation Command: repo-owned role review via `multi_agent_v1` for `runtime_engineer`, `qa_engineer`, and `liveops_community`.
+- Expected Result: each involved role returns findings/no_findings and residual risk.
+- Actual Result: all three returned `no_findings` with residual risks recorded above.
+- Blocker / Next Action: rerun PR preflight after committing review evidence, then continue required validation and PR creation.
+
+- Pre-PR Local Role Review: passed
+- Task UID: task_031e846e8bef41179637ec9ba8c487aa
+- Source Worktree: /Users/scc/ccwork/worktrees/oasis7-engineering-ci-artifact-mainnet-compat
+- Source Branch: task/engineering-ci-artifact-mainnet-compat
+- Source Head: ed35548c3dec0d3f0711afcbfbc4b5de7eb809ea
+- Comparison Ref: refs/remotes/origin/main
+- Reviewed Changed Paths: .github/workflows/mainnet-packages.yml; .pm/tasks/task_031e846e8bef41179637ec9ba8c487aa.yaml; .pm/tasks/task_031e846e8bef41179637ec9ba8c487aa.execution.md
+- Role Selection Basis: changed CI packaging workflow affects release/runtime gates, QA validation, and mainnet/public-claim boundary; selected runtime_engineer, qa_engineer, liveops_community.
+- Review Roles: runtime_engineer, qa_engineer, liveops_community
+- Review Evidence: runtime_engineer no_findings via agent 019e9c56-3b9f-7ec3-882b-efb873b3b7ab; qa_engineer no_findings via agent 019e9c56-826c-7d33-ba77-574dae509752; liveops_community no_findings via agent 019e9c57-2760-7e23-87f3-c5c3be25cecd.
+- Review Findings Disposition: no_findings
+- Finding Disposition Evidence: no code changes required by review.
+- Residual Risk: GitHub Actions has not executed the new workflow; local actionlint unavailable; full local required validation needs a successful uninterrupted rerun; mainnet package artifacts do not by themselves authorize mainnet-live deployment or public claims.

--- a/.pm/tasks/task_031e846e8bef41179637ec9ba8c487aa.yaml
+++ b/.pm/tasks/task_031e846e8bef41179637ec9ba8c487aa.yaml
@@ -1,0 +1,27 @@
+task_uid: task_031e846e8bef41179637ec9ba8c487aa
+title: "Assess testnet package artifact mainnet deployability"
+owner_role: tpm
+worktree_hint: /Users/scc/ccwork/worktrees/oasis7-engineering-ci-artifact-mainnet-compat
+execution_log_path: .pm/tasks/task_031e846e8bef41179637ec9ba8c487aa.execution.md
+status: done
+priority: P2
+source_signal: null
+source_refs:
+  - AGENTS.md
+  - .github/workflows
+doc_refs:
+  - doc/engineering/workflow/source-of-truth.md
+related_prd: []
+acceptance:
+  - "Inspect testnet packaging CI config and determine whether produced artifacts are mainnet-deployable"
+  - "Add a dedicated mainnet package workflow that is separate from the testnet package workflow"
+  - "Run local static/governance verification before merge flow"
+handoff_to: []
+updated_at: 2026-06-06T17:25:13+08:00
+last_started_at: 2026-06-06T17:02:39+08:00
+last_claim_type: task_complete
+last_verify_command: "bash -lc 'set -euo pipefail; ruby -e '\\''require \"yaml\"; YAML.load_file(\".github/workflows/mainnet-packages.yml\"); puts \"yaml ok\"'\\''; rg -n \"^name: Mainnet Packages|workflow_dispatch|plan-mainnet-package|network_tier=mainnet|package_scope=all_existing|oasis7-mainnet-checksums\" .github/workflows/mainnet-packages.yml; out=$(git diff --check --no-index /dev/null .github/workflows/mainnet-packages.yml || true); if [[ -n \"$out\" ]]; then printf \"%s\\n\" \"$out\"; exit 1; fi; ./scripts/doc-governance-check.sh'"
+last_verified_at: 2026-06-06T17:25:11+08:00
+last_verification_exit_code: 0
+last_verification_status: verified
+last_closed_at: 2026-06-06T17:25:13+08:00


### PR DESCRIPTION
## Summary
- Add a dedicated `Mainnet Packages` GitHub Actions workflow separate from `Testnet Packages`.
- Require an explicit release tag, force release-profile all-platform packaging, run release gates before packaging, and upload unpublished mainnet package artifacts with BUILDINFO, per-platform checksums, manifests, and aggregate checksums.
- Preserve the existing testnet and release workflows unchanged.

## Verification
- YAML parse for `.github/workflows/mainnet-packages.yml`: passed.
- Mainnet workflow marker check: passed.
- New-file diff whitespace check: passed.
- `./scripts/doc-governance-check.sh`: passed.
- Pre-PR local role review: passed (`runtime_engineer`, `qa_engineer`, `liveops_community`, all no findings).
- Full local required validation: attempted; one NewAPI bridge test and one libp2p retry test failed in full runs but each passed targeted rerun. GitHub CI remains the merge gate.

## Mainnet Boundary
This adds package-generation artifacts only. It does not declare mainnet deployment readiness or mainnet-live status; those still require separate genesis, bootstrap, RPC/explorer, claims boundary, custody/signing, rollback, incident, and communication gate evidence.
