### PR TITLE
Centralize subagent runtime config

### DIFF
--- a/.agents/roles/tpm.md
+++ b/.agents/roles/tpm.md
@@ -37,7 +37,7 @@ TPM 只做 workflow coordination / integration，不做任何专业性工作本�
 - 每个用户请求必须先创建或进入标准 task worktree 并绑定 `.pm` task；只读、聊天、纯事实读取和专业判断都不能绕过 task/worktree 真值。
 - 可决定哪些专业角色参与、参与顺序、是否允许互斥范围并行写入，以及哪些结果只读采纳。
 - 派工前必须把当前 TODO、slice contract、formal sink 和 integration order 写入 `.pm/tasks/<TASK-UID>.execution.md`；project、handoff、signal、memory 或 PR evidence 只能作为补充 sink。
-- 专业角色 slice 默认请求 workflow source-of-truth 的 `Default subagent runtime`；slice contract 必须同时写明 intended model 与 actual dispatched model/reasoning。非默认、继承父线程、请求选择后无法验证 actual model、或其他无法验证 actual model 的情况都必须记录原因。
+- 专业角色 slice 默认请求 workflow source-of-truth 的 `Default subagent runtime` policy（具体配置真值在 `.codex/config.toml` 的 `[workflow.subagent_runtime]`）；slice contract 必须同时写明 intended model 与 actual dispatched model/reasoning。非默认、继承父线程、请求选择后无法验证 actual model、或其他无法验证 actual model 的情况都必须记录原因。
 - 专业角色 slice 默认使用 full-thread/full-history fork 或等价上下文；若改用手工显式 context packet，必须记录 fallback 原因，例如工具限制、上下文安全、模型选择冲突或默认 fork 卡住。
 - 兼容契约词：`mandatory context packet` 在当前语义下指必须记录的 mandatory context checklist/packet，不等同于必须手工组装显式上下文包。
 - 非窄范围只读 explorer 的 subagent 必须获得 `AGENTS.md`、对应 role card、workflow source-of-truth、当前 `.pm` task yaml/execution log、相关 PRD/project/handoff、当前 diff/evidence 和 sibling slice 边界。

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -5,3 +5,8 @@ memories = true
 [memories]
 generate_memories = true
 use_memories = true
+
+[workflow.subagent_runtime]
+model = "gpt-5.4"
+reasoning_effort = "medium"
+shorthand = "gpt-5.4-medium"

