### PR TITLE
Fix testnet observer high-state checkpoint sync

### DIFF
--- a/.pm/tasks/task_761375d25bc24fe59147a853e8c8acb0.execution.md
+++ b/.pm/tasks/task_761375d25bc24fe59147a853e8c8acb0.execution.md
@@ -1,0 +1,64 @@
+# task_761375d25bc24fe59147a853e8c8acb0 Execution Log
+
+- task_uid: task_761375d25bc24fe59147a853e8c8acb0
+- title: Implement automatic high-state testnet sync
+- owner_role: tpm
+- worktree_hint: /Users/scc/ccwork/worktrees/oasis7-p2p-windows-testnet-node-redeploy
+
+## 2026-06-13 10:39:02 CST / tpm
+- 完成内容: Bootstrapped task truth for automatic high-state observer sync and dispatched a bounded blockchain_ops_engineer/runtime_engineer design slice. The design hypothesis was that observer high-state bootstrap must probe the retained checkpoint window, not only the advertised head/latest boundary, because release_default retains eight 64-height execution checkpoints and public testnet heads are often non-checkpoint heights.
+- 遗留事项: Initial implementation and verification still pending at this point.
+- Action: Record workflow route and professional slice contract before code edits.
+- Validation Command: ./scripts/pm/workflow-report.sh --role tpm --phase start --task-uid task_761375d25bc24fe59147a853e8c8acb0 --json
+- Expected Result: Task has started workflow truth and execution-log sink before implementation.
+- Actual Result: Task entered committed workflow with last_started_at=2026-06-13T10:39:02+08:00.
+- Blocker / Next Action: Implement retained checkpoint discovery and regression coverage.
+
+## 2026-06-13 11:03:00 CST / tpm
+- 完成内容: Implemented retained-window checkpoint probing for observer high-state sync, added transient fetch-commit NetworkProtocolUnavailable/Timeout continuation to lower candidates, split retained-window tests into a dedicated test file, and updated the public testnet runbook runtime contract to state that standard observer attach should not require seed/state-sync when retained checkpoints are available.
+- 遗留事项: checkpoint keep/interval remains an implicit release_default mirror in node candidate constants; future work can make it config-driven for non-release profiles.
+- Action: Added high checkpoint candidate window and timeout behavior in crates/oasis7_node/src/node_engine_replication.rs; added tests_storage_replication_high_checkpoint_retained.rs; wired it from tests_storage_replication.rs; updated doc/p2p/blockchain/p2p-public-testnet-governed-bootstrap-2026-06-06.runbook.md.
+- Validation Command: env -u RUSTC_WRAPPER cargo fmt --check && ./scripts/check-rust-file-size.sh && git diff --check && env -u RUSTC_WRAPPER cargo test -p oasis7_node storage_replication_high_checkpoint_retained_tests -- --nocapture && env -u RUSTC_WRAPPER cargo test -p oasis7_node storage_replication_high_checkpoint_tests -- --nocapture && env -u RUSTC_WRAPPER cargo test -p oasis7_node storage_replication_progress_tests -- --nocapture && ./scripts/doc-governance-check.sh
+- Expected Result: Formatting, file-size, whitespace, retained/high checkpoint regressions, progress regressions, and doc governance pass.
+- Actual Result: All listed checks passed locally; retained tests cover 16715 retained-window candidates, transient fetch-commit timeout continuation, and non-checkpoint head fallback to a retained checkpoint.
+- Blocker / Next Action: Run required pre-PR local role review and record passed evidence packet before PR creation.
+
+## 2026-06-13 11:08:00 CST / tpm
+- 完成内容: Completed pre-PR local role review. Avicenna confirmed checkpoint discovery as the root cause and recommended retained-window candidates plus timeout continuation. Lorentz reviewed the final diff for runtime_engineer, blockchain_ops_engineer, qa_engineer, and repository_health_engineer and returned no_findings.
+- 遗留事项: Live deployment still depends on peers actually retaining and serving checkpoint commit payloads and checkpoint blobs inside the documented window.
+- Action: Integrated no_findings review result and recorded the required Pre-PR Local Role Review packet.
+- Validation Command: multi_agent_v1.wait_agent for 019ebee8-c59e-7aa0-83de-160516f62fe1
+- Expected Result: Review returns findings or no_findings plus residual risk for the final diff.
+- Actual Result: no_findings; residual risks were hard-coded release_default keep/interval and live peer checkpoint blob retention.
+- Blocker / Next Action: Run task-closeout.sh with the fresh verification command, then commit and create PR.
+
+## 2026-06-13 11:09:40 CST / tpm
+- 完成内容: Closed task after fresh verification; task-closeout wrote task_complete claim evidence and marked the task done. Repo-wide pm lint still reports unrelated historical task lint debt, so the task-local verification evidence is preserved separately.
+- 遗留事项: repo-wide .pm lint has unrelated historical failures outside this task; do not treat them as part of this code fix.
+- Action: ./scripts/pm/task-closeout.sh --role tpm --task-uid task_761375d25bc24fe59147a853e8c8acb0 --verify-command "<fresh verification command>"; internally this records claim-ready.sh task_complete evidence.
+- Validation Command: env -u RUSTC_WRAPPER cargo fmt --check && ./scripts/check-rust-file-size.sh && git diff --check && env -u RUSTC_WRAPPER cargo test -p oasis7_node storage_replication_high_checkpoint_retained_tests -- --nocapture && env -u RUSTC_WRAPPER cargo test -p oasis7_node storage_replication_high_checkpoint_tests -- --nocapture && env -u RUSTC_WRAPPER cargo test -p oasis7_node storage_replication_progress_tests -- --nocapture && ./scripts/doc-governance-check.sh
+- Expected Result: Fresh verification passes and task closeout records task_complete evidence.
+- Actual Result: Fresh verification passed; task yaml has last_claim_type=task_complete, last_verification_status=verified, last_closed_at=2026-06-13T11:09:40+08:00. Final task-closeout process exited nonzero only because repo-wide pm lint found unrelated historical task debt plus the now-fixed local heading issue.
+- Blocker / Next Action: Run workflow-lint --task-uid task_761375d25bc24fe59147a853e8c8acb0 --phase pr-ready, then stage/commit and create PR.
+
+## 2026-06-13 11:10:00 CST / tpm
+- Pre-PR Local Role Review: passed
+- Task UID: task_761375d25bc24fe59147a853e8c8acb0
+- Source Worktree: /Users/scc/ccwork/worktrees/oasis7-p2p-windows-testnet-node-redeploy
+- Source Branch: codex/testnet-auto-high-state-sync
+- Source Head: 45d1e3a763011135bfb1b1678af2961f5c3aff2a
+- Comparison Ref: origin/main
+- Reviewed Changed Paths: crates/oasis7_node/src/node_engine_replication.rs; crates/oasis7_node/src/tests_storage_replication.rs; crates/oasis7_node/src/tests_storage_replication_high_checkpoint_retained.rs; doc/p2p/blockchain/p2p-public-testnet-governed-bootstrap-2026-06-06.runbook.md; .pm/tasks/task_761375d25bc24fe59147a853e8c8acb0.*; .pm/roles/tpm/backlog/committed.yaml
+- Role Selection Basis: runtime checkpoint discovery logic and public-testnet runbook changed; regression evidence and test-file-size split changed; selected runtime_engineer, blockchain_ops_engineer, qa_engineer, repository_health_engineer.
+- Review Roles: runtime_engineer, blockchain_ops_engineer, qa_engineer, repository_health_engineer
+- Review Evidence: Lorentz pre-PR bounded review returned no_findings after final diff review; Avicenna design slice confirmed checkpoint discovery root cause and recommended retained-window candidates plus timeout continuation.
+- Review Findings Disposition: no_findings
+- Finding Disposition Evidence: no actionable findings; residual risks recorded below.
+- Residual Risk: checkpoint keep/interval remains hard-coded to release_default rather than config-driven; live deployment still depends on peers retaining and serving checkpoint blobs inside the documented window.
+- 完成内容: Recorded the required Pre-PR Local Role Review: passed packet for prepare-task-pr.
+- 遗留事项: GitHub PR checks and comments still need to run after PR creation.
+- Action: Prepare task for PR creation.
+- Validation Command: ./scripts/pm/workflow-lint.sh --task-uid task_761375d25bc24fe59147a853e8c8acb0 --phase pr-ready
+- Expected Result: Task-local PR readiness lint passes.
+- Actual Result: Pending at log rewrite time.
+- Blocker / Next Action: Run task-local pr-ready lint.

