### PR TITLE
Keep testnet sync after DHT head timeout

### DIFF
--- a/.pm/tasks/task_96c772c830e043f9b1e40b03e6f73d38.execution.md
+++ b/.pm/tasks/task_96c772c830e043f9b1e40b03e6f73d38.execution.md
@@ -148,11 +148,12 @@ Example:
 - Task UID: task_96c772c830e043f9b1e40b03e6f73d38
 - Source Worktree: /Users/scc/ccwork/worktrees/oasis7-testnet-high-state-peer-retry
 - Source Branch: codex/testnet-proactive-high-checkpoint-sync
-- Source Head: d18d252f321a20e78c319b03c29325154c03e19a
+- Source Head: bc5a015500fc66dd529d907df3bf7f8a52c6866d
 - Comparison Ref: refs/remotes/origin/main
 - Reviewed Changed Paths: `crates/oasis7_node/src/network_bridge.rs`; `crates/oasis7_node/src/tests_storage_replication_high_checkpoint_timeout.rs`; `.pm/tasks/task_96c772c830e043f9b1e40b03e6f73d38.execution.md`
 - Role Selection Basis: runtime replication world-head discovery fallback, public testnet high checkpoint sync behavior, and regression/release-readiness verification.
 - Review Roles: runtime_engineer, qa_engineer
 - Review Evidence: runtime_engineer no_findings and qa_engineer no_findings recorded above.
-- Review Findings Disposition: no_findings; non-blocking QA readability suggestion addressed.
+- Review Findings Disposition: no_findings
+- Finding Disposition Evidence: non-blocking QA readability suggestion addressed with an attempts-order assertion.
 - Residual Risk: packaged CI artifact and live Linux/storage/local/Windows redeploy smoke remain required after merge.

--- a/.pm/tasks/task_96c772c830e043f9b1e40b03e6f73d38.execution.md
+++ b/.pm/tasks/task_96c772c830e043f9b1e40b03e6f73d38.execution.md
@@ -107,3 +107,52 @@ Example:
 - Validation Command: ./scripts/pm/workflow-lint.sh --phase pr-ready --task-uid task_96c772c830e043f9b1e40b03e6f73d38
 - Actual Result: passed.
 - Blocker / Next Action: create PR, use CI package, redeploy observer/storage, then verify live observer leaves high-state fallback.
