### PR TITLE
Keep testnet checkpoint probes after fetch timeout

### DIFF
--- a/.pm/tasks/task_96c772c830e043f9b1e40b03e6f73d38.execution.md
+++ b/.pm/tasks/task_96c772c830e043f9b1e40b03e6f73d38.execution.md
@@ -82,3 +82,28 @@ Example:
 - Expected Result: PR exists on GitHub with the expected title and branch.
 - Actual Result: PR #431 created at https://github.com/eng-cc/oasis7/pull/431
 - Blocker / Next Action: push PR evidence commit, then watch normal PR CI/comments/mergeability; this is `normal_pr_ci_watch`, not a manual packaging hold.
+
+## 2026-06-13 14:20:36 CST / tpm
+- 完成内容: Post-merge live smoke on 192.168.1.4 observer and 39.104.205.67 storage found a second high-state sync implementation gap. Storage was active at `committed_height=16715` / `replication_persisted_height=16715` and registered fetch-commit/fetch-blob/fetch-head protocols; observer connected to storage but remained at `replication_persisted_height=0`, `state_sync_fallback_required=true`, with `runtime_last_error="node replication error: replication network availability gap: libp2p-replication outbound request failed: NetworkProtocolUnavailable { protocol: \"request failed: Timeout\" }"`.
+- 设计结论: High checkpoint probing must continue across transient replication availability gaps even when the libp2p/network layer omits the concrete fetch-commit protocol name from the compacted error string. Public testnet observer sync already has enough `network_committed_height` truth to keep trying retained checkpoint boundaries; a protocol-omitted timeout should not abort after the first advertised-height candidate.
+- 代码改动: Broadened `PosNodeEngine::high_replication_checkpoint_probe_can_continue` so protocol-omitted `replication network availability gap` / timeout errors are treated as transient for high checkpoint candidates, while non-network blob/execution errors still fail closed.
+- 回归测试: Added `observer_gap_sync_continues_checkpoint_candidates_after_protocol_omitted_timeout`, which simulates fetch-head timeout and a first advertised-height fetch-commit timeout without the protocol name, then verifies the observer continues to the retained checkpoint boundary and installs the checkpoint.
+- Validation Command: env -u RUSTC_WRAPPER cargo fmt --check
+- Actual Result: passed.
+- Validation Command: env -u RUSTC_WRAPPER cargo test -p oasis7_node observer_gap_sync_continues_checkpoint_candidates_after_protocol_omitted_timeout -- --nocapture
+- Actual Result: passed; 1 test passed.
+- Validation Command: env -u RUSTC_WRAPPER cargo test -p oasis7_node storage_replication_high_checkpoint -- --nocapture
+- Actual Result: passed; 14 tests passed.
+- Review Trigger: post-merge live-smoke follow-up pre-PR local role review
+- Review Roles: runtime_engineer, qa_engineer
+- Review Finding: P1. The first implementation treated any protocol-omitted `replication network availability gap` / timeout as high-checkpoint probe-continuable, which could misclassify checkpoint blob-route timeouts after a valid checkpoint descriptor as skippable.
+- Review Finding Disposition: addressed by moving protocol-omitted timeout annotation into the fetch-commit request path only; `high_replication_checkpoint_probe_can_continue` now remains fetch-commit-specific, and blob/execution/materialization errors continue to fail closed.
+- Validation Command: env -u RUSTC_WRAPPER cargo test -p oasis7_node high_replication_checkpoint_probe_does_not_continue_after_blob_or_execution_errors -- --nocapture
+- Actual Result: passed; 1 test passed.
+- Validation Command: ./scripts/check-rust-file-size.sh
+- Actual Result: passed; oversized code files=0, test files=0.
+- Validation Command: git diff --check
+- Actual Result: passed.
+- Validation Command: ./scripts/pm/workflow-lint.sh --phase pr-ready --task-uid task_96c772c830e043f9b1e40b03e6f73d38
+- Actual Result: passed.
+- Blocker / Next Action: create PR, use CI package, redeploy observer/storage, then verify live observer leaves high-state fallback.

