### PR TITLE
Add testnet request failure diagnostics

### DIFF
--- a/.pm/tasks/task_96c772c830e043f9b1e40b03e6f73d38.execution.md
+++ b/.pm/tasks/task_96c772c830e043f9b1e40b03e6f73d38.execution.md
@@ -315,3 +315,47 @@ Example:
 - Review Evidence: bounded role review returned no_findings and residual risks recorded above.
 - Review Findings Disposition: no_findings
 - Residual Risk: live CI package/redeploy smoke remains required for Linux storage, local observer, and reachable Windows host.
+
+## 2026-06-13 20:24:00 CST / tpm
+- 完成内容: PR #447 merged as `30b2f7a606cfadff462f959696e8d7f2aff3aa6b`; Testnet Packages run #62 (`27465999218`) succeeded for Linux/macOS/Windows. Linux artifact `testnet-package-linux-x64-0.0.0+testnet.62.30b2f7a606cf` was SHA256-verified and deployed to storage `39.104.205.67` and observer `192.168.1.4`.
+- 部署验证: #62 confirmed the liveness guard remains effective: observer advanced from `tick_count=1` to `tick_count=6` and worker did not wedge. However, high-state sync still did not complete. Initial observer errors moved from `no connected peers` during startup to `libp2p command request_to_peer timed out after 12000ms` once the storage peer became active. Storage also reported matching `request_to_peer timed out after 12000ms`.
+- 新线上证据: observer traffic metrics show request/response activity for `/aw/node/replication/fetch-commit/head/1.0.0`, `/aw/node/replication/fetch-commit/1.0.0`, and `/aw/node/replication/fetch-blob/1.0.0`, plus `request_response.outbound_failure` events. The current error path loses the application protocol and peer when the local command watchdog fires and does not write pending outbound failures into `recent_errors`, leaving the next root cause opaque.
+- 设计结论: Before the next deployment can accurately distinguish fetch-head, fetch-commit, fetch-blob, response-size, remote handler, or request-response transport failures, libp2p request failure telemetry must preserve `protocol`, `peer`, and concrete libp2p failure in both returned errors and `debug_errors`.
+- 代码改动: `request_to_peer_with_timeout` and generic `request_with_providers` now include application protocol and peer/providers in the command wait operation string. Request-response `OutboundFailure` now writes `libp2p request failed protocol=... peer=... error=...` to recent errors and returns the same context through the pending response. `InboundFailure` is also written to recent errors instead of only stderr.
+- Validation Command: env -u RUSTC_WRAPPER cargo fmt --check
+- Actual Result: passed.
+- Validation Command: env -u RUSTC_WRAPPER cargo test -p oasis7_net command_response_wait -- --nocapture
+- Actual Result: passed; 2 tests passed.
+- Validation Command: env -u RUSTC_WRAPPER cargo test -p oasis7_node libp2p_replication_network_caps_peer_request_by_remaining_budget -- --nocapture
+- Actual Result: passed; 1 test passed.
+- Validation Command: git diff --check
+- Actual Result: passed.
+- Review Trigger: #62 live deploy still opaque request_to_peer timeout; request failure diagnostics pre-PR local role review.
+- Review Roles: runtime_engineer, blockchain_ops_engineer, qa_engineer
+- Review Question: confirm whether preserving protocol/peer/error in request_to_peer watchdog and request-response failures is a safe diagnostic hardening step for the public testnet sync root-cause loop, without changing request semantics.
+- Expected Return Contract: findings | no_findings | residual_risk
+- Formal Sink: `.pm/tasks/task_96c772c830e043f9b1e40b03e6f73d38.execution.md`
+- Blocker / Next Action: run review, workflow lint, PR, CI package, deploy diagnostic build, then use protocol-level errors to finish root fix.
+
+## 2026-06-13 20:35:00 CST / tpm
+- runtime_engineer/blockchain_ops_engineer/qa_engineer finding: P1. The first diagnostic error string `libp2p request failed protocol=... peer=... error=Timeout` would have dropped the existing `request failed: Timeout` substring used by retryable availability-gap classification, potentially changing peer scoring/cooldown semantics.
+- Finding Disposition: addressed. `fail_pending_request` now emits `request failed: {error:?} protocol=... peer=...`, preserving the legacy retryable substring while adding protocol/peer context.
+- Finding Disposition Evidence: added `network_protocol_unavailable_request_failure_with_context_stays_retryable`, proving the contextual request failure is still classified as `RetryableGap`, maps to `ErrNotAvailable`, and remains retryable.
+- Review residual_risk: this diagnostic PR does not fix the underlying timeout; the next package deployment must use the new protocol/peer/error context in `recent_errors` and returned `last_error` to finish root-cause isolation.
+- Validation Command: env -u RUSTC_WRAPPER cargo test -p oasis7_net command_response_wait -- --nocapture
+- Actual Result: passed; 2 tests passed.
+- Validation Command: env -u RUSTC_WRAPPER cargo test -p oasis7_net network_protocol_unavailable_request_failure_with_context_stays_retryable -- --nocapture
+- Actual Result: passed; 1 test passed.
+- Validation Command: env -u RUSTC_WRAPPER cargo test -p oasis7_node libp2p_replication_network -- --nocapture
+- Actual Result: passed; 32 tests passed.
+- Validation Command: env -u RUSTC_WRAPPER cargo fmt --check && ./scripts/check-rust-file-size.sh && git diff --check && ./scripts/pm/workflow-lint.sh --phase pr-ready --task-uid task_96c772c830e043f9b1e40b03e6f73d38
+- Actual Result: passed.
+- Pre-PR Local Role Review: passed
+- Task UID: task_96c772c830e043f9b1e40b03e6f73d38
+- Source Worktree: /Users/scc/ccwork/worktrees/oasis7-testnet-high-state-peer-retry
+- Source Branch: codex/testnet-request-failure-diagnostics
+- Comparison Ref: refs/remotes/origin/main
+- Reviewed Changed Paths: `crates/oasis7_net/src/libp2p_net.rs`; `crates/oasis7_net/src/libp2p_net/api.rs`; `crates/oasis7_net/src/libp2p_net/runtime_loop.rs`; `crates/oasis7_net/src/libp2p_net/error_mapping.rs`; `crates/oasis7_net/src/libp2p_net/utils.rs`; `.pm/tasks/task_96c772c830e043f9b1e40b03e6f73d38.execution.md`
+- Review Roles: runtime_engineer, blockchain_ops_engineer, qa_engineer
+- Review Findings Disposition: addressed
+- Residual Risk: live diagnostic package/redeploy still required before final root fix.