+
+## 2026-06-13 16:03:30 CST / tpm
+- 完成内容: Rebased follow-up work onto `origin/main=6ccce712fadbe3eef7d2bb3a38525f0827f35b8d` and opened branch `codex/testnet-proactive-high-checkpoint-sync`. Post-deploy smoke of testnet.55 showed storage healthy at `committed_height=16715` / `replication_persisted_height=16715`, while 192.168.1.4 observer had `connected=1 active=1 network_committed_height=16715 replication_persisted_height=0 state_sync_fallback_required=true` and `last_error="node replication error: replication network availability gap: libp2p-replication outbound request failed: NetworkProtocolUnavailable { protocol: \"request failed: Timeout\" }"`.
+- 线上证据: observer env is standard `NODE_ROLE=observer`, `P2P_NODE_ROLE=observer_light`, `REPLICATION_ROOT=$STACK_ROOT/data/replication-root`, and has storage bootstrap peer configured. `tick_count=2` after restart plus `repair_h=null` showed the tick was failing before high checkpoint candidate probing. Code inspection isolated the pre-probe failure to `ReplicationNetworkEndpoint::lookup_world_head`: DHT `get_world_head` used `?`, so a retryable DHT availability gap prevented peer/headless fallback and prevented use of already-known `network_committed_height`.
+- 设计结论: DHT world-head is an optional discovery accelerator, not a hard dependency for public testnet high-state sync. Retryable DHT availability/route gaps must degrade to `None` so observer can continue with peer world-head lookup and, if that is also unavailable, use `network_committed_height` to probe retained checkpoint candidates. DHT world-id mismatch and non-transient errors remain fail-closed.
+- 代码改动: `lookup_world_head` now treats DHT `REPLICATION_NETWORK_AVAILABILITY_GAP_PREFIX` / `REPLICATION_NETWORK_ROUTE_UNAVAILABLE_PREFIX` as fallbackable and continues to peer/headless lookup; other DHT errors still return. Added `world_head_lookup_can_fallback` to keep the error policy scoped to world-head discovery.
+- 回归测试: Added `observer_gap_sync_uses_network_height_when_dht_head_lookup_times_out`, which reproduces DHT world-head timeout, peer-head timeout, a leading `network_committed_height`, and a retained checkpoint available via fetch-commit/blob; the observer installs the checkpoint without seed/state-sync.
+- Validation Command: env -u RUSTC_WRAPPER cargo test -p oasis7_node observer_gap_sync_uses_network_height_when_dht_head_lookup_times_out -- --nocapture
+- Expected Result: new regression passes after DHT transient fallback and fails before the code fix.
+- Actual Result: red before fix with `Replication { reason: "replication network availability gap: request failed: Timeout" }`; passed after fix, 1 test passed.
+- Validation Command: env -u RUSTC_WRAPPER cargo test -p oasis7_node storage_replication_high_checkpoint_timeout -- --nocapture
+- Actual Result: passed; 2 tests passed.
+- Validation Command: env -u RUSTC_WRAPPER cargo test -p oasis7_node storage_replication_high_checkpoint -- --nocapture
+- Actual Result: passed; 15 tests passed.
+- Validation Command: env -u RUSTC_WRAPPER cargo fmt --check
+- Actual Result: passed.
+- Validation Command: ./scripts/check-rust-file-size.sh
+- Actual Result: passed; oversized code files=0, test files=0.
+- Validation Command: git diff --check
+- Actual Result: passed.
+- Review Trigger: proactive high checkpoint sync follow-up pre-PR local role review
+- Review Roles: runtime_engineer, qa_engineer
+- Review Question: confirm whether DHT world-head transient fallback preserves fail-closed validation while allowing observer high-state sync to proceed from `network_committed_height`, and whether regression coverage matches the live public testnet failure.
+- Expected Return Contract: findings | no_findings | residual_risk
+- Formal Sink: `.pm/tasks/task_96c772c830e043f9b1e40b03e6f73d38.execution.md`
+- Blocker / Next Action: integrate role review results, then commit, push PR, wait CI, merge, run package CI, and redeploy Linux/storage/local/Windows from the fixed package.
+
+## 2026-06-13 16:12:30 CST / tpm
+- runtime_engineer: no_findings. `lookup_world_head` correctly treats DHT `Ok(None)` and retryable availability/route errors as optional discovery misses, still validates `Ok(Some(head))` world id before use, and continues to peer/headless lookup so `network_committed_height` can drive retained-checkpoint probing.
+- runtime_engineer residual_risk: non-blocking suggestion to add direct negative tests for DHT wrong-world/non-transient failures; existing `observer_gap_sync_rejects_mismatched_world_head` and error-prefix scoping already preserve the fail-closed contract for this PR.
+- qa_engineer: no_findings. Regression coverage matches the live failure: DHT world-head timeout, peer head timeout, `network_committed_height` ahead, retained checkpoint fetch available, and observer installs the checkpoint. Existing high-checkpoint negative coverage still covers DHT mismatch and blob/execution errors not being swallowed.
+- qa_engineer residual_risk: unit/integration coverage is not a packaged multi-host systemd/libp2p soak; final confidence still requires deploying the new CI package and confirming `/v1/chain/status` leaves `height=0` / `state_sync_fallback_required=true`.
+- Finding Disposition Evidence: added the QA-suggested attempts assertion to `observer_gap_sync_uses_network_height_when_dht_head_lookup_times_out`, proving the sync probes `advertised_height` before falling back to the retained checkpoint boundary.
+- Validation Command: env -u RUSTC_WRAPPER cargo test -p oasis7_node storage_replication_high_checkpoint_timeout -- --nocapture
+- Actual Result: passed; 2 tests passed.
+- Validation Command: env -u RUSTC_WRAPPER cargo fmt --check
+- Actual Result: passed.
+- Pre-PR Local Role Review: passed
+- Task UID: task_96c772c830e043f9b1e40b03e6f73d38
+- Source Worktree: /Users/scc/ccwork/worktrees/oasis7-testnet-high-state-peer-retry
+- Source Branch: codex/testnet-proactive-high-checkpoint-sync
+- Source Head: d18d252f321a20e78c319b03c29325154c03e19a
+- Comparison Ref: refs/remotes/origin/main
+- Reviewed Changed Paths: `crates/oasis7_node/src/network_bridge.rs`; `crates/oasis7_node/src/tests_storage_replication_high_checkpoint_timeout.rs`; `.pm/tasks/task_96c772c830e043f9b1e40b03e6f73d38.execution.md`
+- Role Selection Basis: runtime replication world-head discovery fallback, public testnet high checkpoint sync behavior, and regression/release-readiness verification.
+- Review Roles: runtime_engineer, qa_engineer
+- Review Evidence: runtime_engineer no_findings and qa_engineer no_findings recorded above.
+- Review Findings Disposition: no_findings; non-blocking QA readability suggestion addressed.
+- Residual Risk: packaged CI artifact and live Linux/storage/local/Windows redeploy smoke remain required after merge.

