### PR TITLE
Keep sole transport-cooled peer available

### DIFF
--- a/crates/oasis7_node/src/libp2p_replication_network.rs
+++ b/crates/oasis7_node/src/libp2p_replication_network.rs
@@ -321,19 +321,25 @@ impl Libp2pReplicationNetwork {
             })
             .unwrap_or_default();
         let keep_protocol_entry = !protocol_cooldown_peers.is_empty();
+        let mut deferred_transport_peers = Vec::new();
         let mut scored: Vec<(PeerId, u8, usize)> = ordered_peers
             .into_iter()
             .enumerate()
             .filter_map(|(index, peer)| {
-                if protocol_cooldown_peers.contains_key(&peer)
-                    || transport_retry_cooldown_peers.contains_key(&peer)
-                {
+                if protocol_cooldown_peers.contains_key(&peer) {
                     return None;
                 }
                 let score = self.request_peer_score(peer);
+                if transport_retry_cooldown_peers.contains_key(&peer) {
+                    deferred_transport_peers.push((peer, score, index));
+                    return None;
+                }
                 Some((peer, score, index))
             })
             .collect();
+        if scored.is_empty() && !deferred_transport_peers.is_empty() {
+            scored = deferred_transport_peers;
+        }
         scored.sort_by(|left, right| right.1.cmp(&left.1).then_with(|| left.2.cmp(&right.2)));
         let filtered = scored
             .into_iter()

--- a/crates/oasis7_node/src/libp2p_replication_network/tests.rs
+++ b/crates/oasis7_node/src/libp2p_replication_network/tests.rs
@@ -290,6 +290,12 @@ fn filtered_request_peers_excludes_transport_retry_cooldown_peers_across_protoco
         vec![observer_peer, sequencer_peer],
     );
     assert_eq!(cross_protocol_filtered, vec![sequencer_peer]);
+
+    let filtered_only_cooldown = network.filtered_request_peers(
+        "/aw/node/replication/fetch-commit/1.0.0",
+        vec![observer_peer],
+    );
+    assert_eq!(filtered_only_cooldown, vec![observer_peer]);
 }
 
 #[test]
@@ -366,7 +372,7 @@ fn filtered_request_peers_retries_transport_retry_cooldown_peer_after_retry_wind
         "/aw/node/replication/fetch-commit/1.0.0",
         vec![sequencer_peer],
     );
-    assert!(filtered_initial.is_empty());
+    assert_eq!(filtered_initial, vec![sequencer_peer]);
 
     std::thread::sleep(Duration::from_millis(15));
 
@@ -749,14 +755,14 @@ fn libp2p_replication_network_connection_gap_cools_peer_across_protocols() {
         crate::replication::REPLICATION_FETCH_COMMIT_PROTOCOL,
         b"node",
     );
-    assert!(matches!(
-        second,
-        Err(WorldError::NetworkProtocolUnavailable { .. })
-    ));
+    assert_eq!(
+        second.expect("sole connected peer remains a last-resort request target"),
+        b"commit-ok".to_vec()
+    );
     assert_eq!(
         fetch_commit_request_count.load(Ordering::SeqCst),
-        0,
-        "transport cooldown should suppress immediate cross-protocol reuse of the same peer"
+        1,
+        "transport cooldown should not suppress the only connected peer"
     );
 
     std::thread::sleep(Duration::from_millis(300));
@@ -768,7 +774,7 @@ fn libp2p_replication_network_connection_gap_cools_peer_across_protocols() {
         )
         .expect("fetch commit should recover after transport cooldown");
     assert_eq!(third, b"commit-ok".to_vec());
-    assert_eq!(fetch_commit_request_count.load(Ordering::SeqCst), 1);
+    assert_eq!(fetch_commit_request_count.load(Ordering::SeqCst), 2);
 }
 
 #[test]
@@ -913,13 +919,16 @@ fn libp2p_replication_network_connection_gap_on_ping_enters_short_cooldown() {
     let second = dialer.request("/aw/node/replication/ping", b"node");
     assert!(matches!(
         second,
-        Err(WorldError::NetworkProtocolUnavailable { .. })
+        Err(WorldError::NetworkRequestFailed {
+            code: DistributedErrorCode::ErrNotAvailable,
+            ..
+        })
     ));
-    assert_eq!(
-        request_count.load(Ordering::SeqCst),
-        request_count_after_first,
-        "cooldown should suppress an immediate second ping request after a connection gap"
+    assert!(
+        request_count.load(Ordering::SeqCst) > request_count_after_first,
+        "transport cooldown should not suppress the only connected peer"
     );
+    let request_count_after_second = request_count.load(Ordering::SeqCst);
 
     std::thread::sleep(Duration::from_millis(300));
 
@@ -932,7 +941,7 @@ fn libp2p_replication_network_connection_gap_on_ping_enters_short_cooldown() {
         })
     ));
     assert!(
-        request_count.load(Ordering::SeqCst) > request_count_after_first,
+        request_count.load(Ordering::SeqCst) > request_count_after_second,
         "request count should grow again after the short cooldown expires"
     );
 }


### PR DESCRIPTION
## Summary
- keep transport-cooldown peers as a last-resort request target when every connected peer is otherwise filtered out
- preserve protocol-cooldown suppression for peers that returned protocol-scoped failures
- update libp2p replication tests for the single-peer recovery path

## Verification
- env -u RUSTC_WRAPPER cargo fmt --check
- git diff --check
- ./scripts/check-rust-file-size.sh
- env -u RUSTC_WRAPPER cargo test -p oasis7_node libp2p_replication_network -- --nocapture
- env -u RUSTC_WRAPPER cargo test -p oasis7_node storage_replication_peer_head_tests -- --nocapture
- env -u RUSTC_WRAPPER cargo test -p oasis7_node storage_replication_high_checkpoint_tests -- --nocapture
- env -u RUSTC_WRAPPER cargo test -p oasis7_node storage_replication_progress_tests -- --nocapture