### PR TITLE
Use synchronous testnet command timeouts

### DIFF
--- a/.pm/tasks/task_96c772c830e043f9b1e40b03e6f73d38.execution.md
+++ b/.pm/tasks/task_96c772c830e043f9b1e40b03e6f73d38.execution.md
@@ -210,3 +210,66 @@ Example:
 - Review Findings Disposition: addressed
 - Finding Disposition Evidence: QA evidence gap closed with fresh local gates and workflow lint.
 - Residual Risk: packaged CI artifact and live Linux/storage/local/Windows redeploy smoke remain required after merge; deployment smoke should watch for repeated command timeout errors and process memory/pending growth.
+
+## 2026-06-13 17:50:00 CST / tpm
+- 完成内容: PR #442 was merged as `c0d0c73d8445b7d4e21ccb06b57d8f111607a484`; Testnet Packages run #58 (`package_scope=all_existing`) produced Linux/macOS/Windows artifacts. Linux artifact `testnet-package-linux-x64-0.0.0+testnet.58.c0d0c73d8445` passed SHA256 verification and was deployed to storage `39.104.205.67` and observer `192.168.1.4`.
+- 部署验证: storage restarted active on `testnet.58.c0d0c73d8445`. Observer restarted active with the expected binary hash `7dfdf1a2dae4b54c601d836d66be5d8cd90d367b63dd4f412c99ee750df12289`, but after more than 40s remained stuck at `tick_count=1`, `worker_poll_count=1`, and `last_error=null`.
+- 新根因证据: gdb backtrace on the live observer showed thread `aw-node-triad-t` blocked in `futures_executor::local_pool::block_on`, inside `oasis7_net::libp2p_net::api::<impl Libp2pNetwork>::request_to_peer`, called from `Libp2pReplicationNetwork::request_via_peer` and `ReplicationNetworkEndpoint::request_fetch_commit_for_gap_sync_with_policy`. This confirmed the first watchdog design reached the right fetch-commit command path, but `async_std::future::timeout(..., futures::channel::oneshot::Receiver)` did not wake the synchronous worker under the packaged release runtime.
+- 设计结论: The command response liveness boundary must be synchronous end-to-end. A sync caller must not depend on async timer/executor wakeups to escape a missing libp2p runtime-loop response. Command response channels should use `std::sync::mpsc`, and API methods should wait with `recv_timeout`.
+- 代码改动: Replaced libp2p `Command` response senders and pending DHT response senders with `std::sync::mpsc::Sender<Result<...>>`; API methods now create `std::sync::mpsc::channel()` and use `recv_timeout(30s)`. Runtime-loop and DHT send sites continue to send explicit command results unchanged. Tests that directly exercise command/DHT responses now use std mpsc receive semantics.
+- Validation Command: env -u RUSTC_WRAPPER cargo test -p oasis7_net command_response_wait -- --nocapture
+- Actual Result: passed; 2 tests passed.
+- Validation Command: env -u RUSTC_WRAPPER cargo test -p oasis7_node storage_replication_high_checkpoint_timeout -- --nocapture
+- Actual Result: passed; 2 tests passed.
+- Validation Command: env -u RUSTC_WRAPPER cargo test -p oasis7_node storage_replication_high_checkpoint -- --nocapture
+- Actual Result: passed; 15 tests passed.
+- Validation Command: ./scripts/check-rust-file-size.sh
+- Actual Result: passed; oversized code files=0, test files=0.
+- Validation Command: git diff --check
+- Actual Result: passed.
+- Validation Command: env -u RUSTC_WRAPPER cargo fmt --check
+- Actual Result: passed.
+- Validation Command: ./scripts/pm/workflow-lint.sh --phase pr-ready --task-uid task_96c772c830e043f9b1e40b03e6f73d38
+- Actual Result: passed.
+- Review Trigger: live observer still wedged after PR #442/testnet.58; sync command response v2 pre-PR local role review
+- Review Roles: runtime_engineer, qa_engineer
+- Review Question: confirm whether replacing libp2p command response oneshots with std mpsc `recv_timeout` is the correct root fix for the packaged observer `request_to_peer` hang, whether it preserves command/DHT error semantics, and whether regression coverage plus live backtrace evidence is sufficient before a new PR/package/deploy.
+- Expected Return Contract: findings | no_findings | residual_risk
+- Formal Sink: `.pm/tasks/task_96c772c830e043f9b1e40b03e6f73d38.execution.md`
+- Blocker / Next Action: dispatch runtime_engineer and qa_engineer review slices, integrate findings, create follow-up PR, run CI package again, then redeploy Linux/storage/local/Windows from the v2 package.
+
+## 2026-06-13 18:02:00 CST / tpm
+- runtime_engineer: no_findings. `request_to_peer` now uses `std::sync::mpsc::channel` and `recv_timeout`, so it no longer blocks on a futures oneshot executor path; this directly addresses the packaged observer gdb backtrace.
+- runtime_engineer semantic review: runtime loop still sends success or the original `Err(WorldError)` unchanged; API helper preserves `Ok(result) => result` and only maps channel closed/timeout to `NetworkProtocolUnavailable`. DHT pending query outcomes keep their original Kademlia result semantics.
+- runtime_engineer residual_risk: caller liveness is fixed, but already-issued runtime-loop pending request/DHT entries are not actively canceled; deployment smoke should watch repeated timeout logs or pending/memory growth. The 30s timeout remains fixed and can be made configurable later if needed.
+- qa_engineer finding: P2 branch state. The branch was behind `origin/main` by 4 commits; per the user's explicit rebase requirement, PR creation requires rebasing/syncing onto current main and rerunning fresh gates.
+- qa_engineer finding disposition: addressed by rebasing `codex/testnet-sync-command-timeouts-v2` onto `origin/main` after merge commit `57f9d9347` and rerunning fresh gates.
+- qa_engineer: no code findings. The `command_response_wait_times_out_when_runtime_does_not_reply` test covers the exact live risk where the sender remains alive and never replies, and the closed-channel test covers runtime-loop exit/channel-close behavior. High checkpoint timeout and broad high checkpoint suites are sufficient for the sync path.
+- qa_engineer residual_risk: this is an API liveness boundary test rather than a full libp2p swarm hang simulation; live redeploy must verify observer `tick_count` advances and watch repeated command timeout errors.
+- Validation Command: env -u RUSTC_WRAPPER cargo fmt --check
+- Actual Result: passed after rebase.
+- Validation Command: ./scripts/check-rust-file-size.sh
+- Actual Result: passed after rebase; oversized code files=0, test files=0.
+- Validation Command: git diff --check
+- Actual Result: passed after rebase.
+- Validation Command: env -u RUSTC_WRAPPER cargo test -p oasis7_net command_response_wait -- --nocapture
+- Actual Result: passed after rebase; 2 tests passed.
+- Validation Command: env -u RUSTC_WRAPPER cargo test -p oasis7_node storage_replication_high_checkpoint_timeout -- --nocapture
+- Actual Result: passed after rebase; 2 tests passed.
+- Validation Command: env -u RUSTC_WRAPPER cargo test -p oasis7_node storage_replication_high_checkpoint -- --nocapture
+- Actual Result: passed after rebase; 15 tests passed.
+- Validation Command: ./scripts/pm/workflow-lint.sh --phase pr-ready --task-uid task_96c772c830e043f9b1e40b03e6f73d38
+- Actual Result: passed after rebase.
+- Pre-PR Local Role Review: passed
+- Task UID: task_96c772c830e043f9b1e40b03e6f73d38
+- Source Worktree: /Users/scc/ccwork/worktrees/oasis7-testnet-high-state-peer-retry
+- Source Branch: codex/testnet-sync-command-timeouts-v2
+- Source Head: e24341954
+- Comparison Ref: refs/remotes/origin/main
+- Reviewed Changed Paths: `crates/oasis7_net/src/libp2p_net.rs`; `crates/oasis7_net/src/libp2p_net/api.rs`; `crates/oasis7_net/src/libp2p_net/kad_queries.rs`; `crates/oasis7_net/src/libp2p_net/peer_record.rs`; `crates/oasis7_net/src/libp2p_net/runtime_loop.rs`; `crates/oasis7_net/src/libp2p_net/tests.rs`; `crates/oasis7_net/src/libp2p_net/tests/subscribe_ack_tests.rs`; `crates/oasis7_net/src/libp2p_net/transport_retry_tests.rs`; `.pm/tasks/task_96c772c830e043f9b1e40b03e6f73d38.execution.md`
+- Role Selection Basis: packaged observer request_to_peer hang root cause, libp2p command response liveness semantics, and high checkpoint sync regression coverage.
+- Review Roles: runtime_engineer, qa_engineer
+- Review Evidence: runtime_engineer no_findings and qa_engineer no code findings/P2 rebase finding disposition recorded above.
+- Review Findings Disposition: addressed
+- Finding Disposition Evidence: branch rebased onto current `origin/main` and fresh gates/tests rerun successfully.
+- Residual Risk: live package/redeploy smoke must verify observer `tick_count` advances past 1, high-state sync either installs checkpoint or emits bounded retryable errors, and no repeated command timeout/pending growth appears.

