### PR TITLE
Fix testnet checkpoint provider sync

### DIFF
--- a/.pm/tasks/task_96c772c830e043f9b1e40b03e6f73d38.execution.md
+++ b/.pm/tasks/task_96c772c830e043f9b1e40b03e6f73d38.execution.md
@@ -1,0 +1,75 @@
+# task_96c772c830e043f9b1e40b03e6f73d38 Execution Log
+
+- task_uid: task_96c772c830e043f9b1e40b03e6f73d38
+- title: Repair testnet high-state peer retry sync
+- owner_role: tpm
+- worktree_hint: /Users/scc/ccwork/worktrees/oasis7-testnet-high-state-peer-retry
+
+<!-- Append entries using:
+Example:
+  ## YYYY-MM-DD HH:MM:SS CST / role_name
+  - 完成内容: ...
+  - 遗留事项: ...
+  - Action: ...
+  - Validation Command: ...
+  - Expected Result: ...
+  - Actual Result: ...
+  - Blocker / Next Action: ...
+-->
+
+## 2026-06-13 12:28:00 CST / tpm
+- 完成内容: 复现 testnet.52 部署后的第二根因。192.168.1.4 observer 已运行新 high-state candidate 逻辑，`last_error=null`，但仍 `height=0 replication=0 network=16715 fallback=true repair_summary=null`；storage 39.104.205.67 已运行 testnet.52，`height=16715 replication=16715 last_error=null earliest_checkpoint=16256 latest_checkpoint=16704`。
+- 线上证据: storage 本地 execution records 在 16256/16640/16704 均有 `checkpoint_ref`，但对应 sequencer replication commit payload 只有 `execution_block_hash`/`execution_state_root`，无 `execution_checkpoint` descriptor。旧 fetch handler 只在当前 provider signer 等于原 message writer 时才附加 descriptor；observer 只连 storage provider 时拿到的仍是 legacy sequencer commit，无法安装高 checkpoint。
+- 设计结论: 标准 observer attach 不应要求 seed/state-sync；storage/full-storage provider 必须能为本地 retained checkpoint 动态附加 descriptor，并以自身 authorized replication writer 身份重签增强 commit message。observer 仍通过 allowlist、payload hash、signature、execution binding 和 checkpoint blob hash/size 校验，不信任未授权 provider。
+- 代码改动: `register_replication_fetch_handlers_with_checkpoint_export` 传入本地 provider node_id；`ReplicationRuntime::attach_execution_checkpoint_descriptor_to_message` 支持跨 writer 增强消息时用 provider signer 重建 replication record、更新 writer guard/state、重签并 pin augmented payload；同 writer 路径保持原有 hash/pin 行为。
+- 回归测试: 更新 checkpoint attach 单测，新增/改造三节点高 checkpoint 用例：A sequencer 产出 legacy commit，C storage provider 保存 commit 并导出 checkpoint，B observer 只信 C 的 writer，最终通过 C 的增强 fetch-commit 响应安装高 checkpoint。
+- Validation Command: env -u RUSTC_WRAPPER cargo test -p oasis7_node replication::checkpoint_tests -- --nocapture
+- Actual Result: passed; 2 tests passed.
+- Validation Command: env -u RUSTC_WRAPPER cargo test -p oasis7_node observer_gap_sync_installs_exported_checkpoint_for_legacy_commit_payload -- --nocapture
+- Actual Result: passed; 1 test passed.
+- Validation Command: env -u RUSTC_WRAPPER cargo test -p oasis7_node storage_replication_high_checkpoint -- --nocapture
+- Actual Result: passed; 13 tests passed.
+- 遗留事项: packaged CI artifact and live storage/observer redeploy smoke still required after merge.
+- Action: implement code/docs fix and continue to PR packaging/deploy workflow.
+- Expected Result: local regression confirms observer can install a high execution checkpoint from a storage provider that re-signs a legacy sequencer commit.
+- Blocker / Next Action: run format/doc/file checks, then prepare PR and CI package/deploy.
+
+## 2026-06-13 12:36:44 CST / tpm
+- Review Trigger: pre-PR local role review
+- Review Scope: `crates/oasis7_node/src/lib.rs`; `crates/oasis7_node/src/replication_checkpoint.rs`; `crates/oasis7_node/src/replication/checkpoint_tests.rs`; `crates/oasis7_node/src/tests_storage_replication_high_checkpoint.rs`; `doc/p2p/blockchain/p2p-public-testnet-governed-bootstrap-2026-06-06.runbook.md`; `doc/p2p/project.md`; `.pm/tasks/task_96c772c830e043f9b1e40b03e6f73d38.*`; `.pm/roles/tpm/backlog/committed.yaml`
+- Review Roles: runtime_engineer, blockchain_ops_engineer, qa_engineer
+- Review Question: confirm whether the checkpoint augmentation fix correctly lets authorized storage/full-storage providers dynamically attach retained execution checkpoint descriptors to legacy sequencer-signed commits, re-sign as the provider writer, preserve replication trust boundaries, document the public testnet runtime contract, and has sufficient regression coverage for PR readiness.
+- Evidence Available: `env -u RUSTC_WRAPPER cargo fmt --check`; `./scripts/check-rust-file-size.sh`; `git diff --check`; `env -u RUSTC_WRAPPER cargo test -p oasis7_node replication::checkpoint_tests -- --nocapture`; `env -u RUSTC_WRAPPER cargo test -p oasis7_node storage_replication_high_checkpoint -- --nocapture`; `./scripts/doc-governance-check.sh`
+- Expected Return Contract: findings | no_findings | residual_risk
+- Formal Sink: `.pm/tasks/task_96c772c830e043f9b1e40b03e6f73d38.execution.md`
+
+## 2026-06-13 12:43:15 CST / tpm
+- runtime_engineer: no_findings. The implementation correctly lets an authorized storage/full-storage provider attach a retained checkpoint descriptor to a legacy sequencer commit, rebuild the replication record under the provider signer, persist provider-local guard/writer state, and return a provider-signed augmented message. Observer validation remains bounded by `remote_writer_allowlist`, signature binding, payload hash, checkpoint descriptor binding, and blob hash/size materialization.
+- runtime_engineer residual_risk: repeated fetches for the same legacy checkpoint will mint a new provider-writer sequence each time; monotonic records remain valid, but production metrics should watch for pathological repeated fetches.
+- blockchain_ops_engineer finding: P2 runbook gap. Phase F still described observer `REPLICATION_REMOTE_WRITERS_CSV` as the validator writer allowlist, which could make a future non-validator storage/full-storage checkpoint provider re-sign commits with a writer key observers reject.
+- blockchain_ops_engineer finding disposition: addressed by updating the runbook to require every checkpoint-serving storage/full-storage provider signer in observer `REPLICATION_REMOTE_WRITERS_CSV`, in addition to validator signers.
+- blockchain_ops_engineer residual_risk: live deployment still must validate that observer moves from `height=0/state_sync_fallback_required=true` to an installed checkpoint height and tail syncs after CI package rollout.
+- qa_engineer: no_findings. Regression coverage is sufficient for PR readiness: unit coverage verifies provider re-signing of legacy sequencer commits, integration coverage verifies A sequencer / C storage provider / B observer trust topology, and existing negative coverage still covers mismatched checkpoint, sparse checkpoint without hook, execution-history skip prevention, and low-history-missing bootstrap behavior.
+- qa_engineer residual_risk: local/in-memory verification is not a packaged multi-host testnet soak; release confidence still depends on CI packaging plus redeploy smoke on storage and observer.
+- Pre-PR Local Role Review: passed
+- Task UID: task_96c772c830e043f9b1e40b03e6f73d38
+- Source Worktree: /Users/scc/ccwork/worktrees/oasis7-testnet-high-state-peer-retry
+- Source Branch: codex/testnet-high-state-peer-retry
+- Source Head: 4b16638bb3492760b93bc68551cc0c4a3f86f3b6
+- Comparison Ref: main
+- Reviewed Changed Paths: `.pm/roles/tpm/backlog/committed.yaml`; `.pm/tasks/task_96c772c830e043f9b1e40b03e6f73d38.execution.md`; `.pm/tasks/task_96c772c830e043f9b1e40b03e6f73d38.yaml`; `crates/oasis7_node/src/lib.rs`; `crates/oasis7_node/src/replication/checkpoint_tests.rs`; `crates/oasis7_node/src/replication_checkpoint.rs`; `crates/oasis7_node/src/tests_storage_replication_high_checkpoint.rs`; `doc/p2p/blockchain/p2p-public-testnet-governed-bootstrap-2026-06-06.runbook.md`; `doc/p2p/project.md`
+- Role Selection Basis: runtime checkpoint/signature behavior, public testnet operator contract, and regression/release-readiness verification.
+- Review Roles: runtime_engineer, blockchain_ops_engineer, qa_engineer
+- Review Evidence: role review results above plus local gates listed in the review request.
+- Review Findings Disposition: addressed
+- Finding Disposition Evidence: runbook now states observer `REPLICATION_REMOTE_WRITERS_CSV` must include checkpoint-serving storage/full-storage provider signers as well as validator signers.
+- Residual Risk: packaged CI artifact and live storage/observer redeploy smoke remain required after merge.
+
+## 2026-06-13 12:47:24 CST / tpm
+- 完成内容: Ran task closeout for `task_96c772c830e043f9b1e40b03e6f73d38`; embedded `claim-ready.sh` verification passed and task yaml was moved to `status: done` with `last_claim_type: task_complete`.
+- 遗留事项: repo-wide `.pm lint` still has unrelated historical failures in other task files, so this task will continue through `workflow-lint --phase pr-ready` and `prepare-task-pr.sh` rather than broad repo lint cleanup.
+- Action: `./scripts/pm/task-closeout.sh --role tpm --task-uid task_96c772c830e043f9b1e40b03e6f73d38 --verify-command "<full checkpoint verification command>"`
+- Validation Command: env -u RUSTC_WRAPPER cargo fmt --check && ./scripts/check-rust-file-size.sh && git diff --check && env -u RUSTC_WRAPPER cargo test -p oasis7_node replication::checkpoint_tests -- --nocapture && env -u RUSTC_WRAPPER cargo test -p oasis7_node storage_replication_high_checkpoint -- --nocapture && ./scripts/doc-governance-check.sh
+- Expected Result: format, file-size, diff, checkpoint tests, high-checkpoint integration tests, and doc governance pass.
+- Actual Result: passed; task yaml records `last_verification_exit_code: 0` and `last_verification_status: verified`. The helper exited after repo-wide `.pm lint` reported unrelated existing task debt plus pre-fix execution-log shape issues; this task log was then normalized for PR-ready workflow lint.
+- Blocker / Next Action: commit code/docs first, then commit `.pm` evidence with `Source Head` pointing at the reviewed code/docs commit, then run `./scripts/prepare-task-pr.sh --create`.