--- a/.pm/tasks/task_2213d0234f14439983dd67fa6b2944e5.execution.md
+++ b/.pm/tasks/task_2213d0234f14439983dd67fa6b2944e5.execution.md
@@ -1,0 +1,69 @@
+# task_2213d0234f14439983dd67fa6b2944e5 Execution Log
+
+- task_uid: task_2213d0234f14439983dd67fa6b2944e5
+- title: centralize subagent runtime config
+- owner_role: tpm
+- worktree_hint: /Users/scc/ccwork/worktrees/oasis7-engineering-subagent-runtime-config-source
+
+<!-- Append entries using:
+Example:
+  ## YYYY-MM-DD HH:MM:SS CST / role_name
+  - 完成内容: ...
+  - 遗留事项: ...
+  - Action: ...
+  - Validation Command: ...
+  - Expected Result: ...
+  - Actual Result: ...
+  - Blocker / Next Action: ...
+-->
+
+## 2026-06-08 11:34:40 CST / tpm
+- 完成内容: Bootstrapped isolated engineering task worktree for centralizing the default subagent runtime policy. Inspected current source-of-truth, synced workflow surfaces, and workflow eval implementation; confirmed the concrete runtime still lives in prose and eval parses that prose today.
+- 遗留事项: Add a single config file for the default subagent runtime, point workflow source-of-truth and synced guidance at it, and update workflow behavior eval to read the config source directly.
+- Action: Create one canonical config file, replace concrete runtime prose with config references where appropriate, and keep required workflow checks green.
+- Validation Command: rtk rg -n "Default subagent runtime|gpt-5\.5|reasoning_effort=medium" AGENTS.md doc .agents scripts/pm/workflow-behavior-eval.sh && rtk sed -n '140,210p' doc/engineering/workflow/source-of-truth.md
+- Expected Result: Current state is captured in the task log before edits, with the existing single concrete runtime source and all synced references identified.
+- Actual Result: PASS. Located the concrete runtime marker in source-of-truth section 5.2 and confirmed downstream docs/templates reference that prose; workflow-behavior-eval currently regex-parses the prose marker rather than a config file.
+- Blocker / Next Action: No blocker. Proceed to add the canonical runtime config file and repoint workflow surfaces and eval to it.
+
+## 2026-06-08 11:47:38 CST / tpm
+- 完成内容: Centralized the default subagent runtime into `.codex/config.toml` and rewired workflow source-of-truth, AGENTS markers, TPM role guidance, and workflow eval to reference that config-backed policy instead of embedding the concrete runtime in prose.
+- 遗留事项: Change the canonical default subagent runtime from gpt-5.5-medium to gpt-5.4-medium in the single config source and re-verify that downstream references still resolve through the config-backed policy.
+- Action: Edit `.codex/config.toml` only for the concrete runtime value unless focused verification exposes another config-coupled surface.
+- Validation Command: rtk rg -n "gpt-5\.5|gpt-5\.5-medium|\[workflow\.subagent_runtime\]" .codex/config.toml AGENTS.md doc/engineering/workflow/source-of-truth.md .agents/roles/tpm.md scripts/pm/workflow-behavior-eval.sh
+- Expected Result: The task log records the config-centralization step before changing the canonical runtime value, and the only concrete value should still live in `.codex/config.toml`.
+- Actual Result: PASS. The concrete default runtime value is centralized in `.codex/config.toml`; workflow prose and eval now reference the config-backed policy rather than carrying their own concrete model string.
+- Blocker / Next Action: No blocker. Update the canonical model string in `.codex/config.toml` from gpt-5.5-medium to gpt-5.4-medium and run focused verification.
+
+## 2026-06-08 11:48:33 CST / tpm
+- 完成内容: Updated the canonical default subagent runtime in the single config source from gpt-5.5-medium to gpt-5.4-medium by editing only .codex/config.toml.
+- 遗留事项: Run focused verification to confirm the concrete runtime value still exists only in the config source and downstream workflow surfaces continue to reference the config-backed policy.
+- Action: Verify the new model string, absence of stale gpt-5.5 markers in the touched workflow surfaces, and shell syntax for workflow-behavior-eval.
+- Validation Command: rtk rg -n 'gpt-5\.4|gpt-5\.4-medium|gpt-5\.5|gpt-5\.5-medium|\[workflow\.subagent_runtime\]' .codex/config.toml AGENTS.md doc/engineering/workflow/source-of-truth.md .agents/roles/tpm.md scripts/pm/workflow-behavior-eval.sh && bash -n scripts/pm/workflow-behavior-eval.sh && git diff --check
+- Expected Result: The concrete runtime value is gpt-5.4-medium only in .codex/config.toml, stale gpt-5.5 markers are absent from the touched workflow surfaces, and the eval shell script remains syntactically valid.
+- Actual Result: PASS. Focused search shows `gpt-5.4` / `gpt-5.4-medium` only in `.codex/config.toml` among active workflow surfaces; stale `gpt-5.5` strings are limited to historical execution-log entries describing the migration. `bash -n scripts/pm/workflow-behavior-eval.sh` and `git diff --check` passed. Full `./scripts/pm/workflow-behavior-eval.sh --json` passed with 24 routing scenarios and all workflow smoke segments, including the source-of-truth default model configuration reported as `gpt-5.4-medium`.
+- Blocker / Next Action: No blocker. QA local review identified this entry as a PR-blocking evidence gap while it still said Pending verification; this update resolves that finding with the completed verification output.
+
+## 2026-06-08 12:04:30 CST / tpm
+- Review Trigger: pre-PR local role review
+- Review Scope: `.codex/config.toml`; `AGENTS.md`; `.agents/roles/tpm.md`; `doc/engineering/workflow/source-of-truth.md`; `scripts/pm/workflow-behavior-eval.sh`; `.pm/tasks/task_2213d0234f14439983dd67fa6b2944e5.execution.md`
+- Review Roles: agent_engineer, qa_engineer
+- Review Question: Confirm the default subagent runtime is centralized in `.codex/config.toml` `[workflow.subagent_runtime]`, the active default is `gpt-5.4-medium`, workflow guidance references the config-backed policy, and verification evidence is sufficient for PR.
+- Evidence Available: `bash -n scripts/pm/workflow-behavior-eval.sh`; `git diff --check`; `./scripts/pm/workflow-behavior-eval.sh --json`; focused stale marker search; subagent review outputs from `019ea561-517e-7b92-a799-6a66b05b348c` and `019ea561-6666-7e10-b6f6-5c544a8c7da6`.
+- Expected Return Contract: findings | no_findings | residual_risk
+- Formal Sink: `.pm/tasks/task_2213d0234f14439983dd67fa6b2944e5.execution.md`
+
+## 2026-06-08 12:05:00 CST / tpm
+- Pre-PR Local Role Review: passed
+- Task UID: task_2213d0234f14439983dd67fa6b2944e5
+- Source Worktree: /Users/scc/ccwork/worktrees/oasis7-engineering-subagent-runtime-config-source
+- Source Branch: task/engineering-subagent-runtime-config-source
+- Source Head: efac0caf862b47961c0438beae3c999c368d3873
+- Comparison Ref: refs/remotes/origin/main
+- Reviewed Changed Paths: .agents/roles/tpm.md; .codex/config.toml; .pm/roles/tpm/backlog/committed.yaml; .pm/tasks/task_2213d0234f14439983dd67fa6b2944e5.execution.md; .pm/tasks/task_2213d0234f14439983dd67fa6b2944e5.yaml; AGENTS.md; doc/engineering/workflow/source-of-truth.md; scripts/pm/workflow-behavior-eval.sh
+- Role Selection Basis: workflow config, TPM role guidance, source-of-truth, and workflow eval changes require agent_engineer review; verification and PR readiness evidence require qa_engineer review. No gameplay, visual interaction, runtime, blockchain ops, WASM, viewer, or liveops surfaces were touched.
+- Review Roles: agent_engineer, qa_engineer
+- Review Evidence: agent_engineer subagent `019ea561-517e-7b92-a799-6a66b05b348c` returned no_findings and acceptable_for_pre_pr_packet yes; qa_engineer subagent `019ea561-6666-7e10-b6f6-5c544a8c7da6` found one P1 evidence gap because this log still said Pending verification, then the gap was addressed by recording the completed focused and full eval verification above.
+- Review Findings Disposition: addressed
+- Finding Disposition Evidence: Updated this execution log entry from `Actual Result: Pending verification` to the completed PASS evidence for focused stale marker search, `bash -n`, `git diff --check`, and `./scripts/pm/workflow-behavior-eval.sh --json`.
+- Residual Risk: The `workflow-behavior-eval.sh` config reader is intentionally minimal and supports the simple key/value shape used by `.codex/config.toml`; it should be hardened if the workflow config grows beyond this block.