--- a/crates/oasis7_net/src/libp2p_net.rs
+++ b/crates/oasis7_net/src/libp2p_net.rs
@@ -111,6 +111,8 @@ const RR_GET_CACHED_PEER_RECORD: &str = "/aw/rr/1.0.0/get_cached_peer_record";
 const RR_GET_CACHED_DISCOVERY_PEERS: &str = "/aw/rr/1.0.0/get_cached_discovery_peers";
 const LIFECYCLE_EVENT_ERROR_COOLDOWN_MS: i64 = 5_000;
 
+type CommandResponseSender<T> = std::sync::mpsc::Sender<Result<T, WorldError>>;
+
 #[derive(Clone)]
 pub struct Libp2pNetwork {
     peer_id: PeerId,

--- a/crates/oasis7_net/src/libp2p_net/api.rs
+++ b/crates/oasis7_net/src/libp2p_net/api.rs
@@ -1,8 +1,8 @@
 use std::collections::{HashMap, HashSet};
+use std::sync::mpsc;
 use std::sync::Arc;
 use std::time::Duration;
 
-use futures::channel::oneshot;
 use libp2p::{Multiaddr, PeerId};
 use oasis7_proto::distributed_dht::DistributedDht as ProtoDistributedDht;
 use oasis7_proto::distributed_net::DistributedNetwork as ProtoDistributedNetwork;
@@ -81,7 +81,7 @@ impl Libp2pNetwork {
         payload: &[u8],
         peer: PeerId,
     ) -> Result<Vec<u8>, WorldError> {
-        let (sender, receiver) = oneshot::channel();
+        let (sender, receiver) = mpsc::channel();
         self.enqueue_command(Command::RequestToPeer {
             protocol: protocol.to_string(),
             payload: payload.to_vec(),
@@ -240,7 +240,7 @@ pub(super) fn dedup_sorted_peers(mut peers: Vec<PeerId>) -> Vec<PeerId> {
 
 impl ProtoDistributedNetwork<WorldError> for Libp2pNetwork {
     fn publish(&self, topic: &str, payload: &[u8]) -> Result<(), WorldError> {
-        let (sender, receiver) = oneshot::channel();
+        let (sender, receiver) = mpsc::channel();
         self.enqueue_command(Command::Publish {
             topic: topic.to_string(),
             payload: payload.to_vec(),
@@ -250,7 +250,7 @@ impl ProtoDistributedNetwork<WorldError> for Libp2pNetwork {
     }
 
     fn subscribe(&self, topic: &str) -> Result<NetworkSubscription, WorldError> {
-        let (sender, receiver) = oneshot::channel();
+        let (sender, receiver) = mpsc::channel();
         self.enqueue_command(Command::Subscribe {
             topic: topic.to_string(),
             response: sender,
@@ -272,7 +272,7 @@ impl ProtoDistributedNetwork<WorldError> for Libp2pNetwork {
         payload: &[u8],
         providers: &[String],
     ) -> Result<Vec<u8>, WorldError> {
-        let (sender, receiver) = oneshot::channel();
+        let (sender, receiver) = mpsc::channel();
         self.enqueue_command(Command::Request {
             protocol: protocol.to_string(),
             payload: payload.to_vec(),
@@ -287,7 +287,7 @@ impl ProtoDistributedNetwork<WorldError> for Libp2pNetwork {
         protocol: &str,
         handler: Box<dyn Fn(&[u8]) -> Result<Vec<u8>, WorldError> + Send + Sync>,
     ) -> Result<(), WorldError> {
-        let (sender, receiver) = oneshot::channel();
+        let (sender, receiver) = mpsc::channel();
         self.enqueue_command(Command::RegisterHandler {
             protocol: protocol.to_string(),
             handler: Arc::from(handler),
@@ -305,7 +305,7 @@ impl ProtoDistributedDht<WorldError> for Libp2pNetwork {
         _provider_id: &str,
     ) -> Result<(), WorldError> {
         let key = dht_provider_key(world_id, content_hash);
-        let (sender, receiver) = oneshot::channel();
+        let (sender, receiver) = mpsc::channel();
         self.enqueue_command(Command::PublishProvider(key, sender))?;
         block_on_command_response(receiver, "publish_provider")
     }
@@ -316,7 +316,7 @@ impl ProtoDistributedDht<WorldError> for Libp2pNetwork {
         content_hash: &str,
     ) -> Result<Vec<ProviderRecord>, WorldError> {
         let key = dht_provider_key(world_id, content_hash);
-        let (sender, receiver) = oneshot::channel();
+        let (sender, receiver) = mpsc::channel();
         self.enqueue_command(Command::GetProviders(key, sender))?;
         block_on_command_response(receiver, "get_providers")
     }
@@ -324,7 +324,7 @@ impl ProtoDistributedDht<WorldError> for Libp2pNetwork {
     fn put_world_head(&self, world_id: &str, head: &WorldHeadAnnounce) -> Result<(), WorldError> {
         let key = dht_world_head_key(world_id);
         let payload = to_canonical_cbor(head)?;
-        let (sender, receiver) = oneshot::channel();
+        let (sender, receiver) = mpsc::channel();
         self.enqueue_command(Command::PutWorldHead {
             key,
             payload,
@@ -335,7 +335,7 @@ impl ProtoDistributedDht<WorldError> for Libp2pNetwork {
 
     fn get_world_head(&self, world_id: &str) -> Result<Option<WorldHeadAnnounce>, WorldError> {
         let key = dht_world_head_key(world_id);
-        let (sender, receiver) = oneshot::channel();
+        let (sender, receiver) = mpsc::channel();
         self.enqueue_command(Command::GetWorldHead(key, sender))?;
         block_on_command_response(receiver, "get_world_head")
     }
@@ -347,7 +347,7 @@ impl ProtoDistributedDht<WorldError> for Libp2pNetwork {
     ) -> Result<(), WorldError> {
         let key = dht_membership_key(world_id);
         let payload = to_canonical_cbor(snapshot)?;
-        let (sender, receiver) = oneshot::channel();
+        let (sender, receiver) = mpsc::channel();
         self.enqueue_command(Command::PutMembershipDirectory {
             key,
             payload,
@@ -361,7 +361,7 @@ impl ProtoDistributedDht<WorldError> for Libp2pNetwork {
         world_id: &str,
     ) -> Result<Option<MembershipDirectorySnapshot>, WorldError> {
         let key = dht_membership_key(world_id);
-        let (sender, receiver) = oneshot::channel();
+        let (sender, receiver) = mpsc::channel();
         self.enqueue_command(Command::GetMembershipDirectory {
             key,
             response: sender,
@@ -372,7 +372,7 @@ impl ProtoDistributedDht<WorldError> for Libp2pNetwork {
     fn put_peer_record(&self, world_id: &str, record: &SignedPeerRecord) -> Result<(), WorldError> {
         let key = dht_peer_record_key(world_id, record.record.peer_id.as_str());
         let payload = to_canonical_cbor(record)?;
-        let (sender, receiver) = oneshot::channel();
+        let (sender, receiver) = mpsc::channel();
         self.enqueue_command(Command::PutPeerRecord {
             key,
             payload,
@@ -387,7 +387,7 @@ impl ProtoDistributedDht<WorldError> for Libp2pNetwork {
         peer_id: &str,
     ) -> Result<Option<SignedPeerRecord>, WorldError> {
         let key = dht_peer_record_key(world_id, peer_id);
-        let (sender, receiver) = oneshot::channel();
+        let (sender, receiver) = mpsc::channel();
         self.enqueue_command(Command::GetPeerRecord {
             key,
             response: sender,
@@ -397,23 +397,23 @@ impl ProtoDistributedDht<WorldError> for Libp2pNetwork {
 }
 
 fn block_on_command_response<T>(
-    receiver: oneshot::Receiver<Result<T, WorldError>>,
+    receiver: mpsc::Receiver<Result<T, WorldError>>,
     operation: &str,
 ) -> Result<T, WorldError> {
     block_on_command_response_with_timeout(receiver, operation, LIBP2P_COMMAND_RESPONSE_TIMEOUT)
 }
 
 fn block_on_command_response_with_timeout<T>(
-    receiver: oneshot::Receiver<Result<T, WorldError>>,
+    receiver: mpsc::Receiver<Result<T, WorldError>>,
     operation: &str,
     timeout: Duration,
 ) -> Result<T, WorldError> {
-    match futures::executor::block_on(async_std::future::timeout(timeout, receiver)) {
-        Ok(Ok(result)) => result,
-        Ok(Err(_closed)) => Err(WorldError::NetworkProtocolUnavailable {
+    match receiver.recv_timeout(timeout) {
+        Ok(result) => result,
+        Err(mpsc::RecvTimeoutError::Disconnected) => Err(WorldError::NetworkProtocolUnavailable {
             protocol: format!("libp2p command {operation} response channel closed"),
         }),
-        Err(_elapsed) => Err(WorldError::NetworkProtocolUnavailable {
+        Err(mpsc::RecvTimeoutError::Timeout) => Err(WorldError::NetworkProtocolUnavailable {
             protocol: format!(
                 "libp2p command {operation} timed out after {}ms",
                 timeout.as_millis()
@@ -428,7 +428,7 @@ mod command_response_tests {
 
     #[test]
     fn command_response_wait_times_out_when_runtime_does_not_reply() {
-        let (_sender, receiver) = oneshot::channel::<Result<(), WorldError>>();
+        let (_sender, receiver) = mpsc::channel::<Result<(), WorldError>>();
 
         let err =
             block_on_command_response_with_timeout(receiver, "request", Duration::from_millis(1))
@@ -444,7 +444,7 @@ mod command_response_tests {
 
     #[test]
     fn command_response_wait_reports_closed_channel() {
-        let (sender, receiver) = oneshot::channel::<Result<(), WorldError>>();
+        let (sender, receiver) = mpsc::channel::<Result<(), WorldError>>();
         drop(sender);
 
         let err =

--- a/crates/oasis7_net/src/libp2p_net/kad_queries.rs
+++ b/crates/oasis7_net/src/libp2p_net/kad_queries.rs
@@ -1,6 +1,5 @@
 use std::collections::HashSet;
 
-use futures::channel::oneshot;
 use libp2p::kad;
 use libp2p::PeerId;
 
@@ -11,37 +10,38 @@ use oasis7_proto::distributed_dht::{
 };
 
 use super::peer_record::decode_peer_record;
+use super::CommandResponseSender;
 
 pub(super) enum PendingDhtQuery {
     PublishProvider {
-        response: Option<oneshot::Sender<Result<(), WorldError>>>,
+        response: Option<CommandResponseSender<()>>,
     },
     GetProviders {
-        response: Option<oneshot::Sender<Result<Vec<ProviderRecord>, WorldError>>>,
+        response: Option<CommandResponseSender<Vec<ProviderRecord>>>,
         providers: HashSet<PeerId>,
         error: Option<WorldError>,
     },
     PutWorldHead {
-        response: Option<oneshot::Sender<Result<(), WorldError>>>,
+        response: Option<CommandResponseSender<()>>,
     },
     GetWorldHead {
-        response: Option<oneshot::Sender<Result<Option<WorldHeadAnnounce>, WorldError>>>,
+        response: Option<CommandResponseSender<Option<WorldHeadAnnounce>>>,
         head: Option<WorldHeadAnnounce>,
         error: Option<WorldError>,
     },
     PutMembershipDirectory {
-        response: Option<oneshot::Sender<Result<(), WorldError>>>,
+        response: Option<CommandResponseSender<()>>,
     },
     GetMembershipDirectory {
-        response: Option<oneshot::Sender<Result<Option<MembershipDirectorySnapshot>, WorldError>>>,
+        response: Option<CommandResponseSender<Option<MembershipDirectorySnapshot>>>,
         snapshot: Option<MembershipDirectorySnapshot>,
         error: Option<WorldError>,
     },
     PutPeerRecord {
-        response: Option<oneshot::Sender<Result<(), WorldError>>>,
+        response: Option<CommandResponseSender<()>>,
     },
     GetPeerRecord {
-        response: Option<oneshot::Sender<Result<Option<SignedPeerRecord>, WorldError>>>,
+        response: Option<CommandResponseSender<Option<SignedPeerRecord>>>,
         record: Option<SignedPeerRecord>,
         error: Option<WorldError>,
     },

--- a/crates/oasis7_net/src/libp2p_net/peer_record.rs
+++ b/crates/oasis7_net/src/libp2p_net/peer_record.rs
@@ -1,7 +1,6 @@
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
-use futures::channel::oneshot;
 use libp2p::identity::Keypair;
 use libp2p::kad::{self, Quorum, RecordKey};
 use libp2p::multiaddr::Protocol;
@@ -17,7 +16,7 @@ use super::kad_queries::PendingDhtQuery;
 use super::reachability::{
     is_loopback_direct_addr, is_public_direct_addr, snapshot_clone, Libp2pReachabilitySnapshot,
 };
-use super::Behaviour;
+use super::{Behaviour, CommandResponseSender};
 
 pub(super) fn publish_configured_peer_record(
     swarm: &mut Swarm<Behaviour>,
@@ -27,7 +26,7 @@ pub(super) fn publish_configured_peer_record(
     listening_addrs: &Arc<Mutex<Vec<Multiaddr>>>,
     reachability: &Arc<Mutex<Libp2pReachabilitySnapshot>>,
     allow_loopback_external_addrs_for_testing: bool,
-    response: Option<oneshot::Sender<Result<(), WorldError>>>,
+    response: Option<CommandResponseSender<()>>,
 ) -> Result<SignedPeerRecord, WorldError> {
     let signed = build_configured_peer_record(
         keypair,

--- a/crates/oasis7_net/src/libp2p_net/runtime_loop.rs
+++ b/crates/oasis7_net/src/libp2p_net/runtime_loop.rs
@@ -2,7 +2,6 @@ use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex};
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use futures::channel::oneshot;
 use libp2p::gossipsub::{IdentTopic, TopicHash};
 use libp2p::kad::{self, Quorum, RecordKey};
 use libp2p::request_response;
@@ -19,12 +18,12 @@ use super::{
     classify_network_protocol, classify_network_topic, maybe_discover_rendezvous_namespace,
     maybe_register_rendezvous_namespace, maybe_request_cached_discovery_peers, now_ms,
     publish_configured_peer_record, publish_discovery_provider, push_bounded_clone,
-    put_record_query, should_republish, start_peer_discovery_query, Behaviour, Handler, Keypair,
-    Libp2pReachabilitySnapshot, MembershipDirectorySnapshot, NetworkMessage, NetworkRequest,
-    PeerManagerBlockArtifact, PeerManagerHealthIssue, PeerManagerHealthStatus,
-    PeerManagerPeerHealth, PeerManagerPolicy, PeerRecord, PendingDhtQuery,
-    PendingPeerRecordRequest, ProviderRecord, SignedPeerRecord, TransportPath, WorldError,
-    WorldHeadAnnounce, DEFAULT_SUBSCRIPTION_INBOX_MAX_MESSAGES,
+    put_record_query, should_republish, start_peer_discovery_query, Behaviour,
+    CommandResponseSender, Handler, Keypair, Libp2pReachabilitySnapshot,
+    MembershipDirectorySnapshot, NetworkMessage, NetworkRequest, PeerManagerBlockArtifact,
+    PeerManagerHealthIssue, PeerManagerHealthStatus, PeerManagerPeerHealth, PeerManagerPolicy,
+    PeerRecord, PendingDhtQuery, PendingPeerRecordRequest, ProviderRecord, SignedPeerRecord,
+    TransportPath, WorldError, WorldHeadAnnounce, DEFAULT_SUBSCRIPTION_INBOX_MAX_MESSAGES,
 };
 
 pub(super) enum CommandOutcome {
@@ -34,7 +33,7 @@ pub(super) enum CommandOutcome {
 
 pub(super) struct PendingResponse {
     pub protocol: String,
-    pub response: oneshot::Sender<Result<Vec<u8>, WorldError>>,
+    pub response: CommandResponseSender<Vec<u8>>,
 }
 
 pub(super) struct CommandContext<'a> {
@@ -57,61 +56,55 @@ pub(super) enum Command {
     Publish {
         topic: String,
         payload: Vec<u8>,
-        response: oneshot::Sender<Result<(), WorldError>>,
+        response: CommandResponseSender<()>,
     },
     Subscribe {
         topic: String,
-        response: oneshot::Sender<Result<(), WorldError>>,
+        response: CommandResponseSender<()>,
     },
     Dial(Multiaddr),
     Request {
         protocol: String,
         payload: Vec<u8>,
         providers: Vec<String>,
-        response: oneshot::Sender<Result<Vec<u8>, WorldError>>,
+        response: CommandResponseSender<Vec<u8>>,
     },
     RequestToPeer {
         protocol: String,
         payload: Vec<u8>,
         peer: PeerId,
-        response: oneshot::Sender<Result<Vec<u8>, WorldError>>,
+        response: CommandResponseSender<Vec<u8>>,
     },
     RegisterHandler {
         protocol: String,
         handler: Handler,
-        response: oneshot::Sender<Result<(), WorldError>>,
+        response: CommandResponseSender<()>,
     },
-    PublishProvider(String, oneshot::Sender<Result<(), WorldError>>),
-    GetProviders(
-        String,
-        oneshot::Sender<Result<Vec<ProviderRecord>, WorldError>>,
-    ),
+    PublishProvider(String, CommandResponseSender<()>),
+    GetProviders(String, CommandResponseSender<Vec<ProviderRecord>>),
     PutWorldHead {
         key: String,
         payload: Vec<u8>,
-        response: oneshot::Sender<Result<(), WorldError>>,
+        response: CommandResponseSender<()>,
     },
-    GetWorldHead(
-        String,
-        oneshot::Sender<Result<Option<WorldHeadAnnounce>, WorldError>>,
-    ),
+    GetWorldHead(String, CommandResponseSender<Option<WorldHeadAnnounce>>),
     PutMembershipDirectory {
         key: String,
         payload: Vec<u8>,
-        response: oneshot::Sender<Result<(), WorldError>>,
+        response: CommandResponseSender<()>,
     },
     GetMembershipDirectory {
         key: String,
-        response: oneshot::Sender<Result<Option<MembershipDirectorySnapshot>, WorldError>>,
+        response: CommandResponseSender<Option<MembershipDirectorySnapshot>>,
     },
     PutPeerRecord {
         key: String,
         payload: Vec<u8>,
-        response: oneshot::Sender<Result<(), WorldError>>,
+        response: CommandResponseSender<()>,
     },
     GetPeerRecord {
         key: String,
-        response: oneshot::Sender<Result<Option<SignedPeerRecord>, WorldError>>,
+        response: CommandResponseSender<Option<SignedPeerRecord>>,
     },
     RefreshPeerDiscovery,
     RepublishProviders,

--- a/crates/oasis7_net/src/libp2p_net/tests.rs
+++ b/crates/oasis7_net/src/libp2p_net/tests.rs
@@ -10,7 +10,6 @@ use super::transport_paths::{
 };
 use super::utils::push_bounded_vec;
 use super::*;
-use futures::channel::oneshot;
 use libp2p::kad::RecordKey;
 use oasis7_proto::distributed_dht::{PeerDeploymentMode, PeerNodeRole};
 use oasis7_proto::distributed_net::DistributedNetwork as _;
@@ -68,7 +67,7 @@ fn wait_until(what: &str, deadline: Instant, mut condition: impl FnMut() -> bool
 
 #[test]
 fn dht_get_providers_collects_results() {
-    let (sender, receiver) = oneshot::channel();
+    let (sender, receiver) = std::sync::mpsc::channel();
     let mut pending = PendingDhtQuery::GetProviders {
         response: Some(sender),
         providers: HashSet::new(),
@@ -83,8 +82,9 @@ fn dht_get_providers_collects_results() {
     let result =
         kad::QueryResult::GetProviders(Ok(kad::GetProvidersOk::FoundProviders { key, providers }));
     handle_dht_progress(&mut pending, result, true);
-    let records = futures::executor::block_on(receiver)
-        .expect("oneshot")
+    let records = receiver
+        .recv()
+        .expect("command response")
         .expect("get providers");
     let actual: HashSet<String> = records
         .into_iter()
@@ -132,7 +132,7 @@ fn dht_get_world_head_decodes_record() {
         expires: None,
     };
     let peer_record = kad::PeerRecord { peer: None, record };
-    let (sender, receiver) = oneshot::channel();
+    let (sender, receiver) = std::sync::mpsc::channel();
     let mut pending = PendingDhtQuery::GetWorldHead {
         response: Some(sender),
         head: None,
@@ -140,8 +140,9 @@ fn dht_get_world_head_decodes_record() {
     };
     let result = kad::QueryResult::GetRecord(Ok(kad::GetRecordOk::FoundRecord(peer_record)));
     handle_dht_progress(&mut pending, result, true);
-    let loaded = futures::executor::block_on(receiver)
-        .expect("oneshot")
+    let loaded = receiver
+        .recv()
+        .expect("command response")
         .expect("get head");
     assert_eq!(loaded, Some(head));
 }
@@ -167,7 +168,7 @@ fn dht_get_membership_directory_decodes_record() {
         expires: None,
     };
     let peer_record = kad::PeerRecord { peer: None, record };
-    let (sender, receiver) = oneshot::channel();
+    let (sender, receiver) = std::sync::mpsc::channel();
     let mut pending = PendingDhtQuery::GetMembershipDirectory {
         response: Some(sender),
         snapshot: None,
@@ -176,8 +177,9 @@ fn dht_get_membership_directory_decodes_record() {
     let result = kad::QueryResult::GetRecord(Ok(kad::GetRecordOk::FoundRecord(peer_record)));
     handle_dht_progress(&mut pending, result, true);
 
-    let loaded = futures::executor::block_on(receiver)
-        .expect("oneshot")
+    let loaded = receiver
+        .recv()
+        .expect("command response")
         .expect("get membership");
     assert_eq!(loaded, Some(snapshot));
 }
@@ -216,7 +218,7 @@ fn dht_get_peer_record_decodes_and_verifies_record() {
         expires: None,
     };
     let peer_record = kad::PeerRecord { peer: None, record };
-    let (sender, receiver) = oneshot::channel();
+    let (sender, receiver) = std::sync::mpsc::channel();
     let mut pending = PendingDhtQuery::GetPeerRecord {
         response: Some(sender),
         record: None,
@@ -225,8 +227,9 @@ fn dht_get_peer_record_decodes_and_verifies_record() {
     let result = kad::QueryResult::GetRecord(Ok(kad::GetRecordOk::FoundRecord(peer_record)));
     handle_dht_progress(&mut pending, result, true);
 
-    let loaded = futures::executor::block_on(receiver)
-        .expect("oneshot")
+    let loaded = receiver
+        .recv()
+        .expect("command response")
         .expect("get peer record");
     assert_eq!(loaded, Some(signed));
 }
@@ -703,7 +706,7 @@ fn request_uses_swarm_connected_peers_when_snapshot_is_empty() {
 fn try_send_command_reports_queue_disconnect() {
     let (sender, receiver) = mpsc::channel(1);
     drop(receiver);
-    let (response, _response_rx) = oneshot::channel();
+    let (response, _response_rx) = std::sync::mpsc::channel();
     let err = try_send_command(
         &sender,
         Command::Subscribe {

--- a/crates/oasis7_net/src/libp2p_net/tests/subscribe_ack_tests.rs
+++ b/crates/oasis7_net/src/libp2p_net/tests/subscribe_ack_tests.rs
@@ -2,7 +2,6 @@ use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use futures::channel::oneshot;
 use futures::{FutureExt, StreamExt};
 use libp2p::swarm::SwarmEvent;
 use libp2p::{identity::Keypair, Multiaddr, PeerId};
@@ -45,7 +44,7 @@ fn handle_command_subscribe_acknowledges_success() {
     let rendezvous_cookies = HashMap::new();
     let mut peer_record_last_published_at_ms = None;
     let mut peer_discovery_query_last_started_at_ms = None;
-    let (sender, receiver) = oneshot::channel();
+    let (sender, receiver) = std::sync::mpsc::channel();
 
     let outcome = handle_command(
         &mut swarm,
@@ -92,8 +91,9 @@ fn handle_command_subscribe_acknowledges_success() {
     );
 
     assert!(matches!(outcome, CommandOutcome::Continue));
-    futures::executor::block_on(receiver)
-        .expect("oneshot")
+    receiver
+        .recv()
+        .expect("command response")
         .expect("subscribe ack");
     assert!(subscriptions.contains("aw.handle-command"));
     assert_eq!(topic_map.len(), 1);
@@ -186,7 +186,7 @@ fn handle_command_request_uses_swarm_connections_when_runtime_peers_are_empty() 
     let rendezvous_cookies = HashMap::new();
     let mut peer_record_last_published_at_ms = None;
     let mut peer_discovery_query_last_started_at_ms = None;
-    let (sender, mut receiver) = oneshot::channel();
+    let (sender, receiver) = std::sync::mpsc::channel();
 
     let outcome = handle_command(
         &mut dialer,
@@ -241,5 +241,8 @@ fn handle_command_request_uses_swarm_connections_when_runtime_peers_are_empty() 
         1,
         "request should be sent through swarm connection"
     );
-    assert!(receiver.try_recv().expect("response channel").is_none());
+    assert!(matches!(
+        receiver.try_recv(),
+        Err(std::sync::mpsc::TryRecvError::Empty)
+    ));
 }

--- a/crates/oasis7_net/src/libp2p_net/transport_retry_tests.rs
+++ b/crates/oasis7_net/src/libp2p_net/transport_retry_tests.rs
@@ -1,7 +1,6 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex};
 
-use futures::channel::oneshot;
 use libp2p::identity::Keypair;
 use libp2p::PeerId;
 use oasis7_proto::distributed_dht::{PeerDeploymentMode, PeerNodeRole, PeerRecord};
@@ -111,7 +110,7 @@ fn request_with_providers_does_not_fallback_outside_provider_subset() {
         true,
         super::wire_bytes::init_shared_wire_byte_counters(),
     );
-    let (sender, receiver) = oneshot::channel();
+    let (sender, receiver) = std::sync::mpsc::channel();
     let mut subscriptions = HashSet::new();
     let mut topic_map = HashMap::new();
     let mut topic_inbox_limits = HashMap::new();
@@ -185,7 +184,8 @@ fn request_with_providers_does_not_fallback_outside_provider_subset() {
     );
     assert!(matches!(outcome, super::CommandOutcome::Continue));
 
-    let err = futures::executor::block_on(receiver)
+    let err = receiver
+        .recv()
         .expect("request response")
         .expect_err("provider subset mismatch must fail");
     assert!(matches!(


### PR DESCRIPTION
## Summary
- replace libp2p command response futures oneshots with `std::sync::mpsc` senders
- make distributed network/DHT API waits use true synchronous `recv_timeout(30s)`
- update direct command/DHT response tests to use std mpsc receive semantics

## Live Root Cause
PR #442/testnet.58 deployed successfully to storage and observer, but the observer still stayed at `tick_count=1`, `worker_poll_count=1`, and `last_error=null`. A live gdb backtrace showed the node worker blocked in:

`Libp2pNetwork::request_to_peer -> futures_executor::local_pool::block_on -> Libp2pReplicationNetwork::request_via_peer -> request_fetch_commit_for_gap_sync_with_policy`

So the previous watchdog targeted the right command path, but `async_std::future::timeout(..., futures::channel::oneshot::Receiver)` did not wake the packaged synchronous worker. The liveness boundary needs to be synchronous end-to-end.

## Verification
After rebasing onto current `origin/main`:
- `env -u RUSTC_WRAPPER cargo fmt --check`
- `./scripts/check-rust-file-size.sh`
- `git diff --check`
- `env -u RUSTC_WRAPPER cargo test -p oasis7_net command_response_wait -- --nocapture`
- `env -u RUSTC_WRAPPER cargo test -p oasis7_node storage_replication_high_checkpoint_timeout -- --nocapture`
- `env -u RUSTC_WRAPPER cargo test -p oasis7_node storage_replication_high_checkpoint -- --nocapture`
- `./scripts/pm/workflow-lint.sh --phase pr-ready --task-uid task_96c772c830e043f9b1e40b03e6f73d38`

## Role Review
Pre-PR Local Role Review: passed.

- `runtime_engineer`: no findings. This directly addresses the packaged `request_to_peer` hang and preserves command/DHT error semantics.
- `qa_engineer`: no code findings. P2 branch-behind finding was addressed by rebasing and rerunning fresh gates.

## Deployment Follow-up
After merge, trigger Testnet Packages with `package_scope=all_existing`, then redeploy storage, observer/local Linux, and Windows from the same v2 package. Live smoke must verify observer `tick_count` advances past 1 and no unbounded `request_to_peer` hang remains.
