### PR TITLE
Refresh mainnet package workflow registration

### DIFF
--- a/.github/workflows/mainnet-packages.yml
+++ b/.github/workflows/mainnet-packages.yml
@@ -53,9 +53,11 @@ jobs:
           version="${tag#v}"
           matrix='{"include":[{"os":"ubuntu-24.04","platform":"linux-x64","asset_name":"oasis7-linux-x86_64.AppImage","target_triple":"native"},{"os":"macos-14","platform":"macos-x64","asset_name":"oasis7-macos-x64.dmg","target_triple":"x86_64-apple-darwin"},{"os":"windows-2022","platform":"windows-x64","asset_name":"oasis7-windows-x64.exe","target_triple":"native"}]}'
 
-          echo "ref=${tag}" >> "${GITHUB_OUTPUT}"
-          echo "version=${version}" >> "${GITHUB_OUTPUT}"
-          echo "matrix=${matrix}" >> "${GITHUB_OUTPUT}"
+          {
+            echo "ref=${tag}"
+            echo "version=${version}"
+            echo "matrix=${matrix}"
+          } >> "${GITHUB_OUTPUT}"
 
   release_gate_runtime_core:
     name: release-gate-runtime-core

--- a/.pm/roles/tpm/backlog/committed.yaml
+++ b/.pm/roles/tpm/backlog/committed.yaml
@@ -12,3 +12,13 @@ tasks:
     handoff_to: []
     status: committed
     task_path: .pm/tasks/task_202b9f812d49432a9f4360b8a66c5364.yaml
+  - task_uid: task_6f255d6605fb429e964780141ed8a6e0
+    title: "Trigger mainnet package workflow"
+    priority: P2
+    source_signal: null
+    related_prd: []
+    acceptance:
+      - "Trigger the mainnet package workflow for the selected release tag and watch the GitHub Actions run to completion"
+    handoff_to: []
+    status: committed
+    task_path: .pm/tasks/task_6f255d6605fb429e964780141ed8a6e0.yaml