--- a/.pm/tasks/task_2213d0234f14439983dd67fa6b2944e5.execution.md
+++ b/.pm/tasks/task_2213d0234f14439983dd67fa6b2944e5.execution.md
@@ -58,7 +58,7 @@ Example:
 - Task UID: task_2213d0234f14439983dd67fa6b2944e5
 - Source Worktree: /Users/scc/ccwork/worktrees/oasis7-engineering-subagent-runtime-config-source
 - Source Branch: task/engineering-subagent-runtime-config-source
-- Source Head: efac0caf862b47961c0438beae3c999c368d3873
+- Source Head: cc3f1125a43e73f50ffdeca28623c9c4574cc63c
 - Comparison Ref: refs/remotes/origin/main
 - Reviewed Changed Paths: .agents/roles/tpm.md; .codex/config.toml; .pm/roles/tpm/backlog/committed.yaml; .pm/tasks/task_2213d0234f14439983dd67fa6b2944e5.execution.md; .pm/tasks/task_2213d0234f14439983dd67fa6b2944e5.yaml; AGENTS.md; doc/engineering/workflow/source-of-truth.md; scripts/pm/workflow-behavior-eval.sh
 - Role Selection Basis: workflow config, TPM role guidance, source-of-truth, and workflow eval changes require agent_engineer review; verification and PR readiness evidence require qa_engineer review. No gameplay, visual interaction, runtime, blockchain ops, WASM, viewer, or liveops surfaces were touched.