--- a/crates/oasis7_net/src/libp2p_net.rs
+++ b/crates/oasis7_net/src/libp2p_net.rs
@@ -83,7 +83,8 @@ use runtime_loop::{
     filter_request_peers_by_health, filter_request_peers_by_lane,
 };
 use runtime_loop::{
-    handle_command, Command, CommandContext, CommandOutcome, CommandStateRefs, PendingResponse,
+    fail_pending_request, handle_command, Command, CommandContext, CommandOutcome,
+    CommandStateRefs, PendingResponse,
 };
 use swarm_behaviour::{build_swarm, dial_addr_with_optional_peer_id, Behaviour, BehaviourEvent};
 use swarm_reachability_events::{
@@ -451,7 +452,7 @@ impl Libp2pNetwork {
                                                 }
                                             }
                                         }
-                                        request_response::Event::OutboundFailure { request_id, error, .. } => {
+                                        request_response::Event::OutboundFailure { request_id, peer, error, .. } => {
                                             if let Some(kind) = pending_peer_record_requests.remove(&request_id) {
                                                 clear_pending_peer_record_request(
                                                     &kind,
@@ -466,17 +467,15 @@ impl Libp2pNetwork {
                                                     "lock errors",
                                                 );
                                             } else if let Some(sender) = pending.remove(&request_id) {
-                                                let _ = sender.response.send(Err(WorldError::NetworkProtocolUnavailable { protocol: format!("request failed: {error:?}") }));
+                                                fail_pending_request(sender, peer, error, &event_errors, max_error_messages);
                                             }
                                         }
                                         request_response::Event::InboundFailure { peer, error, .. } => {
-                                            let stderr_message = format!(
-                                                "libp2p inbound failure from {peer:?}: {error:?}"
-                                            );
-                                            utils::emit_stderr_or_event(
-                                                tracing::Level::WARN,
-                                                stderr_message.as_str(),
-                                                "libp2p inbound failure",
+                                            push_bounded_clone(
+                                                &event_errors,
+                                                format!("libp2p inbound failure from {peer:?}: {error:?}"),
+                                                max_error_messages,
+                                                "lock errors",
                                             );
                                         }
                                         request_response::Event::ResponseSent { .. } => {}

--- a/crates/oasis7_net/src/libp2p_net/api.rs
+++ b/crates/oasis7_net/src/libp2p_net/api.rs
@@ -98,7 +98,8 @@ impl Libp2pNetwork {
             peer,
             response: sender,
         })?;
-        block_on_command_response_with_timeout(receiver, "request_to_peer", timeout)
+        let operation = format!("request_to_peer protocol={protocol} peer={peer}");
+        block_on_command_response_with_timeout(receiver, operation.as_str(), timeout)
     }
 
     pub fn debug_peer_healths(&self) -> Vec<PeerManagerPeerHealth> {
@@ -289,7 +290,15 @@ impl ProtoDistributedNetwork<WorldError> for Libp2pNetwork {
             providers: providers.to_vec(),
             response: sender,
         })?;
-        block_on_command_response(receiver, "request")
+        let operation = if providers.is_empty() {
+            format!("request protocol={protocol}")
+        } else {
+            format!(
+                "request protocol={protocol} providers={}",
+                providers.join(",")
+            )
+        };
+        block_on_command_response(receiver, operation.as_str())
     }
 
     fn register_handler(
@@ -440,13 +449,19 @@ mod command_response_tests {
     fn command_response_wait_times_out_when_runtime_does_not_reply() {
         let (_sender, receiver) = mpsc::channel::<Result<(), WorldError>>();
 
-        let err =
-            block_on_command_response_with_timeout(receiver, "request", Duration::from_millis(1))
-                .expect_err("missing runtime response should time out");
+        let err = block_on_command_response_with_timeout(
+            receiver,
+            "request_to_peer protocol=/aw/node/replication/fetch-commit/1.0.0 peer=12D3KooWTest",
+            Duration::from_millis(1),
+        )
+        .expect_err("missing runtime response should time out");
 
         match err {
             WorldError::NetworkProtocolUnavailable { protocol } => {
-                assert!(protocol.contains("libp2p command request timed out"));
+                assert!(protocol.contains("libp2p command request_to_peer"));
+                assert!(protocol.contains("/aw/node/replication/fetch-commit/1.0.0"));
+                assert!(protocol.contains("peer=12D3KooWTest"));
+                assert!(protocol.contains("timed out"));
             }
             other => panic!("expected NetworkProtocolUnavailable, got {other:?}"),
         }

--- a/crates/oasis7_net/src/libp2p_net/error_mapping.rs
+++ b/crates/oasis7_net/src/libp2p_net/error_mapping.rs
@@ -193,6 +193,22 @@ mod tests {
     }
 
     #[test]
+    fn network_protocol_unavailable_request_failure_with_context_stays_retryable() {
+        let err = WorldError::NetworkProtocolUnavailable {
+            protocol: "request failed: Timeout protocol=/aw/node/replication/fetch-blob/1.0.0 peer=12D3KooWTest".to_string(),
+        };
+        assert_eq!(
+            classify_world_error_availability(&err),
+            Libp2pAvailabilityClass::RetryableGap
+        );
+        assert!(world_error_is_retryable_connection_gap(&err));
+
+        let response = error_response_from_world_error(&err);
+        assert_eq!(response.code, DistributedErrorCode::ErrNotAvailable);
+        assert!(response.retryable);
+    }
+
+    #[test]
     fn network_protocol_unavailable_no_admissible_peers_maps_to_not_available() {
         let response = error_response_from_world_error(&WorldError::NetworkProtocolUnavailable {
             protocol:

--- a/crates/oasis7_net/src/libp2p_net/runtime_loop.rs
+++ b/crates/oasis7_net/src/libp2p_net/runtime_loop.rs
@@ -36,6 +36,28 @@ pub(super) struct PendingResponse {
     pub response: CommandResponseSender<Vec<u8>>,
 }
 
+pub(super) fn fail_pending_request(
+    pending_response: PendingResponse,
+    peer: PeerId,
+    error: request_response::OutboundFailure,
+    event_errors: &Arc<Mutex<Vec<String>>>,
+    max_error_messages: usize,
+) {
+    let protocol = pending_response.protocol;
+    let message = format!("request failed: {error:?} protocol={protocol} peer={peer}");
+    push_bounded_clone(
+        event_errors,
+        message.clone(),
+        max_error_messages,
+        "lock errors",
+    );
+    let _ = pending_response
+        .response
+        .send(Err(WorldError::NetworkProtocolUnavailable {
+            protocol: message,
+        }));
+}
+
 pub(super) struct CommandContext<'a> {
     pub event_published: &'a Arc<Mutex<Vec<NetworkMessage>>>,
     pub event_errors: &'a Arc<Mutex<Vec<String>>>,

--- a/crates/oasis7_net/src/libp2p_net/utils.rs
+++ b/crates/oasis7_net/src/libp2p_net/utils.rs
@@ -2,7 +2,6 @@ use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
 use futures::channel::mpsc;
-use tracing::Level;
 
 use crate::error::WorldError;
 use crate::util::unix_now_ms_i64;
@@ -51,20 +50,6 @@ pub(super) fn push_bounded_clone<T: Clone>(
 ) {
     let mut guard = values.lock().expect(lock_label);
     push_bounded_vec(&mut guard, value, max_len);
-}
-
-pub(super) fn emit_stderr_or_event(level: Level, stderr_message: &str, event_message: &str) {
-    if tracing::dispatcher::has_been_set() {
-        match level {
-            Level::ERROR => tracing::error!(message = %stderr_message, "{event_message}"),
-            Level::WARN => tracing::warn!(message = %stderr_message, "{event_message}"),
-            Level::INFO => tracing::info!(message = %stderr_message, "{event_message}"),
-            Level::DEBUG => tracing::debug!(message = %stderr_message, "{event_message}"),
-            Level::TRACE => tracing::trace!(message = %stderr_message, "{event_message}"),
-        }
-    } else {
-        eprintln!("{stderr_message}");
-    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- Preserve app protocol and peer/provider context in libp2p request command watchdog errors.
- Return and record request-response `OutboundFailure` with protocol, peer, and concrete libp2p failure.
- Record inbound request-response failures in `recent_errors`.
- Keep retry/cooldown semantics by preserving the legacy `request failed: Timeout` style substring and adding a classification regression.

## Live Evidence
- Testnet Packages #62 fixed the observer worker wedge and expanded request timeout to 12s, but live storage/observer still report opaque `request_to_peer timed out after 12000ms`.
- Traffic metrics show fetch-head, fetch-commit, and fetch-blob request/response activity plus `request_response.outbound_failure`; the current error text loses the application protocol and peer needed to finish root-cause isolation.

## Verification
- `env -u RUSTC_WRAPPER cargo fmt --check`
- `env -u RUSTC_WRAPPER cargo test -p oasis7_net command_response_wait -- --nocapture`
- `env -u RUSTC_WRAPPER cargo test -p oasis7_net network_protocol_unavailable_request_failure_with_context_stays_retryable -- --nocapture`
- `env -u RUSTC_WRAPPER cargo test -p oasis7_node libp2p_replication_network -- --nocapture`
- `./scripts/check-rust-file-size.sh`
- `git diff --check`
- `./scripts/pm/workflow-lint.sh --phase pr-ready --task-uid task_96c772c830e043f9b1e40b03e6f73d38`

## Deployment Follow-Up
After package/deploy, inspect observer/storage `last_error` and `replication.recent_errors` for `protocol=/aw/node/replication/... peer=... error=...` and use that to finish the underlying sync fix.