--- a/.pm/tasks/task_6f255d6605fb429e964780141ed8a6e0.execution.md
+++ b/.pm/tasks/task_6f255d6605fb429e964780141ed8a6e0.execution.md
@@ -1,0 +1,70 @@
+# task_6f255d6605fb429e964780141ed8a6e0 Execution Log
+
+- task_uid: task_6f255d6605fb429e964780141ed8a6e0
+- title: Trigger mainnet package workflow
+- owner_role: tpm
+- worktree_hint: /Users/scc/ccwork/worktrees/oasis7-operations-trigger-mainnet-package-20260606
+
+<!-- Append entries using:
+Example:
+  ## YYYY-MM-DD HH:MM:SS CST / role_name
+  - 完成内容: ...
+  - 遗留事项: ...
+  - Action: ...
+  - Validation Command: ...
+  - Expected Result: ...
+  - Actual Result: ...
+  - Blocker / Next Action: ...
+-->
+
+## 2026-06-06 18:24:00 CST / tpm
+- 完成内容: WORKFLOW BOOTSTRAP DECIDED. Created dedicated task worktree for operational mainnet package trigger.
+- Repository State Impact: No tracked code/config change intended; GitHub Actions workflow run will be triggered remotely.
+- Isolation Decision: Reuse not assumed; task worktree `/Users/scc/ccwork/worktrees/oasis7-operations-trigger-mainnet-package-20260606` created on branch `task/operations-trigger-mainnet-package-20260606`.
+- Task Truth: owner role `tpm`; task `task_6f255d6605fb429e964780141ed8a6e0`.
+- Routed Next Phase: execution/verification, because the request is to trigger and watch an existing packaging workflow.
+- Action: Select latest valid mainnet package tag and trigger `.github/workflows/mainnet-packages.yml`.
+- Validation Command: `git tag --sort=-creatordate | head -5`; inspect workflow dispatch inputs.
+- Expected Result: Latest valid tag selected; workflow dispatch is available on GitHub.
+- Actual Result: Latest local tag is `2026-06-06_v1`. Initial `gh workflow view mainnet-packages.yml --yaml` returned 404, indicating GitHub Actions workflow indexing/discovery needs follow-up before dispatch.
+- Blocker / Next Action: List remote workflows and retry dispatch once GitHub exposes `Mainnet Packages`.
+
+## 2026-06-06 18:43:00 CST / tpm
+- 完成内容: Attempted to trigger Mainnet Packages workflow for tag `2026-06-06_v1`; created Codex heartbeat `oasis7-mainnet-package-trigger-watch` to continue retry/watch flow.
+- Action: Verified remote default branch and tag, checked GitHub Actions registry, attempted `gh workflow run .github/workflows/mainnet-packages.yml -f tag=2026-06-06_v1 --ref main`, then polled registry for 20 attempts.
+- Validation Command: `gh repo view eng-cc/oasis7 --json defaultBranchRef`; `gh api 'repos/eng-cc/oasis7/contents/.github/workflows/mainnet-packages.yml?ref=main'`; `git ls-remote origin main refs/tags/2026-06-06_v1`; `gh api repos/eng-cc/oasis7/actions/workflows --paginate`; `actionlint .github/workflows/mainnet-packages.yml`.
+- Expected Result: GitHub Actions registry lists `.github/workflows/mainnet-packages.yml`; dispatch starts a `Mainnet Packages` run.
+- Actual Result: Remote `main` is default branch; workflow file exists on remote `main`; tag `2026-06-06_v1` exists remotely; Actions is enabled. GitHub Actions registry still does not list `Mainnet Packages`, and `gh workflow run` returns HTTP 404. `actionlint` did not report workflow syntax errors, only shellcheck style warning `SC2129`.
+- Blocker / Next Action: Current blocker is GitHub Actions not yet registering the newly merged workflow. Heartbeat will retry workflow registry discovery, dispatch `2026-06-06_v1` when available, then watch the run to completion.
+
+## 2026-06-06 18:51:00 CST / tpm
+- 完成内容: Retried mainnet package dispatch on user request.
+- Action: Rechecked Actions workflow registry, retried `gh workflow run .github/workflows/mainnet-packages.yml -f tag=2026-06-06_v1 --ref main`, and retried REST dispatch endpoints using both filename and encoded path.
+- Validation Command: `gh api repos/eng-cc/oasis7/actions/workflows --paginate`; `gh api 'repos/eng-cc/oasis7/contents/.github/workflows/mainnet-packages.yml?ref=main'`; `gh api --method POST 'repos/eng-cc/oasis7/actions/workflows/mainnet-packages.yml/dispatches' -f ref=main -F 'inputs[tag]=2026-06-06_v1'`; `gh api --method POST 'repos/eng-cc/oasis7/actions/workflows/.github%2Fworkflows%2Fmainnet-packages.yml/dispatches' -f ref=main -F 'inputs[tag]=2026-06-06_v1'`.
+- Expected Result: Dispatch accepted and new Mainnet Packages run created.
+- Actual Result: Workflow file remains visible through contents API on `main`, but Actions workflow registry still does not list it. Both REST dispatch forms returned HTTP 404.
+- Blocker / Next Action: Continue heartbeat retry/watch; dispatch cannot succeed until GitHub Actions registers the workflow.
+
+## 2026-06-06 18:56:00 CST / tpm
+- 完成内容: Heartbeat retry for mainnet package workflow registration and dispatch.
+- Action: Queried Actions workflow registry for `.github/workflows/mainnet-packages.yml`, checked recent runs for `Mainnet Packages`, then retried dispatch for tag `2026-06-06_v1`.
+- Validation Command: `gh api repos/eng-cc/oasis7/actions/workflows --paginate`; `gh run list --limit 20 --json databaseId,workflowName,event,status,conclusion,createdAt,url,displayTitle`; `gh workflow run .github/workflows/mainnet-packages.yml -f tag=2026-06-06_v1 --ref main`.
+- Expected Result: Workflow registered and dispatch accepted.
+- Actual Result: Workflow still absent from Actions registry, no `Mainnet Packages` runs found, dispatch still returned HTTP 404.
+- Blocker / Next Action: Keep heartbeat active and retry on next tick.
+
+## 2026-06-06 19:03:00 CST / tpm
+- 完成内容: Implemented minimal workflow-file update to force GitHub Actions re-ingest path while preserving package behavior.
+- Action: Updated `.github/workflows/mainnet-packages.yml` plan step to group `GITHUB_OUTPUT` writes into a single redirected block, resolving `actionlint`/shellcheck `SC2129`.
+- Validation Command: `actionlint .github/workflows/mainnet-packages.yml`; `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/mainnet-packages.yml"); puts "yaml ok"'`; `git diff --check`.
+- Expected Result: Workflow remains syntactically valid; output names/values remain unchanged; diff has no whitespace errors.
+- Actual Result: `actionlint` passed with no output; YAML parse returned `yaml ok`; `git diff --check` passed. Diff only changes `ref`, `version`, and `matrix` output writes from separate redirects to a grouped redirect.
+- Blocker / Next Action: Await repo-owned QA role review, then commit, push, create PR, merge, and retry mainnet package dispatch.
+
+## 2026-06-06 19:06:00 CST / qa_engineer
+- 完成内容: Pre-PR Local Role Review: passed.
+- Reviewer: qa_engineer subagent `019e9ca0-febe-77e0-a19b-807de797799a`.
+- Findings: no_findings.
+- Evidence Command: `git diff -- .github/workflows/mainnet-packages.yml`; `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/mainnet-packages.yml"); puts "yaml ok"'`; `actionlint -shellcheck= .github/workflows/mainnet-packages.yml`; `rg -n "workflow_dispatch|tag:|id: plan|GITHUB_OUTPUT|fromJson|package-native|oasis7-mainnet" .github/workflows/mainnet-packages.yml`.
+- Evidence Result: Only `jobs.plan.steps[id=plan]` changed from three individual `GITHUB_OUTPUT` redirects to one grouped redirect. Workflow input, tag validation, version derivation, matrix JSON, job outputs, downstream consumers, package commands, artifact names, and checksum index remain unchanged. YAML parse passed; actionlint passed; key markers remain present.
+- Residual Risk: This real workflow-file touch should not alter runtime behavior, but whether it forces GitHub Actions to re-ingest depends on GitHub workflow registry/security behavior after merge.