--- a/.pm/tasks/task_96c772c830e043f9b1e40b03e6f73d38.execution.md
+++ b/.pm/tasks/task_96c772c830e043f9b1e40b03e6f73d38.execution.md
@@ -73,3 +73,12 @@ Example:
 - Expected Result: format, file-size, diff, checkpoint tests, high-checkpoint integration tests, and doc governance pass.
 - Actual Result: passed; task yaml records `last_verification_exit_code: 0` and `last_verification_status: verified`. The helper exited after repo-wide `.pm lint` reported unrelated existing task debt plus pre-fix execution-log shape issues; this task log was then normalized for PR-ready workflow lint.
 - Blocker / Next Action: commit code/docs first, then commit `.pm` evidence with `Source Head` pointing at the reviewed code/docs commit, then run `./scripts/prepare-task-pr.sh --create`.
+
+## 2026-06-13 12:55:20 CST / tpm
+- 完成内容: Created GitHub PR #431 for `codex/testnet-high-state-peer-retry`: https://github.com/eng-cc/oasis7/pull/431
+- 遗留事项: PR required checks, comments/review threads, mergeability, merge, CI package trigger, and live storage/observer redeploy smoke remain.
+- Action: `gh pr create --base main --head codex/testnet-high-state-peer-retry --title "Fix testnet checkpoint provider sync" --body-file <tmp_body>`
+- Validation Command: gh pr view codex/testnet-high-state-peer-retry --json number,url,title,state
+- Expected Result: PR exists on GitHub with the expected title and branch.
+- Actual Result: PR #431 created at https://github.com/eng-cc/oasis7/pull/431
+- Blocker / Next Action: push PR evidence commit, then watch normal PR CI/comments/mergeability; this is `normal_pr_ci_watch`, not a manual packaging hold.