--- a/crates/oasis7_node/src/node_engine_network.rs
+++ b/crates/oasis7_node/src/node_engine_network.rs
@@ -142,7 +142,8 @@ impl PosNodeEngine {
         ) -> Result<GapSyncFetchCommitResponse, NodeError>,
     ) -> Result<GapSyncHeightOutcome, NodeError> {
         let request = replication_runtime.build_fetch_commit_request(world_id, height)?;
-        let fetch_commit = fetch_commit(endpoint, &request)?;
+        let fetch_commit = fetch_commit(endpoint, &request)
+            .map_err(|err| Self::annotate_fetch_commit_gap_sync_error(height, err))?;
         if !fetch_commit.response.found {
             return Ok(GapSyncHeightOutcome::NotFound {
                 repair_summary: fetch_commit.repair_summary,
@@ -262,6 +263,26 @@ impl PosNodeEngine {
             },
         );
         Ok(GapSyncHeightOutcome::Synced { message, payload })
+    }
+
+    fn annotate_fetch_commit_gap_sync_error(height: u64, err: NodeError) -> NodeError {
+        let NodeError::Replication { reason } = err else {
+            return err;
+        };
+        if reason.contains(REPLICATION_FETCH_COMMIT_PROTOCOL) {
+            return NodeError::Replication { reason };
+        }
+        if reason.contains("replication network availability gap")
+            && (reason.contains("NetworkProtocolUnavailable")
+                || reason.contains("request failed: Timeout"))
+        {
+            return NodeError::Replication {
+                reason: format!(
+                    "{reason}; gap sync height {height} fetch-commit {REPLICATION_FETCH_COMMIT_PROTOCOL}"
+                ),
+            };
+        }
+        NodeError::Replication { reason }
     }
 
     pub(super) fn persist_synced_replication_message(

--- a/crates/oasis7_node/src/node_engine_replication.rs
+++ b/crates/oasis7_node/src/node_engine_replication.rs
@@ -35,9 +35,10 @@ impl PosNodeEngine {
         let NodeError::Replication { reason } = err else {
             return false;
         };
-        reason.contains(REPLICATION_FETCH_COMMIT_PROTOCOL)
+        let fetch_commit_route_error = reason.contains(REPLICATION_FETCH_COMMIT_PROTOCOL)
             && (reason.contains("NetworkProtocolUnavailable")
-                || reason.contains("request failed: Timeout"))
+                || reason.contains("request failed: Timeout"));
+        fetch_commit_route_error
     }
 
     fn clear_replication_gap_sync_blocked_if_unblocked(&mut self) {

--- a/crates/oasis7_node/src/tests_storage_replication.rs
+++ b/crates/oasis7_node/src/tests_storage_replication.rs
@@ -6,6 +6,8 @@ mod storage_replication_failover_tests;
 mod storage_replication_high_checkpoint_tests;
 #[path = "tests_storage_replication_high_checkpoint_retained.rs"]
 mod storage_replication_high_checkpoint_retained_tests;
+#[path = "tests_storage_replication_high_checkpoint_timeout.rs"]
+mod storage_replication_high_checkpoint_timeout_tests;
 #[path = "tests_storage_replication_peer_head.rs"]
 mod storage_replication_peer_head_tests;
 #[path = "tests_storage_replication_progress.rs"]

--- a/crates/oasis7_node/src/tests_storage_replication_high_checkpoint_retained.rs
+++ b/crates/oasis7_node/src/tests_storage_replication_high_checkpoint_retained.rs
@@ -87,12 +87,20 @@ fn high_replication_checkpoint_probe_does_not_continue_after_blob_or_execution_e
         reason: "execution checkpoint install returned mismatched binding at height 16640"
             .to_string(),
     };
+    let protocol_omitted_blob_timeout = NodeError::Replication {
+        reason:
+            "replication network availability gap: libp2p-replication outbound request failed: NetworkProtocolUnavailable { protocol: \"request failed: Timeout\" }"
+                .to_string(),
+    };
 
     assert!(!PosNodeEngine::high_replication_checkpoint_probe_can_continue(
         &blob_err
     ));
     assert!(!PosNodeEngine::high_replication_checkpoint_probe_can_continue(
         &execution_err
+    ));
+    assert!(!PosNodeEngine::high_replication_checkpoint_probe_can_continue(
+        &protocol_omitted_blob_timeout
     ));
 }
 

--- a/crates/oasis7_node/src/tests_storage_replication_high_checkpoint_timeout.rs
+++ b/crates/oasis7_node/src/tests_storage_replication_high_checkpoint_timeout.rs
@@ -1,0 +1,337 @@
+use super::*;
+
+struct CheckpointInstallingExecutionHook {
+    installed: Vec<u64>,
+}
+
+impl NodeExecutionHook for CheckpointInstallingExecutionHook {
+    fn on_commit(
+        &mut self,
+        context: NodeExecutionCommitContext,
+    ) -> Result<NodeExecutionCommitResult, String> {
+        Err(format!(
+            "{} at height {}",
+            EXECUTION_MISSING_PREDECESSOR_RECORD_SIGNATURE, context.height
+        ))
+    }
+
+    fn install_checkpoint_bundle(
+        &mut self,
+        context: NodeExecutionCheckpointInstallContext,
+        bundle: NodeExecutionCheckpointBundle,
+    ) -> Result<NodeExecutionCommitResult, String> {
+        if bundle.height != context.height
+            || bundle.execution_block_hash != context.execution_block_hash
+            || bundle.execution_state_root != context.execution_state_root
+        {
+            return Err("checkpoint bundle mismatch".to_string());
+        }
+        self.installed.push(context.height);
+        Ok(NodeExecutionCommitResult {
+            execution_height: context.height,
+            execution_block_hash: context.execution_block_hash,
+            execution_state_root: context.execution_state_root,
+        })
+    }
+}
+
+#[derive(Default)]
+struct TimeoutThenCheckpointNetwork {
+    messages: Mutex<BTreeMap<u64, replication::GossipReplicationMessage>>,
+    blobs: Mutex<BTreeMap<String, Vec<u8>>>,
+    attempts: Mutex<Vec<u64>>,
+    advertised_height: u64,
+}
+
+impl oasis7_proto::distributed_net::DistributedNetwork<WorldError> for TimeoutThenCheckpointNetwork {
+    fn publish(&self, _topic: &str, _payload: &[u8]) -> Result<(), WorldError> {
+        Ok(())
+    }
+
+    fn subscribe(&self, topic: &str) -> Result<NetworkSubscription, WorldError> {
+        Ok(NetworkSubscription::new(
+            topic.to_string(),
+            Arc::new(Mutex::new(HashMap::new())),
+        ))
+    }
+
+    fn request(&self, protocol: &str, payload: &[u8]) -> Result<Vec<u8>, WorldError> {
+        if protocol == replication::REPLICATION_GET_HEAD_PROTOCOL {
+            return Err(WorldError::NetworkProtocolUnavailable {
+                protocol: "request failed: Timeout".to_string(),
+            });
+        }
+        if protocol == replication::REPLICATION_FETCH_COMMIT_PROTOCOL {
+            let request =
+                serde_json::from_slice::<replication::FetchCommitRequest>(payload).map_err(
+                    |err| WorldError::DistributedValidationFailed {
+                        reason: format!("decode fetch-commit request failed: {err}"),
+                    },
+                )?;
+            if request.height == self.advertised_height {
+                return Err(WorldError::NetworkProtocolUnavailable {
+                    protocol: "request failed: Timeout".to_string(),
+                });
+            }
+            return encode_fetch_commit_response(None);
+        }
+        if protocol == replication::REPLICATION_FETCH_BLOB_PROTOCOL {
+            return self.fetch_blob_response(payload);
+        }
+        Err(WorldError::NetworkProtocolUnavailable {
+            protocol: protocol.to_string(),
+        })
+    }
+
+    fn request_with_providers(
+        &self,
+        protocol: &str,
+        payload: &[u8],
+        _providers: &[String],
+    ) -> Result<Vec<u8>, WorldError> {
+        if protocol == replication::REPLICATION_GET_HEAD_PROTOCOL {
+            return Err(WorldError::NetworkProtocolUnavailable {
+                protocol: "request failed: Timeout".to_string(),
+            });
+        }
+        if protocol == replication::REPLICATION_FETCH_BLOB_PROTOCOL {
+            return self.fetch_blob_response(payload);
+        }
+        if protocol != replication::REPLICATION_FETCH_COMMIT_PROTOCOL {
+            return Err(WorldError::NetworkProtocolUnavailable {
+                protocol: protocol.to_string(),
+            });
+        }
+        let request =
+            serde_json::from_slice::<replication::FetchCommitRequest>(payload).map_err(|err| {
+                WorldError::DistributedValidationFailed {
+                    reason: format!("decode fetch-commit request failed: {err}"),
+                }
+            })?;
+        self.attempts
+            .lock()
+            .expect("lock attempts")
+            .push(request.height);
+        if request.height == self.advertised_height {
+            return Err(WorldError::NetworkProtocolUnavailable {
+                protocol: "request failed: Timeout".to_string(),
+            });
+        }
+        let message = self
+            .messages
+            .lock()
+            .expect("lock messages")
+            .get(&request.height)
+            .cloned();
+        encode_fetch_commit_response(message)
+    }
+
+    fn connected_peer_ids(&self) -> Vec<String> {
+        vec!["peer-a".to_string()]
+    }
+
+    fn register_handler(
+        &self,
+        _protocol: &str,
+        _handler: Box<dyn Fn(&[u8]) -> Result<Vec<u8>, WorldError> + Send + Sync>,
+    ) -> Result<(), WorldError> {
+        Ok(())
+    }
+}
+
+impl TimeoutThenCheckpointNetwork {
+    fn fetch_blob_response(&self, payload: &[u8]) -> Result<Vec<u8>, WorldError> {
+        let request =
+            serde_json::from_slice::<replication::FetchBlobRequest>(payload).map_err(|err| {
+                WorldError::DistributedValidationFailed {
+                    reason: format!("decode fetch-blob request failed: {err}"),
+                }
+            })?;
+        let blob = self
+            .blobs
+            .lock()
+            .expect("lock blobs")
+            .get(request.content_hash.as_str())
+            .cloned();
+        serde_json::to_vec(&replication::FetchBlobResponse {
+            found: blob.is_some(),
+            blob,
+        })
+        .map_err(|err| WorldError::DistributedValidationFailed {
+            reason: format!("encode fetch-blob response failed: {err}"),
+        })
+    }
+}
+
+fn encode_fetch_commit_response(
+    message: Option<replication::GossipReplicationMessage>,
+) -> Result<Vec<u8>, WorldError> {
+    serde_json::to_vec(&replication::FetchCommitResponse {
+        found: message.is_some(),
+        message,
+    })
+    .map_err(|err| WorldError::DistributedValidationFailed {
+        reason: format!("encode fetch-commit response failed: {err}"),
+    })
+}
+
+fn test_execution_checkpoint_bundle(
+    height: u64,
+    execution_block_hash: &str,
+    execution_state_root: &str,
+) -> NodeExecutionCheckpointBundle {
+    let snapshot_bytes =
+        format!("checkpoint-snapshot-{height}-{execution_state_root}").into_bytes();
+    NodeExecutionCheckpointBundle {
+        height,
+        execution_block_hash: execution_block_hash.to_string(),
+        execution_state_root: execution_state_root.to_string(),
+        manifest_json: br#"{"test":"manifest"}"#.to_vec(),
+        blobs: vec![NodeExecutionCheckpointBlob {
+            content_hash: oasis7_distfs::blake3_hex(snapshot_bytes.as_slice()),
+            bytes: snapshot_bytes,
+        }],
+    }
+}
+
+fn committed_decision(height: u64, approved_stake: u64, required_stake: u64) -> PosDecision {
+    PosDecision {
+        height,
+        slot: height,
+        epoch: 0,
+        status: PosConsensusStatus::Committed,
+        block_hash: format!("block-{height}"),
+        action_root: empty_action_root(),
+        committed_actions: Vec::new(),
+        approved_stake,
+        rejected_stake: 0,
+        required_stake,
+        total_stake: 100,
+    }
+}
+
+#[test]
+fn observer_gap_sync_continues_checkpoint_candidates_after_protocol_omitted_timeout() {
+    let world_id = "world-gap-sync-timeout-then-checkpoint";
+    let dir_a = temp_dir("gap-sync-timeout-then-checkpoint-a");
+    let dir_b = temp_dir("gap-sync-timeout-then-checkpoint-b");
+    let (_, public_key_a) = deterministic_keypair_hex(252);
+    let (_, public_key_b) = deterministic_keypair_hex(253);
+    let pos_config = signed_pos_config_with_signer_seeds(
+        vec![PosValidator {
+            validator_id: "node-a".to_string(),
+            stake: 100,
+        }],
+        &[("node-a", 252)],
+    );
+    let replication_config_a = signed_replication_config(dir_a.clone(), 252)
+        .with_remote_writer_allowlist(vec![public_key_b.clone()])
+        .expect("allowlist a")
+        .with_fetch_requester_allowlist(vec![public_key_b.clone()])
+        .expect("fetch allowlist a");
+    let replication_config_b = signed_replication_config(dir_b.clone(), 253)
+        .with_remote_writer_allowlist(vec![public_key_a])
+        .expect("allowlist b")
+        .with_fetch_requester_allowlist(vec![public_key_b])
+        .expect("fetch allowlist b");
+    let config_a = NodeConfig::new("node-a", world_id, NodeRole::Sequencer)
+        .expect("config a")
+        .with_pos_config(pos_config.clone())
+        .expect("pos config a")
+        .with_replication(replication_config_a);
+    let config_b = NodeConfig::new("node-b", world_id, NodeRole::Observer)
+        .expect("config b")
+        .with_pos_config(pos_config)
+        .expect("pos config b")
+        .with_replication(replication_config_b.clone());
+
+    let checkpoint_height = REPLICATION_GAP_SYNC_MAX_HEIGHTS_PER_POLL;
+    let advertised_height = checkpoint_height + 2;
+    let mut replication_a =
+        ReplicationRuntime::new(config_a.replication.as_ref().expect("repl a"), "node-a")
+            .expect("runtime a");
+    let execution_block_hash = format!("exec-block-{checkpoint_height}");
+    let execution_state_root = format!("exec-state-{checkpoint_height}");
+    let checkpoint_bundle = test_execution_checkpoint_bundle(
+        checkpoint_height,
+        execution_block_hash.as_str(),
+        execution_state_root.as_str(),
+    );
+    let message = replication_a
+        .build_local_commit_message_with_checkpoint(
+            "node-a",
+            world_id,
+            7_000,
+            &committed_decision(checkpoint_height, 100, 67),
+            Some(execution_block_hash.as_str()),
+            Some(execution_state_root.as_str()),
+            Some(checkpoint_bundle.clone()),
+        )
+        .expect("build checkpoint message")
+        .expect("checkpoint message");
+
+    let network_impl = Arc::new(TimeoutThenCheckpointNetwork {
+        advertised_height,
+        ..Default::default()
+    });
+    network_impl
+        .messages
+        .lock()
+        .expect("lock messages")
+        .insert(checkpoint_height, message.clone());
+    let mut blobs = network_impl.blobs.lock().expect("lock blobs");
+    blobs.insert(message.record.content_hash.clone(), message.payload.clone());
+    blobs.insert(
+        oasis7_distfs::blake3_hex(message.payload.as_slice()),
+        message.payload.clone(),
+    );
+    blobs.insert(
+        oasis7_distfs::blake3_hex(checkpoint_bundle.manifest_json.as_slice()),
+        checkpoint_bundle.manifest_json.clone(),
+    );
+    for blob in &checkpoint_bundle.blobs {
+        blobs.insert(blob.content_hash.clone(), blob.bytes.clone());
+    }
+    drop(blobs);
+
+    let network: Arc<
+        dyn oasis7_proto::distributed_net::DistributedNetwork<WorldError> + Send + Sync,
+    > = network_impl.clone();
+    let endpoint_b = ReplicationNetworkEndpoint::new(
+        &NodeReplicationNetworkHandle::new(network),
+        world_id,
+        false,
+        &config_b.network_policy,
+    )
+    .expect("endpoint b");
+    let mut replication_b =
+        ReplicationRuntime::new(config_b.replication.as_ref().expect("repl b"), "node-b")
+            .expect("runtime b");
+    let mut engine_b = PosNodeEngine::new(&config_b).expect("engine b");
+    engine_b.network_committed_height = advertised_height;
+    let mut install_hook = CheckpointInstallingExecutionHook {
+        installed: Vec::new(),
+    };
+
+    engine_b
+        .sync_missing_replication_commits(
+            &endpoint_b,
+            "node-b",
+            world_id,
+            Some(&mut replication_b),
+            Some(&mut install_hook),
+        )
+        .expect("checkpoint candidate fallback after protocol-omitted timeout");
+
+    assert_eq!(install_hook.installed, vec![checkpoint_height]);
+    assert_eq!(engine_b.committed_height, checkpoint_height);
+    assert_eq!(engine_b.replication_persisted_height, checkpoint_height);
+    let attempts = network_impl.attempts.lock().expect("lock attempts").clone();
+    assert!(
+        attempts.starts_with(&[advertised_height, checkpoint_height]),
+        "expected advertised height timeout before checkpoint candidate, got {attempts:?}"
+    );
+
+    let _ = fs::remove_dir_all(&dir_a);
+    let _ = fs::remove_dir_all(&dir_b);
+}


### PR DESCRIPTION
## Summary
- keep high checkpoint probing alive when fetch-commit times out without the protocol name in the compacted error
- annotate protocol-omitted availability gaps at the fetch-commit call site only, so checkpoint blob/execution failures still fail closed
- add a regression covering the live observer shape: advertised-height timeout, then retained checkpoint boundary succeeds

## Verification
- `env -u RUSTC_WRAPPER cargo fmt --check`
- `./scripts/check-rust-file-size.sh`
- `git diff --check`
- `env -u RUSTC_WRAPPER cargo test -p oasis7_node observer_gap_sync_continues_checkpoint_candidates_after_protocol_omitted_timeout -- --nocapture`
- `env -u RUSTC_WRAPPER cargo test -p oasis7_node high_replication_checkpoint_probe_does_not_continue_after_blob_or_execution_errors -- --nocapture`
- `env -u RUSTC_WRAPPER cargo test -p oasis7_node storage_replication_high_checkpoint -- --nocapture`
- `./scripts/pm/workflow-lint.sh --phase pr-ready --task-uid task_96c772c830e043f9b1e40b03e6f73d38`

## Live Context
Post-merge testnet.53 smoke showed the observer connected to storage but still at `replication_persisted_height=0` with a protocol-omitted libp2p timeout. This patch keeps probing retained high checkpoint candidates for that fetch-commit-only transient shape.