--- a/.pm/tasks/task_6f255d6605fb429e964780141ed8a6e0.yaml
+++ b/.pm/tasks/task_6f255d6605fb429e964780141ed8a6e0.yaml
@@ -1,0 +1,19 @@
+task_uid: task_6f255d6605fb429e964780141ed8a6e0
+title: "Trigger mainnet package workflow"
+owner_role: tpm
+worktree_hint: /Users/scc/ccwork/worktrees/oasis7-operations-trigger-mainnet-package-20260606
+execution_log_path: .pm/tasks/task_6f255d6605fb429e964780141ed8a6e0.execution.md
+status: committed
+priority: P2
+source_signal: null
+source_refs:
+  - AGENTS.md
+  - .github/workflows/mainnet-packages.yml
+doc_refs:
+  - doc/engineering/workflow/source-of-truth.md
+related_prd: []
+acceptance:
+  - "Trigger the mainnet package workflow for the selected release tag and watch the GitHub Actions run to completion"
+handoff_to: []
+updated_at: 2026-06-06T18:25:39+08:00
+last_started_at: 2026-06-06T18:25:39+08:00


### PR DESCRIPTION
## Summary
- Touch the Mainnet Packages workflow with a behavior-preserving `GITHUB_OUTPUT` write cleanup.
- Resolve the `actionlint`/shellcheck SC2129 warning so GitHub Actions gets a real workflow-file update to re-ingest.
- Record the trigger/watch task evidence and QA role review.

## Verification
- `actionlint .github/workflows/mainnet-packages.yml`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/mainnet-packages.yml"); puts "yaml ok"'`
- `git diff --check`

## Review
- Pre-PR repo-owned QA role review: passed (`no_findings`).

## Follow-up
- After merge, retry dispatching `Mainnet Packages` with tag `2026-06-06_v1` and watch the run to completion.