### PR TITLE
Bound testnet libp2p command waits

### DIFF
--- a/.pm/tasks/task_96c772c830e043f9b1e40b03e6f73d38.execution.md
+++ b/.pm/tasks/task_96c772c830e043f9b1e40b03e6f73d38.execution.md
@@ -157,3 +157,56 @@ Example:
 - Review Findings Disposition: no_findings
 - Finding Disposition Evidence: non-blocking QA readability suggestion addressed with an attempts-order assertion.
 - Residual Risk: packaged CI artifact and live Linux/storage/local/Windows redeploy smoke remain required after merge.
+
+## 2026-06-13 16:56:41 CST / tpm
+- 完成内容: PR #438 was merged and Testnet Packages run #56 produced Linux artifact `testnet-package-linux-x64-0.0.0+testnet.56.6d4a9674eab8` from merge commit `6d4a9674eab8ba85a22308192e44d71ea8eda860`. Deployed the artifact to storage `39.104.205.67:/opt/oasis7/p2p-testnet` and observer `192.168.1.4:/opt/oasis7/p2p-testnet-local`.
+- 部署验证: storage restarted healthy at `height=16715`, `network_committed_height=16715`, `replication_persisted_height=16715`, `connected_peers=1`, `active_peers=1`, and registered fetch-blob/fetch-commit/fetch-head protocols. Observer restarted and connected to storage with `connected_peers=1` / `active_peers=1`, but after 90s and 180s remained at `height=0`, `replication_persisted_height=0`, `network_committed_height=16715`, `state_sync_fallback_required=true`, `last_error=null`.
+- 线上根因证据: observer status showed `worker_poll_count=1`, `tick_count=1`, and unchanged `last_tick_unix_ms` while liveness stayed ok and no new error was recorded. This means the first runtime tick entered `engine.tick_with_progress` and never returned, instead of failing and retrying like the earlier DHT/protocol-omitted cases.
+- 代码定位: `Libp2pNetwork` synchronous API methods in `crates/oasis7_net/src/libp2p_net/api.rs` used bare `futures::executor::block_on(receiver)` for command responses from the libp2p runtime loop. If a request/DHT command is accepted but no response is delivered back through the oneshot, the node runtime worker can block forever and never advance to the next tick.
+- 设计结论: libp2p command response waits are a node liveness boundary. The synchronous distributed network/DHT API must convert a missing runtime-loop response into `WorldError::NetworkProtocolUnavailable` after a bounded timeout so replication sync can retry/fallback instead of wedging the observer process.
+- 代码改动: Added a unified `block_on_command_response` helper with a 30s watchdog and replaced all libp2p distributed network/DHT command response waits in `api.rs`, preserving explicit command errors while mapping closed or timed-out command channels to `NetworkProtocolUnavailable`.
+- 回归测试: Added unit coverage for a command response that never replies and for a closed command response channel; both now return bounded `NetworkProtocolUnavailable` errors instead of blocking indefinitely.
+- Validation Command: env -u RUSTC_WRAPPER cargo test -p oasis7_net command_response_wait -- --nocapture
+- Actual Result: passed; 2 tests passed.
+- Validation Command: env -u RUSTC_WRAPPER cargo test -p oasis7_node storage_replication_high_checkpoint_timeout -- --nocapture
+- Actual Result: passed; 2 tests passed.
+- Review Trigger: post-deploy observer worker hang follow-up pre-PR local role review
+- Review Roles: runtime_engineer, qa_engineer
+- Review Question: confirm whether adding a bounded libp2p command response timeout is the correct liveness fix for the deployed observer tick hang, whether it preserves distributed network/DHT error semantics and high-state sync retry behavior, and whether regression coverage is sufficient before packaging/deploying a new testnet artifact.
+- Expected Return Contract: findings | no_findings | residual_risk
+- Formal Sink: `.pm/tasks/task_96c772c830e043f9b1e40b03e6f73d38.execution.md`
+- Blocker / Next Action: finish local gates, dispatch runtime_engineer and qa_engineer review slices, integrate findings, then commit/push/create PR and use CI package for Linux/storage/local/Windows redeploy.
+
+## 2026-06-13 17:10:04 CST / tpm
+- runtime_engineer: no_findings. The deployed `tick_count=1` / `worker_poll_count=1` / `last_error=null` symptom matches the node worker incrementing tick before entering `tick_with_progress`; a bare sync API oneshot wait can wedge the worker without recording an error. A bounded libp2p command response timeout correctly converts the missing runtime-loop response into a retryable liveness error.
+- runtime_engineer semantic review: explicit runtime-loop `WorldError` results are still propagated unchanged; only closed command channels or response watchdog expiry are newly mapped to `WorldError::NetworkProtocolUnavailable`, preserving downstream route/unavailable fallback semantics without swallowing blob/hash/serde failures.
+- runtime_engineer residual_risk: the API timeout protects the caller but does not actively cancel a request/DHT query already accepted by the libp2p runtime loop; normal libp2p/Kad events should still settle those entries, and deployment smoke should watch for repeated `libp2p command ... timed out` plus pending/memory growth. The 30s watchdog is fixed rather than config-driven; acceptable for this testnet repair, but a future hardening pass may make it configurable.
+- qa_engineer: no_findings on code/test coverage. `command_response_wait_times_out_when_runtime_does_not_reply` covers the core live risk where a command is accepted and the oneshot sender remains alive forever; the old code would block indefinitely while the new helper returns bounded `NetworkProtocolUnavailable`. The closed-channel test covers runtime-loop exit/channel-close behavior. The high checkpoint timeout regression still covers DHT world-head timeout, peer-head timeout, `network_committed_height` ahead, retained checkpoint fetch, and checkpoint install.
+- qa_engineer finding: P2 evidence gap before PR/deploy; fresh `cargo fmt --check`, `check-rust-file-size`, `git diff --check`, and `workflow-lint --phase pr-ready` were required. Disposition: addressed with fresh gates below.
+- qa_engineer residual_risk: helper-level liveness tests are sufficient for PR, but real libp2p/network behavior must be validated by CI package plus live testnet redeploy smoke. Suggested non-blocking broader high checkpoint suite before deploy.
+- Validation Command: env -u RUSTC_WRAPPER cargo fmt --check
+- Actual Result: passed.
+- Validation Command: ./scripts/check-rust-file-size.sh
+- Actual Result: passed; oversized code files=0, test files=0.
+- Validation Command: git diff --check
+- Actual Result: passed.
+- Validation Command: env -u RUSTC_WRAPPER cargo test -p oasis7_net command_response_wait -- --nocapture
+- Actual Result: passed; 2 tests passed.
+- Validation Command: env -u RUSTC_WRAPPER cargo test -p oasis7_node storage_replication_high_checkpoint_timeout -- --nocapture
+- Actual Result: passed; 2 tests passed.
+- Validation Command: ./scripts/pm/workflow-lint.sh --phase pr-ready --task-uid task_96c772c830e043f9b1e40b03e6f73d38
+- Actual Result: passed.
+- Validation Command: env -u RUSTC_WRAPPER cargo test -p oasis7_node storage_replication_high_checkpoint -- --nocapture
+- Actual Result: passed; 15 tests passed.
+- Pre-PR Local Role Review: passed
+- Task UID: task_96c772c830e043f9b1e40b03e6f73d38
+- Source Worktree: /Users/scc/ccwork/worktrees/oasis7-testnet-high-state-peer-retry
+- Source Branch: codex/testnet-sync-command-timeouts
+- Comparison Ref: refs/remotes/origin/main
+- Reviewed Changed Paths: `crates/oasis7_net/src/libp2p_net/api.rs`; `.pm/tasks/task_96c772c830e043f9b1e40b03e6f73d38.execution.md`
+- Role Selection Basis: libp2p runtime liveness boundary, public testnet observer high-state sync behavior, and regression/release-readiness verification.
+- Review Roles: runtime_engineer, qa_engineer
+- Review Evidence: runtime_engineer no_findings and qa_engineer no_findings/fresh-gate finding disposition recorded above.
+- Review Findings Disposition: addressed
+- Finding Disposition Evidence: QA evidence gap closed with fresh local gates and workflow lint.
+- Residual Risk: packaged CI artifact and live Linux/storage/local/Windows redeploy smoke remain required after merge; deployment smoke should watch for repeated command timeout errors and process memory/pending growth.