--- a/.pm/tasks/task_761375d25bc24fe59147a853e8c8acb0.execution.md
+++ b/.pm/tasks/task_761375d25bc24fe59147a853e8c8acb0.execution.md
@@ -46,8 +46,8 @@
 - Task UID: task_761375d25bc24fe59147a853e8c8acb0
 - Source Worktree: /Users/scc/ccwork/worktrees/oasis7-p2p-windows-testnet-node-redeploy
 - Source Branch: codex/testnet-auto-high-state-sync
-- Source Head: 45d1e3a763011135bfb1b1678af2961f5c3aff2a
-- Comparison Ref: origin/main
+- Source Head: 24323d737b6f964d4a0d0dfea87bcf5a27461273
+- Comparison Ref: refs/remotes/origin/main
 - Reviewed Changed Paths: crates/oasis7_node/src/node_engine_replication.rs; crates/oasis7_node/src/tests_storage_replication.rs; crates/oasis7_node/src/tests_storage_replication_high_checkpoint_retained.rs; doc/p2p/blockchain/p2p-public-testnet-governed-bootstrap-2026-06-06.runbook.md; .pm/tasks/task_761375d25bc24fe59147a853e8c8acb0.*; .pm/roles/tpm/backlog/committed.yaml
 - Role Selection Basis: runtime checkpoint discovery logic and public-testnet runbook changed; regression evidence and test-file-size split changed; selected runtime_engineer, blockchain_ops_engineer, qa_engineer, repository_health_engineer.
 - Review Roles: runtime_engineer, blockchain_ops_engineer, qa_engineer, repository_health_engineer