--- a/.pm/tasks/task_96c772c830e043f9b1e40b03e6f73d38.execution.md
+++ b/.pm/tasks/task_96c772c830e043f9b1e40b03e6f73d38.execution.md
@@ -56,7 +56,7 @@ Example:
 - Source Worktree: /Users/scc/ccwork/worktrees/oasis7-testnet-high-state-peer-retry
 - Source Branch: codex/testnet-high-state-peer-retry
 - Source Head: 4b16638bb3492760b93bc68551cc0c4a3f86f3b6
-- Comparison Ref: main
+- Comparison Ref: refs/remotes/origin/main
 - Reviewed Changed Paths: `.pm/roles/tpm/backlog/committed.yaml`; `.pm/tasks/task_96c772c830e043f9b1e40b03e6f73d38.execution.md`; `.pm/tasks/task_96c772c830e043f9b1e40b03e6f73d38.yaml`; `crates/oasis7_node/src/lib.rs`; `crates/oasis7_node/src/replication/checkpoint_tests.rs`; `crates/oasis7_node/src/replication_checkpoint.rs`; `crates/oasis7_node/src/tests_storage_replication_high_checkpoint.rs`; `doc/p2p/blockchain/p2p-public-testnet-governed-bootstrap-2026-06-06.runbook.md`; `doc/p2p/project.md`
 - Role Selection Basis: runtime checkpoint/signature behavior, public testnet operator contract, and regression/release-readiness verification.
 - Review Roles: runtime_engineer, blockchain_ops_engineer, qa_engineer

--- a/.pm/tasks/task_96c772c830e043f9b1e40b03e6f73d38.yaml
+++ b/.pm/tasks/task_96c772c830e043f9b1e40b03e6f73d38.yaml
@@ -1,0 +1,25 @@
+task_uid: task_96c772c830e043f9b1e40b03e6f73d38
+title: "Repair testnet high-state peer retry sync"
+owner_role: tpm
+worktree_hint: /Users/scc/ccwork/worktrees/oasis7-testnet-high-state-peer-retry
+execution_log_path: .pm/tasks/task_96c772c830e043f9b1e40b03e6f73d38.execution.md
+status: done
+priority: P1
+source_signal: null
+source_refs:
+  - doc/p2p/project.md
+doc_refs:
+  - doc/p2p/blockchain/p2p-public-testnet-governed-bootstrap-2026-06-06.runbook.md
+related_prd: []
+acceptance:
+  - "Cold observer can auto-install a retained high checkpoint when an initially unavailable peer later exposes replication protocols."
+  - "Regression tests cover retry cooldown/protocol availability behavior for high checkpoint sync."
+handoff_to: []
+updated_at: 2026-06-13T12:47:24+08:00
+last_started_at: 2026-06-13T12:12:01+08:00
+last_claim_type: task_complete
+last_verify_command: "env -u RUSTC_WRAPPER cargo fmt --check && ./scripts/check-rust-file-size.sh && git diff --check && env -u RUSTC_WRAPPER cargo test -p oasis7_node replication::checkpoint_tests -- --nocapture && env -u RUSTC_WRAPPER cargo test -p oasis7_node storage_replication_high_checkpoint -- --nocapture && ./scripts/doc-governance-check.sh"
+last_verified_at: 2026-06-13T12:47:19+08:00
+last_verification_exit_code: 0
+last_verification_status: verified
+last_closed_at: 2026-06-13T12:47:24+08:00