--- a/crates/oasis7_net/src/libp2p_net/api.rs
+++ b/crates/oasis7_net/src/libp2p_net/api.rs
@@ -1,5 +1,6 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
+use std::time::Duration;
 
 use futures::channel::oneshot;
 use libp2p::{Multiaddr, PeerId};
@@ -22,6 +23,8 @@ use super::{
     Libp2pTrafficMetricsSnapshot, PeerManagerBlockArtifact, PeerManagerHealthIssue,
     PeerManagerHealthStatus, PeerManagerPeerHealth,
 };
+
+const LIBP2P_COMMAND_RESPONSE_TIMEOUT: Duration = Duration::from_secs(30);
 
 impl Libp2pNetwork {
     pub fn peer_id(&self) -> PeerId {
@@ -85,11 +88,7 @@ impl Libp2pNetwork {
             peer,
             response: sender,
         })?;
-        futures::executor::block_on(receiver).map_err(|_| {
-            WorldError::NetworkProtocolUnavailable {
-                protocol: "libp2p".to_string(),
-            }
-        })?
+        block_on_command_response(receiver, "request_to_peer")
     }
 
     pub fn debug_peer_healths(&self) -> Vec<PeerManagerPeerHealth> {
@@ -247,11 +246,7 @@ impl ProtoDistributedNetwork<WorldError> for Libp2pNetwork {
             payload: payload.to_vec(),
             response: sender,
         })?;
