### PR TITLE
Add performance coverage baselines and runtime routing harness

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -78,6 +78,7 @@ jobs:
           echo "run_oasis7_net_libp2p_tests=${{ steps.scope.outputs.run_oasis7_net_libp2p_tests }}"
           echo "run_viewer_contract_tests=${{ steps.scope.outputs.run_viewer_contract_tests }}"
           echo "run_viewer_wasm_check=${{ steps.scope.outputs.run_viewer_wasm_check }}"
+          echo "run_viewer_perf_smoke=${{ steps.scope.outputs.run_viewer_perf_smoke }}"
           echo "run_launcher_web_build=${{ steps.scope.outputs.run_launcher_web_build }}"
           echo "needs_node=${{ steps.scope.outputs.needs_node }}"
           echo "needs_trunk=${{ steps.scope.outputs.needs_trunk }}"
@@ -128,6 +129,7 @@ jobs:
           OASIS7_CI_RUN_OASIS7_NET_LIBP2P_TESTS: ${{ steps.scope.outputs.run_oasis7_net_libp2p_tests }}
           OASIS7_CI_RUN_VIEWER_CONTRACT_TESTS: ${{ steps.scope.outputs.run_viewer_contract_tests }}
           OASIS7_CI_RUN_VIEWER_WASM_CHECK: ${{ steps.scope.outputs.run_viewer_wasm_check }}
+          OASIS7_CI_RUN_VIEWER_PERF_SMOKE: ${{ steps.scope.outputs.run_viewer_perf_smoke }}
           OASIS7_CI_RUN_LAUNCHER_WEB_BUILD: ${{ steps.scope.outputs.run_launcher_web_build }}
         run: CI_VERBOSE=1 ./scripts/ci-tests.sh required
 

--- a/.pm/tasks/task_35657c5f0a5543dda5d57f51fc4b8841.execution.md
+++ b/.pm/tasks/task_35657c5f0a5543dda5d57f51fc4b8841.execution.md
@@ -657,3 +657,33 @@ Example:
 - Review Findings Disposition: addressed
 - Finding Disposition Evidence: testing-manual.md now records only the baseline numbers and treats local .tmp summaries as ephemeral while the execution log remains the durable evidence source; the runtime and QA verification set was rerun with no new blocking findings
 - Residual Risk: runtime module routing harness remains local/report-only, covers only the inner routing loop on a single host, and the first cold release compile still costs about 23 minutes before the harness itself executes
+
+## 2026-06-10 13:03:00 CST / tpm
+- 完成内容: 跟进 PR `#396` 的首轮 GitHub CI，定位并修复唯一阻断项 `required-gate` 的 `cargo fmt --check` 失败。
+- 遗留事项:
+  - 待推送本次 formatting-only 修复并等待 GitHub `required-gate` 重跑；
+  - 若 rerun 后仍有新的 required-check 失败，再按新失败签名进入 fix/verify/push 循环。
+- Action:
+  - 检查 PR `#396` 的 `statusCheckRollup`、`gh pr checks 396` 与 `gh run view 27252456313 --job 80479632665 --log-failed`，确认失败发生在 `env -u RUSTC_WRAPPER cargo fmt --all -- --check`；
+  - 失败 diff 仅涉及 `crates/oasis7/src/bin/oasis7_runtime_module_routing_perf.rs` 的 import 顺序与一处长行换行；
+  - 基于已存在的 `qa_pre_pr_review` / `runtime_pre_pr_review` 线程追加 bounded triage，二者都确认这是 formatting/verification contract failure，不是 runtime 行为回归；
+  - 运行 `rustfmt crates/oasis7/src/bin/oasis7_runtime_module_routing_perf.rs` 应用最小修复。
+- Validation Command:
+  - `gh pr checks 396`
+  - `gh run view 27252456313 --job 80479632665 --log-failed`
+  - `rustfmt crates/oasis7/src/bin/oasis7_runtime_module_routing_perf.rs`
+  - `env -u RUSTC_WRAPPER cargo fmt --all -- --check`
+  - `git diff --check`
+- Expected Result:
+  - `required-gate` 的阻断签名被确认是单文件 formatting mismatch；
+  - 本地 `cargo fmt --check` 在修复后 fresh 通过；
+  - 可安全提交并推送 formatting-only 修复，等待 GitHub 重跑。
+- Actual Result:
+  - `required-gate` 除 `cargo fmt --check` 外其余已跑到的 docs/lint/tests 均通过；
+  - `runtime_pre_pr_review` 与 `qa_pre_pr_review` follow-up 一致确认：这是纯 formatting miss，不是产品/运行时行为回归；
+  - `rustfmt` 后该文件只产生 import 排序与换行差异；
+  - `env -u RUSTC_WRAPPER cargo fmt --all -- --check` fresh 通过；
+  - `git diff --check` 通过。
+- Blocker / Next Action:
+  - 提交并推送本次 formatting-only 修复，等待 PR `#396` 的 `required-gate` 重跑；
+  - 若 GitHub 重跑全绿，继续检查 comments/review threads/mergeability 后推进合入。

--- a/.pm/tasks/task_35657c5f0a5543dda5d57f51fc4b8841.execution.md
+++ b/.pm/tasks/task_35657c5f0a5543dda5d57f51fc4b8841.execution.md
@@ -687,3 +687,33 @@ Example:
 - Blocker / Next Action:
   - 提交并推送本次 formatting-only 修复，等待 PR `#396` 的 `required-gate` 重跑；
   - 若 GitHub 重跑全绿，继续检查 comments/review threads/mergeability 后推进合入。
+
+## 2026-06-10 13:54:00 CST / tpm
+- 完成内容: 处理 PR `#396` 上剩余的 unresolved review thread，修复 viewer perf smoke 在 hosted CI 上可能缺少全局 `agent-browser` 时无信号却静默成功的覆盖缺口。
+- 遗留事项:
+  - 待提交并推送本次 `agent-browser` fallback 修复；
+  - 推送后需要等待 PR checks 再次通过，并关闭对应 review thread 后才能继续合入。
+- Action:
+  - 用 `./scripts/pr-review-thread-closeout.sh 396 --unresolved-only` 发现 1 条 unresolved thread：`PRRT_kwDORHhWec6IW1vd`，指向 `scripts/ci-tests.sh:212` 的 viewer perf smoke；
+  - 读取 review comment 与 `crates/oasis7_viewer/scripts/viewer-performance-probe.mjs`、`scripts/agent-browser-lib.sh` repo truth，确认 review 指出的问题成立：probe 直接调用 `agent-browser`，没有沿用 repo 里的 `npx agent-browser` fallback；
+  - 修改 `crates/oasis7_viewer/scripts/viewer-performance-probe.mjs`，新增 agent-browser invocation resolver：
+    - 优先使用显式 `AGENT_BROWSER_BIN`
+    - 否则使用 PATH 中的 `agent-browser`
+    - 再否则退回 `npx --yes ${AGENT_BROWSER_NPX_PACKAGE:-agent-browser}`
+  - 保持 probe 行为不变，只补 hosted CI 缺少全局二进制时的可执行后备路径。
+- Validation Command:
+  - `node --check crates/oasis7_viewer/scripts/viewer-performance-probe.mjs`
+  - `npm --prefix crates/oasis7_viewer run test:perf-harness`
+  - `git diff --check`
+- Expected Result:
+  - unresolved review thread 对应的 hosted CI coverage gap 被修复；
+  - viewer perf probe 脚本语法正确，现有 perf harness 测试继续通过；
+  - 推送后 PR checks 可以基于真实 probe 可执行路径重跑。
+- Actual Result:
+  - `node --check` 通过；
+  - `npm --prefix crates/oasis7_viewer run test:perf-harness` 通过（`1` file / `4` tests）；
+  - `git diff --check` 通过；
+  - 当前修复已准备好提交推送，并在推送后关闭 `PRRT_kwDORHhWec6IW1vd`。
+- Blocker / Next Action:
+  - 提交并推送本次 review-thread fix；
+  - 关闭对应 thread，等待 checks 再次全绿后继续执行 merge。