--- a/.pm/tasks/task_761375d25bc24fe59147a853e8c8acb0.yaml
+++ b/.pm/tasks/task_761375d25bc24fe59147a853e8c8acb0.yaml
@@ -1,0 +1,28 @@
+task_uid: task_761375d25bc24fe59147a853e8c8acb0
+title: "Implement automatic high-state testnet sync"
+owner_role: tpm
+worktree_hint: /Users/scc/ccwork/worktrees/oasis7-p2p-windows-testnet-node-redeploy
+execution_log_path: .pm/tasks/task_761375d25bc24fe59147a853e8c8acb0.execution.md
+status: done
+priority: P1
+source_signal: null
+source_refs:
+  - doc/p2p/blockchain/p2p-public-testnet-governed-bootstrap-2026-06-06.runbook.md
+  - crates/oasis7_node/src/node_engine_replication.rs
+doc_refs:
+  - doc/engineering/workflow/source-of-truth.md
+  - doc/p2p/project.md
+related_prd: []
+acceptance:
+  - "New observer can bootstrap from retained high execution checkpoint when low commit history is unavailable."
+  - "Design notes and execution log distinguish checkpoint discovery, commit replay, and deployment expectations."
+  - "Regression tests cover non-checkpoint head / retained checkpoint discovery."
+handoff_to: []
+updated_at: 2026-06-13T11:09:40+08:00
+last_started_at: 2026-06-13T10:39:02+08:00
+last_claim_type: task_complete
+last_verify_command: "env -u RUSTC_WRAPPER cargo fmt --check && ./scripts/check-rust-file-size.sh && git diff --check && env -u RUSTC_WRAPPER cargo test -p oasis7_node storage_replication_high_checkpoint_retained_tests -- --nocapture && env -u RUSTC_WRAPPER cargo test -p oasis7_node storage_replication_high_checkpoint_tests -- --nocapture && env -u RUSTC_WRAPPER cargo test -p oasis7_node storage_replication_progress_tests -- --nocapture && ./scripts/doc-governance-check.sh"
+last_verified_at: 2026-06-13T11:09:39+08:00
+last_verification_exit_code: 0
+last_verification_status: verified
+last_closed_at: 2026-06-13T11:09:40+08:00