--- a/.pm/tasks/task_2213d0234f14439983dd67fa6b2944e5.execution.md
+++ b/.pm/tasks/task_2213d0234f14439983dd67fa6b2944e5.execution.md
@@ -67,3 +67,12 @@ Example:
 - Review Findings Disposition: addressed
 - Finding Disposition Evidence: Updated this execution log entry from `Actual Result: Pending verification` to the completed PASS evidence for focused stale marker search, `bash -n`, `git diff --check`, and `./scripts/pm/workflow-behavior-eval.sh --json`.
 - Residual Risk: The `workflow-behavior-eval.sh` config reader is intentionally minimal and supports the simple key/value shape used by `.codex/config.toml`; it should be hardened if the workflow config grows beyond this block.
+
+## 2026-06-08 12:14:19 CST / tpm
+- 完成内容: Created PR #382 for the centralized subagent runtime config branch after preflight passed and the branch was pushed.
+- 遗留事项: Continue normal PR CI / mergeability / comments / review-thread watch until the PR is either mergeable and clean or a real blocker appears.
+- Action: Record PR purpose decision as normal_pr_ci_watch and inspect GitHub PR status.
+- Validation Command: gh pr view 382 --json url,state,reviewDecision,mergeStateStatus,statusCheckRollup,comments,reviews
+- Expected Result: PR exists, status can be inspected, and this task remains on the normal PR watch-fix-merge path rather than a manual packaging CI hold.
+- Actual Result: Pending PR state inspection.
+- Blocker / Next Action: No blocker yet; inspect PR checks and review/comment state next.

--- a/.pm/tasks/task_2213d0234f14439983dd67fa6b2944e5.yaml
+++ b/.pm/tasks/task_2213d0234f14439983dd67fa6b2944e5.yaml
@@ -1,0 +1,27 @@
+task_uid: task_2213d0234f14439983dd67fa6b2944e5
+title: "centralize subagent runtime config"
+owner_role: tpm
+worktree_hint: /Users/scc/ccwork/worktrees/oasis7-engineering-subagent-runtime-config-source
+execution_log_path: .pm/tasks/task_2213d0234f14439983dd67fa6b2944e5.execution.md
+status: done
+priority: P2
+source_signal: null
+source_refs:
+  - AGENTS.md
+  - doc/engineering/workflow/source-of-truth.md
+  - .agents/roles/templates/subagent-slice-card.md
+  - .agents/skills/repo-owned-workflow-router/SKILL.md
+doc_refs: []
+related_prd: []
+acceptance:
+  - "default subagent runtime lives in one config file and workflow surfaces reference it"
+  - "workflow verification reads the config source instead of parsing prose for the concrete runtime"
+handoff_to: []
+updated_at: 2026-06-08T12:07:58+08:00
+last_started_at: 2026-06-08T11:33:37+08:00
+last_claim_type: task_complete
+last_verify_command: "rtk rg -n 'gpt-5\\.4|gpt-5\\.4-medium|gpt-5\\.5|gpt-5\\.5-medium|\\[workflow\\.subagent_runtime\\]' .codex/config.toml AGENTS.md doc/engineering/workflow/source-of-truth.md .agents/roles/tpm.md scripts/pm/workflow-behavior-eval.sh && bash -n scripts/pm/workflow-behavior-eval.sh && git diff --check && ./scripts/pm/workflow-behavior-eval.sh --json"
+last_verified_at: 2026-06-08T12:07:55+08:00
+last_verification_exit_code: 0
+last_verification_status: verified
+last_closed_at: 2026-06-08T12:07:58+08:00

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,7 @@
 
 - `default-workflow-bootstrap`: 任何用户请求都必须先经过 repo-owned bootstrap，确认标准 task worktree / `.pm` task / owner role 真值，再进入后续 workflow surface；禁止用只读、聊天、纯事实读取绕过 bootstrap。
 - 只读专业判断分流：只读/聊天请求也必须先进入 task/worktree bootstrap；但凡输出产品/系统设计、游戏视觉/交互、runtime、blockchain ops、WASM、agent、viewer、QA、LiveOps/community 等专业结论，仍必须由对应专业角色 slice 给出或验证，TPM 只能合流与标注来源。