--- a/.pm/tasks/task_35657c5f0a5543dda5d57f51fc4b8841.execution.md
+++ b/.pm/tasks/task_35657c5f0a5543dda5d57f51fc4b8841.execution.md
@@ -1,0 +1,659 @@
+# task_35657c5f0a5543dda5d57f51fc4b8841 Execution Log
+
+- task_uid: task_35657c5f0a5543dda5d57f51fc4b8841
+- title: Assess performance tests and code quality safeguards
+- owner_role: tpm
+- worktree_hint: /Users/scc/ccwork/worktrees/oasis7-engineering-code-quality-performance-readonly
+
+<!-- Append entries using:
+Example:
+  ## YYYY-MM-DD HH:MM:SS CST / role_name
+  - 完成内容: ...
+  - 遗留事项: ...
+  - Action: ...
+  - Validation Command: ...
+  - Expected Result: ...
+  - Actual Result: ...
+  - Blocker / Next Action: ...
+-->
+
+## 2026-06-09 18:06:00 CST / tpm
+- 完成内容: 完成本次只读咨询的 workflow bootstrap，确认当前用户问题属于“先进入 task truth，再由专业角色给出只读专业判断”的路径。
+- Action: 读取 `AGENTS.md`、`doc/engineering/workflow/source-of-truth.md`、`testing-manual.md`，检查当前 branch/worktree 状态，并创建隔离 task worktree `task/engineering-code-quality-performance-readonly` 绑定本 task。
+- Validation Command: `rtk git branch --show-current`; `rtk git status --short`; `rtk git worktree list`; `rtk ./scripts/new-task-worktree.sh engineering code-quality-performance-readonly --pm-owner-role tpm --pm-title "Assess performance tests and code quality safeguards" --pm-source-ref AGENTS.md --pm-source-ref testing-manual.md --pm-source-ref doc/engineering/workflow/source-of-truth.md --json`
+- Expected Result: 不在主 worktree 直接回答；新建单一 canonical worktree 与 `.pm` task，并满足 read-only specialist routing 前置条件。
+- Actual Result: 源 worktree 位于 `main`，未绑定本任务；已创建 `/Users/scc/ccwork/worktrees/oasis7-engineering-code-quality-performance-readonly`，branch 为 `task/engineering-code-quality-performance-readonly`，task uid 为 `task_35657c5f0a5543dda5d57f51fc4b8841`。
+- WORKFLOW BOOTSTRAP DECIDED:
+  - Repository State Impact: 创建了新 task worktree 与 `.pm` task；本次目标是只读分析，不计划改业务代码。
+  - Isolation Decision: 当前主 worktree 虽干净，但按 repo workflow 不能把新请求直接绑定到 `main`；因此新建专用 worktree。
+  - Task Truth: owner role=`tpm`; `.pm` task=`task_35657c5f0a5543dda5d57f51fc4b8841`; formal docs=`AGENTS.md`, `testing-manual.md`, `doc/engineering/workflow/source-of-truth.md`。
+  - Routed Next Phase: read-only specialist routing under TPM coordination。
+- TODO Decomposition:
+  - 1. 由 `runtime_engineer` 盘点仓库现有性能测试/性能探针/性能门禁。
+  - 2. 由 `qa_engineer` 盘点当前代码正确性保障链路，包括测试分层、CI gate、fresh verification 与缺口。
+  - 3. TPM 仅负责整合两类结论，明确“已有机制”和“实际还缺什么”。
+- Integration Order:
+  - 先收 `runtime_engineer` 的性能机制 inventory。
+  - 再收 `qa_engineer` 的质量保障判断与残余风险。
+  - 最终回答中显式区分 TPM 程序性总结与专业角色结论。
+- Subagent Slice Contract 1:
+  - role: `runtime_engineer`
+  - slice_type: `read_only_analysis`
+  - question: 当前仓库现在是否已有性能测试或性能探针？分别覆盖什么、怎么运行、是否形成硬门禁？
+  - non_goals: 不修改代码；不做新的 benchmark 设计；不把 QA judgment 混入 runtime 结论。
+  - intended multi-agent runtime: `multi_agent_v2`
+  - actual runtime/tool surface: `spawn_agent` tool surface available in current Codex thread; canonical runtime label unverified
+  - intended model: repo default subagent runtime from `.codex/config.toml`
+  - actual model: inherited/unverified
+  - context delivery mode: full-thread/full-history fork requested via subagent inheritance
+  - mandatory context checklist: `AGENTS.md`; `doc/engineering/workflow/source-of-truth.md`; `testing-manual.md`; current task yaml/execution log; canonical worktree path; branch name; user question about performance tests and code correctness; `third_party` read-only constraint
+  - scoped evidence: `testing-manual.md`; `scripts/viewer-performance-probe.sh`; `crates/oasis7_viewer/scripts/viewer-performance-probe.mjs`; `scripts/ci-compile-metrics.sh`; `.github/workflows/compile-metrics.yml`; any `bench`/`criterion`/perf scripts found in repo
+  - write scope: none
+  - return contract: concise conclusion, concrete commands/paths, whether each mechanism is smoke/probe/gate, and residual performance assurance gap
+  - validation command: repo text inspection only
+  - mandatory sink: this execution log entry plus subagent final response captured by TPM
+  - integration order: first
+- Subagent Slice Contract 2:
+  - role: `qa_engineer`
+  - slice_type: `verification_judgment`
+  - question: 当前仓库是如何保障“代码写得没问题”的？已有哪些测试层、CI gate、fresh verification 要求与明显缺口？
+  - non_goals: 不做 runtime 性能实现分析；不修改测试；不把 TPM 自己的判断包装成 QA 结论。
+  - intended multi-agent runtime: `multi_agent_v2`
+  - actual runtime/tool surface: `spawn_agent` tool surface available in current Codex thread; canonical runtime label unverified
+  - intended model: repo default subagent runtime from `.codex/config.toml`
+  - actual model: inherited/unverified
+  - context delivery mode: full-thread/full-history fork requested via subagent inheritance
+  - mandatory context checklist: `AGENTS.md`; `doc/engineering/workflow/source-of-truth.md`; `testing-manual.md`; current task yaml/execution log; canonical worktree path; branch name; user question about whether performance tests exist and how code quality is ensured
+  - scoped evidence: `testing-manual.md`; `scripts/ci-tests.sh`; relevant workflow docs/skills mentioning verification-before-completion; any CI workflow files tied to required gates
+  - write scope: none
+  - return contract: concise QA judgment with current safeguards, enforcement points, missing guarantees, and practical recommendation ladder
+  - validation command: repo text inspection only
+  - mandatory sink: this execution log entry plus subagent final response captured by TPM
+  - integration order: second
+- 遗留事项: 等待两位专业角色返回只读结论，再整合为对用户的最终说明。
+
+## 2026-06-09 18:18:00 CST / tpm
+- 完成内容: 根据用户追加请求“ci上跑一下看看，有没有性能问题”，将当前只读咨询任务路由到实际执行性能相关 CI 验证。
+- WORKFLOW ROUTE DECIDED:
+  - Current phase: `executing-project-tasks`
+  - Why: task truth 已存在，用户现在要求实际执行仓库现有 CI/perf gate，而不是继续停留在只读盘点。
+  - Selected workflow skills:
+    1. `executing-project-tasks` - 执行本地等价 CI/perf gate 并收集输出
+    2. `systematic-debugging` - 仅在 gate 失败或出现异常指标时启用
+  - Skipped workflow skills:
+    - `bounded-brainstorming` - 方向明确，无需方案发散
+    - `tdd-test-writer` - 本轮不改代码，只执行现有验证
+    - `verification-before-completion` - 本轮目标是回报运行结果，不做“任务完成/ready for PR”声明
+    - `finishing-a-development-branch` - 当前不是 closeout/PR 阶段
+  - Specialist skills considered:
+    - `optimization-performance` / `qa_engineer` 相关专业判断将通过 bounded subagent slice 在命令输出产生后给出
+- TODO Decomposition:
+  - 1. 机械执行当前最接近 CI 的性能门禁 `compile-metrics`。
+  - 2. 如可行，再执行一条代表性的本地 required CI 入口或相关性能 smoke。
+  - 3. 将输出交由 `runtime_engineer` 判断是否存在性能回归信号，必要时由 `qa_engineer`补充“CI 是否足够说明没问题”的边界。
+- Action: 记录本轮执行路径，并准备运行性能相关 gate。
+- Validation Command: `rtk git branch --show-current`; `rtk git status --short`
+- Expected Result: 在已绑定 task worktree 内执行，不跨出 canonical task truth。
+- Actual Result: 当前 branch=`task/engineering-code-quality-performance-readonly`；存在本任务 `.pm` 写回改动，允许继续执行只读验证/产物输出。
+- 遗留事项: 开始运行性能相关 CI gate，并在获得结果后派发专业判断 slice。
+
+## 2026-06-09 19:46:00 CST / tpm
+- 完成内容: 第一轮性能相关本地 CI 执行完成初步排障，识别到当前阻塞更像环境/依赖获取问题，而非代码性能回归。
+- Action: 运行 `./scripts/ci-compile-metrics.sh --package oasis7_client_launcher --binary oasis7_client_launcher --baseline-ref origin/main --out-dir output/compile-metrics/local-check`，并补跑 launcher 依赖树与 viewer 契约 smoke。
+- Validation Command: `cat output/compile-metrics/local-check/logs/current-cargo-fetch.log`; `ps -axo pid,ppid,etime,stat,command | rg "ci-compile-metrics|cargo fetch --locked"`; `cargo tree -p oasis7_client_launcher --prefix none | sort -u | wc -l`; `node crates/oasis7_viewer/scripts/software-safe-feedback-contract.test.mjs`
+- Expected Result: 获得 compile-metrics 比较结果，或至少获得可归因的失败签名，继续判断是否存在真实性能问题。
+- Actual Result:
+  - `compile-metrics` 在 `cargo fetch --locked` 阶段卡于 `Updating crates.io index`，尚未进入 `cargo check`/`cargo build --release` 指标阶段；
+  - `cargo tree` 首次执行命中 package cache lock，说明存在 cargo 缓存竞争；
+  - viewer 合约 smoke 直接失败，签名为 `ERR_MODULE_NOT_FOUND: Cannot find package 'solid-js'`，属于前端依赖未安装问题，而非性能回归信号。
+- Blocker: 当前结果无法直接证明“有性能问题”；需要先消除 cargo cache lock 与 viewer node_modules 缺失，再继续跑本地等价 CI/perf check。
+- Next Action: 检查并清理残留 cargo 进程/锁竞争，安装 `crates/oasis7_viewer` 前端依赖，然后重跑 launcher 依赖树与 viewer CI smoke；如仍失败，再按环境问题归类回报。
+
+## 2026-06-09 19:49:00 CST / tpm
+- 完成内容: 第二轮本地等价 CI/perf 检查完成，未发现明确代码级性能回归信号；发现的主要问题属于环境/依赖获取层。
+- Action: 安装 `crates/oasis7_viewer` 前端依赖，并重跑 launcher 依赖面与 viewer 契约/性能 harness。
+- Validation Command:
+  - `rtk npm --prefix crates/oasis7_viewer ci`
+  - `cargo tree -p oasis7_client_launcher --prefix none | sort -u | wc -l`
+  - `if cargo tree -p oasis7_client_launcher -i wasmtime ...`
+  - `if cargo tree -p oasis7_client_launcher -i oasis7_wasm_executor ...`
+  - `rtk node crates/oasis7_viewer/scripts/software-safe-feedback-contract.test.mjs`
+  - `rtk npm --prefix crates/oasis7_viewer run test:perf-harness`
+- Expected Result: 获得至少一组不依赖 crates.io 现场更新的本地 CI/perf 信号，用于判断当前代码是否存在明显性能问题。
+- Actual Result:
+  - `npm --prefix crates/oasis7_viewer ci` 成功；
+  - launcher package closure count = `606`；
+  - `wasmtime` 对 `oasis7_client_launcher` 逆依赖检查结果为 `absent`；
+  - `oasis7_wasm_executor` 仍出现在 launcher 闭包中，但当前 compile-metrics gate 只硬性要求 `wasmtime` 不得误入；
+  - `software-safe feedback contract tests passed`；
+  - `test:perf-harness` 通过，`1` 个 test file / `4` 个 tests 全通过。
+- Judgment Boundary:
+  - 当前 branch 与 `origin/main` 没有代码差异，因此本轮未观察到“新改动导致的性能退化”信号；
+  - 无法完整跑透 `compile-metrics` 的根因是 `cargo fetch --locked` 卡在 `Updating crates.io index`，这是环境/网络依赖获取问题，不足以证明代码存在性能问题。
+- Next Action: 向用户回报“当前没有看到明确性能问题，唯一显著阻塞是 compile-metrics 受 crates.io index 更新拖住”；若需要更强证据，再在网络稳定环境下补跑完整 `compile-metrics` 或 headed viewer performance probe。
+
+## 2026-06-09 20:02:00 CST / tpm
+- 完成内容: 用户要求“结合现有功能和已有测试，整理一个哪里应该补的表”；当前任务从口头咨询进入文档产物整理。
+- WORKFLOW ROUTE DECIDED:
+  - Current phase: `executing-project-tasks`
+  - Why: task truth 已存在，下一步是基于现有功能面与测试面整理一份 repo 内可复用的补测矩阵文档。
+  - Selected workflow skills:
+    1. `executing-project-tasks` - 产出补测矩阵文档
+    2. `verification-before-completion` - 仅用于文档落盘后做最小校验，不做 PR/closeout claim
+  - Skipped workflow skills:
+    - `bounded-brainstorming` - 方向明确，目标是收敛现状与 gap
+    - `tdd-test-writer` - 本轮改动是文档，不是行为实现
+    - `finishing-a-development-branch` - 当前不是 closeout 阶段
+- TODO Decomposition:
+  - 1. 由 `runtime_engineer` 给出“按功能/性能热点补哪些性能测试”的建议矩阵。
+  - 2. 由 `qa_engineer` 给出“哪些补测该进默认 gate、哪些维持按需执行”的建议矩阵。
+  - 3. TPM 将两者合流为一份 repo 内 markdown 表，重点写“现有覆盖”“当前缺口”“建议补什么”“建议优先级”。
+- Integration Order:
+  - 先收 runtime 的热点/链路建议。
+  - 再收 QA 的 gate/覆盖策略建议。
+  - 最后由 TPM 合并成单一表格文档并做最小校验。
+- Subagent Slice Contract 3:
+  - role: `runtime_engineer`
+  - slice_type: `read_only_analysis`
+  - question: 结合当前功能面与现有性能测试，哪些运行时/Viewer/launcher/p2p/LLM 链路最值得补性能测试？建议补哪种测试与指标？
+  - non_goals: 不改代码；不设计完整新框架；不代替 QA 决定默认 gate 策略
+  - intended multi-agent runtime: `multi_agent_v2`
+  - actual runtime/tool surface: existing agent thread follow-up via current Codex tool surface; canonical runtime label unverified
+  - intended model: repo default subagent runtime from `.codex/config.toml`
+  - actual model: inherited/unverified
+  - context delivery mode: existing full-history thread follow-up
+  - mandatory context checklist: `AGENTS.md`; `doc/engineering/workflow/source-of-truth.md`; `testing-manual.md`; `doc/testing/prd.md`; current task yaml/execution log; user request to organize a supplement matrix
+  - scoped evidence: existing `testing-manual.md`; `.github/workflows/*.yml`; `scripts/*perf*`; `scripts/*stress*`; `scripts/*soak*`; relevant ignored perf probes in crates
+  - write scope: none
+  - return contract: flat list of 5-10 rows with surface, current coverage, gap, recommended added test, and priority
+  - mandatory sink: this execution log plus subagent reply integrated by TPM
+  - integration order: first
+- Subagent Slice Contract 4:
+  - role: `qa_engineer`
+  - slice_type: `verification_judgment`
+  - question: 结合当前功能面与现有测试，哪些补测应进入 default required/full/release gate，哪些保持按需执行更合适？
+  - non_goals: 不做 runtime 实现设计；不编造不存在的 CI 能力
+  - intended multi-agent runtime: `multi_agent_v2`
+  - actual runtime/tool surface: existing agent thread follow-up via current Codex tool surface; canonical runtime label unverified
+  - intended model: repo default subagent runtime from `.codex/config.toml`
+  - actual model: inherited/unverified
+  - context delivery mode: existing full-history thread follow-up
+  - mandatory context checklist: `AGENTS.md`; `doc/engineering/workflow/source-of-truth.md`; `testing-manual.md`; `doc/testing/prd.md`; current task yaml/execution log; user request to organize supplement matrix
+  - scoped evidence: existing `testing-manual.md`; `scripts/ci-tests.sh`; workflow docs; current CI/perf inventory from this task
+  - write scope: none
+  - return contract: flat list of 5-10 rows or edits focusing on gating policy, coverage gap, recommended tier, and priority
+  - mandatory sink: this execution log plus subagent reply integrated by TPM
+  - integration order: second
+- Next Action: follow up existing runtime/QA agent threads for concise matrix rows, then create repo doc under `doc/testing/performance/`.
+
+## 2026-06-09 20:08:00 CST / tpm
+- 完成内容: 用户要求继续推进，目标从“补测矩阵”升级为“实施顺序清单”，明确先做哪几项最划算及其最小交付。
+- WORKFLOW ROUTE DECIDED:
+  - Current phase: `executing-project-tasks`
+  - Why: 现有矩阵已经给出 surface 与 priority，下一步应把 P1 项落成可执行顺序与最小交付说明，便于直接开工。
+  - Selected workflow skills:
+    1. `executing-project-tasks` - 产出实施顺序文档
+    2. `verification-before-completion` - 仅做文档最小校验
+  - Skipped workflow skills:
+    - `bounded-brainstorming` - 当前不是发散阶段
+    - `tdd-test-writer` - 本轮仍然是文档整理，不改行为代码
+    - `finishing-a-development-branch` - 当前不是 closeout 阶段
+- TODO Decomposition:
+  - 1. 由 `runtime_engineer` 给出 P1 面向运行时/性能热点的实施先后和最小交付。
+  - 2. 由 `qa_engineer` 给出哪些项最容易先接入现有 gate、哪些应保留按需执行。
+  - 3. TPM 合成一份“先做哪三项”的执行清单，并补到 `doc/testing/performance/`。
+- Subagent Slice Contract 5:
+  - role: `runtime_engineer`
+  - slice_type: `read_only_analysis`
+  - question: 基于现有 P1 项，建议的实施顺序是什么？每项最小技术交付是什么？
+  - non_goals: 不改代码；不替 QA 决定 gate policy；不展开成长篇方案
+  - intended multi-agent runtime: `multi_agent_v2`
+  - actual runtime/tool surface: existing agent thread follow-up via current Codex tool surface; canonical runtime label unverified
+  - intended model: repo default subagent runtime from `.codex/config.toml`
+  - actual model: inherited/unverified
+  - context delivery mode: existing full-history thread follow-up
+  - mandatory context checklist: `AGENTS.md`; `doc/engineering/workflow/source-of-truth.md`; `testing-manual.md`; current gap matrix doc; current task yaml/execution log
+  - scoped evidence: current gap matrix plus existing perf scripts and manual sections
+  - write scope: none
+  - return contract: top 3-5 implementation order rows with why-now and minimum deliverable
+  - mandatory sink: this execution log plus subagent reply integrated by TPM
+  - integration order: first
+- Subagent Slice Contract 6:
+  - role: `qa_engineer`
+  - slice_type: `verification_judgment`
+  - question: 基于现有 P1 项，哪些最适合先进入现有 gate 体系，哪些应该先作为 on-demand/experimental 落地？
+  - non_goals: 不做 runtime 技术设计；不创造不存在的 CI surface
+  - intended multi-agent runtime: `multi_agent_v2`
+  - actual runtime/tool surface: existing agent thread follow-up via current Codex tool surface; canonical runtime label unverified
+  - intended model: repo default subagent runtime from `.codex/config.toml`
+  - actual model: inherited/unverified
+  - context delivery mode: existing full-history thread follow-up
+  - mandatory context checklist: `AGENTS.md`; `doc/engineering/workflow/source-of-truth.md`; `testing-manual.md`; current gap matrix doc; current task yaml/execution log
+  - scoped evidence: current gap matrix; `scripts/ci-tests.sh`; current workflow gates
+  - write scope: none
+  - return contract: top 3-5 order rows with suggested gate tier and rollout caution
+  - mandatory sink: this execution log plus subagent reply integrated by TPM
+  - integration order: second
+- Next Action: follow up existing runtime/QA agent threads for a top-3 order recommendation, then extend the repo doc with an implementation sequence section.
+
+## 2026-06-09 20:14:00 CST / tpm
+- 完成内容: 按 repo 默认流程进入专业 subagent 默认派发阶段，针对前三个 P1 项并行派发实现前置切片。
+- TODO Decomposition:
+  - 1. `viewer_engineer` 收敛 Viewer changed-path scoped 性能 gate 的最小落地方案与文件接线点。
+  - 2. `runtime_engineer` 收敛 runtime tick/step 轻量 deterministic perf harness 的最小落地方案与文件接线点。
+  - 3. `blockchain_ops_engineer` 收敛 P2P/存储/共识短窗 scoped soak 的最小落地方案与文件接线点。
+  - 4. TPM 合流三者输出，决定是否直接进入实现，或先把执行计划/文档补齐。
+- Integration Order:
+  - `viewer_engineer` -> `runtime_engineer` -> `blockchain_ops_engineer` -> TPM 合流
+- Subagent Slice Contract 7:
+  - role: `viewer_engineer`
+  - slice_type: `implementation_planning`
+  - ownership: Viewer changed-path scoped performance gate; files likely under `scripts/viewer-performance-probe.sh`, `crates/oasis7_viewer/scripts/viewer-performance-probe.mjs`, `scripts/ci-tests.sh`, `scripts/plan-rust-required-scope.sh`, `.github/workflows/rust.yml`, `testing-manual.md`
+  - question: 如果现在开始做第 1 项，最小可落地方案是什么？需要改哪些文件、如何 changed-path 触发、如何先 report-only 再升 blocking？
+  - non_goals: 不实现代码；不替 QA 决定最终放行策略；不扩展到 runtime/p2p
+  - intended multi-agent runtime: `multi_agent_v2`
+  - actual runtime/tool surface: `spawn_agent` tool surface available in current Codex thread; canonical runtime label unverified
+  - intended model: repo default subagent runtime from `.codex/config.toml`
+  - actual model: inherited/unverified
+  - context delivery mode: full-thread/full-history fork requested via subagent inheritance
+  - mandatory context checklist: `AGENTS.md`; `doc/engineering/workflow/source-of-truth.md`; `testing-manual.md`; current task yaml/execution log; `doc/testing/performance/performance-coverage-gap-matrix-2026-06-09.md`; `third_party` read-only boundary
+  - write scope: none
+  - return contract: concise plan with files, trigger rule, minimum deliverable, rollout path, and residual risk
+  - mandatory sink: this execution log plus subagent final response captured by TPM
+  - integration order: first
+- Subagent Slice Contract 8:
+  - role: `runtime_engineer`
+  - slice_type: `implementation_planning`
+  - ownership: runtime tick/step deterministic perf harness; files likely under `crates/oasis7/**`, `scripts/ci-tests.sh`, `testing-manual.md`, and any new/updated perf harness entry
+  - question: 如果现在开始做第 2 项，最小可落地方案是什么？应该挑哪类 hot path、落哪些指标、接到哪里最稳？
+  - non_goals: 不实现代码；不扩大到长跑体系重构；不替 QA 决定最终 gate 层级
+  - intended multi-agent runtime: `multi_agent_v2`
+  - actual runtime/tool surface: `spawn_agent` tool surface available in current Codex thread; canonical runtime label unverified
+  - intended model: repo default subagent runtime from `.codex/config.toml`
+  - actual model: inherited/unverified
+  - context delivery mode: full-thread/full-history fork requested via subagent inheritance
+  - mandatory context checklist: `AGENTS.md`; `doc/engineering/workflow/source-of-truth.md`; `testing-manual.md`; current task yaml/execution log; current performance gap matrix
+  - write scope: none
+  - return contract: concise plan with candidate hot path, candidate metrics, likely files, minimal command shape, and residual risk
+  - mandatory sink: this execution log plus subagent final response captured by TPM
+  - integration order: second
+- Subagent Slice Contract 9:
+  - role: `blockchain_ops_engineer`
+  - slice_type: `implementation_planning`
+  - ownership: short scoped soak for p2p/storage-risk changes; files likely under `scripts/p2p-longrun-soak.sh`, `scripts/p2p-mixed-topology-matrix*.sh`, `scripts/plan-rust-required-scope.sh`, release workflows, `testing-manual.md`
+  - question: 如果现在开始做第 3 项，最小可落地方案是什么？短窗 soak 应该怎么 scoped、放在哪个命令入口、如何避免污染普通 PR？
+  - non_goals: 不实现代码；不重写 release soak 体系；不替 QA 决定阻断策略
+  - intended multi-agent runtime: `multi_agent_v2`
+  - actual runtime/tool surface: `spawn_agent` tool surface available in current Codex thread; canonical runtime label unverified
+  - intended model: repo default subagent runtime from `.codex/config.toml`
+  - actual model: inherited/unverified
+  - context delivery mode: full-thread/full-history fork requested via subagent inheritance
+  - mandatory context checklist: `AGENTS.md`; `doc/engineering/workflow/source-of-truth.md`; `testing-manual.md`; current task yaml/execution log; current performance gap matrix
+  - write scope: none
+  - return contract: concise plan with trigger scope, likely command shape, likely files, rollout path, and residual risk
+  - mandatory sink: this execution log plus subagent final response captured by TPM
+  - integration order: third
+- Next Action: close completed read-only agents to free capacity, then spawn the three new specialized slices.
+
+## 2026-06-09 20:22:00 CST / tpm
+- 完成内容: 用户要求继续推进，现从“专业规划 slices”切换到“专业实现 slices”，优先实施第 1 项 `Viewer changed-path scoped 性能 gate`。
+- TODO Decomposition:
+  - 1. `viewer_engineer` 负责实现 Viewer scoped performance gate 的代码与文档接线。
+  - 2. `qa_engineer` 负责定义该 gate 的 rollout 方式、最小验证链路和 report-only 到 blocking 的证据要求。
+  - 3. TPM 负责合流、补 `.pm`/文档索引/执行证据，并在本 worktree 里跑 scoped verification。
+- Integration Order:
+  - `viewer_engineer` implementation -> `qa_engineer` validation judgment -> TPM integrate and verify
+- Subagent Slice Contract 10:
+  - role: `viewer_engineer`
+  - slice_type: `implementation`
+  - ownership: implement priority item 1, Viewer changed-path scoped performance gate
+  - likely files: `scripts/viewer-performance-probe.sh`, `crates/oasis7_viewer/scripts/viewer-performance-probe.mjs`, `scripts/plan-rust-required-scope.sh`, `scripts/ci-tests.sh`, `.github/workflows/rust.yml`, `testing-manual.md`, `doc/testing/performance/performance-coverage-gap-matrix-2026-06-09.md`
+  - question: implement the smallest viable path that can run Viewer perf smoke in a changed-path scoped way and support report-only rollout before blocking
+  - non_goals: do not implement runtime perf harness or p2p soak changes; do not revert user/TPM edits; do not create a second task/worktree/PR chain
+  - intended multi-agent runtime: `multi_agent_v2`
+  - actual runtime/tool surface: `spawn_agent` tool surface available in current Codex thread; canonical runtime label unverified
+  - intended model: repo default subagent runtime from `.codex/config.toml`
+  - actual model: inherited/unverified
+  - context delivery mode: full-thread/full-history fork requested via subagent inheritance
+  - mandatory context checklist: `AGENTS.md`; `doc/engineering/workflow/source-of-truth.md`; `.agents/roles/viewer_engineer.md`; current task yaml/execution log; current performance gap matrix doc; `testing-manual.md`; relevant scripts/workflows; `third_party` read-only boundary
+  - write scope: only files needed for Viewer scoped performance gate and its docs/tests; do not touch unrelated surfaces
+  - return contract: implemented diff, concise rationale, exact verification run, residual risk
+  - mandatory sink: this execution log plus code changes in current worktree
+  - integration order: first
+- Subagent Slice Contract 11:
+  - role: `qa_engineer`
+  - slice_type: `verification_judgment`
+  - ownership: validate rollout/gate strategy and verification for priority item 1
+  - likely files for review context: `scripts/plan-rust-required-scope.sh`, `scripts/ci-tests.sh`, `.github/workflows/rust.yml`, `testing-manual.md`, Viewer perf scripts, current gap matrix doc
+  - question: once Viewer scoped perf gate implementation is present, what is the correct rollout posture (report-only vs blocking), and what verification evidence is sufficient for this task?
+  - non_goals: do not implement code unless asked later; do not broaden scope to runtime/p2p items
+  - intended multi-agent runtime: `multi_agent_v2`
+  - actual runtime/tool surface: `spawn_agent` tool surface available in current Codex thread; canonical runtime label unverified
+  - intended model: repo default subagent runtime from `.codex/config.toml`
+  - actual model: inherited/unverified
+  - context delivery mode: full-thread/full-history fork requested via subagent inheritance
+  - mandatory context checklist: `AGENTS.md`; `doc/engineering/workflow/source-of-truth.md`; `.agents/roles/qa_engineer.md`; current task yaml/execution log; current gap matrix doc; relevant scripts/workflows
+  - write scope: none by default; review/validation judgment only
+  - return contract: concise verification judgment, rollout recommendation, and any must-fix findings
+  - mandatory sink: this execution log plus subagent response captured by TPM
+  - integration order: second
+- Next Action: spawn the Viewer implementation slice and QA validation slice.
+
+## 2026-06-09 20:38:00 CST / tpm
+- 完成内容: 尝试按默认流程派发 `viewer_engineer` 实现 slice 与 `qa_engineer` 审核 slice，但当前 exposed subagent runtime 连续未在目标文件面产出 diff；按 source-of-truth fallback 规则，改为由 TPM 在当前 canonical worktree 内执行最小接线实现，并显式记录 attribution boundary。
+- Intended Dispatch:
+  - `viewer_engineer` implementation slice for Viewer scoped performance gate
+  - `qa_engineer` review slice for rollout / verification judgment
+- Actual Limitation:
+  - 多次 spawn/follow-up 后，subagent runtime 在本轮未对目标文件 `scripts/plan-rust-required-scope.sh`、`scripts/ci-tests.sh`、`.github/workflows/rust.yml`、`testing-manual.md` 产生可观测 diff，无法在当前时间窗内继续等待而不阻塞主线。
+- Fallback Attribution Boundary:
+  - 以下实现与验证步骤由 TPM 作为机械 fallback 执行，不宣称其为专业角色结论；
+  - 关于是否应默认启用、何时从 report-only 升 blocking 的专业判断，后续仍应由 `qa_engineer` / `viewer_engineer` 正式复核。
+- Action:
+  - 在 `scripts/plan-rust-required-scope.sh` 为 Viewer 路径新增 `run_viewer_perf_smoke` scoped flag；
+  - 在 `scripts/ci-tests.sh` 新增 `run_oasis7_viewer_performance_smoke_report_only`，用 report-only 方式执行 `./scripts/viewer-performance-probe.sh --profile smoke`；
+  - 在 `.github/workflows/rust.yml` 接入 `OASIS7_CI_RUN_VIEWER_PERF_SMOKE` planner output/env；
+  - 在 `scripts/plan-rust-required-scope.test.sh` 增加 Viewer path planner 断言；
+  - 在 `testing-manual.md` 写明 Viewer perf smoke 已进入 `required-gate` 的 report-only scoped coverage。
+- Validation Command:
+  - `bash ./scripts/plan-rust-required-scope.test.sh`
+  - `./scripts/plan-rust-required-scope.sh --event-name pull_request --changed-path crates/oasis7_viewer/src/lib.rs`
+  - `python3 - <<'PY' ... yaml.safe_load('.github/workflows/rust.yml') ... PY`
+  - `bash -n ./scripts/ci-tests.sh`
+- Expected Result:
+  - Viewer changed-path 可导出 `run_viewer_perf_smoke=true`
+  - workflow YAML 合法
+  - `ci-tests.sh` 具备 report-only 执行钩子
+  - 手册同步新增 scoped coverage 口径
+- Actual Result:
+  - planner test passed；
+  - explicit viewer path 输出 `scope=targeted` 且 `run_viewer_perf_smoke=true`；
+  - workflow YAML load OK；
+  - `ci-tests.sh` syntax OK，新增 report-only hook 已接入；
+  - `testing-manual.md` 已同步说明该 smoke 现在是 `required-gate` 内的 report-only scoped coverage。
+- Residual Risk:
+  - 本轮未拿到 `qa_engineer` 对实际 diff 的正式 verdict；
+  - report-only hook 仍依赖 CI runner 上可用的 `agent-browser` / `npx` browser automation 环境，需在真实 CI 上再观察一轮；
+  - 当前未把 Viewer perf smoke 升为 blocking gate。
+- Next Action:
+  - 由 TPM 向用户汇报已完成的最小实现与残余风险；
+  - 若继续推进，可在下一步请求/等待 `qa_engineer` 对实际 diff 做正式 review，再决定是否保留 report-only 或升级 gate。
+
+## 2026-06-09 18:24:00 CST / tpm
+- 完成内容: 收到 `runtime_engineer` 只读性能机制结论，并补充 QA/verification workflow 证据；同时记录 `qa_engineer` 二次派发受当前 agent thread limit 限制，未能在本轮实际创建新的 QA slice。
+- Action: 读取 `testing-manual.md`、`scripts/ci-tests.sh`、`.github/workflows/rust.yml`、`.github/workflows/compile-metrics.yml`、`.github/workflows/release-packages.yml`、`.agents/skills/verification-before-completion/SKILL.md`，并尝试创建新的 `qa_engineer` bounded slice。
+- Validation Command: `rtk sed -n '1,260p' testing-manual.md`; `rtk sed -n '1,240p' scripts/ci-tests.sh`; `rtk sed -n '1,240p' .github/workflows/rust.yml`; `rtk sed -n '1,240p' .github/workflows/compile-metrics.yml`; `rtk sed -n '1,220p' .github/workflows/release-packages.yml`; `rtk sed -n '1,220p' .agents/skills/verification-before-completion/SKILL.md`; `spawn_agent qa_safeguards_readonly`
+- Expected Result: 获得 runtime/perf 与 QA safeguard 两个专业角色的只读结论，并据此形成用户答复。
+- Actual Result:
+  - `runtime_engineer` slice 已返回：仓库存在 `compile-metrics`、viewer performance probe、LLM/p2p/S10 soak 与 release gate 等性能相关机制，但默认 PR gate 仍以功能正确性为主，运行时性能更多依赖按改动面补跑 probe/soak。
+  - `qa_engineer` 二次派发失败，错误为 `collab spawn failed: agent thread limit reached`；因此未能在本轮获得新的 QA role-authored reply。
+- Fallback Evidence Path:
+  - `testing-manual.md` 的“CI 现状与缺口”“分层模型”“S0~S10”章节
+  - `scripts/ci-tests.sh`
+  - `.github/workflows/rust.yml`
+  - `.agents/skills/verification-before-completion/SKILL.md`
+  - `doc/engineering/workflow/source-of-truth.md` 第 1、3、5 节
+- Attribution Boundary:
+  - 关于“是否已有性能测试/性能探针/性能门禁”的判断，归因于本轮 `runtime_engineer` slice 返回。
+  - 关于“workflow 明文要求哪些 fresh verification / CI gate / completion gate”的总结，属于 TPM 基于仓库 source-of-truth、测试手册与 CI 脚本的程序性归纳，不包装为独立 QA 专业裁决。
+- 遗留事项: 若后续需要正式 QA role 结论或发布阻断级判断，应在 agent 配额可用时补派 `qa_engineer` slice 复核。
+
+## 2026-06-09 22:24:47 CST / tpm
+- 完成内容: 用户选择继续实施优先级第 2 项，当前从 Viewer scoped gate 推进到 `Runtime tick/step 轻量 deterministic perf harness` 的专业实现阶段。
+- WORKFLOW ROUTE DECIDED:
+  - Current phase: `executing-project-tasks`
+  - Why: 当前 task truth 与补测优先级矩阵已具备，用户已明确选择第 2 项继续落地，下一步是最小实现而非继续规划。
+  - Selected workflow skills:
+    1. `executing-project-tasks` - 在现有 runtime perf probe 风格上补一个可日常运行的轻量 harness
+    2. `verification-before-completion` - 仅用于本轮实现后的最小语法/命令验证，不做 ready-for-PR 声明
+- TODO Decomposition:
+  - 1. `runtime_engineer` 负责实现最小 runtime perf harness，优先复用现有 ignored perf probe 风格与 `modules.rs` 热路径。
+  - 2. TPM 负责把实现接入当前 canonical worktree、补文档与执行证据，并跑 scoped verification。
+  - 3. 若 subagent runtime 再次无可观测 diff，TPM 只做机械 fallback，不把 fallback 判断包装成 runtime 专业结论。
+- Integration Order:
+  - `runtime_engineer` implementation -> TPM integrate/verify
+- Subagent Slice Contract 12:
+  - role: `runtime_engineer`
+  - slice_type: `implementation`
+  - ownership: implement priority item 2, runtime tick/step lightweight deterministic perf harness
+  - likely files: `crates/oasis7/src/runtime/tests/modules.rs`, `scripts/*runtime*perf*` 新增最小入口、`testing-manual.md`, `doc/testing/performance/performance-coverage-gap-matrix-2026-06-09.md`
+  - question: implement the smallest viable runtime perf harness by reusing the stable hot path in `modules.rs` and existing repo perf-probe conventions; prefer a local/reporting entrypoint over a broad blocking gate
+  - non_goals: do not implement viewer/p2p items; do not invent a second benchmark framework; do not revert unrelated user/TPM edits; do not create a second task/worktree/PR chain
+  - intended multi-agent runtime: `multi_agent_v2`
+  - actual runtime/tool surface: `spawn_agent` tool surface available in current Codex thread; canonical runtime label unverified
+  - intended model: repo default subagent runtime from `.codex/config.toml`
+  - actual model: inherited/unverified
+  - context delivery mode: full-thread/full-history fork requested via subagent inheritance
+  - mandatory context checklist: `AGENTS.md`; `doc/engineering/workflow/source-of-truth.md`; `.agents/roles/runtime_engineer.md`; current task yaml/execution log; current performance gap matrix doc; `testing-manual.md`; `doc/world-runtime/project.md` perf probe references; `third_party` read-only boundary
+  - write scope: only files needed for the runtime deterministic perf harness and its docs/tests
+  - return contract: implemented diff, concise rationale, exact verification run, residual risk
+- mandatory sink: this execution log plus code changes in current worktree
+- Next Action: 派发 `runtime_engineer` 实现 slice；若短时间内仍无 target-file diff，则按 fallback boundary 直接在主链完成最小接线并补 limitation 记录。
+
+## 2026-06-09 22:49:00 CST / tpm
+- 完成内容: 尝试按默认流程派发 `runtime_engineer` 实现 slice，但当前 exposed subagent runtime 再次未在目标文件面产出可观测 diff；按 source-of-truth fallback 规则，由 TPM 在当前 canonical worktree 内完成第 2 项的最小机械接线实现，并显式记录 attribution boundary。
+- Intended Dispatch:
+  - `runtime_engineer` implementation slice for runtime tick/step lightweight deterministic perf harness
+- Actual Limitation:
+  - 已成功 spawn `runtime_perf_harness_impl`，但在等待窗口内未对目标文件 `crates/oasis7/src/runtime/tests/modules.rs`、`scripts/runtime-module-routing-perf-harness.sh`、`testing-manual.md`、`doc/testing/performance/performance-coverage-gap-matrix-2026-06-09.md` 产生可观测 diff，继续等待会阻塞主线。
+- Fallback Attribution Boundary:
+  - 以下实现与验证步骤由 TPM 作为机械 fallback 执行，不宣称其为 `runtime_engineer` 的专业实现结论；
+  - 关于该 harness 后续应扩到哪些 runtime 热路径、何时可升为 scoped gate 的专业判断，后续仍应由 `runtime_engineer` / `qa_engineer` 正式复核。
+- Action:
+  - 将 `crates/oasis7/src/runtime/tests/modules.rs` 中现有 ignored runtime 路由 probe 规范为 `perf_probe_runtime_module_routing_with_many_active_manifests`，并统一到 repo 现有 `local perf probe` 命名/输出风格；
+  - 新增 `scripts/runtime-module-routing-perf-harness.sh`，以单一脚本入口运行该 probe，并写出 `perf.log`、`summary.json`、`summary.md`；
+  - 在 `testing-manual.md` 的 S8 节新增 runtime 轻量 deterministic perf harness 入口与边界说明；
+  - 在 `doc/testing/performance/performance-coverage-gap-matrix-2026-06-09.md` 将第 2 项状态更新为“第一阶段已落稳定内环 module routing micro harness”。
+- Validation Command:
+  - `rtk bash -n scripts/runtime-module-routing-perf-harness.sh`
+  - `rtk git diff --check`
+  - `rtk env -u RUSTC_WRAPPER cargo test -p oasis7 perf_probe_runtime_module_routing_with_many_active_manifests --release -- --ignored --nocapture`
+  - `rtk bash ./scripts/runtime-module-routing-perf-harness.sh --out-dir .tmp/runtime_module_routing_perf_verify`
+- Expected Result:
+  - 新脚本语法合法；
+  - repo diff 无格式错误；
+  - release perf probe 可作为单独入口运行；
+  - harness 能在本地产出 `summary.json`/`summary.md`。
+- Actual Result:
+  - `bash -n scripts/runtime-module-routing-perf-harness.sh` 通过；
+  - `git diff --check` 通过；
+  - `cargo test -p oasis7 perf_probe_runtime_module_routing_with_many_active_manifests --release -- --ignored --nocapture` 与脚本入口均成功进入首次 `--release` 编译阶段，但在本轮时间窗内仍停留在大型依赖编译，未拿到最终 perf 输出；
+  - 中途发现并清理了重复触发的 probe/harness 进程，避免继续争抢同一 Cargo build lock。
+- Residual Risk:
+  - 当前已验证“实现落盘 + 脚本语法/仓库 diff 正常”，但尚未在本轮时间窗内拿到 release probe 的最终数值与 `summary.{json,md}` 实物；
+  - 第一阶段 harness 目前只覆盖稳定内环 `runtime module routing`，还不是完整 tick/step 全链路预算。
+- Next Action:
+  - 若继续推进下一步，应先在空闲时间窗内把 `bash ./scripts/runtime-module-routing-perf-harness.sh` 跑透，采集第一版基线 summary；
+  - 之后再由 `runtime_engineer` / `qa_engineer` 复核：是否继续扩到更接近 tick/step 的稳定指标，以及何时适合进入 scoped gate 候选。
+
+## 2026-06-10 00:24:00 CST / tpm
+- 完成内容: 按用户“继续”要求，继续追 baseline summary 落地，并把 harness 验证路径进一步收窄，确认当前主要阻塞不是脚本逻辑，而是 `oasis7` 主 crate 首次测试编译成本。
+- Action:
+  - 持续运行 `bash ./scripts/runtime-module-routing-perf-harness.sh --out-dir .tmp/runtime_module_routing_perf_verify`，观察首轮 `release` profile；
+  - 为降低首次验证成本，将脚本增加 `--profile release|dev` 开关，并在 cargo 命令中收窄到 `cargo test -p oasis7 --lib perf_probe_runtime_module_routing_with_many_active_manifests ...`；
+  - 改用 `--profile dev` 再次追跑 summary 落地，以验证端到端产物链路。
+- Validation Command:
+  - `rtk bash ./scripts/runtime-module-routing-perf-harness.sh --out-dir .tmp/runtime_module_routing_perf_verify`
+  - `rtk bash ./scripts/runtime-module-routing-perf-harness.sh --profile dev --out-dir .tmp/runtime_module_routing_perf_dev_verify`
+  - `rtk bash ./scripts/runtime-module-routing-perf-harness.sh --profile dev --out-dir .tmp/runtime_module_routing_perf_dev_verify_lib`
+  - `rtk git diff --check`
+- Expected Result:
+  - 至少有一条 profile 在当前时间窗内跑出 `summary.json`/`summary.md`，形成第一版 baseline 样本；
+  - 若仍跑不透，则要明确阻塞在脚本逻辑、probe 本身还是首轮测试编译成本。
+- Actual Result:
+  - `release` profile 持续推进到 `oasis7` 主 crate 编译/链接阶段，但在本轮长时间窗内仍未进入 probe 输出，最新 run 只落 `perf.log`；
+  - 新增 `--profile dev` 后，`dev` profile 同样能进入 `oasis7` 主 crate 编译阶段，说明脚本入口、参数解析与日志/summary 链路设计无误；
+  - 再收窄到 `cargo test -p oasis7 --lib ...` 后，验证面已缩到最小，但首轮仍卡在 `oasis7` 主 lib test binary 编译/链接，仍未拿到 `summary.{json,md}` 实物；
+  - `git diff --check` 通过，说明本轮继续迭代后的脚本改动没有引入格式问题。
+- New Finding:
+  - 当前 baseline 未落地的主要阻塞已定位为：`oasis7` 主 crate 首次测试 binary 的编译/链接成本过高；这不同于 harness 逻辑错误，也不同于 Cargo build lock 冲突。
+- Residual Risk:
+  - 目前仍缺首个 `summary.json`/`summary.md` 样本，因此尚不能给出 runtime module routing 的数值基线；
+  - 即使 `dev` 能先跑透，后续仍需在更长时间窗内补一轮 `release` baseline，作为更接近目标 gate 的真值。
+- Next Action:
+  - 若继续执行，应在更长的非交互时间窗或预热后的环境中单独跑透 `./scripts/runtime-module-routing-perf-harness.sh --profile release`；
+  - 若想先快速拿到第一版数值样本，可优先继续追 `--profile dev` 跑透，再把 `release` baseline 作为后续收口项。
+
+## 2026-06-10 10:32:00 CST / tpm
+- 完成内容: 继续第 2 项最小实现，已把 dedicated runtime perf bin 的 setup 从治理 proposal/apply 路径切到 `Snapshot -> module_registry 注入 -> World::from_snapshot` 轻量 restore 路径，并成功跑出首个 `dev` baseline summary。
+- Intended Dispatch:
+  - `runtime_engineer` bounded read-only slice：仅查找“更轻的模块注册/激活路径”，不改文件。
+- Actual Specialist Evidence:
+  - 运行时专业 slice 返回：对当前 `route_event_to_modules` / `route_action_to_modules` micro harness，最轻且安全的公开接缝是 `Snapshot` 预置 `module_registry.records` 与 `module_registry.active`，然后用 `World::from_snapshot(snapshot, Journal::new())` restore；若实际会执行模块调用，则 restore 后还需重新 `register_module_artifact` 补回 `module_artifact_bytes`，否则会在 `load_module()` 处失败。
+- Action:
+  - 修改 `crates/oasis7/src/bin/oasis7_runtime_module_routing_perf.rs`：
+    - 删除 `propose_manifest_update -> shadow_proposal -> approve_proposal -> apply_proposal` 的激活路径；
+    - 新增 `build_world_with_active_manifests()`，通过 `base.snapshot()` 注入 `ModuleRegistry` 后调用 `World::from_snapshot(snapshot, Journal::default())`；
+    - 新增 `build_module_registry()` 直接填充 `ModuleRecord` 与 `active` map；
+    - restore 后重新 `register_module_artifact`，确保 `route_*` 真正调用 `sandbox` 时不会因 `module_artifact_bytes missing` 失败。
+- Validation Command:
+  - `rtk env -u RUSTC_WRAPPER cargo check -p oasis7 --bin oasis7_runtime_module_routing_perf`
+  - `rtk git -C /Users/scc/ccwork/worktrees/oasis7-engineering-code-quality-performance-readonly diff --check`
+  - `rtk bash ./scripts/runtime-module-routing-perf-harness.sh --profile dev --out-dir .tmp/runtime_module_routing_perf_bin_dev_verify_snapshot`
+- Expected Result:
+  - dedicated bin 编译通过；
+  - repo diff 无格式问题；
+  - dev harness 在当前时间窗内真正打印 perf line，并落出 `perf.log`、`summary.json`、`summary.md`。
+- Actual Result:
+  - `cargo check` 通过；
+  - `git diff --check` 通过；
+  - harness 成功输出：
+    - `perf_probe_runtime_module_routing_with_many_active_manifests: modules=192 iterations=80 event_total_ms=14195.030 event_avg_ms=177.438 action_total_ms=8554.236 action_avg_ms=106.928 event_invoked=15360 action_invoked=15360`
+  - 已生成产物：
+    - `.tmp/runtime_module_routing_perf_bin_dev_verify_snapshot/20260610-103033/perf.log`
+    - `.tmp/runtime_module_routing_perf_bin_dev_verify_snapshot/20260610-103033/summary.json`
+    - `.tmp/runtime_module_routing_perf_bin_dev_verify_snapshot/20260610-103033/summary.md`
+- Fallback Attribution Boundary:
+  - 本次 dedicated bin 的实现改动由 TPM 在当前 canonical worktree 内完成，不包装为 `runtime_engineer` 实现产出；
+  - “为何 snapshot restore 是当前最轻公开接缝”这一点，归因于本轮 `runtime_engineer` 只读专业 slice 与对应代码证据。
+- Residual Risk:
+  - 当前 baseline 仅为 `dev` profile，仍需后续补一轮 `release` profile baseline；
+  - 当前 micro harness 只覆盖 runtime module routing 内环，不代表完整 tick/step 总预算；
+  - 当前数值仍包含实际 `sandbox.call()` 次数与输入构造开销，适合作为稳定内环回归基线，不应直接外推为整世界 tick 耗时。
+- Next Action:
+  - 若继续推进，可在预热/更长时间窗内补跑 `./scripts/runtime-module-routing-perf-harness.sh --profile release`；
+  - 再由 `runtime_engineer` / `qa_engineer` 复核：是否把该 micro harness 保持为本地/report-only，或进一步扩成 scoped required 候选。
+
+## 2026-06-10 10:57:00 CST / tpm
+- 完成内容: 按用户“盯着”要求持续跟踪同一条 `release` run，现已成功跑透 `runtime-module-routing-perf-harness.sh --profile release`，补齐首个 `release` baseline summary。
+- Action:
+  - 持续轮询同一进程的 stdout、`perf.log` 与 `ps` 状态，不重复触发第二次 run；
+  - 等待 `cargo run -p oasis7 --bin oasis7_runtime_module_routing_perf --release` 从高优化编译阶段进入 dedicated bin 执行并落出 summary 产物。
+- Validation Command:
+  - `rtk bash ./scripts/runtime-module-routing-perf-harness.sh --profile release --out-dir .tmp/runtime_module_routing_perf_bin_release_verify_snapshot`
+  - 轮询：`rtk tail -n 120 .tmp/runtime_module_routing_perf_bin_release_verify_snapshot/20260610-103307/perf.log`
+  - 轮询：`rtk proxy ps -axo pid,ppid,etime,%cpu,%mem,stat,command | grep -E "cargo run -p oasis7 --bin oasis7_runtime_module_routing_perf --release|rustc --crate-name oasis7 --edition=2021 crates/oasis7/src/lib.rs" | grep -v grep`
+- Expected Result:
+  - 同一条 `release` run 最终完成；
+  - 输出 `perf_probe_runtime_module_routing_with_many_active_manifests` 数值；
+  - 生成 `summary.json` / `summary.md`。
+- Actual Result:
+  - `release` run 在 `oasis7` 主 crate 高优化编译阶段耗时约 `23m 10s` 后完成；
+  - dedicated bin 成功输出：
+    - `perf_probe_runtime_module_routing_with_many_active_manifests: modules=192 iterations=80 event_total_ms=447.317 event_avg_ms=5.591 action_total_ms=559.331 action_avg_ms=6.992 event_invoked=15360 action_invoked=15360`
+  - 已生成产物：
+    - `.tmp/runtime_module_routing_perf_bin_release_verify_snapshot/20260610-103307/perf.log`
+    - `.tmp/runtime_module_routing_perf_bin_release_verify_snapshot/20260610-103307/summary.json`
+    - `.tmp/runtime_module_routing_perf_bin_release_verify_snapshot/20260610-103307/summary.md`
+- New Finding:
+  - 当前 runtime module routing micro harness 在 `release` profile 下的首个基线明显低于 `dev`：
+    - `event_avg_ms`: `5.591`
+    - `action_avg_ms`: `6.992`
+  - 之前长时间“看起来像卡住”的主要原因已证实只是 `oasis7` 主 crate 的 `release` 编译成本，而不是 harness 逻辑或 snapshot-restore setup 再次回退。
+- Residual Risk:
+  - 当前 baseline 仍只代表 `runtime.module_routing` 内环，不是完整 tick/step 预算；
+  - 若后续把它升到 scoped gate，需要再评估 CI 上首次 `release` 编译时长是否可接受，或是否应该利用预热/缓存策略减少前置成本。
+- Next Action:
+  - 若继续推进第 2 项收口，可把这组 `release` baseline 回写到 gap matrix / testing manual 的示例基线说明；
+  - 再由 `runtime_engineer` / `qa_engineer` 判断：是保持本地/report-only，还是把它纳入某种 changed-path scoped perf signal。
+
+## 2026-06-10 11:08:00 CST / tpm
+- 完成内容: 按用户要求将 `release` baseline 回写到文档，并启动 pre-PR 本地角色评审前置流程。
+- Action:
+  - 将 runtime module routing micro harness 的首个 `release` baseline 回写到 `testing-manual.md` 与 `doc/testing/performance/performance-coverage-gap-matrix-2026-06-09.md`；
+  - 运行最小文档校验；
+  - 准备发起本地 involved-role pre-PR review。
+- Validation Command:
+  - `rtk git -C /Users/scc/ccwork/worktrees/oasis7-engineering-code-quality-performance-readonly diff --check`
+  - `rtk ./scripts/doc-governance-check.sh`
+- Expected Result:
+  - 文档回写无格式问题；
+  - 文档治理检查通过；
+  - 可以进入本地 pre-PR review 前置流程。
+- Actual Result:
+  - `git diff --check` 通过；
+  - `doc-governance-check: OK`；
+  - 可以继续进入 pre-PR 本地角色评审。
+
+## 2026-06-10 11:09:00 CST / tpm
+- Review Trigger: pre-PR local role review
+- Review Scope: `.github/workflows/rust.yml`; `scripts/ci-tests.sh`; `scripts/plan-rust-required-scope.sh`; `scripts/plan-rust-required-scope.test.sh`; `crates/oasis7/src/runtime/tests/modules.rs`; `crates/oasis7/src/bin/oasis7_runtime_module_routing_perf.rs`; `scripts/runtime-module-routing-perf-harness.sh`; `testing-manual.md`; `doc/testing/performance/performance-coverage-gap-matrix-2026-06-09.md`; `.pm/tasks/task_35657c5f0a5543dda5d57f51fc4b8841.execution.md`; `.pm/tasks/task_35657c5f0a5543dda5d57f51fc4b8841.yaml`
+- Review Roles: `runtime_engineer`, `qa_engineer`
+- Review Question: 当前 Viewer changed-path scoped perf gate 与 runtime module routing micro harness 的本地实现和验证证据，是否足以进入 PR 主链；若有阻断性问题，请给出 findings；若无，请给出 residual risk。
+- Evidence Available: `git diff --check`; `doc-governance-check: OK`; `cargo check -p oasis7 --bin oasis7_runtime_module_routing_perf`; dev/release harness summaries under `.tmp/runtime_module_routing_perf_*`; execution log evidence above
+- Expected Return Contract: `findings | no_findings | residual_risk`
+- Formal Sink: `.pm/tasks/task_35657c5f0a5543dda5d57f51fc4b8841.execution.md`
+
+## 2026-06-10 11:20:00 CST / tpm
+- 完成内容: 集成本地 `runtime_engineer` / `qa_engineer` pre-PR review 结果，已处理唯一有效 finding，并将当前 task 推进到可进入 PR 主链的本地准备状态。
+- 遗留事项:
+  - 若继续进入真正 PR/合入主链，下一步还需执行 `claim-ready` / closeout / commit / `prepare-task-pr`；
+  - `pm-lint` 当前存在大量 repo 级历史 task/execution-log 噪音，不适合作为本 task 单独是否可进 PR 的唯一阻断依据。
+- Action:
+  - 集成 `runtime_engineer` review：唯一 finding 为 `testing-manual.md` 不能把本地 `.tmp/.../summary.json` 临时路径写成 handbook 真值；
+  - 将 `testing-manual.md` 调整为只记录 baseline 数值，并明确以当前 task execution log 中登记的验证记录作为持久证据来源；
+  - 集成 `qa_engineer` review：在上述文档修正后，无新增 blocking finding，剩余仅为 local/report-only perf harness 的 residual risk；
+  - 重新执行 task-scoped readiness 验证，确认当前 changed-path Viewer perf smoke 计划与 runtime perf bin 编译状态。
+- Validation Command:
+  - `rtk git -C /Users/scc/ccwork/worktrees/oasis7-engineering-code-quality-performance-readonly diff --check`
+  - `rtk ./scripts/doc-governance-check.sh`
+  - `rtk env -u RUSTC_WRAPPER cargo check -p oasis7 --bin oasis7_runtime_module_routing_perf`
+  - `rtk ./scripts/plan-rust-required-scope.test.sh`
+  - `rtk ./scripts/plan-rust-required-scope.sh --event-name pull_request --changed-path crates/oasis7_viewer/src/lib.rs`
+  - `rtk ./scripts/pm/workflow-lint.sh --task-uid task_35657c5f0a5543dda5d57f51fc4b8841 --phase current`
+- Expected Result:
+  - 本地 pre-PR review 无剩余 blocking finding；
+  - task-scoped workflow-lint `current` 通过；
+  - 当前分支可以进入 PR 主链，但尚未执行 claim-ready / closeout / commit / PR 创建。
+- Actual Result:
+  - `runtime_engineer` review 初始给出 1 条 `[P2]` 文档真值问题，现已修复；
+  - `qa_engineer` review 在修复后未再给出 blocking finding；
+  - 其余结果见紧随其后的验证命令输出与 pre-PR review passed packet。
+- Blocker / Next Action:
+  - 若上述 task-scoped 验证全部通过，则补写 `Pre-PR Local Role Review: passed` packet，并继续进入 claim-ready / closeout / commit / PR 流程；
+  - 若仍有 task-scoped workflow gate 失败，则只修当前 task 自身阻断，不为全仓历史 `.pm` 噪音做无关清扫。
+
+## 2026-06-10 12:11:00 CST / tpm
+- 完成内容: 回填 `claim-ready` / `task-closeout` 的 execution log 证据，绑定 testing 模块 `project.md` trace，并写入可供 `prepare-task-pr.sh` 解析的 `Pre-PR Local Role Review: passed` packet。
+- 遗留事项:
+  - 待执行 `./scripts/pm/workflow-lint.sh --task-uid task_35657c5f0a5543dda5d57f51fc4b8841 --phase pr-ready` 与 `./scripts/prepare-task-pr.sh` 最终确认可进入 PR 主链；
+  - 若 preflight 仍失败，仅按当前 task 的返回项补修，不扩散到仓库历史 `.pm` 噪音。
+- Action:
+  - 回填 task yaml `doc_refs`，将本 task 明确绑定到 `doc/testing/project.md`；
+  - 根据当前 task yaml 已写入的 `last_claim_type=task_complete`、`last_verify_command`、`last_verified_at` 与 `last_closed_at`，补登记 `./scripts/pm/claim-ready.sh --claim-type task_complete --verify-command "git diff --check && ./scripts/doc-governance-check.sh && env -u RUSTC_WRAPPER cargo check -p oasis7 --bin oasis7_runtime_module_routing_perf && ./scripts/plan-rust-required-scope.test.sh && ./scripts/plan-rust-required-scope.sh --event-name pull_request --changed-path crates/oasis7_viewer/src/lib.rs | grep -q '^run_viewer_perf_smoke=true$'" --task-uid task_35657c5f0a5543dda5d57f51fc4b8841` 与 `./scripts/pm/task-closeout.sh --role tpm --task-uid task_35657c5f0a5543dda5d57f51fc4b8841 --verify-command "git diff --check && ./scripts/doc-governance-check.sh && env -u RUSTC_WRAPPER cargo check -p oasis7 --bin oasis7_runtime_module_routing_perf && ./scripts/plan-rust-required-scope.test.sh && ./scripts/plan-rust-required-scope.sh --event-name pull_request --changed-path crates/oasis7_viewer/src/lib.rs | grep -q '^run_viewer_perf_smoke=true$'" --claim-type task_complete` 的 closeout provenance；
+  - 以 `runtime_engineer` / `qa_engineer` 已集成的 pre-PR review 结果，生成针对 `4892064e37c5e6f6f20a52e0b282066d408d34e9` 的本地角色评审通过 packet。
+- Validation Command:
+  - `rtk ./scripts/pm/workflow-lint.sh --task-uid task_35657c5f0a5543dda5d57f51fc4b8841 --phase pr-ready`
+- Expected Result:
+  - task yaml 可以从 `doc_refs` 解析到 `doc/testing/project.md`；
+  - execution log 同时包含 `claim-ready.sh`、`task-closeout.sh` marker 与合法的 `Pre-PR Local Role Review: passed` packet；
+  - `workflow-lint --phase pr-ready` 通过。
+- Actual Result:
+  - 已补齐 `doc_refs`、closeout provenance 与 review packet；
+  - `./scripts/pm/workflow-lint.sh --task-uid task_35657c5f0a5543dda5d57f51fc4b8841 --phase pr-ready` 通过，说明脚本侧已接受当前 task 的 project trace、closeout evidence 与 review packet。
+- Blocker / Next Action:
+  - 下一步提交当前 `.pm` 证据文件并继续执行 `./scripts/prepare-task-pr.sh`；
+  - 若 `prepare-task-pr.sh` 仍失败，则按 preflight 返回的精确 marker 做最小修补后重跑。
+- Pre-PR Local Role Review: passed
+- Task UID: task_35657c5f0a5543dda5d57f51fc4b8841
+- Source Worktree: /Users/scc/ccwork/worktrees/oasis7-engineering-code-quality-performance-readonly
+- Source Branch: task/engineering-code-quality-performance-readonly
+- Source Head: 4892064e37c5e6f6f20a52e0b282066d408d34e9
+- Comparison Ref: origin/main
+- Reviewed Changed Paths: .github/workflows/rust.yml; crates/oasis7/src/bin/oasis7_runtime_module_routing_perf.rs; crates/oasis7/src/runtime/tests/modules.rs; doc/testing/performance/performance-coverage-gap-matrix-2026-06-09.md; doc/testing/prd.index.md; doc/testing/project.md; scripts/ci-tests.sh; scripts/plan-rust-required-scope.sh; scripts/plan-rust-required-scope.test.sh; scripts/runtime-module-routing-perf-harness.sh; testing-manual.md
+- Role Selection Basis: changed paths touch both required-gate perf scope planning and runtime module routing micro-benchmarking, so runtime and QA pre-PR review were both required before entering the PR chain
+- Review Roles: runtime_engineer, qa_engineer
+- Review Evidence: runtime_pre_pr_review raised one documentation-truth finding in testing-manual.md; qa_pre_pr_review confirmed no remaining blocking findings after that fix; supporting verification: git diff --check; ./scripts/doc-governance-check.sh; env -u RUSTC_WRAPPER cargo check -p oasis7 --bin oasis7_runtime_module_routing_perf; ./scripts/plan-rust-required-scope.test.sh; ./scripts/plan-rust-required-scope.sh --event-name pull_request --changed-path crates/oasis7_viewer/src/lib.rs
+- Review Findings Disposition: addressed
+- Finding Disposition Evidence: testing-manual.md now records only the baseline numbers and treats local .tmp summaries as ephemeral while the execution log remains the durable evidence source; the runtime and QA verification set was rerun with no new blocking findings
+- Residual Risk: runtime module routing harness remains local/report-only, covers only the inner routing loop on a single host, and the first cold release compile still costs about 23 minutes before the harness itself executes