--- a/crates/oasis7_node/src/network_bridge.rs
+++ b/crates/oasis7_node/src/network_bridge.rs
@@ -283,9 +283,14 @@ impl ReplicationNetworkEndpoint {
         world_id: &str,
     ) -> Result<Option<WorldHeadAnnounce>, NodeError> {
         if let Some(dht) = self.dht.as_ref() {
-            if let Some(head) = dht.get_world_head(world_id).map_err(network_err)? {
-                validate_world_head_world_id(world_id, &head)?;
-                return Ok(Some(head));
+            match dht.get_world_head(world_id).map_err(network_err) {
+                Ok(Some(head)) => {
+                    validate_world_head_world_id(world_id, &head)?;
+                    return Ok(Some(head));
+                }
+                Ok(None) => {}
+                Err(err) if world_head_lookup_can_fallback(&err) => {}
+                Err(err) => return Err(err),
             }
         }
         self.request_world_head_from_peers(world_id)
@@ -922,6 +927,14 @@ fn network_err(err: WorldError) -> NodeError {
     NodeError::Replication {
         reason: format!("replication network error: {err:?}"),
     }
+}
+
+fn world_head_lookup_can_fallback(err: &NodeError) -> bool {
+    let NodeError::Replication { reason } = err else {
+        return false;
+    };
+    reason.starts_with(REPLICATION_NETWORK_AVAILABILITY_GAP_PREFIX)
+        || reason.starts_with(REPLICATION_NETWORK_ROUTE_UNAVAILABLE_PREFIX)
 }
 
 fn validate_world_head_world_id(world_id: &str, head: &WorldHeadAnnounce) -> Result<(), NodeError> {

--- a/crates/oasis7_node/src/tests_storage_replication_high_checkpoint_timeout.rs
+++ b/crates/oasis7_node/src/tests_storage_replication_high_checkpoint_timeout.rs
@@ -1,4 +1,8 @@
 use super::*;
+use oasis7_proto::distributed::WorldHeadAnnounce;
+use oasis7_proto::distributed_dht::{
+    DistributedDht, MembershipDirectorySnapshot, ProviderRecord, SignedPeerRecord,
+};
 
 struct CheckpointInstallingExecutionHook {
     installed: Vec<u64>,
@@ -41,6 +45,65 @@ struct TimeoutThenCheckpointNetwork {
     blobs: Mutex<BTreeMap<String, Vec<u8>>>,
     attempts: Mutex<Vec<u64>>,
     advertised_height: u64,
+}
+
+#[derive(Default)]
+struct TimeoutWorldHeadDht;
+
+impl DistributedDht<WorldError> for TimeoutWorldHeadDht {
+    fn publish_provider(
+        &self,
+        _world_id: &str,
+        _content_hash: &str,
+        _provider_id: &str,
+    ) -> Result<(), WorldError> {
+        Ok(())
+    }
+
+    fn get_providers(
+        &self,
+        _world_id: &str,
+        _content_hash: &str,
+    ) -> Result<Vec<ProviderRecord>, WorldError> {
+        Ok(Vec::new())
+    }
+
+    fn put_world_head(&self, _world_id: &str, _head: &WorldHeadAnnounce) -> Result<(), WorldError> {
+        Ok(())
+    }
+
+    fn get_world_head(&self, _world_id: &str) -> Result<Option<WorldHeadAnnounce>, WorldError> {
+        Err(WorldError::NetworkProtocolUnavailable {
+            protocol: "request failed: Timeout".to_string(),
+        })
+    }
+
+    fn put_membership_directory(
+        &self,
+        _world_id: &str,
+        _snapshot: &MembershipDirectorySnapshot,
+    ) -> Result<(), WorldError> {
+        Ok(())
+    }
+
+    fn get_membership_directory(
+        &self,
+        _world_id: &str,
+    ) -> Result<Option<MembershipDirectorySnapshot>, WorldError> {
+        Ok(None)
+    }
+
+    fn put_peer_record(&self, _world_id: &str, _record: &SignedPeerRecord) -> Result<(), WorldError> {
+        Ok(())
+    }
+
+    fn get_peer_record(
+        &self,
+        _world_id: &str,
+        _peer_id: &str,
+    ) -> Result<Option<SignedPeerRecord>, WorldError> {
+        Ok(None)
+    }
 }
 
 impl oasis7_proto::distributed_net::DistributedNetwork<WorldError> for TimeoutThenCheckpointNetwork {
@@ -330,6 +393,134 @@ fn observer_gap_sync_continues_checkpoint_candidates_after_protocol_omitted_time
     assert!(
         attempts.starts_with(&[advertised_height, checkpoint_height]),
         "expected advertised height timeout before checkpoint candidate, got {attempts:?}"
+    );
+
+    let _ = fs::remove_dir_all(&dir_a);
+    let _ = fs::remove_dir_all(&dir_b);
+}
+
+#[test]
+fn observer_gap_sync_uses_network_height_when_dht_head_lookup_times_out() {
+    let world_id = "world-gap-sync-dht-timeout-then-checkpoint";
+    let dir_a = temp_dir("gap-sync-dht-timeout-then-checkpoint-a");
+    let dir_b = temp_dir("gap-sync-dht-timeout-then-checkpoint-b");
+    let (_, public_key_a) = deterministic_keypair_hex(254);
+    let (_, public_key_b) = deterministic_keypair_hex(255);
+    let pos_config = signed_pos_config_with_signer_seeds(
+        vec![PosValidator {
+            validator_id: "node-a".to_string(),
+            stake: 100,
+        }],
+        &[("node-a", 254)],
+    );
+    let replication_config_a = signed_replication_config(dir_a.clone(), 254)
+        .with_remote_writer_allowlist(vec![public_key_b.clone()])
+        .expect("allowlist a")
+        .with_fetch_requester_allowlist(vec![public_key_b.clone()])
+        .expect("fetch allowlist a");
+    let replication_config_b = signed_replication_config(dir_b.clone(), 255)
+        .with_remote_writer_allowlist(vec![public_key_a])
+        .expect("allowlist b")
+        .with_fetch_requester_allowlist(vec![public_key_b])
+        .expect("fetch allowlist b");
+    let config_a = NodeConfig::new("node-a", world_id, NodeRole::Sequencer)
+        .expect("config a")
+        .with_pos_config(pos_config.clone())
+        .expect("pos config a")
+        .with_replication(replication_config_a);
+    let config_b = NodeConfig::new("node-b", world_id, NodeRole::Observer)
+        .expect("config b")
+        .with_pos_config(pos_config)
+        .expect("pos config b")
+        .with_replication(replication_config_b.clone());
+
+    let checkpoint_height = REPLICATION_GAP_SYNC_MAX_HEIGHTS_PER_POLL;
+    let advertised_height = checkpoint_height + 2;
+    let mut replication_a =
+        ReplicationRuntime::new(config_a.replication.as_ref().expect("repl a"), "node-a")
+            .expect("runtime a");
+    let execution_block_hash = format!("exec-block-{checkpoint_height}");
+    let execution_state_root = format!("exec-state-{checkpoint_height}");
+    let checkpoint_bundle = test_execution_checkpoint_bundle(
+        checkpoint_height,
+        execution_block_hash.as_str(),
+        execution_state_root.as_str(),
+    );
+    let message = replication_a
+        .build_local_commit_message_with_checkpoint(
+            "node-a",
+            world_id,
+            7_500,
+            &committed_decision(checkpoint_height, 100, 67),
+            Some(execution_block_hash.as_str()),
+            Some(execution_state_root.as_str()),
+            Some(checkpoint_bundle.clone()),
+        )
+        .expect("build checkpoint message")
+        .expect("checkpoint message");
+
+    let network_impl = Arc::new(TimeoutThenCheckpointNetwork {
+        advertised_height,
+        ..Default::default()
+    });
+    network_impl
+        .messages
+        .lock()
+        .expect("lock messages")
+        .insert(checkpoint_height, message.clone());
+    let mut blobs = network_impl.blobs.lock().expect("lock blobs");
+    blobs.insert(message.record.content_hash.clone(), message.payload.clone());
+    blobs.insert(
+        oasis7_distfs::blake3_hex(message.payload.as_slice()),
+        message.payload.clone(),
+    );
+    blobs.insert(
+        oasis7_distfs::blake3_hex(checkpoint_bundle.manifest_json.as_slice()),
+        checkpoint_bundle.manifest_json.clone(),
+    );
+    for blob in &checkpoint_bundle.blobs {
+        blobs.insert(blob.content_hash.clone(), blob.bytes.clone());
+    }
+    drop(blobs);
+
+    let network: Arc<
+        dyn oasis7_proto::distributed_net::DistributedNetwork<WorldError> + Send + Sync,
+    > = network_impl.clone();
+    let dht: Arc<dyn DistributedDht<WorldError> + Send + Sync> =
+        Arc::new(TimeoutWorldHeadDht);
+    let endpoint_b = ReplicationNetworkEndpoint::new(
+        &NodeReplicationNetworkHandle::new(network).with_dht(dht),
+        world_id,
+        false,
+        &config_b.network_policy,
+    )
+    .expect("endpoint b");
+    let mut replication_b =
+        ReplicationRuntime::new(config_b.replication.as_ref().expect("repl b"), "node-b")
+            .expect("runtime b");
+    let mut engine_b = PosNodeEngine::new(&config_b).expect("engine b");
+    engine_b.network_committed_height = advertised_height;
+    let mut install_hook = CheckpointInstallingExecutionHook {
+        installed: Vec::new(),
+    };
+
+    engine_b
+        .sync_missing_replication_commits(
+            &endpoint_b,
+            "node-b",
+            world_id,
+            Some(&mut replication_b),
+            Some(&mut install_hook),
+        )
+        .expect("network-height high checkpoint sync after dht timeout");
+
+    assert_eq!(install_hook.installed, vec![checkpoint_height]);
+    assert_eq!(engine_b.committed_height, checkpoint_height);
+    assert_eq!(engine_b.replication_persisted_height, checkpoint_height);
+    let attempts = network_impl.attempts.lock().expect("lock attempts").clone();
+    assert!(
+        attempts.starts_with(&[advertised_height, checkpoint_height]),
+        "expected network height probe before checkpoint candidate after dht timeout, got {attempts:?}"
     );
 
     let _ = fs::remove_dir_all(&dir_a);


### PR DESCRIPTION
## Summary
- Treat retryable DHT world-head lookup gaps as optional discovery misses so observer sync can continue from known network height.
- Add regression coverage for DHT head timeout + peer head timeout + retained checkpoint sync.
- Record public testnet live-smoke evidence and role review results in the task log.

## Verification
- `env -u RUSTC_WRAPPER cargo fmt --check`
- `./scripts/check-rust-file-size.sh`
- `git diff --check`
- `env -u RUSTC_WRAPPER cargo test -p oasis7_node storage_replication_high_checkpoint_timeout -- --nocapture`
- `env -u RUSTC_WRAPPER cargo test -p oasis7_node storage_replication_high_checkpoint -- --nocapture`
- `./scripts/pm/workflow-lint.sh --phase pr-ready --task-uid task_96c772c830e043f9b1e40b03e6f73d38`

## PR Purpose
normal_pr_ci_watch
