### PR TITLE
Compact testnet blob sync responses

### DIFF
--- a/crates/oasis7_node/src/replication_fetch.rs
+++ b/crates/oasis7_node/src/replication_fetch.rs
@@ -1,5 +1,5 @@
 use super::GossipReplicationMessage;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) struct FetchCommitRequest {
@@ -29,5 +29,69 @@ pub(crate) struct FetchBlobRequest {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) struct FetchBlobResponse {
     pub found: bool,
+    #[serde(
+        default,
+        deserialize_with = "deserialize_optional_hex_or_bytes",
+        serialize_with = "serialize_optional_hex_bytes"
+    )]
     pub blob: Option<Vec<u8>>,
+}
+
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum BlobBytesWire {
+    Hex(String),
+    Bytes(Vec<u8>),
+}
+
+fn serialize_optional_hex_bytes<S>(blob: &Option<Vec<u8>>, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    match blob {
+        Some(bytes) => serializer.serialize_some(&hex::encode(bytes)),
+        None => serializer.serialize_none(),
+    }
+}
+
+fn deserialize_optional_hex_or_bytes<'de, D>(deserializer: D) -> Result<Option<Vec<u8>>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let Some(wire) = Option::<BlobBytesWire>::deserialize(deserializer)? else {
+        return Ok(None);
+    };
+    match wire {
+        BlobBytesWire::Hex(value) => hex::decode(value)
+            .map(Some)
+            .map_err(serde::de::Error::custom),
+        BlobBytesWire::Bytes(bytes) => Ok(Some(bytes)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fetch_blob_response_serializes_blob_as_compact_hex_string() {
+        let response = FetchBlobResponse {
+            found: true,
+            blob: Some(vec![0, 1, 2, 254, 255]),
+        };
+
+        let encoded = serde_json::to_string(&response).expect("encode response");
+
+        assert!(encoded.contains("\"blob\":\"000102feff\""));
+        assert!(!encoded.contains("[0,1,2"));
+    }
+
+    #[test]
+    fn fetch_blob_response_accepts_legacy_json_byte_array() {
+        let decoded: FetchBlobResponse =
+            serde_json::from_str(r#"{"found":true,"blob":[0,1,2,254,255]}"#)
+                .expect("decode legacy response");
+
+        assert_eq!(decoded.blob, Some(vec![0, 1, 2, 254, 255]));
+    }
 }


### PR DESCRIPTION
## Summary
- serialize replication fetch-blob responses as compact hex strings instead of JSON byte arrays
- keep decoding compatibility with legacy JSON byte-array blob responses
- add focused wire-format tests

## Verification
- env -u RUSTC_WRAPPER cargo fmt --check
- env -u RUSTC_WRAPPER cargo test -p oasis7_node replication_fetch -- --nocapture
- env -u RUSTC_WRAPPER cargo test -p oasis7_node storage_replication_high_checkpoint -- --nocapture
- ./scripts/check-rust-file-size.sh
- git diff --check

## Live evidence
- v60 fixed the observer tick deadlock: observer advanced from tick_count=1 to tick_count=9 instead of hanging
- v60 still failed high-state sync with fetch-blob request_to_peer timeout
- storage blob files are about 3MB, but JSON Vec<u8> expands to a large numeric array before being wrapped in libp2p cbor response, which can exceed practical request-response limits; compact hex keeps the same blob under the existing response ceiling