--- a/.pm/tasks/task_35657c5f0a5543dda5d57f51fc4b8841.execution.md
+++ b/.pm/tasks/task_35657c5f0a5543dda5d57f51fc4b8841.execution.md
@@ -649,7 +649,7 @@ Example:
 - Source Worktree: /Users/scc/ccwork/worktrees/oasis7-engineering-code-quality-performance-readonly
 - Source Branch: task/engineering-code-quality-performance-readonly
 - Source Head: 4892064e37c5e6f6f20a52e0b282066d408d34e9
-- Comparison Ref: origin/main
+- Comparison Ref: refs/remotes/origin/main
 - Reviewed Changed Paths: .github/workflows/rust.yml; crates/oasis7/src/bin/oasis7_runtime_module_routing_perf.rs; crates/oasis7/src/runtime/tests/modules.rs; doc/testing/performance/performance-coverage-gap-matrix-2026-06-09.md; doc/testing/prd.index.md; doc/testing/project.md; scripts/ci-tests.sh; scripts/plan-rust-required-scope.sh; scripts/plan-rust-required-scope.test.sh; scripts/runtime-module-routing-perf-harness.sh; testing-manual.md
 - Role Selection Basis: changed paths touch both required-gate perf scope planning and runtime module routing micro-benchmarking, so runtime and QA pre-PR review were both required before entering the PR chain
 - Review Roles: runtime_engineer, qa_engineer