-        futures::executor::block_on(receiver).map_err(|_| {
-            WorldError::NetworkProtocolUnavailable {
-                protocol: "libp2p".to_string(),
-            }
-        })?
+        block_on_command_response(receiver, "publish")
     }
 
     fn subscribe(&self, topic: &str) -> Result<NetworkSubscription, WorldError> {
@@ -260,11 +255,7 @@ impl ProtoDistributedNetwork<WorldError> for Libp2pNetwork {
             topic: topic.to_string(),
             response: sender,
         })?;
-        futures::executor::block_on(receiver).map_err(|_| {
-            WorldError::NetworkProtocolUnavailable {
-                protocol: "libp2p".to_string(),
-            }
-        })??;
+        block_on_command_response(receiver, "subscribe")?;
         Ok(NetworkSubscription::new(
             topic.to_string(),
             Arc::clone(&self.inbox),
@@ -288,11 +279,7 @@ impl ProtoDistributedNetwork<WorldError> for Libp2pNetwork {
             providers: providers.to_vec(),
             response: sender,
         })?;
-        futures::executor::block_on(receiver).map_err(|_| {
-            WorldError::NetworkProtocolUnavailable {
-                protocol: "libp2p".to_string(),
-            }
-        })?
+        block_on_command_response(receiver, "request")
     }
 
     fn register_handler(
@@ -306,11 +293,7 @@ impl ProtoDistributedNetwork<WorldError> for Libp2pNetwork {
             handler: Arc::from(handler),
             response: sender,
         })?;
-        futures::executor::block_on(receiver).map_err(|_| {
-            WorldError::NetworkProtocolUnavailable {
-                protocol: "libp2p".to_string(),
-            }
-        })?
+        block_on_command_response(receiver, "register_handler")
     }
 }
 