-- subagent 默认模型：具体默认值以 `doc/engineering/workflow/source-of-truth.md#52-tpm-planning-and-subagent-dispatch` 的 `Default subagent runtime` 为准；专业角色 slice 默认请求该 runtime，若用户要求其他模型、slice 明确需要更强/更快/更省配置，当前 subagent 工具只能继承父线程模型，或请求选择后无法验证实际派发模型，必须在 slice contract 同时记录 intended model、actual dispatched model/reasoning 与原因；无法验证实际模型时记录 `actual model: inherited/unverified`。
+- subagent 默认模型：具体默认值以 `.codex/config.toml` 的 `[workflow.subagent_runtime]` 为唯一配置真值，并由 `doc/engineering/workflow/source-of-truth.md#52-tpm-planning-and-subagent-dispatch` 的 `Default subagent runtime` policy 引用；专业角色 slice 默认请求该 runtime，若用户要求其他模型、slice 明确需要更强/更快/更省配置，当前 subagent 工具只能继承父线程模型，或请求选择后无法验证实际派发模型，必须在 slice contract 同时记录 intended model、actual dispatched model/reasoning 与原因；无法验证实际模型时记录 `actual model: inherited/unverified`。
 - subagent 默认上下文：专业角色 slice 默认使用 full-thread/full-history fork 或最接近的等价上下文；slice contract 仍必须记录 mandatory context checklist。手工显式 context packet 只能作为补充或 fallback，且必须记录为什么不能使用默认 fork（例如工具限制、上下文安全、模型选择冲突或默认 fork 卡住）。
 - 兼容契约词：`mandatory context packet` 在当前语义下指必须记录的 mandatory context checklist/packet，不等同于必须手工组装显式上下文包。
 - 兼容契约词：TPM 的 TODO decomposition、subagent slice contracts、mandatory context packet 和 integration order 必须先写入 `.pm/tasks/<TASK-UID>.execution.md`；其中 `mandatory context packet` 按当前语义解释为 mandatory context checklist/packet。

--- a/doc/engineering/workflow/source-of-truth.md
+++ b/doc/engineering/workflow/source-of-truth.md
@@ -150,7 +150,7 @@ If a specialist skill is used, TPM must still bind it to the same owner, `.pm` t
 ### 5.2 TPM planning and subagent dispatch
 - For every request, TPM must record the current plan, TODO decomposition when needed, selected roles, and integration order in `.pm/tasks/<TASK-UID>.execution.md` before dispatching professional subagent work.
 - Each subagent slice must declare role, slice type, intended model configuration, actual dispatched model/reasoning, context delivery mode, mandatory context checklist/packet, write scope, return contract, validation command, mandatory `.pm` execution-log sink, and integration order.
-- Default subagent runtime is `gpt-5.5` with `reasoning_effort=medium` (shorthand: `gpt-5.5-medium`). TPM should request this default for bounded professional slices when the available subagent tool permits model selection, unless the user explicitly requests another model or the slice contract records a concrete reason to use a stronger, faster, or cheaper model.
+- Default subagent runtime policy is defined only in `.codex/config.toml` under `[workflow.subagent_runtime]`. TPM should request that configured default for bounded professional slices when the available subagent tool permits model selection, unless the user explicitly requests another model or the slice contract records a concrete reason to use a stronger, faster, or cheaper model.
 - Compatibility marker: Any non-default subagent model or reasoning effort must be recorded in the slice contract.
 - Any actual non-default subagent model or reasoning effort must be recorded in the slice contract with the reason, such as high-risk architecture/review work, simple read-only exploration, a user-specified override, a connector/tool limitation that forces inheritance from the parent thread, or a requested model/reasoning selection whose actual dispatch cannot be verified. If the actual dispatched model cannot be verified, the contract must say `actual model: inherited/unverified` and explain why.
 - Context delivery defaults to full-thread/full-history fork or the closest available equivalent so the subagent receives the same conversation and repository-governance context as TPM. The slice contract must still record a mandatory context checklist identifying the governance/task/user/repo/collaboration context the subagent is expected to have. A manually assembled explicit context packet is allowed only as a delivery supplement or fallback when full-history fork is unavailable, unsafe, stalled, or incompatible with required model/reasoning selection; the slice contract must record that fallback reason.