--- a/.pm/tasks/task_35657c5f0a5543dda5d57f51fc4b8841.yaml
+++ b/.pm/tasks/task_35657c5f0a5543dda5d57f51fc4b8841.yaml
@@ -1,0 +1,25 @@
+task_uid: task_35657c5f0a5543dda5d57f51fc4b8841
+title: "Assess performance tests and code quality safeguards"
+owner_role: tpm
+worktree_hint: /Users/scc/ccwork/worktrees/oasis7-engineering-code-quality-performance-readonly
+execution_log_path: .pm/tasks/task_35657c5f0a5543dda5d57f51fc4b8841.execution.md
+status: done
+priority: P2
+source_signal: null
+source_refs:
+  - AGENTS.md
+  - testing-manual.md
+  - doc/engineering/workflow/source-of-truth.md
+doc_refs:
+  - doc/testing/project.md
+related_prd: []
+acceptance: []
+handoff_to: []
+updated_at: 2026-06-10T12:00:31+08:00
+last_started_at: 2026-06-09T18:07:56+08:00
+last_claim_type: task_complete
+last_verify_command: "git diff --check && ./scripts/doc-governance-check.sh && env -u RUSTC_WRAPPER cargo check -p oasis7 --bin oasis7_runtime_module_routing_perf && ./scripts/plan-rust-required-scope.test.sh && ./scripts/plan-rust-required-scope.sh --event-name pull_request --changed-path crates/oasis7_viewer/src/lib.rs | grep -q '^run_viewer_perf_smoke=true$'"
+last_verified_at: 2026-06-10T12:00:22+08:00
+last_verification_exit_code: 0
+last_verification_status: verified
+last_closed_at: 2026-06-10T12:00:29+08:00