@@ -324,11 +307,7 @@ impl ProtoDistributedDht<WorldError> for Libp2pNetwork {
         let key = dht_provider_key(world_id, content_hash);
         let (sender, receiver) = oneshot::channel();
         self.enqueue_command(Command::PublishProvider(key, sender))?;
-        futures::executor::block_on(receiver).map_err(|_| {
-            WorldError::NetworkProtocolUnavailable {
-                protocol: "libp2p".to_string(),
-            }
-        })?
+        block_on_command_response(receiver, "publish_provider")
     }
 
     fn get_providers(
@@ -339,11 +318,7 @@ impl ProtoDistributedDht<WorldError> for Libp2pNetwork {
         let key = dht_provider_key(world_id, content_hash);
         let (sender, receiver) = oneshot::channel();
         self.enqueue_command(Command::GetProviders(key, sender))?;
-        futures::executor::block_on(receiver).map_err(|_| {
-            WorldError::NetworkProtocolUnavailable {
-                protocol: "libp2p".to_string(),
-            }
-        })?
+        block_on_command_response(receiver, "get_providers")
     }
 
     fn put_world_head(&self, world_id: &str, head: &WorldHeadAnnounce) -> Result<(), WorldError> {
@@ -355,22 +330,14 @@ impl ProtoDistributedDht<WorldError> for Libp2pNetwork {
             payload,
             response: sender,
         })?;
-        futures::executor::block_on(receiver).map_err(|_| {
-            WorldError::NetworkProtocolUnavailable {
-                protocol: "libp2p".to_string(),
-            }
-        })?
+        block_on_command_response(receiver, "put_world_head")
     }
 
     fn get_world_head(&self, world_id: &str) -> Result<Option<WorldHeadAnnounce>, WorldError> {
         let key = dht_world_head_key(world_id);
         let (sender, receiver) = oneshot::channel();
         self.enqueue_command(Command::GetWorldHead(key, sender))?;
-        futures::executor::block_on(receiver).map_err(|_| {
-            WorldError::NetworkProtocolUnavailable {
-                protocol: "libp2p".to_string(),
-            }
-        })?
+        block_on_command_response(receiver, "get_world_head")
     }
 
     fn put_membership_directory(
@@ -386,11 +353,7 @@ impl ProtoDistributedDht<WorldError> for Libp2pNetwork {
             payload,
             response: sender,
         })?;
-        futures::executor::block_on(receiver).map_err(|_| {
-            WorldError::NetworkProtocolUnavailable {
-                protocol: "libp2p".to_string(),
-            }
-        })?
+        block_on_command_response(receiver, "put_membership_directory")
     }
 
     fn get_membership_directory(
@@ -403,11 +366,7 @@ impl ProtoDistributedDht<WorldError> for Libp2pNetwork {
             key,
             response: sender,
         })?;
-        futures::executor::block_on(receiver).map_err(|_| {
-            WorldError::NetworkProtocolUnavailable {
-                protocol: "libp2p".to_string(),
-            }
-        })?
+        block_on_command_response(receiver, "get_membership_directory")
     }
 
     fn put_peer_record(&self, world_id: &str, record: &SignedPeerRecord) -> Result<(), WorldError> {
@@ -419,11 +378,7 @@ impl ProtoDistributedDht<WorldError> for Libp2pNetwork {
             payload,
             response: sender,
         })?;
-        futures::executor::block_on(receiver).map_err(|_| {
-            WorldError::NetworkProtocolUnavailable {
-                protocol: "libp2p".to_string(),
-            }
-        })?
+        block_on_command_response(receiver, "put_peer_record")
     }
 
     fn get_peer_record(
@@ -437,10 +392,70 @@ impl ProtoDistributedDht<WorldError> for Libp2pNetwork {
             key,
             response: sender,
         })?;