@@ -260,8 +260,11 @@ If a specialist skill is used, TPM must still bind it to the same owner, `.pm` t
   - Replaced the optional/risk-based local supplemental review gate with a required pre-PR local role-subagent review gate.
   - Removed the Copilot review request from the standard PR helper flow.
   - Required `prepare-task-pr.sh --create` to verify passed local role review evidence in the task execution log before creating a PR.
+- **v1.4.17 (2026-06-08)**
+  - Moved the concrete default subagent runtime value into the repo-tracked `.codex/config.toml` `[workflow.subagent_runtime]` block so the model configuration has one canonical source.
+  - Updated the workflow source-of-truth and workflow eval contract to reference the config-backed policy instead of carrying the concrete runtime value in prose.
 - **v1.4.10 (2026-06-03)**
-  - Updated the default subagent runtime policy to `gpt-5.5` with `reasoning_effort=medium`.
+  - Updated the default subagent runtime policy.
   - Consolidated synced guidance, templates, and workflow eval checks to reference the section 5.2 `Default subagent runtime` policy instead of duplicating the concrete model string.
   - Added the `capture-todo.sh` pre-task discovery intake path for loose TODOs and follow-up ideas that should become `reflection` signals before any explicit `.pm` task promotion.
 - **v1.4.9 (2026-06-02)**
@@ -276,7 +279,7 @@ If a specialist skill is used, TPM must still bind it to the same owner, `.pm` t
   - Defined the sink for unbound read-only professional slices as the role-tagged user-facing answer or preserved chat/thread transcript. Superseded by v1.4.8, which forbids unbound read-only professional slices.
   - Clarified that `.pm` execution-log sinks are mandatory for task-bound or repository-changing subagent work, not for standalone read-only professional answers. Superseded by v1.4.8, which requires `.pm` task truth for every request.
 - **v1.4.6 (2026-06-01)**
-  - Added the default subagent runtime policy, originally `gpt-5.4` with `reasoning_effort=medium`.
+  - Added the default subagent runtime policy.
   - Required slice contracts to record model configuration and reasons for non-default model/reasoning overrides.
 - **v1.4.5 (2026-06-01)**
   - Split read-only/chat-only handling into pure fact lookup versus read-only professional/domain judgment.

--- a/scripts/pm/workflow-behavior-eval.sh
+++ b/scripts/pm/workflow-behavior-eval.sh
@@ -69,21 +69,31 @@ import re
 import sys
 from pathlib import Path
 
+def load_default_subagent_runtime(text: str) -> dict[str, str]:
+    section = None
+    values: dict[str, str] = {}
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith("[") and line.endswith("]"):
+            section = line[1:-1].strip()
+            continue
+        if section == "workflow.subagent_runtime" and "=" in line:
+            key, raw_value = line.split("=", 1)
+            values[key.strip()] = raw_value.strip().strip('"')
+    return values
+
 root = Path(sys.argv[1])
 bt = chr(96)
 source_text = (root / "doc/engineering/workflow/source-of-truth.md").read_text(encoding="utf-8")
