### PR TITLE
Fix testnet replication timeout budget

### DIFF
--- a/.pm/tasks/task_96c772c830e043f9b1e40b03e6f73d38.execution.md
+++ b/.pm/tasks/task_96c772c830e043f9b1e40b03e6f73d38.execution.md
@@ -273,3 +273,45 @@ Example:
 - Review Findings Disposition: addressed
 - Finding Disposition Evidence: branch rebased onto current `origin/main` and fresh gates/tests rerun successfully.
 - Residual Risk: live package/redeploy smoke must verify observer `tick_count` advances past 1, high-state sync either installs checkpoint or emits bounded retryable errors, and no repeated command timeout/pending growth appears.
+
+## 2026-06-13 19:58:00 CST / tpm
+- 完成内容: PR #445 fixed the permanent observer worker wedge by bounding libp2p replication `request_to_peer` waits with a short retry budget, and PR #446 compacted `FetchBlobResponse.blob` from JSON byte arrays to a hex string while keeping legacy byte-array decode compatibility. Both PRs merged and Testnet Packages run #61 produced Linux/macOS/Windows artifacts from merge commit `b5aaf1966625650b39d8572055f06ab16d287fca`.
+- 部署验证: Linux artifact `testnet-package-linux-x64-0.0.0+testnet.61.b5aaf1966625` passed SHA256 verification and was deployed to storage `39.104.205.67:/opt/oasis7/p2p-testnet` and observer `192.168.1.4:/opt/oasis7/p2p-testnet-local`. Storage restarted active. Observer restarted active and advanced from `tick_count=1` to `tick_count=3`, confirming it no longer wedges permanently.
+- 新线上证据: #61 observer still failed high-state sync with `last_error="node replication error: replication network route unavailable: libp2p-replication outbound request failed: NetworkProtocolUnavailable { protocol: \"libp2p command request_to_peer timed out after 3000ms\" }"`, while connected to storage and `network_height_lag=16715`. The first #445 request timeout was too small for real cross-host request/response startup plus large checkpoint/blob responses; it fixed liveness but caused false unavailability.
+- 设计结论: The replication layer needs two separate limits: a realistic per-peer request timeout for public-testnet checkpoint/blob responses, and a bounded overall retry budget to protect the runtime worker. A 3s per-peer timeout is too aggressive; the total budget must still cap every issued request by remaining budget so increasing the per-peer timeout cannot reintroduce long hangs.
+- 代码改动: In `crates/oasis7_node/src/libp2p_replication_network.rs`, raised default per-peer replication request timeout from 3s to 12s and total retry budget from 8s to 20s; `request_over_refreshed_peers` now computes remaining budget before every `request_to_peer` and passes `min(request_timeout, remaining_budget)`. Mirrored native defaults in `crates/oasis7_node/src/libp2p_replication_network_wasm.rs`.
+- 回归测试: Added `libp2p_replication_network_caps_peer_request_by_remaining_budget`, using two real loopback libp2p replication nodes and a slow handler to prove a 5s configured per-request timeout is capped by a 250ms total retry budget and returns `request budget exhausted` instead of blocking for the full per-request timeout.
+- Validation Command: env -u RUSTC_WRAPPER cargo fmt --check
+- Actual Result: passed.
+- Validation Command: env -u RUSTC_WRAPPER cargo test -p oasis7_node libp2p_replication_network -- --nocapture
+- Actual Result: passed; 32 tests passed.
+- Validation Command: env -u RUSTC_WRAPPER cargo test -p oasis7_node storage_replication_high_checkpoint -- --nocapture
+- Actual Result: passed; 15 tests passed.
+- Validation Command: env -u RUSTC_WRAPPER cargo test -p oasis7_node replication_fetch -- --nocapture
+- Actual Result: passed; 3 tests passed.
+- Validation Command: ./scripts/check-rust-file-size.sh
+- Actual Result: passed; oversized code files=0, test files=0.
+- Validation Command: git diff --check
+- Actual Result: passed.
+- Review Trigger: #61 live deploy still reports 3000ms request_to_peer timeout; replication timeout budget pre-PR local role review.
+- Review Roles: runtime_engineer, blockchain_ops_engineer
+- Review Question: confirm whether raising the replication per-peer timeout while clipping every request by remaining retry budget is the correct design fix for public-testnet high-state checkpoint/blob sync, without reintroducing worker wedging or unbounded peer retries.
+- Expected Return Contract: findings | no_findings | residual_risk
+- Formal Sink: `.pm/tasks/task_96c772c830e043f9b1e40b03e6f73d38.execution.md`
+- Blocker / Next Action: integrate role review results, run workflow lint, commit, push PR, use CI package, then redeploy storage/observer/Windows.
+
+## 2026-06-13 20:07:00 CST / tpm
+- runtime_engineer/blockchain_ops_engineer: no_findings. The review confirmed `request_over_refreshed_peers` clips each peer request by remaining retry budget before calling `request_to_peer`, so the default request window remains bounded by `request_retry_budget=20s` and does not reintroduce the earlier worker wedge. The 12s per-peer timeout plus #446 compact blob wire format is a reasonable public-testnet recovery setting for 3MB checkpoint/blob responses.
+- Review semantic notes: peer retry/cooldown behavior remains acceptable. Timeout/connection gaps still enter transport cooldown, multiple peers avoid recently bad peers, single-peer testnet can still retry as last resort, and protocol cooldown remains scoped to missing handler / fetch-commit not found rather than treating fetch-blob timeout as unsupported protocol.
+- residual_risk: `wait_for_connected_peers` / provider wait can add about 1.8s outside the 20s request budget; very weak public network or high storage CPU can still cause occasional timeout; current regression covers remaining-budget clipping but not a full multi-peer large-blob soak.
+- recommended_verification: run focused/native replication network tests before PR and, after package deploy, observe observer for at least 2-3 ticks, confirm `tick_count` continues advancing, `last_error` no longer stabilizes on `request_to_peer timed out after 3000ms`, and height or replication persisted height starts catching up.
+- Pre-PR Local Role Review: passed
+- Task UID: task_96c772c830e043f9b1e40b03e6f73d38
+- Source Worktree: /Users/scc/ccwork/worktrees/oasis7-testnet-high-state-peer-retry
+- Source Branch: codex/testnet-replication-timeout-budget
+- Comparison Ref: refs/remotes/origin/main
+- Reviewed Changed Paths: `crates/oasis7_node/src/libp2p_replication_network.rs`; `crates/oasis7_node/src/libp2p_replication_network_wasm.rs`; `crates/oasis7_node/src/libp2p_replication_network/tests.rs`
+- Review Roles: runtime_engineer, blockchain_ops_engineer
+- Review Evidence: bounded role review returned no_findings and residual risks recorded above.
+- Review Findings Disposition: no_findings
+- Residual Risk: live CI package/redeploy smoke remains required for Linux storage, local observer, and reachable Windows host.