--- a/crates/oasis7/src/bin/oasis7_runtime_module_routing_perf.rs
+++ b/crates/oasis7/src/bin/oasis7_runtime_module_routing_perf.rs
@@ -1,0 +1,247 @@
+use std::collections::VecDeque;
+use std::hint::black_box;
+use std::process;
+use std::time::Instant;
+
+use oasis7_wasm_abi::{ModuleCallFailure, ModuleCallRequest, ModuleOutput, ModuleSandbox};
+use oasis7::runtime::{
+    Action, ActionEnvelope, DomainEvent, Journal, ModuleAbiContract, ModuleArtifactIdentity,
+    ModuleKind, ModuleLimits, ModuleManifest, ModuleRecord, ModuleRegistry, ModuleRole,
+    ModuleSubscription, ModuleSubscriptionStage, PolicySet, World, WorldEvent, WorldEventBody,
+};
+use sha2::{Digest, Sha256};
+
+const MODULE_COUNT: usize = 192;
+const ITERATIONS: usize = 80;
+const TEST_MODULE_ARTIFACT_SIGNER_NODE_ID: &str = "runtime.module.routing.perf";
+const IDENTITY_HASH_SIGNATURE_SCHEME: &str = "identity_hash_v1";
+const IDENTITY_HASH_SIGNATURE_PREFIX: &str = "idhash:";
+
+fn main() {
+    if let Err(err) = run() {
+        eprintln!("runtime module routing perf failed: {err}");
+        process::exit(1);
+    }
+}
+
+fn run() -> Result<(), String> {
+    let wasm_bytes = b"module-perf-router";
+    let wasm_hash = sha256_hex(wasm_bytes);
+
+    let mut manifests = Vec::with_capacity(MODULE_COUNT);
+    for idx in 0..MODULE_COUNT {
+        let module_id = format!("m.perf-router.{idx:03}");
+        manifests.push(ModuleManifest {
+            module_id: module_id.clone(),
+            name: format!("PerfRouter{idx:03}"),
+            version: "0.1.0".to_string(),
+            kind: if idx % 5 == 0 {
+                ModuleKind::Pure
+            } else {
+                ModuleKind::Reducer
+            },
+            role: ModuleRole::Domain,
+            wasm_hash: wasm_hash.clone(),
+            interface_version: "wasm-1".to_string(),
+            abi_contract: ModuleAbiContract::default(),
+            exports: vec![if idx % 5 == 0 { "call" } else { "reduce" }.to_string()],
+            subscriptions: vec![
+                ModuleSubscription {
+                    event_kinds: vec!["domain.agent_registered".to_string()],
+                    action_kinds: Vec::new(),
+                    stage: Some(ModuleSubscriptionStage::PostEvent),
+                    filters: None,
+                },
+                ModuleSubscription {
+                    event_kinds: Vec::new(),
+                    action_kinds: vec!["action.register_agent".to_string()],
+                    stage: Some(ModuleSubscriptionStage::PreAction),
+                    filters: None,
+                },
+            ],
+            required_caps: Vec::new(),
+            artifact_identity: Some(identity_hash_artifact_identity(
+                wasm_hash.as_str(),
+                module_id.as_str(),
+            )),
+            limits: ModuleLimits {
+                max_mem_bytes: 1024,
+                max_gas: 10_000,
+                max_call_rate: 1,
+                max_output_bytes: 1024,
+                max_effects: 0,
+                max_emits: 0,
+            },
+        });
+    }
+    let mut world = build_world_with_active_manifests(&manifests, wasm_bytes, &wasm_hash)?;
+    world.set_policy(PolicySet::allow_all());
+
+    let event = WorldEvent {
+        id: 1,
+        time: 1,
+        caused_by: None,
+        body: WorldEventBody::Domain(DomainEvent::AgentRegistered {
+            agent_id: "agent-perf".to_string(),
+            pos: pos(0, 0),
+        }),
+    };
+    let action = ActionEnvelope {
+        id: 1,
+        action: Action::RegisterAgent {
+            agent_id: "agent-perf".to_string(),
+            pos: pos(0, 0),
+        },
+    };
+
+    let mut warmup_sandbox = CaptureContextSandbox::default();
+    let warm_event = world
+        .route_event_to_modules(&event, &mut warmup_sandbox)
+        .map_err(|err| format!("warm route_event_to_modules: {err:?}"))?;
+    let warm_action = world
+        .route_action_to_modules(&action, &mut warmup_sandbox)
+        .map_err(|err| format!("warm route_action_to_modules: {err:?}"))?;
+    if warm_event != MODULE_COUNT || warm_action != MODULE_COUNT {
+        return Err(format!(
+            "unexpected warmup invocation counts event={warm_event} action={warm_action}"
+        ));
+    }
+
+    let event_started_at = Instant::now();
+    let mut event_invoked = 0usize;
+    for _ in 0..ITERATIONS {
+        let mut sandbox = CaptureContextSandbox::default();
+        let invoked = world
+            .route_event_to_modules(&event, &mut sandbox)
+            .map_err(|err| format!("route_event_to_modules: {err:?}"))?;
+        event_invoked = event_invoked.saturating_add(black_box(invoked));
+    }
+    let event_elapsed = event_started_at.elapsed();
+
+    let action_started_at = Instant::now();
+    let mut action_invoked = 0usize;
+    for _ in 0..ITERATIONS {
+        let mut sandbox = CaptureContextSandbox::default();
+        let invoked = world
+            .route_action_to_modules(&action, &mut sandbox)
+            .map_err(|err| format!("route_action_to_modules: {err:?}"))?;
+        action_invoked = action_invoked.saturating_add(black_box(invoked));
+    }
+    let action_elapsed = action_started_at.elapsed();
+
+    if event_invoked != MODULE_COUNT * ITERATIONS {
+        return Err(format!(
+            "unexpected event invocation total expected={} actual={event_invoked}",
+            MODULE_COUNT * ITERATIONS
+        ));
+    }
+    if action_invoked != MODULE_COUNT * ITERATIONS {
+        return Err(format!(
+            "unexpected action invocation total expected={} actual={action_invoked}",
+            MODULE_COUNT * ITERATIONS
+        ));
+    }
+
+    println!(
+        "perf_probe_runtime_module_routing_with_many_active_manifests: modules={} iterations={} event_total_ms={:.3} event_avg_ms={:.3} action_total_ms={:.3} action_avg_ms={:.3} event_invoked={} action_invoked={}",
+        MODULE_COUNT,
+        ITERATIONS,
+        event_elapsed.as_secs_f64() * 1000.0,
+        event_elapsed.as_secs_f64() * 1000.0 / ITERATIONS as f64,
+        action_elapsed.as_secs_f64() * 1000.0,
+        action_elapsed.as_secs_f64() * 1000.0 / ITERATIONS as f64,
+        event_invoked,
+        action_invoked,
+    );
+
+    Ok(())
+}
+
+fn build_world_with_active_manifests(
+    manifests: &[ModuleManifest],
+    wasm_bytes: &[u8],
+    wasm_hash: &str,
+) -> Result<World, String> {
+    let mut base = World::new();
+    base.set_policy(PolicySet::allow_all());
+    base.register_module_artifact(wasm_hash.to_string(), wasm_bytes)
+        .map_err(|err| format!("register_module_artifact: {err:?}"))?;
+
+    let mut snapshot = base.snapshot();
+    snapshot.module_registry = build_module_registry(manifests);
+
+    let mut world = World::from_snapshot(snapshot, Journal::default())
+        .map_err(|err| format!("from_snapshot: {err:?}"))?;
+    world
+        .register_module_artifact(wasm_hash.to_string(), wasm_bytes)
+        .map_err(|err| format!("register_module_artifact(restored): {err:?}"))?;
+    Ok(world)
+}
+
+fn build_module_registry(manifests: &[ModuleManifest]) -> ModuleRegistry {
+    let mut registry = ModuleRegistry::default();
+    for manifest in manifests {
+        let key = ModuleRegistry::record_key(&manifest.module_id, &manifest.version);
+        registry.records.insert(
+            key,
+            ModuleRecord {
+                manifest: manifest.clone(),
+                registered_at: 0,
+                registered_by: TEST_MODULE_ARTIFACT_SIGNER_NODE_ID.to_string(),
+                audit_event_id: None,
+            },
+        );
+        registry
+            .active
+            .insert(manifest.module_id.clone(), manifest.version.clone());
+    }
+    registry
+}
+
+fn identity_hash_artifact_identity(wasm_hash: &str, module_id: &str) -> ModuleArtifactIdentity {
+    let source_hash = sha256_hex(format!("test-src:{wasm_hash}").as_bytes());
+    let build_manifest_hash = sha256_hex(b"test-build-manifest-v1");
+    let identity_hash = sha256_hex(
+        format!("{module_id}:{source_hash}:{build_manifest_hash}").as_bytes(),
+    );
+    ModuleArtifactIdentity {
+        source_hash,
+        build_manifest_hash,
+        signer_node_id: TEST_MODULE_ARTIFACT_SIGNER_NODE_ID.to_string(),
+        signature_scheme: IDENTITY_HASH_SIGNATURE_SCHEME.to_string(),
+        artifact_signature: format!("{IDENTITY_HASH_SIGNATURE_PREFIX}{identity_hash}"),
+    }
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    hex::encode(hasher.finalize())
+}
+
+fn pos(x: i64, y: i64) -> oasis7::GeoPos {
+    oasis7::GeoPos {
+        x_cm: x,
+        y_cm: y,
+        z_cm: 0,
+    }
+}
+
+#[derive(Default)]
+struct CaptureContextSandbox {
+    requests: Vec<ModuleCallRequest>,
+    outputs: VecDeque<ModuleOutput>,
+}
+
+impl ModuleSandbox for CaptureContextSandbox {
+    fn call(&mut self, request: &ModuleCallRequest) -> Result<ModuleOutput, ModuleCallFailure> {
+        self.requests.push(request.clone());
+        Ok(self.outputs.pop_front().unwrap_or(ModuleOutput {
+            new_state: None,
+            effects: Vec::new(),
+            emits: Vec::new(),
+            tick_lifecycle: None,
+            output_bytes: 0,
+        }))
+    }
+}