-default_runtime_match = re.search(
-    r"Default subagent runtime is `([^`]+)` with `reasoning_effort=([^`]+)` "
-    r"\(shorthand: `([^`]+)`\)",
-    source_text,
-)
-if not default_runtime_match:
-    raise SystemExit("workflow-behavior-eval: source-of-truth missing parseable Default subagent runtime policy")
-default_model, default_reasoning, default_shorthand = default_runtime_match.groups()
-default_runtime_marker = (
-    f"Default subagent runtime is `{default_model}` with "
-    f"`reasoning_effort={default_reasoning}`"
-)
+default_runtime = load_default_subagent_runtime((root / ".codex/config.toml").read_text(encoding="utf-8"))
+default_model = default_runtime.get("model")
+default_reasoning = default_runtime.get("reasoning_effort")
+default_shorthand = default_runtime.get("shorthand")
+if not all(isinstance(value, str) and value for value in (default_model, default_reasoning, default_shorthand)):
+    raise SystemExit("workflow-behavior-eval: .codex/config.toml missing subagent runtime model/reasoning/shorthand strings")
+default_runtime_config_marker = ".codex/config.toml` under `[workflow.subagent_runtime]`"
 
 checks = [
     (
@@ -109,8 +119,7 @@ checks = [
             "Every user request must enter the standard worktree flow before any substantive handling begins",
             "Read-only professional/domain questions must be dispatched to the matching bounded professional role slice",
             "The task/worktree decision and the professional-slice decision are intentionally decoupled",
-            default_runtime_marker,
-            f"shorthand: `{default_shorthand}`",
+            default_runtime_config_marker,
             "Any non-default subagent model or reasoning effort must be recorded in the slice contract",
         ],
     ),
@@ -148,6 +157,7 @@ checks = [
             "只读专业 slice 的 contract、证据和 sink 必须写入",
             "subagent 默认模型",
             "Default subagent runtime",
+            "[workflow.subagent_runtime]",
         ],
     ),
     (
@@ -160,6 +170,7 @@ checks = [
             "专业角色以 subagent 形式提供切片工作",
             "不得用 TPM 自己的判断替代专业 subagent 结论",
             "Default subagent runtime",
+            "[workflow.subagent_runtime]",
             "派工前必须把当前 TODO",
             "mandatory context packet",
             "workflow source-of-truth",
@@ -363,9 +374,25 @@ import re
 import sys
 from pathlib import Path
 
+def load_default_subagent_runtime(text: str) -> dict[str, str]:
+    section = None
+    values: dict[str, str] = {}
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith("[") and line.endswith("]"):
+            section = line[1:-1].strip()
+            continue
+        if section == "workflow.subagent_runtime" and "=" in line:
+            key, raw_value = line.split("=", 1)
+            values[key.strip()] = raw_value.strip().strip('"')
+    return values
+
 root = Path(sys.argv[1])
 
 surfaces = {
+    ".codex/config.toml": (root / ".codex/config.toml").read_text(encoding="utf-8"),
     "AGENTS.md": (root / "AGENTS.md").read_text(encoding="utf-8"),
     ".agents/skills/default-workflow-bootstrap/SKILL.md": (
         root / ".agents/skills/default-workflow-bootstrap/SKILL.md"
@@ -410,18 +437,12 @@ surfaces = {
         root / ".agents/skills/game-architect/SKILL.md"
     ).read_text(encoding="utf-8"),
 }
-default_runtime_match = re.search(
-    r"Default subagent runtime is `([^`]+)` with `reasoning_effort=([^`]+)` "
-    r"\(shorthand: `([^`]+)`\)",
-    surfaces["doc/engineering/workflow/source-of-truth.md"],
-)
-if not default_runtime_match:
-    raise SystemExit("workflow-behavior-eval: source-of-truth missing parseable Default subagent runtime policy")
-default_model, default_reasoning, default_shorthand = default_runtime_match.groups()
-default_runtime_marker = (
-    f"Default subagent runtime is `{default_model}` with "
-    f"`reasoning_effort={default_reasoning}`"
-)
+default_runtime = load_default_subagent_runtime(surfaces[".codex/config.toml"])
+default_model = default_runtime.get("model")
+default_reasoning = default_runtime.get("reasoning_effort")
+default_shorthand = default_runtime.get("shorthand")
+if not all(isinstance(value, str) and value for value in (default_model, default_reasoning, default_shorthand)):
+    raise SystemExit("workflow-behavior-eval: .codex/config.toml missing subagent runtime model/reasoning/shorthand strings")
 
 scenarios = [
     {
@@ -570,8 +591,8 @@ scenarios = [
         "expected_route": f"TPM records {default_shorthand} as the source-of-truth default subagent model configuration",
         "surface": "doc/engineering/workflow/source-of-truth.md",
         "required_markers": [
-            default_runtime_marker,
-            f"shorthand: `{default_shorthand}`",
+            ".codex/config.toml",
+            "[workflow.subagent_runtime]",
             "Any non-default subagent model or reasoning effort must be recorded in the slice contract",
         ],
     },


### PR DESCRIPTION
## Summary
- move the concrete default subagent runtime into .codex/config.toml [workflow.subagent_runtime]
- switch the configured default to gpt-5.4-medium
- update workflow guidance and workflow-behavior-eval to read/reference the config-backed policy

## Verification
- bash -n scripts/pm/workflow-behavior-eval.sh
- git diff --check
- ./scripts/pm/workflow-behavior-eval.sh --json

## Review
- Pre-PR local role review passed for agent_engineer and qa_engineer
- Residual risk: workflow-behavior-eval uses a minimal reader for the simple [workflow.subagent_runtime] block