--- a/.pm/tasks/task_f81d3e661b7048d8b2fe6987a544a368.yaml
+++ b/.pm/tasks/task_f81d3e661b7048d8b2fe6987a544a368.yaml
@@ -1,7 +1,7 @@
 task_uid: task_f81d3e661b7048d8b2fe6987a544a368
 title: "Redeploy Windows testnet node"
 owner_role: tpm
-worktree_hint: /Users/scc/ccwork/worktrees/oasis7-p2p-windows-testnet-node-redeploy
+worktree_hint: /Users/scc/ccwork/worktrees/closed-task-f81d3e661b7048d8b2fe6987a544a368-oasis7-p2p-windows-testnet-node-redeploy
 execution_log_path: .pm/tasks/task_f81d3e661b7048d8b2fe6987a544a368.execution.md
 status: done
 priority: P2

--- a/crates/oasis7_node/src/node_engine_replication.rs
+++ b/crates/oasis7_node/src/node_engine_replication.rs
@@ -6,7 +6,11 @@ use crate::replication_state_reconcile::ReplicationCommitPayload;
 use oasis7_proto::distributed::WorldHeadAnnounce;
 
 impl PosNodeEngine {
-    fn high_replication_checkpoint_candidates(
+    // Mirrors release_default.execution_checkpoint_keep. The inclusive range probes the
+    // latest aligned boundary plus eight older retained-window boundaries.
+    const HIGH_REPLICATION_CHECKPOINT_LOOKBACK_WINDOWS: u64 = 8;
+
+    pub(super) fn high_replication_checkpoint_candidates(
         advertised_network_height: u64,
         blocked_height: u64,
     ) -> Vec<u64> {
@@ -19,11 +23,21 @@ impl PosNodeEngine {
         push_candidate(advertised_network_height);
         for interval in [64_u64, 32_u64] {
             let aligned = advertised_network_height - (advertised_network_height % interval);
-            push_candidate(aligned);
-            push_candidate(aligned.saturating_sub(interval));
+            for lookback in 0..=Self::HIGH_REPLICATION_CHECKPOINT_LOOKBACK_WINDOWS {
+                push_candidate(aligned.saturating_sub(interval.saturating_mul(lookback)));
+            }
         }
         candidates.sort_unstable_by(|a, b| b.cmp(a));
         candidates
+    }
+
+    pub(super) fn high_replication_checkpoint_probe_can_continue(err: &NodeError) -> bool {
+        let NodeError::Replication { reason } = err else {
+            return false;
+        };
+        reason.contains(REPLICATION_FETCH_COMMIT_PROTOCOL)
+            && (reason.contains("NetworkProtocolUnavailable")
+                || reason.contains("request failed: Timeout"))
     }
 
     fn clear_replication_gap_sync_blocked_if_unblocked(&mut self) {
@@ -752,7 +766,7 @@ impl PosNodeEngine {
             ) {
                 let expected_candidate_head =
                     expected_checkpoint_head.filter(|head| head.height == checkpoint_candidate);
-                if self.try_sync_high_replication_checkpoint_boundary(
+                let probe_result = self.try_sync_high_replication_checkpoint_boundary(
                     endpoint,
                     node_id,
                     world_id,
@@ -762,12 +776,25 @@ impl PosNodeEngine {
                     expected_candidate_head,
                     &mut execution_hook,
                     &mut progress_callback,
-                )? {
-                    if self.replication_persisted_height > starting_replication_persisted_height {
-                        self.network_committed_height =
-                            self.network_committed_height.max(advertised_network_height);
+                );
+                match probe_result {
+                    Ok(true) => {
+                        if self.replication_persisted_height > starting_replication_persisted_height
+                        {
+                            self.network_committed_height =
+                                self.network_committed_height.max(advertised_network_height);
+                        }
+                        return Ok(());
                     }
-                    return Ok(());
+                    Ok(false) => {}
+                    Err(err) if Self::high_replication_checkpoint_probe_can_continue(&err) => {
+                        self.last_replication_gap_sync_repair_attempt_height =
+                            Some(checkpoint_candidate);
+                        self.last_replication_gap_sync_repair_attempt_summary = Some(format!(
+                            "checkpoint_candidate={checkpoint_candidate} transient_error={err}"
+                        ));
+                    }
+                    Err(err) => return Err(err),
                 }
             }
         }
@@ -857,7 +884,7 @@ impl PosNodeEngine {
                 ) {
                     let expected_candidate_head =
                         expected_checkpoint_head.filter(|head| head.height == checkpoint_candidate);
-                    if self.try_sync_high_replication_checkpoint_boundary(
+                    let probe_result = self.try_sync_high_replication_checkpoint_boundary(
                         endpoint,
                         node_id,
                         world_id,
@@ -867,8 +894,18 @@ impl PosNodeEngine {
                         expected_candidate_head,
                         &mut execution_hook,
                         &mut progress_callback,
-                    )? {
-                        break;
+                    );
+                    match probe_result {
+                        Ok(true) => break,
+                        Ok(false) => {}
+                        Err(err) if Self::high_replication_checkpoint_probe_can_continue(&err) => {
+                            self.last_replication_gap_sync_repair_attempt_height =
+                                Some(checkpoint_candidate);
+                            self.last_replication_gap_sync_repair_attempt_summary = Some(format!(
+                                "checkpoint_candidate={checkpoint_candidate} transient_error={err}"
+                            ));
+                        }
+                        Err(err) => return Err(err),
                     }
                 }
                 if self.replication_persisted_height > next_height {

--- a/crates/oasis7_node/src/tests_storage_replication.rs
+++ b/crates/oasis7_node/src/tests_storage_replication.rs
@@ -4,6 +4,8 @@ mod storage_challenge_gate_tests;
 mod storage_replication_failover_tests;
 #[path = "tests_storage_replication_high_checkpoint.rs"]
 mod storage_replication_high_checkpoint_tests;
+#[path = "tests_storage_replication_high_checkpoint_retained.rs"]
+mod storage_replication_high_checkpoint_retained_tests;
 #[path = "tests_storage_replication_peer_head.rs"]
 mod storage_replication_peer_head_tests;
 #[path = "tests_storage_replication_progress.rs"]

--- a/crates/oasis7_node/src/tests_storage_replication_high_checkpoint_retained.rs
+++ b/crates/oasis7_node/src/tests_storage_replication_high_checkpoint_retained.rs
@@ -1,0 +1,215 @@
+use super::*;
+
+struct CheckpointInstallingExecutionHook {
+    installed: Vec<u64>,
+}
+
+impl NodeExecutionHook for CheckpointInstallingExecutionHook {
+    fn on_commit(
+        &mut self,
+        context: NodeExecutionCommitContext,
+    ) -> Result<NodeExecutionCommitResult, String> {
+        Err(format!(
+            "{} at height {}",
+            EXECUTION_MISSING_PREDECESSOR_RECORD_SIGNATURE, context.height
+        ))
+    }
+
+    fn install_checkpoint_bundle(
+        &mut self,
+        context: NodeExecutionCheckpointInstallContext,
+        bundle: NodeExecutionCheckpointBundle,
+    ) -> Result<NodeExecutionCommitResult, String> {
+        if bundle.height != context.height
+            || bundle.execution_block_hash != context.execution_block_hash
+            || bundle.execution_state_root != context.execution_state_root
+        {
+            return Err("checkpoint bundle mismatch".to_string());
+        }
+        self.installed.push(context.height);
+        Ok(NodeExecutionCommitResult {
+            execution_height: context.height,
+            execution_block_hash: context.execution_block_hash,
+            execution_state_root: context.execution_state_root,
+        })
+    }
+}
+
+fn test_execution_checkpoint_bundle(
+    height: u64,
+    execution_block_hash: &str,
+    execution_state_root: &str,
+) -> NodeExecutionCheckpointBundle {
+    let snapshot_bytes =
+        format!("checkpoint-snapshot-{height}-{execution_state_root}").into_bytes();
+    NodeExecutionCheckpointBundle {
+        height,
+        execution_block_hash: execution_block_hash.to_string(),
+        execution_state_root: execution_state_root.to_string(),
+        manifest_json: br#"{"test":"manifest"}"#.to_vec(),
+        blobs: vec![NodeExecutionCheckpointBlob {
+            content_hash: oasis7_distfs::blake3_hex(snapshot_bytes.as_slice()),
+            bytes: snapshot_bytes,
+        }],
+    }
+}
+
+#[test]
+fn high_replication_checkpoint_candidates_cover_release_default_retained_window() {
+    let candidates = PosNodeEngine::high_replication_checkpoint_candidates(16_715, 0);
+
+    assert_eq!(candidates.first().copied(), Some(16_715));
+    for height in [16_640, 16_576, 16_512, 16_448, 16_384, 16_320, 16_256, 16_192] {
+        assert!(
+            candidates.contains(&height),
+            "missing release_default retained checkpoint candidate {height}; candidates={candidates:?}"
+        );
+    }
+}
+
+#[test]
+fn high_replication_checkpoint_probe_continues_after_fetch_commit_timeout() {
+    let err = NodeError::Replication {
+        reason:
+            "replication network error: NetworkProtocolUnavailable { protocol: \"libp2p-replication outbound request failed: request failed: Timeout /aw/node/replication/fetch-commit/1.0.0\" }"
+                .to_string(),
+    };
+
+    assert!(PosNodeEngine::high_replication_checkpoint_probe_can_continue(&err));
+}
+
+#[test]
+fn high_replication_checkpoint_probe_does_not_continue_after_blob_or_execution_errors() {
+    let blob_err = NodeError::Replication {
+        reason: "execution checkpoint blob not found hash=missing-blob".to_string(),
+    };
+    let execution_err = NodeError::Execution {
+        reason: "execution checkpoint install returned mismatched binding at height 16640"
+            .to_string(),
+    };
+
+    assert!(!PosNodeEngine::high_replication_checkpoint_probe_can_continue(
+        &blob_err
+    ));
+    assert!(!PosNodeEngine::high_replication_checkpoint_probe_can_continue(
+        &execution_err
+    ));
+}
+
+#[test]
+fn observer_gap_sync_probes_retained_checkpoint_window_below_non_checkpoint_head() {
+    let world_id = "world-gap-sync-retained-window-below-head";
+    let dir_a = temp_dir("gap-sync-retained-window-below-head-a");
+    let dir_b = temp_dir("gap-sync-retained-window-below-head-b");
+    let (_, public_key_a) = deterministic_keypair_hex(250);
+    let (_, public_key_b) = deterministic_keypair_hex(251);
+    let pos_config = signed_pos_config_with_signer_seeds(
+        vec![PosValidator {
+            validator_id: "node-a".to_string(),
+            stake: 100,
+        }],
+        &[("node-a", 250)],
+    );
+    let replication_config_a = signed_replication_config(dir_a.clone(), 250)
+        .with_remote_writer_allowlist(vec![public_key_b.clone()])
+        .expect("allowlist a")
+        .with_fetch_requester_allowlist(vec![public_key_b])
+        .expect("fetch allowlist a");
+    let replication_config_b = signed_replication_config(dir_b.clone(), 251)
+        .with_remote_writer_allowlist(vec![public_key_a.clone()])
+        .expect("allowlist b")
+        .with_fetch_requester_allowlist(vec![public_key_a])
+        .expect("fetch allowlist b");
+    let config_a = NodeConfig::new("node-a", world_id, NodeRole::Sequencer)
+        .expect("config a")
+        .with_pos_config(pos_config.clone())
+        .expect("pos config a")
+        .with_replication(replication_config_a.clone());
+    let config_b = NodeConfig::new("node-b", world_id, NodeRole::Observer)
+        .expect("config b")
+        .with_pos_config(pos_config)
+        .expect("pos config b")
+        .with_replication(replication_config_b.clone());
+
+    let mut replication_a =
+        ReplicationRuntime::new(config_a.replication.as_ref().expect("repl a"), "node-a")
+            .expect("runtime a");
+    for height in [64_u64, 300_u64] {
+        let decision = PosDecision {
+            height,
+            slot: height,
+            epoch: 0,
+            status: PosConsensusStatus::Committed,
+            block_hash: format!("block-{height}"),
+            action_root: empty_action_root(),
+            committed_actions: Vec::new(),
+            approved_stake: 100,
+            rejected_stake: 0,
+            required_stake: 67,
+            total_stake: 100,
+        };
+        let execution_block_hash = format!("exec-block-{height}");
+        let execution_state_root = format!("exec-state-{height}");
+        let checkpoint = (height == 64).then(|| {
+            test_execution_checkpoint_bundle(height, &execution_block_hash, &execution_state_root)
+        });
+        replication_a
+            .build_local_commit_message_with_checkpoint(
+                "node-a",
+                world_id,
+                7_000 + i64::try_from(height).expect("height fits i64"),
+                &decision,
+                Some(execution_block_hash.as_str()),
+                Some(execution_state_root.as_str()),
+                checkpoint,
+            )
+            .expect("build local message")
+            .expect("message");
+    }
+
+    let network: Arc<
+        dyn oasis7_proto::distributed_net::DistributedNetwork<WorldError> + Send + Sync,
+    > = Arc::new(TestInMemoryNetwork::default());
+    register_replication_fetch_handlers(
+        &NodeReplicationNetworkHandle::new(Arc::clone(&network)),
+        &replication_config_a,
+        world_id,
+        &config_a.network_policy,
+    )
+    .expect("register fetch handlers");
+    let handle_b = NodeReplicationNetworkHandle::new(Arc::clone(&network));
+    let endpoint_b =
+        ReplicationNetworkEndpoint::new(&handle_b, world_id, false, &config_b.network_policy)
+            .expect("endpoint b");
+    let mut replication_b =
+        ReplicationRuntime::new(config_b.replication.as_ref().expect("repl b"), "node-b")
+            .expect("runtime b");
+    let mut engine_b = PosNodeEngine::new(&config_b).expect("engine b");
+    engine_b.network_committed_height = 300;
+    let mut execution_hook = CheckpointInstallingExecutionHook {
+        installed: Vec::new(),
+    };
+
+    engine_b
+        .sync_missing_replication_commits(
+            &endpoint_b,
+            "node-b",
+            world_id,
+            Some(&mut replication_b),
+            Some(&mut execution_hook),
+        )
+        .expect("retained-window checkpoint gap sync");
+
+    assert_eq!(execution_hook.installed, vec![64]);
+    assert_eq!(engine_b.committed_height, 64);
+    assert_eq!(engine_b.replication_persisted_height, 64);
+    assert_eq!(engine_b.last_execution_height, 64);
+    assert_eq!(
+        engine_b.execution_binding_for_height(64),
+        Some(("exec-block-64", "exec-state-64"))
+    );
+    assert_eq!(engine_b.last_replication_gap_sync_blocked_height, None);
+
+    let _ = fs::remove_dir_all(&dir_a);
+    let _ = fs::remove_dir_all(&dir_b);
+}

--- a/doc/p2p/blockchain/p2p-public-testnet-governed-bootstrap-2026-06-06.runbook.md
+++ b/doc/p2p/blockchain/p2p-public-testnet-governed-bootstrap-2026-06-06.runbook.md
@@ -94,6 +94,17 @@
 6. 自动 high-head checkpoint catch-up 只覆盖 observer/light-node 边界；execution-required 节点不能用它跳过历史执行，也不能把它当作完整 snapshot state-sync。
 7. `seed-from-remote` / state-sync 产物只用于自动 checkpoint catch-up 失败后的 recovery；产物必须包含 execution restore 所需 blob 闭包，否则 observer 会在 restore snapshot/journal 时落入 `BlobNotFound`。
 
+### 4.1 Runtime high-state sync contract
+`public_testnet` observer 的标准 attach 设计是不要求操作者预先提供 seed/state-sync 目录。新 observer 在发现远端链头远高于本地高度时，必须先尝试从 P2P replication 网络拉取一个受验证的高位 execution checkpoint，再从该 checkpoint 后继续 tail gap sync。
+
+运行时实现必须满足以下约束：
+
+1. 候选 checkpoint 不能只看 advertised head 或最近一个对齐边界；必须覆盖 storage profile 保留窗口内的多个 checkpoint 边界。
+2. `release_default` 当前按 64 高度间隔保留 8 个 execution checkpoint，因此 observer gap sync 至少要回看 8 个 64-height checkpoint windows。
+3. checkpoint commit payload 的 `execution_block_hash`、`execution_state_root` 与 checkpoint descriptor 必须完全匹配，blob 内容必须按 content hash 和 size 校验后才能安装。
+4. 如果 advertised head 不是 checkpoint 高度，observer 可以安装 head 之前最近仍被保留且可验证的 checkpoint；安装后再由正常 gap sync 追尾。
+5. 若保留窗口内没有可获取的 checkpoint，状态接口应继续报告 `state_sync_fallback_required=true`，此时才进入 break-glass seed/state-sync recovery。
+
 ## 5. Required Inputs
 开始前，操作者必须准备好以下输入：
 

--- a/doc/p2p/project.md
+++ b/doc/p2p/project.md
@@ -923,6 +923,7 @@
     - `./scripts/doc-governance-check.sh`
     - `git diff --check`
 - [x] testnet-routing-peer-record-bootstrap (PRD-P2P-001/003) [test_tier_required]: 修复 reset public testnet observer 在 routing 已发现 bootstrap peer、connected snapshot 仍为空时无法启动 peer-record 交换的问题，允许 routing update 直接触发 connected peer-record request，并用回归覆盖空 connected snapshot 的 bootstrap 窗口。 Trace: .pm/tasks/task_f81d3e661b7048d8b2fe6987a544a368.yaml
+- [x] testnet-auto-high-state-sync (PRD-P2P-001/003) [test_tier_required]: 修复新 public testnet observer 在低位 commit 历史不可用且 advertised head 非 checkpoint 高度时无法自动发现仍被保留的高位 execution checkpoint 的问题；observer gap sync 现在覆盖 release_default retained checkpoint window，并在 fetch-commit transient timeout/unavailable 时继续探测更低候选。 Trace: .pm/tasks/task_761375d25bc24fe59147a853e8c8acb0.yaml
 
 ## 依赖
 - 模块设计总览：`doc/p2p/design.md`


### PR DESCRIPTION
Task: task_761375d25bc24fe59147a853e8c8acb0

## Summary
- Expand observer high-state checkpoint discovery to probe the release_default retained checkpoint window instead of only the advertised head/latest boundary.
- Continue probing lower checkpoint candidates after transient fetch-commit NetworkProtocolUnavailable/Timeout errors while preserving hard validation/blob failures.
- Document the public testnet runtime contract: standard observer attach should not require seed/state-sync when retained checkpoints are available.

## Verification
- env -u RUSTC_WRAPPER cargo fmt --check
- ./scripts/check-rust-file-size.sh
- git diff --check
- env -u RUSTC_WRAPPER cargo test -p oasis7_node storage_replication_high_checkpoint_retained_tests -- --nocapture
- env -u RUSTC_WRAPPER cargo test -p oasis7_node storage_replication_high_checkpoint_tests -- --nocapture
- env -u RUSTC_WRAPPER cargo test -p oasis7_node storage_replication_progress_tests -- --nocapture
- ./scripts/doc-governance-check.sh

## Local Review
Pre-PR Local Role Review: passed. Roles: runtime_engineer, blockchain_ops_engineer, qa_engineer, repository_health_engineer.

## Residual Risk
- Checkpoint keep/interval remains hard-coded to release_default rather than config-driven.
- Live deployment still depends on peers retaining and serving checkpoint blobs inside the documented window.