--- a/crates/oasis7/src/bin/oasis7_runtime_module_routing_perf.rs
+++ b/crates/oasis7/src/bin/oasis7_runtime_module_routing_perf.rs
@@ -3,12 +3,12 @@ use std::hint::black_box;
 use std::process;
 use std::time::Instant;
 
-use oasis7_wasm_abi::{ModuleCallFailure, ModuleCallRequest, ModuleOutput, ModuleSandbox};
 use oasis7::runtime::{
     Action, ActionEnvelope, DomainEvent, Journal, ModuleAbiContract, ModuleArtifactIdentity,
     ModuleKind, ModuleLimits, ModuleManifest, ModuleRecord, ModuleRegistry, ModuleRole,
     ModuleSubscription, ModuleSubscriptionStage, PolicySet, World, WorldEvent, WorldEventBody,
 };
+use oasis7_wasm_abi::{ModuleCallFailure, ModuleCallRequest, ModuleOutput, ModuleSandbox};
 use sha2::{Digest, Sha256};
 
 const MODULE_COUNT: usize = 192;
@@ -201,9 +201,8 @@ fn build_module_registry(manifests: &[ModuleManifest]) -> ModuleRegistry {
 fn identity_hash_artifact_identity(wasm_hash: &str, module_id: &str) -> ModuleArtifactIdentity {
     let source_hash = sha256_hex(format!("test-src:{wasm_hash}").as_bytes());
     let build_manifest_hash = sha256_hex(b"test-build-manifest-v1");
-    let identity_hash = sha256_hex(
-        format!("{module_id}:{source_hash}:{build_manifest_hash}").as_bytes(),
-    );
+    let identity_hash =
+        sha256_hex(format!("{module_id}:{source_hash}:{build_manifest_hash}").as_bytes());
     ModuleArtifactIdentity {
         source_hash,
         build_manifest_hash,

--- a/crates/oasis7/src/runtime/tests/modules.rs
+++ b/crates/oasis7/src/runtime/tests/modules.rs
@@ -52,8 +52,8 @@ include!("modules_permissions.rs");
 include!("modules_permissions_policy_hooks.rs");
 
 #[test]
-#[ignore = "perf harness"]
-fn perf_route_module_subscriptions_with_many_active_manifests() {
+#[ignore = "local perf probe"]
+fn perf_probe_runtime_module_routing_with_many_active_manifests() {
     const MODULE_COUNT: usize = 192;
     const ITERATIONS: usize = 80;
 
@@ -166,9 +166,10 @@ fn perf_route_module_subscriptions_with_many_active_manifests() {
     }
     let action_elapsed = action_started_at.elapsed();
 
-    println!(
-        "perf runtime_route modules={} event_total_ms={:.2} event_avg_ms={:.3} action_total_ms={:.2} action_avg_ms={:.3} event_invoked={} action_invoked={}",
+    eprintln!(
+        "perf_probe_runtime_module_routing_with_many_active_manifests: modules={} iterations={} event_total_ms={:.3} event_avg_ms={:.3} action_total_ms={:.3} action_avg_ms={:.3} event_invoked={} action_invoked={}",
         MODULE_COUNT,
+        ITERATIONS,
         event_elapsed.as_secs_f64() * 1000.0,
         event_elapsed.as_secs_f64() * 1000.0 / ITERATIONS as f64,
         action_elapsed.as_secs_f64() * 1000.0,

--- a/crates/oasis7_viewer/scripts/viewer-performance-probe.mjs
+++ b/crates/oasis7_viewer/scripts/viewer-performance-probe.mjs
@@ -13,8 +13,42 @@ import {
 const scriptDir = dirname(fileURLToPath(import.meta.url));
 const viewerRoot = resolve(scriptDir, "..");
 const repoRoot = resolve(viewerRoot, "../..");
-const agentBrowserBin = process.env.AGENT_BROWSER_BIN || "agent-browser";
+const configuredAgentBrowserBin = process.env.AGENT_BROWSER_BIN || "agent-browser";
+const agentBrowserNpxPackage = process.env.AGENT_BROWSER_NPX_PACKAGE || "agent-browser";
+const npxBin = process.platform === "win32" ? "npx.cmd" : "npx";
 const session = `viewer-performance-probe-${process.pid}`;
+
+function commandAvailable(command, args = ["--version"]) {
+  const result = spawnSync(command, args, { stdio: "ignore" });
+  return !result.error;
+}
+
+function resolveAgentBrowserInvocation() {
+  if (process.env.AGENT_BROWSER_BIN) {
+    return {
+      command: configuredAgentBrowserBin,
+      prefixArgs: [],
+      label: configuredAgentBrowserBin,
+    };
+  }
+  if (commandAvailable(configuredAgentBrowserBin)) {
+    return {
+      command: configuredAgentBrowserBin,
+      prefixArgs: [],
+      label: configuredAgentBrowserBin,
+    };
+  }
+  if (commandAvailable(npxBin)) {
+    return {
+      command: npxBin,
+      prefixArgs: ["--yes", agentBrowserNpxPackage],
+      label: `${npxBin} --yes ${agentBrowserNpxPackage}`,
+    };
+  }
+  throw new Error(`missing required browser automation command: ${configuredAgentBrowserBin} (or npx fallback)`);
+}
+
+const agentBrowserInvocation = resolveAgentBrowserInvocation();
 
 function positiveInteger(value, fallback) {
   const numeric = Number(value);
@@ -152,14 +186,24 @@ function serveFile(request, response) {
 }
 
 function ensureAgentBrowser() {
-  const result = spawnSync(agentBrowserBin, ["--version"], { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] });
-  if (result.status !== 0) throw new Error(`missing required browser automation command: ${agentBrowserBin}`);
+  const result = spawnSync(
+    agentBrowserInvocation.command,
+    [...agentBrowserInvocation.prefixArgs, "--version"],
+    { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
+  );
+  if (result.status !== 0) {
+    throw new Error(`missing required browser automation command: ${agentBrowserInvocation.label}`);
+  }
 }
 
 function runAgentBrowser(args, options = {}) {
   const timeout = options.timeout ?? 30_000;
   return new Promise((resolveRun, rejectRun) => {
-    const child = spawn(agentBrowserBin, ["--session", session, ...args], { stdio: ["pipe", "pipe", "pipe"] });
+    const child = spawn(
+      agentBrowserInvocation.command,
+      [...agentBrowserInvocation.prefixArgs, "--session", session, ...args],
+      { stdio: ["pipe", "pipe", "pipe"] },
+    );
     let stdout = "";
     let stderr = "";
     const timer = setTimeout(() => {
@@ -204,7 +248,11 @@ async function evalJson(source, options = {}) {
 }
 
 function closeBrowser() {
-  spawnSync(agentBrowserBin, ["--session", session, "close"], { stdio: "ignore", timeout: 10_000 });
+  spawnSync(
+    agentBrowserInvocation.command,
+    [...agentBrowserInvocation.prefixArgs, "--session", session, "close"],
+    { stdio: "ignore", timeout: 10_000 },
+  );
 }
 
 function probeScript({ durationMs, agents, locations }) {

--- a/doc/testing/performance/performance-coverage-gap-matrix-2026-06-09.md
+++ b/doc/testing/performance/performance-coverage-gap-matrix-2026-06-09.md
@@ -1,0 +1,66 @@
+# oasis7：性能测试补测矩阵（2026-06-09）
+
+## 目的
+- 基于当前仓库的现有功能面与已接入测试，整理“哪些性能测试已经有”“哪些地方更值得补”“适合进哪个测试层级”。
+- 本表回答的是“性能测试该补到哪里最划算”，不是要求“每个功能都补一套独立性能测试”。
+
+## 使用原则
+- 性能测试优先覆盖高频路径、长时路径、发布敏感路径和已知易退化热点，不要求覆盖所有功能。
+- 功能正确性仍主要由 `commit / required / full`、Web 闭环、契约测试和发布 gate 承担；性能测试负责补“慢了、卡了、抖了、长跑崩了”这类风险。
+- 建议 tier 含义：
+  - `required-scoped`: 仅在 changed-path 命中时进入默认 PR gate
+  - `full-scoped`: 仅在较重改动或 full-tier 抽样时进入
+  - `release`: 发布或高风险合流前必须覆盖
+  - `on-demand`: 默认不进 PR gate，按改动面或故障排查补跑
+
+## 补测矩阵
+| Surface | 当前已有覆盖 | 当前缺口 | 建议补充 | 建议 tier | 优先级 |
+| --- | --- | --- | --- | --- | --- |
+| Viewer Web 帧率 / frame time | `./scripts/viewer-performance-probe.sh --profile smoke|release`；`test:perf-harness` 覆盖部分前端性能指标 contract | PR 默认 gate 不盯 FPS / frame p95 / long task，Viewer 改动可能到人工验收才暴露卡顿 | 把 `viewer-performance-probe.sh --profile smoke` 做成 `crates/oasis7_viewer/**` 命中时的 changed-path scoped gate，保留 `release` profile 给更高风险改动 | `required-scoped` | P1 |
+| Viewer headed Web 真环境渲染 | 有 `agent-browser` 闭环、software-safe contract、build/UI tests | 当前缺少“真实 headed + GPU 路径”的轻量性能回归，容易只测 DOM/contract 不测渲染体感 | 补一条 headed smoke profile，记录 `readyMs`、FPS、frame p95、long task count，并把 SwiftShader/软件渲染继续当环境阻断处理 | `full-scoped` | P2 |
+| Viewer 移动端 / 窄屏性能 | 现有手册强调 desktop/mobile 截图与 visual review，但性能 probe 主要围绕当前默认 Viewer Web 入口 | 缺少移动布局下 DOM 规模、ready time、交互响应的独立预算 | 给 `viewer-performance-probe.mjs` 增加 mobile viewport profile，至少落 `readyMs + frame p95 + DOM size` | `on-demand`，稳定后可升 `required-scoped` | P2 |
+| Runtime tick / step 热路径 | `test_tier_required/full` 覆盖正确性；`llm-longrun-stress.sh` 会产出 `runtime_perf.tick.p95_ms` 等指标；`./scripts/runtime-module-routing-perf-harness.sh` 已补上稳定内环 module routing micro harness，并已有首个 `release` baseline（`event_avg_ms=5.591`、`action_avg_ms=6.992`、`modules=192`、`iterations=80`） | 现阶段轻量 harness 只覆盖 runtime module routing 内环，尚未扩到更完整 tick/step 预算；冷 `release` 编译耗时仍偏高 | 下一步把更多稳定热路径收进同一 summary/checklist，并评估哪些指标适合变成 scoped gate | `required-scoped`（仅限稳定 harness 命中路径）候选 | P1 |
+| Runtime 长时稳定性 | `./scripts/llm-longrun-stress.sh` 已有 runtime perf health、bottleneck、tick 指标聚合 | 仍偏长窗和按需使用，不适合普通 PR 快速暴露持续退化 | 增加一个更短的 smoke profile，缩短到适合 pre-PR 的窗口，只盯最关键 perf health 指标 | `full-scoped` | P2 |
+| Launcher 编译效率 / 依赖闭包 / 包体积 | `compile-metrics.yml` + `ci-compile-metrics.sh` 已测 package closure、冷 `cargo check`、冷 `cargo build --release`、binary size，并 gate `wasmtime` 不得漏入 | 目前只盯 launcher；其他关键 crate 的编译膨胀没有统一基线 | 保持 launcher 为默认 compile gate；如后续某些 crate 成为热点，再按热点增量扩展，不建议一开始全仓铺开 | launcher 继续 `required`；其他 crate 先 `on-demand` | P1 |
+| Launcher 运行时启动/健康探测延迟 | 现有测试更多关注 build、bundle、可用性、provider probe 正确性 | 缺少冷启动耗时、provider info/health latency 的回归预算 | 补一个 launcher startup perf smoke，记录 `info_latency_ms`、`health_latency_ms`、首屏 ready/可交互时间 | `on-demand`，稳定后可升 `required-scoped` | P2 |
+| P2P / 共识 / 存储短窗性能回归 | `p2p-longrun-soak.sh` / `s10-five-node-game-soak.sh` / release soak gate 已存在，且 release 口径较强 | 日常 PR 默认不跑，很多退化只能到 release 或专项长跑才显现 | 为 `oasis7_node/**`、`oasis7_net/**`、存储/复制热点改动补一条短窗 scoped soak，减少“只在 release 才看到”的回归 | `on-demand` for dev, `release` for high-risk merge path | P1 |
+| LLM / provider 回路性能 | `llm-longrun-stress.sh` 已采 `runtime_perf` 聚合；provider contract smoke 偏正确性 | 缺少“模型可用但变慢”的短窗预算，容易只知道能跑，不知道延迟在升高 | 补 provider-backed smoke，记录 request latency、extra wait、tick over-budget ratio，并与 builtin/基线做相对对比 | `on-demand`，关键 provider 改动时强制 | P2 |
+| WASM 执行器 / module cache 热点 | 仓库里已有 ignored perf probes，如 `oasis7_wasm_executor` / `oasis7_wasm_abi` 的 local perf probe | 这些 probe 没有进入标准回归，热点退化更依赖手工意识 | 把 ignored probe 收敛成可复用的本地 perf checklist，先作为诊断手册，不急着进默认 CI | `on-demand` | P3 |
+| 跨 surface 统一预算口径 | 局部有 compile closure/size、Viewer probe、release soak 阈值 | 缺少统一的 surface budget 表，导致哪些指标算退化依赖人记忆 | 建一份 repo-level perf budget 表，只维护少量核心指标：Viewer FPS/frame p95、runtime tick p95、launcher build/size、soak stall/lag | 先文档化，后逐步接 gate | P2 |
+
+## 建议优先顺序
+1. 先补 Viewer changed-path scoped 性能 gate，因为这是最容易感知、也最容易退化的用户面。
+2. 再补 runtime tick/step 的轻量 deterministic perf harness，减少只能靠长跑发现性能退化的问题。
+3. 然后补 P2P/存储/共识的短窗 scoped soak，把一部分 release 才暴露的问题前移。
+4. 最后再考虑 launcher runtime startup perf、LLM/provider latency 预算和 WASM ignored probes 的标准化。
+
+## 先做哪三项
+| Rank | Item | Why now | Minimum deliverable | Gate recommendation | Rollout caution |
+| --- | --- | --- | --- | --- | --- |
+| 1 | Viewer changed-path scoped 性能 gate | Viewer 是最直接的用户面，掉帧/卡顿最容易被感知；现有 `viewer-performance-probe.sh` 已经存在，补 gate 的改造成本最低 | 在 `crates/oasis7_viewer/**` 命中时运行 `./scripts/viewer-performance-probe.sh --profile smoke`，先稳定产出 `summary.json`/`summary.md` 与基础阈值结果 | 先做 `required-scoped` 候选 | 前几轮建议 `report-only`，先稳定阈值和环境噪音，再转 blocking |
+| 2 | Runtime tick/step 轻量 deterministic perf harness | 当前 runtime 性能更多靠 longrun/stress 暴露，反馈太晚；需要一条能日常回归的热路径预算 | 第一阶段已落 `./scripts/runtime-module-routing-perf-harness.sh`，固定输入输出 `event/action avg ms`；首个 `release` baseline 为 `event_avg_ms=5.591`、`action_avg_ms=6.992`；后续再扩到更接近 tick/step 的稳定指标 | 先保持本地/reporting 入口，再评估 `required-scoped` 候选 | 不要一开始就拿整场景总耗时做 gate，优先选最稳定的内环指标，避免 flaky；冷 `release` 编译成本也要一起纳入 gate 设计 |
+| 3 | P2P/存储/共识短窗 scoped soak | 这类退化现在太容易拖到 release soak 才暴露，修复成本高；需要前移一条便宜但有代表性的短窗检查 | 为 `oasis7_node/**`、`oasis7_net/**`、复制/存储高风险改动准备一个 reduced-duration soak 命令和统一 summary 判读 | 开发期先 `on-demand`，高风险合流或 release 前强制 | 必须按 changed paths 和风险等级触发，不能把 release 级长跑成本扩散到普通 PR |
+
+## 实施顺序建议
+1. 先做第 1 项，因为脚本和指标基础已经存在，最容易快速落成一条可见收益高的 gate。
+2. 再做第 2 项，因为 runtime 缺的不是“有没有长跑”，而是“有没有日常可回归的小预算”。
+3. 第 3 项随后做，因为它收益很高，但执行成本和 CI 时长影响也更大，需要在 scoped 触发条件上更谨慎。
+
+## 每项完成定义
+- Viewer changed-path scoped 性能 gate:
+  - changed-path planner 能识别 `crates/oasis7_viewer/**`
+  - smoke profile 能稳定落 summary 产物
+  - 至少完成一轮 report-only 基线收集
+- Runtime tick/step harness:
+  - 至少 1 个稳定 hot path 场景
+  - 指标输出可机读
+  - 有明确“超预算”判定，但先不要求覆盖所有 runtime 功能
+- P2P/短窗 soak:
+  - 至少 1 条 reduced-duration 命令
+  - summary 字段和 pass/fail 语义固定
+  - changed-path/risk-class 触发条件清楚，不污染普通 PR
+
+## 当前不建议做的事
+- 不建议把所有性能测试都塞进默认 `required`，否则日常 PR 时延会明显上升，且噪音会很大。
+- 不建议为每个功能单独建 perf case；优先围绕关键路径、共享热点和发布风险面抽样。
+- 不建议在没有稳定基线前就给所有 surface 设硬阈值；先文档化预算，再逐步 gate 化。

--- a/doc/testing/prd.index.md
+++ b/doc/testing/prd.index.md
@@ -18,6 +18,7 @@
 - 想先回答“对应标准角色 subagent 到底怎么设计、如何组合成 review 流程”：先读 `doc/testing/governance/playability-subagent-review-system-2026-05-06.prd.md`
 - 想先回答“如何用多个 simulated player personas 补内部玩家视角，但不新增正式 `player` 角色”：先读 `doc/testing/governance/playability-simulated-player-persona-panel-2026-05-06.prd.md`
 - 想用模型视觉判断替代常规人工视觉 review：先读 `doc/testing/manual/model-visual-review-sop-2026-05-29.manual.md`，再按 `doc/testing/templates/model-visual-review-card-template.md` 输出评审卡
+- 想快速判断“现有性能测试覆盖到哪、哪些功能面最值得补性能测试、哪些更适合进 scoped gate”：先读 `doc/testing/performance/performance-coverage-gap-matrix-2026-06-09.md`
 - 想先回答当前在推进什么、哪些测试治理任务或 QA 阻断仍在影响收口：先读 `doc/testing/project.md`
 - 想直接决定要跑哪套测试或按步骤执行：先读 `testing-manual.md` 与 `doc/testing/manual/web-ui-agent-browser-closure-manual.manual.md`
 - 想先进入 `evidence` 热点子域，并按 release gate / hosted-world / p2p-shared-network / governance drill / claim-audit 问题分流：先读 `doc/testing/evidence/README.md`
@@ -53,6 +54,7 @@
 - `testing-manual.md`：仓库级系统测试手册，不并入下方模块 PRD 三件套长表。
 - `doc/testing/manual/web-ui-agent-browser-closure-manual.manual.md`：Web UI 闭环 canonical 操作手册，不并入下方模块 PRD 三件套长表。
 - `doc/testing/manual/model-visual-review-sop-2026-05-29.manual.md`：截图加模型视觉评审 SOP，用于替代 routine 人工视觉 review，不并入下方模块 PRD 三件套长表。
+- `doc/testing/performance/performance-coverage-gap-matrix-2026-06-09.md`：按 surface 汇总现有性能覆盖、当前缺口、建议补测和建议 tier 的速查表。
 - `doc/testing/provider-dual-mode-t4-blocker-2026-03-16.md`：当前 QA 阻断摘要，适合在判断 provider 双模式收口风险时定向进入。
 
 ## 默认阅读面边界

--- a/doc/testing/project.md
+++ b/doc/testing/project.md
@@ -383,6 +383,25 @@
     - `./scripts/viewer-software-safe-step-regression-smoke.sh`
     - `./scripts/doc-governance-check.sh`
     - `git diff --check`
+- [x] engineering-code-quality-performance-baselines (PRD-TESTING-002/003) [test_tier_required]: 为 `required-gate` 增补 Viewer changed-path perf smoke scope，并新增本地 report-only runtime module routing micro harness、覆盖缺口矩阵与首个 dev/release baseline，补齐“哪些性能面该补、哪些只保留本地观测”的当前执行依据。 Trace: .pm/tasks/task_35657c5f0a5543dda5d57f51fc4b8841.yaml
+  - 产物文件:
+    - `.github/workflows/rust.yml`
+    - `scripts/ci-tests.sh`
+    - `scripts/plan-rust-required-scope.sh`
+    - `scripts/plan-rust-required-scope.test.sh`
+    - `crates/oasis7/src/runtime/tests/modules.rs`
+    - `crates/oasis7/src/bin/oasis7_runtime_module_routing_perf.rs`
+    - `scripts/runtime-module-routing-perf-harness.sh`
+    - `testing-manual.md`
+    - `doc/testing/performance/performance-coverage-gap-matrix-2026-06-09.md`
+    - `doc/testing/project.md`
+    - `.pm/tasks/task_35657c5f0a5543dda5d57f51fc4b8841.execution.md`
+  - 验收命令 (`test_tier_required`):
+    - `git diff --check`
+    - `./scripts/doc-governance-check.sh`
+    - `env -u RUSTC_WRAPPER cargo check -p oasis7 --bin oasis7_runtime_module_routing_perf`
+    - `./scripts/plan-rust-required-scope.test.sh`
+    - `./scripts/plan-rust-required-scope.sh --event-name pull_request --changed-path crates/oasis7_viewer/src/lib.rs | grep -q '^run_viewer_perf_smoke=true$'`
 
 - 当前阻断摘要：`doc/testing/provider-dual-mode-t4-blocker-2026-03-16.md`
 

--- a/scripts/ci-tests.sh
+++ b/scripts/ci-tests.sh
@@ -134,6 +134,15 @@ run_oasis7_viewer_software_safe_build() {
   run ./scripts/build-viewer-software-safe.sh
 }
 
+run_oasis7_viewer_performance_smoke_report_only() {
+  local status=0
+  run ./scripts/viewer-performance-probe.sh --profile smoke || status=$?
+  if [[ "$status" -ne 0 ]]; then
+    echo "warning: viewer performance smoke failed (report-only)"
+    return 0
+  fi
+}
+
 run_hosted_account_local_smoke() {
   run bash ./scripts/hosted-account-staging-smoke.sh --mode local
 }
@@ -200,6 +209,7 @@ case "$tier" in
     run_required_component "oasis7_net libp2p tests" "${OASIS7_CI_RUN_OASIS7_NET_LIBP2P_TESTS:-false}" run_oasis7_net_libp2p_tests
     run_required_component "viewer software-safe contract" "${OASIS7_CI_RUN_VIEWER_CONTRACT_TESTS:-}" run_oasis7_viewer_software_safe_feedback_contract_tests
     run_required_component "viewer software-safe build" "${OASIS7_CI_RUN_VIEWER_WASM_CHECK:-}" run_oasis7_viewer_software_safe_build
+    run_required_component "viewer performance smoke (report-only)" "${OASIS7_CI_RUN_VIEWER_PERF_SMOKE:-false}" run_oasis7_viewer_performance_smoke_report_only
     run_required_component "hosted account local smoke" "${OASIS7_CI_RUN_HOSTED_ACCOUNT_SMOKE:-false}" run_hosted_account_local_smoke
     run_required_component "launcher web build" "${OASIS7_CI_RUN_LAUNCHER_WEB_BUILD:-false}" run_oasis7_client_launcher_web_build
     ;;

--- a/scripts/plan-rust-required-scope.sh
+++ b/scripts/plan-rust-required-scope.sh
@@ -21,6 +21,7 @@ run_oasis7_net_tests=0
 run_oasis7_net_libp2p_tests=0
 run_viewer_contract_tests=0
 run_viewer_wasm_check=0
+run_viewer_perf_smoke=0
 run_launcher_web_build=0
 
 usage() {
@@ -64,6 +65,7 @@ mark_full() {
   run_oasis7_net_libp2p_tests=1
   run_viewer_contract_tests=1
   run_viewer_wasm_check=1
+  run_viewer_perf_smoke=1
   run_launcher_web_build=1
   append_reason "$1"
 }
@@ -97,6 +99,7 @@ mark_net() {
 mark_viewer() {
   run_viewer_contract_tests=1
   run_viewer_wasm_check=1
+  run_viewer_perf_smoke=1
   append_reason "$1"
 }
 
@@ -274,6 +277,7 @@ elif [[ \
   "$run_oasis7_net_libp2p_tests" -eq 1 || \
   "$run_viewer_contract_tests" -eq 1 || \
   "$run_viewer_wasm_check" -eq 1 || \
+  "$run_viewer_perf_smoke" -eq 1 || \
   "$run_launcher_web_build" -eq 1 \
   ]]; then
   scope="targeted"
@@ -300,6 +304,7 @@ emit_output() {
     echo "run_oasis7_net_libp2p_tests=$([[ "$run_oasis7_net_libp2p_tests" -eq 1 ]] && echo true || echo false)"
     echo "run_viewer_contract_tests=$([[ "$run_viewer_contract_tests" -eq 1 ]] && echo true || echo false)"
     echo "run_viewer_wasm_check=$([[ "$run_viewer_wasm_check" -eq 1 ]] && echo true || echo false)"
+    echo "run_viewer_perf_smoke=$([[ "$run_viewer_perf_smoke" -eq 1 ]] && echo true || echo false)"
     echo "run_launcher_web_build=$([[ "$run_launcher_web_build" -eq 1 ]] && echo true || echo false)"
     echo "needs_node=$needs_node"
     echo "needs_system_deps=$needs_system_deps"
@@ -324,6 +329,7 @@ run_oasis7_net_tests=$([[ "$run_oasis7_net_tests" -eq 1 ]] && echo true || echo 
 run_oasis7_net_libp2p_tests=$([[ "$run_oasis7_net_libp2p_tests" -eq 1 ]] && echo true || echo false)
 run_viewer_contract_tests=$([[ "$run_viewer_contract_tests" -eq 1 ]] && echo true || echo false)
 run_viewer_wasm_check=$([[ "$run_viewer_wasm_check" -eq 1 ]] && echo true || echo false)
+run_viewer_perf_smoke=$([[ "$run_viewer_perf_smoke" -eq 1 ]] && echo true || echo false)
 run_launcher_web_build=$([[ "$run_launcher_web_build" -eq 1 ]] && echo true || echo false)
 needs_node=$needs_node
 needs_system_deps=$needs_system_deps

--- a/scripts/plan-rust-required-scope.test.sh
+++ b/scripts/plan-rust-required-scope.test.sh
@@ -54,4 +54,11 @@ assert_key_equals "$proto_output" run_launcher_web_build true
 assert_key_equals "$proto_output" needs_trunk true
 assert_reason_contains "$proto_output" "launcher_proto:crates/oasis7_proto/src/lib.rs"
 
+viewer_output="$(plan_for_path crates/oasis7_viewer/src/lib.rs)"
+assert_key_equals "$viewer_output" scope targeted
+assert_key_equals "$viewer_output" run_viewer_contract_tests true
+assert_key_equals "$viewer_output" run_viewer_wasm_check true
+assert_key_equals "$viewer_output" run_viewer_perf_smoke true
+assert_reason_contains "$viewer_output" "viewer:crates/oasis7_viewer/src/lib.rs"
+
 echo "plan-rust-required-scope.test: OK"

--- a/scripts/runtime-module-routing-perf-harness.sh
+++ b/scripts/runtime-module-routing-perf-harness.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+cd "$repo_root"
+
+usage() {
+  cat <<'USAGE'
+Usage: ./scripts/runtime-module-routing-perf-harness.sh [options]
+
+Purpose:
+  Run the lightweight deterministic runtime module-routing perf probe and
+  write a small machine-readable summary for local regression tracking.
+
+Outputs:
+  <out-dir>/<timestamp>/
+    perf.log
+    summary.json
+    summary.md
+
+Options:
+  --out-dir <path>   Output root (default: .tmp/runtime_module_routing_perf)
+  --profile <name>   Cargo profile: release | dev (default: release)
+  -h, --help         Show help
+USAGE
+}
+
+need_cmd() {
+  command -v "$1" >/dev/null 2>&1 || {
+    echo "error: required command not found: $1" >&2
+    exit 2
+  }
+}
+
+out_dir=".tmp/runtime_module_routing_perf"
+profile="release"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --out-dir)
+      out_dir=${2:-}
+      shift 2
+      ;;
+    --profile)
+      profile=${2:-}
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "error: unknown option: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+need_cmd python3
+
+case "$profile" in
+  release|dev) ;;
+  *)
+    echo "error: --profile must be one of: release, dev" >&2
+    exit 2
+    ;;
+esac
+
+timestamp=$(date '+%Y%m%d-%H%M%S')
+run_dir="$out_dir/$timestamp"
+mkdir -p "$run_dir"
+
+log_path="$run_dir/perf.log"
+summary_json="$run_dir/summary.json"
+summary_md="$run_dir/summary.md"
+
+declare -a cargo_args=(
+  run
+  -p oasis7
+  --bin oasis7_runtime_module_routing_perf
+)
+if [[ "$profile" == "release" ]]; then
+  cargo_args+=(--release)
+fi
+
+env -u RUSTC_WRAPPER cargo "${cargo_args[@]}" 2>&1 | tee "$log_path"
+
+python3 - "$log_path" "$summary_json" "$summary_md" "$profile" <<'PY'
+import json
+import pathlib
+import re
+import sys
+
+log_path = pathlib.Path(sys.argv[1])
+summary_json = pathlib.Path(sys.argv[2])
+summary_md = pathlib.Path(sys.argv[3])
+profile = sys.argv[4]
+
+text = log_path.read_text(encoding="utf-8")
+pattern = re.compile(
+    r"perf_probe_runtime_module_routing_with_many_active_manifests: "
+    r"modules=(?P<modules>\d+) "
+    r"iterations=(?P<iterations>\d+) "
+    r"event_total_ms=(?P<event_total_ms>[0-9.]+) "
+    r"event_avg_ms=(?P<event_avg_ms>[0-9.]+) "
+    r"action_total_ms=(?P<action_total_ms>[0-9.]+) "
+    r"action_avg_ms=(?P<action_avg_ms>[0-9.]+) "
+    r"event_invoked=(?P<event_invoked>\d+) "
+    r"action_invoked=(?P<action_invoked>\d+)"
+)
+match = pattern.search(text)
+if not match:
+    raise SystemExit("error: perf probe output not found in log")
+
+data = {
+    "probe": "perf_probe_runtime_module_routing_with_many_active_manifests",
+    "surface": "runtime.module_routing",
+    "profile": profile,
+    "modules": int(match.group("modules")),
+    "iterations": int(match.group("iterations")),
+    "event_total_ms": float(match.group("event_total_ms")),
+    "event_avg_ms": float(match.group("event_avg_ms")),
+    "action_total_ms": float(match.group("action_total_ms")),
+    "action_avg_ms": float(match.group("action_avg_ms")),
+    "event_invoked": int(match.group("event_invoked")),
+    "action_invoked": int(match.group("action_invoked")),
+    "log_path": str(log_path.resolve()),
+}
+
+summary_json.write_text(json.dumps(data, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+summary_md.write_text(
+    "\n".join(
+        [
+            "# Runtime Module Routing Perf Harness",
+            "",
+            f"- probe: `{data['probe']}`",
+            f"- surface: `{data['surface']}`",
+            f"- profile: `{data['profile']}`",
+            f"- modules: `{data['modules']}`",
+            f"- iterations: `{data['iterations']}`",
+            f"- event_total_ms: `{data['event_total_ms']:.3f}`",
+            f"- event_avg_ms: `{data['event_avg_ms']:.3f}`",
+            f"- action_total_ms: `{data['action_total_ms']:.3f}`",
+            f"- action_avg_ms: `{data['action_avg_ms']:.3f}`",
+            f"- event_invoked: `{data['event_invoked']}`",
+            f"- action_invoked: `{data['action_invoked']}`",
+            f"- log_path: `{data['log_path']}`",
+        ]
+    )
+    + "\n",
+    encoding="utf-8",
+)
+PY
+
+echo "runtime module routing perf summary: $summary_md"
+echo "runtime module routing perf summary json: $summary_json"

--- a/testing-manual.md
+++ b/testing-manual.md
@@ -109,6 +109,7 @@
   - planner 先执行：`./scripts/plan-rust-required-scope.sh --event-name <push|pull_request> --base-ref <base> --head-ref <head>`
   - `CI_VERBOSE=1 ./scripts/ci-tests.sh required`
   - 本地显式 `./scripts/ci-tests.sh required` 仍保持基础 required 语义；只有 CI `required-gate` 与 `prepare-task-pr.sh` 推荐命令会根据 planner 输出注入选择性组件环境变量，并在命中 `crates/oasis7_node/**` / `crates/oasis7_net/**` 或 shared gate/full scope 时额外拉起 support-crate shard
+  - 当 planner 命中 `crates/oasis7_viewer/**` 时，`required-gate` 现在还会追加一条 `viewer-performance-probe.sh --profile smoke` 的 report-only scoped smoke；当前阶段用于收集 summary 和阈值噪音，不作为 blocking failure
 - 入口 C：`.github/workflows/wasm-determinism-gate.yml`（构建 hash / receipt evidence 独立 gate）
   - GitHub-hosted runner 矩阵：`(m1|m4|m5) x (ubuntu-24.04/linux-x86_64)`
   - planner 先执行：`./scripts/plan-wasm-determinism-scope.sh --event-name <push|pull_request|workflow_dispatch> --base-ref <base> --head-ref <head>`
@@ -122,6 +123,7 @@
 - Web UI agent-browser 闭环（现为手动/agent 流程，不在 CI 默认路径中）。
 - `m4/m5` builtin wasm hash 校验（`scripts/ci-tests.sh` 已移除 `sync-m4/m5 --check`）。
 - runtime builtin wasm bootstrap / default-module / body-action 闭环（已从 required 下放到 `test_tier_full`）。
+- Viewer headed / GPU 真环境性能当前仍不是 blocking required gate；现阶段 only report-only scoped smoke 已接入 `required-gate`
 
 结论：
 - `commit` 是默认本地提交基线，目标是尽快暴露格式/治理/viewer-support 回归，但不承担 `oasis7 --tests` required shard；
@@ -486,6 +488,10 @@ OASIS7_CHAIN_STORAGE_PROFILE=dev_local bash -x <bundle>/run-chain-runtime.sh --h
 ./scripts/viewer-performance-probe.sh --profile smoke
 ./scripts/viewer-performance-probe.sh --profile release --duration-ms 8000
 ```
+- Runtime 轻量 deterministic perf harness（当前先覆盖稳定内环 module routing）：
+```bash
+./scripts/runtime-module-routing-perf-harness.sh
+```
 - LLM 长稳：
 ```bash
 ./scripts/llm-longrun-stress.sh --scenario llm_bootstrap --ticks 240
@@ -509,6 +515,8 @@ OASIS7_CHAIN_STORAGE_PROFILE=dev_local bash -x <bundle>/run-chain-runtime.sh --h
 ```
 - 说明：
   - 详细参数与 profile 组合请以 `./scripts/llm-longrun-stress.sh --help` 为准；
+  - `./scripts/runtime-module-routing-perf-harness.sh` 现在走专用 bin `cargo run -p oasis7 --bin oasis7_runtime_module_routing_perf`，避免继续依赖 ignored test 的重编译路径；它会把稳定内环 module routing 的 event/action 平均耗时写到 `.tmp/runtime_module_routing_perf/<run>/summary.{json,md}`；当前目的是提供日常可回归的轻量 runtime perf 入口，不替代长窗 `runtime_perf.tick.*` 指标；
+  - 当前已记录首个 `release` baseline 数值：`modules=192`、`iterations=80`、`event_avg_ms=5.591`、`action_avg_ms=6.992`；对应一次本地验证 run 的冷 `release` 编译耗时约 `23m 10s`。原始 `summary.json` 属于本地临时产物，应以 task execution log 中登记的验证记录为证据来源；因此当前更适合先作为本地/report-only 基线，而不是立刻升成默认 blocking gate；
   - Viewer 性能 probe 使用当前 `crates/oasis7_viewer` software-safe Web 入口，通过 `agent-browser` 采集 rAF frame timing、Long Task、ready time、DOM 规模与 gate 结果，并输出 `output/playwright/viewer-performance/<run>/summary.{json,md}`；
   - 旧 `viewer-owr4-stress` 属于历史已删除入口，不再作为当前 Viewer 性能门禁真值；
   - `scripts/ci-tests.sh full` 已接入 `./scripts/llm-baseline-fixture-smoke.sh`；


### PR DESCRIPTION
## Summary
- add viewer changed-path perf smoke scope to the required gate planner and CI wrapper
- add a local runtime module routing perf harness plus baseline documentation and coverage gap matrix
- record the task workflow evidence needed for the PR path

## Verification
- git diff --check
- ./scripts/doc-governance-check.sh
- env -u RUSTC_WRAPPER cargo check -p oasis7 --bin oasis7_runtime_module_routing_perf
- ./scripts/plan-rust-required-scope.test.sh
- ./scripts/plan-rust-required-scope.sh --event-name pull_request --changed-path crates/oasis7_viewer/src/lib.rs
- ./scripts/pm/workflow-lint.sh --task-uid task_35657c5f0a5543dda5d57f51fc4b8841 --phase pr-ready
- ./scripts/prepare-task-pr.sh