--- a/crates/oasis7_node/src/lib.rs
+++ b/crates/oasis7_node/src/lib.rs
@@ -388,6 +388,7 @@ impl NodeRuntime {
             if let Err(err) = register_replication_fetch_handlers_with_checkpoint_export(
                 network,
                 replication_config,
+                self.config.node_id.as_str(),
                 self.config.world_id.as_str(),
                 &self.config.network_policy,
                 self.execution_hook.clone(),
@@ -772,6 +773,7 @@ fn register_replication_fetch_handlers(
     register_replication_fetch_handlers_with_checkpoint_export(
         handle,
         replication,
+        "replication-fetch-handler",
         world_id,
         network_policy,
         None,
@@ -781,6 +783,7 @@ fn register_replication_fetch_handlers(
 fn register_replication_fetch_handlers_with_checkpoint_export(
     handle: &NodeReplicationNetworkHandle,
     replication: &NodeReplicationConfig,
+    node_id: &str,
     world_id: &str,
     network_policy: &NodeNetworkPolicy,
     execution_hook: Option<Arc<Mutex<Box<dyn NodeExecutionHook>>>>,
@@ -791,6 +794,7 @@ fn register_replication_fetch_handlers_with_checkpoint_export(
         oasis7_proto::distributed_net::NetworkLaneOperation::Serve,
     ) {
         let commit_root_dir = replication.root_dir.clone();
+        let commit_node_id = node_id.to_string();
         let commit_world_id = world_id.to_string();
         let commit_replication_config = replication.clone();
         let commit_execution_hook = execution_hook.clone();
@@ -839,14 +843,15 @@ fn register_replication_fetch_handlers_with_checkpoint_export(
                                     network_internal_error(NodeError::Execution { reason })
                                 })?;
                             if let Some(checkpoint) = checkpoint {
-                                let runtime = ReplicationRuntime::new(
+                                let mut runtime = ReplicationRuntime::new(
                                     &commit_replication_config,
-                                    message.node_id.as_str(),
+                                    commit_node_id.as_str(),
                                 )
                                 .map_err(network_internal_error)?;
                                 Some(
                                     runtime
                                         .attach_execution_checkpoint_descriptor_to_message(
+                                            commit_node_id.as_str(),
                                             &message,
                                             &checkpoint,
                                         )

--- a/crates/oasis7_node/src/replication/checkpoint_tests.rs
+++ b/crates/oasis7_node/src/replication/checkpoint_tests.rs
@@ -60,7 +60,7 @@ fn committed_decision(height: u64) -> PosDecision {
 }
 
 #[test]
-fn attach_execution_checkpoint_descriptor_preserves_remote_writer_legacy_message() {
+fn attach_execution_checkpoint_descriptor_resigns_remote_writer_legacy_message() {
     let dir_a = temp_dir("remote-writer-a");
     let dir_b = temp_dir("remote-writer-b");
     let world_id = "world-checkpoint-attach-remote-writer";
@@ -72,10 +72,10 @@ fn attach_execution_checkpoint_descriptor_preserves_remote_writer_legacy_message
         .expect("signing a");
     let config_b = NodeReplicationConfig::new(&dir_b)
         .expect("config b")
-        .with_signing_keypair(private_b, public_b)
+        .with_signing_keypair(private_b, public_b.clone())
         .expect("signing b");
     let mut runtime_a = ReplicationRuntime::new(&config_a, "node-a").expect("runtime a");
-    let runtime_b = ReplicationRuntime::new(&config_b, "node-b").expect("runtime b");
+    let mut runtime_b = ReplicationRuntime::new(&config_b, "node-b").expect("runtime b");
     let message = runtime_a
         .build_local_commit_message(
             "node-a",
@@ -90,16 +90,33 @@ fn attach_execution_checkpoint_descriptor_preserves_remote_writer_legacy_message
     let checkpoint = checkpoint_bundle(1, "exec-block-1", "exec-state-1", b"remote-writer");
 
     let augmented = runtime_b
-        .attach_execution_checkpoint_descriptor_to_message(&message, &checkpoint)
-        .expect("attach should preserve remote writer message");
+        .attach_execution_checkpoint_descriptor_to_message("node-b", &message, &checkpoint)
+        .expect("attach should re-sign remote writer message");
 
-    assert_eq!(augmented, message);
+    assert_ne!(augmented, message);
+    assert_eq!(augmented.node_id, "node-a");
+    assert_eq!(augmented.record.writer_id, public_b);
+    assert_eq!(augmented.public_key_hex.as_deref(), Some(public_b.as_str()));
+    assert!(augmented.signature_hex.is_some());
     let payload = serde_json::from_slice::<ReplicatedCommitPayload>(augmented.payload.as_slice())
         .expect("payload");
-    assert!(payload.execution_checkpoint.is_none());
+    assert_eq!(payload.node_id, "node-a");
+    assert_eq!(payload.height, 1);
+    assert!(payload.execution_checkpoint.is_some());
+    let dir_observer = temp_dir("remote-writer-observer");
+    let observer_config = NodeReplicationConfig::new(&dir_observer)
+        .expect("observer config")
+        .with_remote_writer_allowlist(vec![public_b])
+        .expect("observer allowlist");
+    let observer_runtime =
+        ReplicationRuntime::new(&observer_config, "node-observer").expect("observer runtime");
+    assert!(observer_runtime
+        .validate_remote_message_for_apply("node-observer", world_id, &augmented)
+        .expect("augmented message validates"));
 
     let _ = std::fs::remove_dir_all(&dir_a);
     let _ = std::fs::remove_dir_all(&dir_b);
+    let _ = std::fs::remove_dir_all(&dir_observer);
 }
 
 #[test]
@@ -127,7 +144,7 @@ fn attach_execution_checkpoint_descriptor_pins_augmented_payload_blob() {
         .expect("message");
     let checkpoint = checkpoint_bundle(1, "exec-block-1", "exec-state-1", b"pinned-snapshot");
     let augmented = runtime
-        .attach_execution_checkpoint_descriptor_to_message(&message, &checkpoint)
+        .attach_execution_checkpoint_descriptor_to_message("node-a", &message, &checkpoint)
         .expect("attach checkpoint descriptor");
     assert_ne!(augmented.record.content_hash, message.record.content_hash);
     assert!(runtime

--- a/crates/oasis7_node/src/replication_checkpoint.rs
+++ b/crates/oasis7_node/src/replication_checkpoint.rs
@@ -1,4 +1,6 @@
-use oasis7_distfs::{blake3_hex, BlobStore as _};
+use oasis7_distfs::{
+    apply_replication_record, blake3_hex, build_replication_record_with_epoch, BlobStore as _,
+};
 
 use crate::{
     NodeError, NodeExecutionCheckpointBlob, NodeExecutionCheckpointBlobRef,
@@ -106,7 +108,8 @@ impl ReplicationRuntime {
     }
 
     pub(crate) fn attach_execution_checkpoint_descriptor_to_message(
-        &self,
+        &mut self,
+        local_node_id: &str,
         message: &GossipReplicationMessage,
         checkpoint: &NodeExecutionCheckpointBundle,
     ) -> Result<GossipReplicationMessage, NodeError> {
@@ -146,11 +149,7 @@ impl ReplicationRuntime {
                 });
             }
         }
-        if let Some(signer) = &self.signer {
-            if message.record.writer_id != signer.public_key_hex {
-                return Ok(message.clone());
-            }
-        } else if message.signature_hex.is_some() {
+        if self.signer.is_none() && message.signature_hex.is_some() {
             return Err(NodeError::Replication {
                 reason: "cannot re-sign augmented replication checkpoint message without signer"
                     .to_string(),
@@ -163,8 +162,41 @@ impl ReplicationRuntime {
         })?;
         let mut augmented = message.clone();
         augmented.payload = payload_bytes;
-        augmented.record.content_hash = blake3_hex(augmented.payload.as_slice());
-        augmented.record.size_bytes = augmented.payload.len() as u64;
+        if let Some(signer) = &self.signer {
+            if message.record.writer_id != signer.public_key_hex {
+                let writer_id = signer.public_key_hex.clone();
+                let (writer_epoch, sequence) = self.next_local_record_position(&writer_id)?;
+                let path = format!("consensus/commits/{:020}.json", payload.height);
+                augmented.record = build_replication_record_with_epoch(
+                    message.world_id.as_str(),
+                    writer_id.as_str(),
+                    writer_epoch,
+                    sequence,
+                    path.as_str(),
+                    augmented.payload.as_slice(),
+                    message.record.updated_at_ms,
+                )
+                .map_err(distfs_error_to_node_error)?;
+                apply_replication_record(
+                    &self.store,
+                    &mut self.guard,
+                    &augmented.record,
+                    augmented.payload.as_slice(),
+                )
+                .map_err(distfs_error_to_node_error)?;
+                self.writer_state.writer_epoch = augmented.record.writer_epoch;
+                self.writer_state.last_sequence = augmented.record.sequence;
+                self.writer_state.last_replicated_height =
+                    self.writer_state.last_replicated_height.max(payload.height);
+                self.persist_state(local_node_id)?;
+            } else {
+                augmented.record.content_hash = blake3_hex(augmented.payload.as_slice());
+                augmented.record.size_bytes = augmented.payload.len() as u64;
+            }
+        } else {
+            augmented.record.content_hash = blake3_hex(augmented.payload.as_slice());
+            augmented.record.size_bytes = augmented.payload.len() as u64;
+        }
         self.store
             .put(
                 augmented.record.content_hash.as_str(),

--- a/crates/oasis7_node/src/tests_storage_replication_high_checkpoint.rs
+++ b/crates/oasis7_node/src/tests_storage_replication_high_checkpoint.rs
@@ -94,13 +94,31 @@ fn test_execution_checkpoint_bundle(
     }
 }
 
+fn committed_decision(height: u64, approved_stake: u64, required_stake: u64) -> PosDecision {
+    PosDecision {
+        height,
+        slot: height,
+        epoch: 0,
+        status: PosConsensusStatus::Committed,
+        block_hash: format!("block-{height}"),
+        action_root: empty_action_root(),
+        committed_actions: Vec::new(),
+        approved_stake,
+        rejected_stake: 0,
+        required_stake,
+        total_stake: 100,
+    }
+}
+
 #[test]
 fn observer_gap_sync_installs_exported_checkpoint_for_legacy_commit_payload() {
     let world_id = "world-gap-sync-exported-legacy-checkpoint";
     let dir_a = temp_dir("gap-sync-exported-legacy-checkpoint-a");
     let dir_b = temp_dir("gap-sync-exported-legacy-checkpoint-b");
+    let dir_c = temp_dir("gap-sync-exported-legacy-checkpoint-c");
     let (_, public_key_a) = deterministic_keypair_hex(246);
     let (_, public_key_b) = deterministic_keypair_hex(247);
+    let (_, public_key_c) = deterministic_keypair_hex(248);
     let pos_config = signed_pos_config_with_signer_seeds(
         vec![PosValidator {
             validator_id: "node-a".to_string(),
@@ -111,13 +129,18 @@ fn observer_gap_sync_installs_exported_checkpoint_for_legacy_commit_payload() {
     let replication_config_a = signed_replication_config(dir_a.clone(), 246)
         .with_remote_writer_allowlist(vec![public_key_b.clone()])
         .expect("allowlist a")
-        .with_fetch_requester_allowlist(vec![public_key_b])
+        .with_fetch_requester_allowlist(vec![public_key_b.clone()])
         .expect("fetch allowlist a");
     let replication_config_b = signed_replication_config(dir_b.clone(), 247)
-        .with_remote_writer_allowlist(vec![public_key_a.clone()])
+        .with_remote_writer_allowlist(vec![public_key_c.clone()])
         .expect("allowlist b")
-        .with_fetch_requester_allowlist(vec![public_key_a])
+        .with_fetch_requester_allowlist(vec![public_key_c.clone()])
         .expect("fetch allowlist b");
+    let replication_config_c = signed_replication_config(dir_c.clone(), 248)
+        .with_remote_writer_allowlist(vec![public_key_a.clone()])
+        .expect("allowlist c")
+        .with_fetch_requester_allowlist(vec![public_key_b.clone()])
+        .expect("fetch allowlist c");
     let config_a = NodeConfig::new("node-a", world_id, NodeRole::Sequencer)
         .expect("config a")
         .with_pos_config(pos_config.clone())
@@ -133,21 +156,11 @@ fn observer_gap_sync_installs_exported_checkpoint_for_legacy_commit_payload() {
     let mut replication_a =
         ReplicationRuntime::new(config_a.replication.as_ref().expect("repl a"), "node-a")
             .expect("runtime a");
+    let mut replication_c =
+        ReplicationRuntime::new(&replication_config_c, "node-c").expect("runtime c");
     for height in 1..=high_height {
-        let decision = PosDecision {
-            height,
-            slot: height,
-            epoch: 0,
-            status: PosConsensusStatus::Committed,
-            block_hash: format!("block-{height}"),
-            action_root: empty_action_root(),
-            committed_actions: Vec::new(),
-            approved_stake: 100,
-            rejected_stake: 0,
-            required_stake: 67,
-            total_stake: 100,
-        };
-        replication_a
+        let decision = committed_decision(height, 100, 67);
+        let message = replication_a
             .build_local_commit_message(
                 "node-a",
                 world_id,
@@ -158,6 +171,9 @@ fn observer_gap_sync_installs_exported_checkpoint_for_legacy_commit_payload() {
             )
             .expect("build legacy local message")
             .expect("message");
+        replication_c
+            .apply_remote_message("node-c", world_id, &message)
+            .expect("storage provider applies sequencer commit");
     }
 
     let network: Arc<
@@ -178,7 +194,8 @@ fn observer_gap_sync_installs_exported_checkpoint_for_legacy_commit_payload() {
         })));
     register_replication_fetch_handlers_with_checkpoint_export(
         &NodeReplicationNetworkHandle::new(Arc::clone(&network)),
-        &replication_config_a,
+        &replication_config_c,
+        "node-c",
         world_id,
         &config_a.network_policy,
         Some(export_hook),
@@ -218,6 +235,7 @@ fn observer_gap_sync_installs_exported_checkpoint_for_legacy_commit_payload() {
 
     let _ = fs::remove_dir_all(&dir_a);
     let _ = fs::remove_dir_all(&dir_b);
+    let _ = fs::remove_dir_all(&dir_c);
 }
 
 #[test]
@@ -259,19 +277,7 @@ fn observer_gap_sync_discovers_high_checkpoint_from_world_head() {
         ReplicationRuntime::new(config_a.replication.as_ref().expect("repl a"), "node-a")
             .expect("runtime a");
     for height in 1..=3 {
-        let decision = PosDecision {
-            height,
-            slot: height,
-            epoch: 0,
-            status: PosConsensusStatus::Committed,
-            block_hash: format!("block-{height}"),
-            action_root: empty_action_root(),
-            committed_actions: Vec::new(),
-            approved_stake: 100,
-            rejected_stake: 0,
-            required_stake: 67,
-            total_stake: 100,
-        };
+        let decision = committed_decision(height, 100, 67);
         replication_a
             .build_local_commit_message(
                 "node-a",
@@ -388,19 +394,7 @@ fn observer_gap_sync_discovers_high_checkpoint_from_peer_world_head_request() {
         ReplicationRuntime::new(config_a.replication.as_ref().expect("repl a"), "node-a")
             .expect("runtime a");
     for height in 1..=3 {
-        let decision = PosDecision {
-            height,
-            slot: height,
-            epoch: 0,
-            status: PosConsensusStatus::Committed,
-            block_hash: format!("block-{height}"),
-            action_root: empty_action_root(),
-            committed_actions: Vec::new(),
-            approved_stake: 100,
-            rejected_stake: 0,
-            required_stake: 67,
-            total_stake: 100,
-        };
+        let decision = committed_decision(height, 100, 67);
         replication_a
             .build_local_commit_message(
                 "node-a",
@@ -504,19 +498,7 @@ fn observer_gap_sync_installs_execution_checkpoint_bundle_when_low_history_is_mi
         ReplicationRuntime::new(config_a.replication.as_ref().expect("repl a"), "node-a")
             .expect("runtime a");
     for height in 1..=3 {
-        let decision = PosDecision {
-            height,
-            slot: height,
-            epoch: 0,
-            status: PosConsensusStatus::Committed,
-            block_hash: format!("block-{height}"),
-            action_root: empty_action_root(),
-            committed_actions: Vec::new(),
-            approved_stake: 100,
-            rejected_stake: 0,
-            required_stake: 67,
-            total_stake: 100,
-        };
+        let decision = committed_decision(height, 100, 67);
         let execution_block_hash = format!("exec-block-{height}");
         let execution_state_root = format!("exec-state-{height}");
         let checkpoint = (height == 3).then(|| {
@@ -626,19 +608,7 @@ fn observer_gap_sync_does_not_persist_sparse_execution_checkpoint_without_hook()
         ReplicationRuntime::new(config_a.replication.as_ref().expect("repl a"), "node-a")
             .expect("runtime a");
     for height in 1..=3 {
-        let decision = PosDecision {
-            height,
-            slot: height,
-            epoch: 0,
-            status: PosConsensusStatus::Committed,
-            block_hash: format!("block-{height}"),
-            action_root: empty_action_root(),
-            committed_actions: Vec::new(),
-            approved_stake: 100,
-            rejected_stake: 0,
-            required_stake: 67,
-            total_stake: 100,
-        };
+        let decision = committed_decision(height, 100, 67);
         let execution_block_hash = format!("exec-block-{height}");
         let execution_state_root = format!("exec-state-{height}");
         let checkpoint = (height == 3).then(|| {
@@ -743,19 +713,7 @@ fn observer_gap_sync_probes_checkpoint_boundary_below_non_checkpoint_head() {
         ReplicationRuntime::new(config_a.replication.as_ref().expect("repl a"), "node-a")
             .expect("runtime a");
     for height in 1..=70 {
-        let decision = PosDecision {
-            height,
-            slot: height,
-            epoch: 0,
-            status: PosConsensusStatus::Committed,
-            block_hash: format!("block-{height}"),
-            action_root: empty_action_root(),
-            committed_actions: Vec::new(),
-            approved_stake: 100,
-            rejected_stake: 0,
-            required_stake: 67,
-            total_stake: 100,
-        };
+        let decision = committed_decision(height, 100, 67);
         let execution_block_hash = format!("exec-block-{height}");
         let execution_state_root = format!("exec-state-{height}");
         let checkpoint = (height == 64).then(|| {
@@ -867,19 +825,7 @@ fn observer_gap_sync_rejects_mismatched_world_head_checkpoint() {
         ReplicationRuntime::new(config_a.replication.as_ref().expect("repl a"), "node-a")
             .expect("runtime a");
     for height in 1..=3 {
-        let decision = PosDecision {
-            height,
-            slot: height,
-            epoch: 0,
-            status: PosConsensusStatus::Committed,
-            block_hash: format!("block-{height}"),
-            action_root: empty_action_root(),
-            committed_actions: Vec::new(),
-            approved_stake: 100,
-            rejected_stake: 0,
-            required_stake: 67,
-            total_stake: 100,
-        };
+        let decision = committed_decision(height, 100, 67);
         replication_a
             .build_local_commit_message(
                 "node-a",
@@ -992,19 +938,7 @@ fn high_checkpoint_gap_sync_does_not_skip_execution_history() {
         ReplicationRuntime::new(config_a.replication.as_ref().expect("repl a"), "node-a")
             .expect("runtime a");
     for height in 1..=3 {
-        let decision = PosDecision {
-            height,
-            slot: height,
-            epoch: 0,
-            status: PosConsensusStatus::Committed,
-            block_hash: format!("block-{height}"),
-            action_root: empty_action_root(),
-            committed_actions: Vec::new(),
-            approved_stake: 100,
-            rejected_stake: 0,
-            required_stake: 67,
-            total_stake: 100,
-        };
+        let decision = committed_decision(height, 100, 67);
         replication_a
             .build_local_commit_message(
                 "node-a",
@@ -1112,19 +1046,7 @@ fn observer_gap_sync_bootstraps_from_high_checkpoint_when_low_commits_are_unavai
     for height in 1..=3 {
         let execution_block_hash = format!("execution-block-{height}");
         let execution_state_root = format!("execution-state-{height}");
-        let decision = PosDecision {
-            height,
-            slot: height,
-            epoch: 0,
-            status: PosConsensusStatus::Committed,
-            block_hash: format!("block-{height}"),
-            action_root: empty_action_root(),
-            committed_actions: Vec::new(),
-            approved_stake: 60,
-            rejected_stake: 0,
-            required_stake: 40,
-            total_stake: 100,
-        };
+        let decision = committed_decision(height, 60, 40);
         replication_a
             .build_local_commit_message(
                 "node-a",

--- a/doc/p2p/blockchain/p2p-public-testnet-governed-bootstrap-2026-06-06.runbook.md
+++ b/doc/p2p/blockchain/p2p-public-testnet-governed-bootstrap-2026-06-06.runbook.md
@@ -103,7 +103,8 @@
 2. `release_default` 当前按 64 高度间隔保留 8 个 execution checkpoint，因此 observer gap sync 至少要回看 8 个 64-height checkpoint windows。
 3. checkpoint commit payload 的 `execution_block_hash`、`execution_state_root` 与 checkpoint descriptor 必须完全匹配，blob 内容必须按 content hash 和 size 校验后才能安装。
 4. 如果 advertised head 不是 checkpoint 高度，observer 可以安装 head 之前最近仍被保留且可验证的 checkpoint；安装后再由正常 gap sync 追尾。
-5. 若保留窗口内没有可获取的 checkpoint，状态接口应继续报告 `state_sync_fallback_required=true`，此时才进入 break-glass seed/state-sync recovery。
+5. storage/full-storage provider 即使不是原始 sequencer writer，也必须能在 fetch-commit 响应中为本地 retained execution checkpoint 动态附加 checkpoint descriptor，并以自身 authorized replication writer 身份重新签发增强 commit message；否则只连到 storage peer 的冷 observer 无法获得可安装的高状态入口。
+6. 若保留窗口内没有可获取的 checkpoint，状态接口应继续报告 `state_sync_fallback_required=true`，此时才进入 break-glass seed/state-sync recovery。
 
 ## 5. Required Inputs
 开始前，操作者必须准备好以下输入：
@@ -223,7 +224,7 @@ ssh root@39.104.205.67 'curl -s http://127.0.0.1:6632/v1/chain/status | jq -r .r
 2. 用新的 signer truth 生成 deployment-only validator registry。
 3. 用新的 registry 重建 deployment-only governed bootstrap world。
 4. 读取 validator 实际 `local_peer_id`，更新 observer 的 `REPLICATION_NETWORK_BOOTSTRAP_PEERS_CSV`。
-5. 更新 observer 的 `REPLICATION_REMOTE_WRITERS_CSV`，对齐 validator 当前 allowlist。
+5. 更新 observer 的 `REPLICATION_REMOTE_WRITERS_CSV`，对齐当前 deployment truth 中所有 authorized replication writers；除 validator signer 外，必须包含会提供 retained execution checkpoint 的 storage/full-storage provider signer。
 
 ### Pass criteria
 1. deployment-only registry 与 host 当前 signer truth 一致
@@ -385,7 +386,7 @@ curl -s http://127.0.0.1:6632/v1/chain/status | jq '{running,last_error,committe
 
 ### Required prep
 1. observer env 使用当前 deployment truth bootstrap peer ids
-2. observer env 使用当前 validator writer allowlist；fetch requester 不再需要逐个 observer 手动加 allowlist，只要 validators 运行的 runtime 对 `public_testnet` + `allow_observer_nodes=true` 开启开放签名读取策略
+2. observer env 使用当前 deployment truth writer allowlist；除 validator signer 外，必须包含会提供 retained execution checkpoint 的 storage/full-storage provider signer。fetch requester 不再需要逐个 observer 手动加 allowlist，只要 providers 运行的 runtime 对 `public_testnet` + `allow_observer_nodes=true` 开启开放签名读取策略
 3. observer manifest 指向当前 deployment truth genesis/manifest
 4. observer env 的 `WORLD_ID`、governed registry/manifest、bootstrap peers、remote writer allowlist、node identity、listen/status ports 必须全部来自当前 deployment truth
 5. systemd service unit 必须是当前 testnet observer unit；不得让旧 devnet/triad observer service 继续占用状态端口或被误当作 public testnet 节点

--- a/doc/p2p/project.md
+++ b/doc/p2p/project.md
@@ -924,6 +924,7 @@
     - `git diff --check`
 - [x] testnet-routing-peer-record-bootstrap (PRD-P2P-001/003) [test_tier_required]: 修复 reset public testnet observer 在 routing 已发现 bootstrap peer、connected snapshot 仍为空时无法启动 peer-record 交换的问题，允许 routing update 直接触发 connected peer-record request，并用回归覆盖空 connected snapshot 的 bootstrap 窗口。 Trace: .pm/tasks/task_f81d3e661b7048d8b2fe6987a544a368.yaml
 - [x] testnet-auto-high-state-sync (PRD-P2P-001/003) [test_tier_required]: 修复新 public testnet observer 在低位 commit 历史不可用且 advertised head 非 checkpoint 高度时无法自动发现仍被保留的高位 execution checkpoint 的问题；observer gap sync 现在覆盖 release_default retained checkpoint window，并在 fetch-commit transient timeout/unavailable 时继续探测更低候选。 Trace: .pm/tasks/task_761375d25bc24fe59147a853e8c8acb0.yaml
+- [x] testnet-high-state-peer-retry (PRD-P2P-001/003) [test_tier_required]: 修复 cold observer 只连到 storage/full-storage peer 时无法获得 checkpoint descriptor 的问题；fetch-commit provider 现在可为 legacy sequencer commit 动态附加 retained execution checkpoint descriptor，并以 provider 自身 authorized replication writer 身份重签增强 message，支持 observer 无 seed/state-sync 自动安装高状态 checkpoint。 Trace: .pm/tasks/task_96c772c830e043f9b1e40b03e6f73d38.yaml
 
 ## 依赖
 - 模块设计总览：`doc/p2p/design.md`


### PR DESCRIPTION
## Summary
- Allow checkpoint-serving storage/full-storage providers to attach retained execution checkpoint descriptors to legacy sequencer commit payloads and re-sign the augmented response as their authorized replication writer.
- Wire fetch handlers with the local provider node id so provider-side checkpoint export uses the provider signer/state.
- Update public testnet runbook trust contract so observers allow checkpoint-serving storage/full-storage writer signers, not only validator signers.

## Verification
- `env -u RUSTC_WRAPPER cargo fmt --check`
- `./scripts/check-rust-file-size.sh`
- `git diff --check`
- `env -u RUSTC_WRAPPER cargo test -p oasis7_node replication::checkpoint_tests -- --nocapture`
- `env -u RUSTC_WRAPPER cargo test -p oasis7_node storage_replication_high_checkpoint -- --nocapture`
- `./scripts/doc-governance-check.sh`
- `./scripts/pm/workflow-lint.sh --phase pr-ready --task-uid task_96c772c830e043f9b1e40b03e6f73d38`

Task: `.pm/tasks/task_96c772c830e043f9b1e40b03e6f73d38.yaml`