--- a/crates/oasis7_node/src/libp2p_replication_network.rs
+++ b/crates/oasis7_node/src/libp2p_replication_network.rs
@@ -61,8 +61,8 @@ const REQUEST_PEER_TRANSPORT_PENALTY: u8 = 20;
 const REQUEST_PEER_PROTOCOL_PENALTY: u8 = 30;
 const REQUEST_PEER_GENERIC_PENALTY: u8 = 10;
 const REQUEST_PEER_SUCCESS_RECOVERY: u8 = 5;
-const REQUEST_TO_PEER_TIMEOUT_MS: u64 = 3_000;
-const REQUEST_RETRY_BUDGET_MS: u64 = 8_000;
+const REQUEST_TO_PEER_TIMEOUT_MS: u64 = 12_000;
+const REQUEST_RETRY_BUDGET_MS: u64 = 20_000;
 
 #[derive(Debug, Clone)]
 struct RequestPeerScore {
@@ -293,10 +293,11 @@ impl Libp2pReplicationNetwork {
         protocol: &str,
         payload: &[u8],
         peer: PeerId,
+        timeout: Duration,
     ) -> Result<Vec<u8>, WorldError> {
         let response = self
             .inner
-            .request_to_peer_with_timeout(protocol, payload, peer, self.request_timeout)
+            .request_to_peer_with_timeout(protocol, payload, peer, timeout)
             .map_err(|err| WorldError::NetworkProtocolUnavailable {
                 protocol: format!("libp2p-replication outbound request failed: {err:?}"),
             })?;
@@ -526,7 +527,17 @@ impl Libp2pReplicationNetwork {
             let mut retryable_connection_gap = false;
             for peer in ordered_peers {
                 attempted_peers.insert(peer);
-                match self.request_via_peer(protocol, payload, peer) {
+                let elapsed = started_at.elapsed();
+                if elapsed >= self.request_retry_budget {
+                    return Err(replication_request_budget_exhausted(
+                        protocol,
+                        self.request_retry_budget,
+                        last_error,
+                    ));
+                }
+                let remaining_budget = self.request_retry_budget.saturating_sub(elapsed);
+                let request_timeout = self.request_timeout.min(remaining_budget);
+                match self.request_via_peer(protocol, payload, peer, request_timeout) {
                     Ok(reply) => {
                         self.mark_peer_request_success(peer);
                         return Ok(reply);

--- a/crates/oasis7_node/src/libp2p_replication_network/tests.rs
+++ b/crates/oasis7_node/src/libp2p_replication_network/tests.rs
@@ -947,6 +947,58 @@ fn libp2p_replication_network_connection_gap_on_ping_enters_short_cooldown() {
 }
 
 #[test]
+fn libp2p_replication_network_caps_peer_request_by_remaining_budget() {
+    let listener = Libp2pReplicationNetwork::new(Libp2pReplicationNetworkConfig {
+        listen_addrs: vec!["/ip4/127.0.0.1/tcp/0".parse().expect("listener addr")],
+        peer_record: Some(test_peer_record("listener-slow-handler")),
+        ..Libp2pReplicationNetworkConfig::default()
+    });
+    let listen_deadline = Instant::now() + Duration::from_secs(10);
+    wait_until("listener bind", listen_deadline, || {
+        !listener.listening_addrs().is_empty()
+    });
+
+    listener
+        .register_handler(
+            "/aw/node/replication/slow",
+            Box::new(|_payload| {
+                std::thread::sleep(Duration::from_millis(1_500));
+                Ok(b"late".to_vec())
+            }),
+        )
+        .expect("register listener handler");
+
+    let dialer = Libp2pReplicationNetwork::new(Libp2pReplicationNetworkConfig {
+        listen_addrs: vec!["/ip4/127.0.0.1/tcp/0".parse().expect("dialer addr")],
+        bootstrap_peers: vec![listening_addr_with_peer_id(&listener)],
+        request_timeout: Duration::from_secs(5),
+        request_retry_budget: Duration::from_millis(250),
+        ..Libp2pReplicationNetworkConfig::default()
+    });
+    let connect_deadline = Instant::now() + Duration::from_secs(10);
+    wait_until("dialer connection", connect_deadline, || {
+        !dialer.connected_peers().is_empty()
+    });
+
+    let started_at = Instant::now();
+    let result = dialer.request("/aw/node/replication/slow", b"node");
+    let elapsed = started_at.elapsed();
+    match result {
+        Err(WorldError::NetworkProtocolUnavailable { protocol }) => {
+            assert!(
+                protocol.contains("request budget exhausted") && protocol.contains("budget_ms=250"),
+                "unexpected protocol error: {protocol}"
+            );
+        }
+        other => panic!("expected request budget exhaustion, got {other:?}"),
+    }
+    assert!(
+        elapsed < Duration::from_millis(1_000),
+        "request should be capped by the retry budget, elapsed={elapsed:?}"
+    );
+}
+
+#[test]
 fn retryable_connection_gap_detection_matches_request_to_peer_disconnects() {
     let err = WorldError::NetworkProtocolUnavailable {
         protocol: "libp2p-replication outbound request failed: NetworkProtocolUnavailable { protocol: \"peer 12D3KooW... is not connected for protocol /aw/node/replication/fetch-commit/1.0.0\" }".to_string(),

--- a/crates/oasis7_node/src/libp2p_replication_network_wasm.rs
+++ b/crates/oasis7_node/src/libp2p_replication_network_wasm.rs
@@ -8,8 +8,8 @@ use oasis7_proto::distributed_net::{DistributedNetwork, NetworkSubscription};
 use oasis7_proto::world_error::WorldError;
 
 const PROTOCOL_RETRY_COOLDOWN_AFTER_MS: u64 = 5_000;
-const REQUEST_TO_PEER_TIMEOUT_MS: u64 = 3_000;
-const REQUEST_RETRY_BUDGET_MS: u64 = 8_000;
+const REQUEST_TO_PEER_TIMEOUT_MS: u64 = 12_000;
+const REQUEST_RETRY_BUDGET_MS: u64 = 20_000;
 
 // wasm32 target intentionally does not ship a full-node networking stack.
 // This stub exists only to keep API shape stable for compile-time compatibility.


### PR DESCRIPTION
## Summary
- Raise libp2p replication per-peer request timeout from 3s to 12s for public-testnet checkpoint/blob responses.
- Keep runtime liveness bounded by clipping every peer request to the remaining 20s retry budget.
- Mirror native timeout defaults in the wasm compatibility stub.
- Add loopback libp2p regression coverage proving a long per-request timeout is capped by the total retry budget.

## Live Evidence
- Testnet Packages #61 (`b5aaf1966625650b39d8572055f06ab16d287fca`) fixed the permanent observer tick wedge, but 192.168.1.4 still failed high-state sync with `libp2p command request_to_peer timed out after 3000ms`.
- Storage and observer were connected, and storage had large retained checkpoint blobs; the 3s request timeout is too aggressive for real cross-host checkpoint/blob fetch after the compact blob wire fix.

## Verification
- `env -u RUSTC_WRAPPER cargo fmt --check`
- `env -u RUSTC_WRAPPER cargo test -p oasis7_node libp2p_replication_network -- --nocapture`
- `env -u RUSTC_WRAPPER cargo test -p oasis7_node storage_replication_high_checkpoint -- --nocapture`
- `env -u RUSTC_WRAPPER cargo test -p oasis7_node replication_fetch -- --nocapture`
- `./scripts/check-rust-file-size.sh`
- `git diff --check`
- `./scripts/pm/workflow-lint.sh --phase pr-ready --task-uid task_96c772c830e043f9b1e40b03e6f73d38`

## Deployment Follow-Up
After merge/package, redeploy storage and observer from the new CI artifact, then verify observer `tick_count` continues advancing and high-state sync no longer stabilizes on the 3000ms request timeout.