-        futures::executor::block_on(receiver).map_err(|_| {
-            WorldError::NetworkProtocolUnavailable {
-                protocol: "libp2p".to_string(),
+        block_on_command_response(receiver, "get_peer_record")
+    }
+}
+
+fn block_on_command_response<T>(
+    receiver: oneshot::Receiver<Result<T, WorldError>>,
+    operation: &str,
+) -> Result<T, WorldError> {
+    block_on_command_response_with_timeout(receiver, operation, LIBP2P_COMMAND_RESPONSE_TIMEOUT)
+}
+
+fn block_on_command_response_with_timeout<T>(
+    receiver: oneshot::Receiver<Result<T, WorldError>>,
+    operation: &str,
+    timeout: Duration,
+) -> Result<T, WorldError> {
+    match futures::executor::block_on(async_std::future::timeout(timeout, receiver)) {
+        Ok(Ok(result)) => result,
+        Ok(Err(_closed)) => Err(WorldError::NetworkProtocolUnavailable {
+            protocol: format!("libp2p command {operation} response channel closed"),
+        }),
+        Err(_elapsed) => Err(WorldError::NetworkProtocolUnavailable {
+            protocol: format!(
+                "libp2p command {operation} timed out after {}ms",
+                timeout.as_millis()
+            ),
+        }),
+    }
+}
+
+#[cfg(test)]
+mod command_response_tests {
+    use super::*;
+
+    #[test]
+    fn command_response_wait_times_out_when_runtime_does_not_reply() {
+        let (_sender, receiver) = oneshot::channel::<Result<(), WorldError>>();
+
+        let err =
+            block_on_command_response_with_timeout(receiver, "request", Duration::from_millis(1))
+                .expect_err("missing runtime response should time out");
+
+        match err {
+            WorldError::NetworkProtocolUnavailable { protocol } => {
+                assert!(protocol.contains("libp2p command request timed out"));
             }
-        })?
+            other => panic!("expected NetworkProtocolUnavailable, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn command_response_wait_reports_closed_channel() {
+        let (sender, receiver) = oneshot::channel::<Result<(), WorldError>>();
+        drop(sender);
+
+        let err =
+            block_on_command_response_with_timeout(receiver, "request", Duration::from_millis(100))
+                .expect_err("closed runtime response should fail");
+
+        match err {
+            WorldError::NetworkProtocolUnavailable { protocol } => {
+                assert!(protocol.contains("libp2p command request response channel closed"));
+            }
+            other => panic!("expected NetworkProtocolUnavailable, got {other:?}"),
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add a bounded watchdog for libp2p distributed network/DHT command response waits
- convert missing runtime-loop command responses into retryable `NetworkProtocolUnavailable` errors instead of wedging the node worker
- add regression coverage for never-replying and closed command response channels

## Live Root Cause
After deploying testnet package #56 from merged PR #438, storage stayed healthy at height 16715 and the observer connected to it, but the observer stayed at height 0 with `worker_poll_count=1`, `tick_count=1`, and `last_error=null` for several minutes. That means the first node tick entered `tick_with_progress` and never returned.

Code inspection found that `Libp2pNetwork` synchronous API methods used bare `futures::executor::block_on(receiver)` for command responses from the libp2p runtime loop. If a request/DHT command is accepted but no response is delivered through the oneshot, the runtime worker can block forever and never reach the next sync retry/fallback.

## Verification
- `env -u RUSTC_WRAPPER cargo fmt --check`
- `./scripts/check-rust-file-size.sh`
- `git diff --check`
- `env -u RUSTC_WRAPPER cargo test -p oasis7_net command_response_wait -- --nocapture`
- `env -u RUSTC_WRAPPER cargo test -p oasis7_node storage_replication_high_checkpoint_timeout -- --nocapture`
- `env -u RUSTC_WRAPPER cargo test -p oasis7_node storage_replication_high_checkpoint -- --nocapture`
- `./scripts/pm/workflow-lint.sh --phase pr-ready --task-uid task_96c772c830e043f9b1e40b03e6f73d38`

## Role Review
Pre-PR Local Role Review: passed.

- `runtime_engineer`: no findings. The fix is the correct liveness boundary for the deployed tick hang and preserves existing distributed network/DHT error semantics.
- `qa_engineer`: no code findings. Fresh gate evidence was required and has been completed; helper-level liveness coverage plus high-checkpoint regression is sufficient before CI package and live redeploy smoke.

## Follow-up After Merge
Use Testnet Packages CI artifact, then redeploy Linux storage, local observer, and Windows node. Live smoke should verify the observer leaves `height=0` / `state_sync_fallback_required=true` and watch for repeated `libp2p command ... timed out` errors or memory/pending growth.
