### PR TITLE
Chunk testnet blob fetch transfers

### DIFF
--- a/.pm/tasks/task_96c772c830e043f9b1e40b03e6f73d38.execution.md
+++ b/.pm/tasks/task_96c772c830e043f9b1e40b03e6f73d38.execution.md
@@ -359,3 +359,69 @@ Example:
 - Review Roles: runtime_engineer, blockchain_ops_engineer, qa_engineer
 - Review Findings Disposition: addressed
 - Residual Risk: live diagnostic package/redeploy still required before final root fix.
+
+## 2026-06-13 21:34:04 CST / tpm
+- 完成内容: PR #448 merged as `85b6ce63649f2164b1a8b97f7752cda6d556b7e9`; Testnet Packages run #63 (`27466860424`) produced Linux diagnostic artifact `testnet-package-linux-x64-0.0.0+testnet.63.85b6ce63649f`. Linux artifact passed SHA256 verification and was deployed to storage `39.104.205.67:/opt/oasis7/p2p-testnet` and observer `192.168.1.4:/opt/oasis7/p2p-testnet-local`.
+- 部署验证: #63 confirmed the worker remains live and diagnostic context is now useful. Observer connected to storage peer `12D3KooWAuNCCEDu7CdUUDwALuAhuLekZHgVWxAYp4Ag5ti79fJj`; storage connected to observer peer `12D3KooWNphsGixZxpqmZf9RSVhCWHH7hWFYZBN8izmWfXQYAXTQ`. Traffic metrics showed `/aw/node/replication/fetch-commit/head/1.0.0`, `/fetch-commit/1.0.0`, and `/fetch-blob/1.0.0` activity.
+- 新线上证据: observer `recent_errors` now reports `request failed: Io(Custom { kind: UnexpectedEof, error: Eof { name: "u8", expect: Small(1) } }) protocol=/aw/node/replication/fetch-blob/1.0.0 peer=12D3KooWAuNCCEDu7CdUUDwALuAhuLekZHgVWxAYp4Ag5ti79fJj` followed by `request failed: Timeout protocol=/aw/node/replication/fetch-blob/1.0.0 peer=...`. Storage reported outbound `/fetch-blob` responses totalling about 136MB application payload and about 23MB substream wire, plus inbound request-response timeouts.
+- 设计结论: #63 rules out seed/state-sync/deploy-startup as the primary failure: nodes start, connect, and auto-discover peers; head/commit protocols run. The remaining root cause is large fetch-blob transfer budget. The previous 12s replication request budget is reasonable for head/commit but too short for checkpoint/state blobs; the underlying `libp2p::request_response::Config::default()` also had a 10s timeout, so even after the outer watchdog was raised, libp2p could close the substream mid-response and make the observer decode a partial CBOR response as EOF.
+- 代码改动: `crates/oasis7_net/src/libp2p_net/config.rs` now exposes `request_response_timeout` with a 30s default; `swarm_behaviour.rs` applies it via `request_response::Config::with_request_timeout`. `crates/oasis7_node/src/libp2p_replication_network.rs` gives `/fetch-blob/` a dedicated 120s per-peer timeout and 180s retry budget while preserving 12s/20s for non-blob protocols, and initializes the underlying libp2p request-response timeout to the largest replication retry budget. WASM stub config was kept API-compatible.
+- 回归测试: Added tests proving fetch-blob uses the long transfer budget and fetch-commit/non-blob protocols retain the short budget. Existing libp2p and high-checkpoint tests cover command response behavior and high-state catch-up path.
+- Validation Command: env -u RUSTC_WRAPPER cargo fmt --check
+- Actual Result: passed.
+- Validation Command: env -u RUSTC_WRAPPER cargo test -p oasis7_net libp2p_net -- --nocapture
+- Actual Result: passed; 102 tests passed.
+- Validation Command: env -u RUSTC_WRAPPER cargo test -p oasis7_node libp2p_replication_network -- --nocapture
+- Actual Result: passed; 34 tests passed.
+- Validation Command: env -u RUSTC_WRAPPER cargo test -p oasis7_node storage_replication_high_checkpoint -- --nocapture
+- Actual Result: passed; 15 tests passed.
+- Validation Command: ./scripts/check-rust-file-size.sh
+- Actual Result: passed; oversized code files=0, test files=0.
+- Validation Command: git diff --check
+- Actual Result: passed.
+- Review Trigger: #63 live deploy localized high-state sync failure to large `/fetch-blob` EOF/timeout; request-response and replication protocol budget root fix pre-PR local role review.
+- Review Roles: runtime_engineer, blockchain_ops_engineer, qa_engineer
+- Review Question: confirm whether making libp2p request-response timeout configurable and giving fetch-blob a dedicated long transfer budget fixes the live high-state auto-sync failure without reopening the earlier worker-wedge class or changing non-blob protocol retry behavior.
+- Expected Return Contract: findings | no_findings | residual_risk
+- Formal Sink: `.pm/tasks/task_96c772c830e043f9b1e40b03e6f73d38.execution.md`
+- Blocker / Next Action: integrate role review results, finish workflow lint, commit, push PR, use CI package, deploy Linux and Windows once artifacts are available.
+
+## 2026-06-13 22:02:00 CST / tpm
+- Review finding: runtime_engineer/blockchain_ops_engineer/qa_engineer P2. The first implementation raised the underlying libp2p request-response timeout to `max(request_retry_budget, fetch_blob_request_retry_budget)`, which would keep all app protocols, including fetch-head/fetch-commit, alive in the lower libp2p behaviour for up to the 180s blob budget after the adapter returned at the shorter non-blob timeout.
+- Finding Disposition: addressed by changing the design from "single huge blob response under a huge global timeout" to chunked fetch-blob transfer. `FetchBlobRequest` now accepts optional `offset_bytes` and `limit_bytes`; the fetch-blob handler slices the blob response; `request_fetch_blob_with_route_fallback` requests and assembles 2MiB chunks while preserving provider/generic route fallback. The native replication adapter keeps non-blob protocols at 12s/20s and uses 30s per fetch-blob chunk with a 180s total blob retry budget. The underlying libp2p request-response timeout is now `max(request_retry_budget, fetch_blob_request_timeout)`, so non-blob lower-layer retention is bounded by the 30s chunk timeout instead of the 180s total blob budget.
+- Compatibility notes: unsigned range fields do not broaden blob access because authorization still gates on the signed content hash/requester identity; old un-ranged requests still receive the full blob; legacy full-blob peers are accepted when the first ranged response returns more than the chunk size.
+- Validation Command: env -u RUSTC_WRAPPER cargo test -p oasis7_node fetch_blob_response_slice_honors_offset_and_limit -- --nocapture
+- Actual Result: passed; 1 test passed.
+- Validation Command: env -u RUSTC_WRAPPER cargo test -p oasis7_node libp2p_replication_network -- --nocapture --test-threads=1
+- Actual Result: passed; 34 tests passed. A prior parallel run showed one cooldown timing flake, and the exact failed test passed when rerun alone.
+- Validation Command: env -u RUSTC_WRAPPER cargo test -p oasis7_net libp2p_net -- --nocapture
+- Actual Result: passed; 102 tests passed.
+- Validation Command: env -u RUSTC_WRAPPER cargo test -p oasis7_node storage_replication_high_checkpoint -- --nocapture
+- Actual Result: passed; 15 tests passed.
+- Validation Command: env -u RUSTC_WRAPPER cargo fmt --check
+- Actual Result: passed.
+- Validation Command: git diff --check && ./scripts/check-rust-file-size.sh
+- Actual Result: passed; oversized code files=0, test files=0.
+- Validation Command: ./scripts/pm/workflow-lint.sh --phase pr-ready --task-uid task_96c772c830e043f9b1e40b03e6f73d38
+- Actual Result: passed.
+- Validation Command: ./scripts/pm/workflow-behavior-eval.sh
+- Actual Result: passed.
+- Review Recheck: requested from the same repo-owned review slice after the P2 fix.
+- Review Recheck Result: no_findings after the P1 follow-up. The review confirmed the P2 was closed by bounding underlying request-response timeout to the 30s fetch-blob per-peer chunk timeout, and the P1 was closed because only responses that echo `range_offset_bytes == requested offset` continue chunking; legacy exact-2MiB responses without range echo now return as full blobs instead of looping.
+- Review residual_risk: range fields are intentionally outside the signature domain because the signature authorizes access to the whole `content_hash`; downstream size/hash checks still guard incorrect range-aware peers that echo an offset but return the wrong bytes. CI package deployment must live-verify a >2MiB blob transfer and continued tick progress.
+- Validation Command: env -u RUSTC_WRAPPER cargo test -p oasis7_node fetch_blob_chunking_accepts_exact_chunk_legacy_full_response_without_looping -- --nocapture
+- Actual Result: passed after splitting the regression into `tests_fetch_blob_chunking.rs`; 1 test passed.
+- Validation Command: env -u RUSTC_WRAPPER cargo test -p oasis7_node replication_fetch -- --nocapture
+- Actual Result: passed after range metadata changes; 3 tests passed.
+- Validation Command: env -u RUSTC_WRAPPER cargo fmt --check && git diff --check && ./scripts/check-rust-file-size.sh && ./scripts/pm/workflow-lint.sh --phase pr-ready --task-uid task_96c772c830e043f9b1e40b03e6f73d38
+- Actual Result: passed after splitting oversized `tests_network_gap_sync.rs`; file-size gate reported oversized code files=0, test files=0.
+- Pre-PR Local Role Review: passed
+- Task UID: task_96c772c830e043f9b1e40b03e6f73d38
+- Source Worktree: /Users/scc/ccwork/worktrees/oasis7-testnet-high-state-peer-retry
+- Source Branch: codex/testnet-fetch-blob-transfer-budget
+- Comparison Ref: refs/remotes/origin/main
+- Reviewed Changed Paths: `crates/oasis7_net/src/libp2p_net.rs`; `crates/oasis7_net/src/libp2p_net/config.rs`; `crates/oasis7_net/src/libp2p_net/swarm_behaviour.rs`; `crates/oasis7_net/src/libp2p_net/tests.rs`; `crates/oasis7_net/src/libp2p_net/tests/discovery_peer_record_tests.rs`; `crates/oasis7_net/src/libp2p_net/tests/subscribe_ack_tests.rs`; `crates/oasis7_net/src/libp2p_net/transport_retry_tests.rs`; `crates/oasis7_node/src/lib.rs`; `crates/oasis7_node/src/libp2p_replication_network.rs`; `crates/oasis7_node/src/libp2p_replication_network/tests.rs`; `crates/oasis7_node/src/libp2p_replication_network_wasm.rs`; `crates/oasis7_node/src/replication.rs`; `crates/oasis7_node/src/replication_fetch.rs`; `crates/oasis7_node/src/replication_probe_gate.rs`; `crates/oasis7_node/src/tests.rs`; `crates/oasis7_node/src/tests_network_gap_sync.rs`; `crates/oasis7_node/src/tests_consensus_signatures.rs`; `crates/oasis7_node/src/replication/tests.rs`; affected fetch-blob test fixtures.
+- Review Roles: runtime_engineer, blockchain_ops_engineer, qa_engineer
+- Review Findings Disposition: addressed
+- Residual Risk: live CI package/deployment still required for Linux storage, Linux observer, and reachable Windows host; verify chunked fetch-blob transfer, final size/hash checks, and worker tick progress.
+- Blocker / Next Action: commit, push PR, then use CI package for Linux/Windows deployment.

--- a/crates/oasis7_net/src/libp2p_net.rs
+++ b/crates/oasis7_net/src/libp2p_net.rs
@@ -188,6 +188,7 @@ impl Libp2pNetwork {
                 &keypair_clone,
                 enable_rendezvous,
                 config_clone.enable_autonat,
+                config_clone.request_response_timeout,
                 Arc::clone(&event_wire_byte_counters),
             );
             let mut subscriptions = HashSet::new();

--- a/crates/oasis7_net/src/libp2p_net/config.rs
+++ b/crates/oasis7_net/src/libp2p_net/config.rs
@@ -1,5 +1,6 @@
 use libp2p::identity::Keypair;
 use libp2p::Multiaddr;
+use std::time::Duration;
 
 use oasis7_proto::distributed_dht::PeerRecord;
 
@@ -12,6 +13,7 @@ const DEFAULT_MAX_LISTENING_ADDRS: usize = 128;
 const DEFAULT_BOOTSTRAP_REDIAL_INTERVAL_MS: i64 = 1_000;
 const DEFAULT_DISCOVERY_QUERY_INTERVAL_MS: i64 = 15_000;
 const DEFAULT_DISCOVERY_QUERY_COOLDOWN_MS: i64 = 60_000;
+const DEFAULT_REQUEST_RESPONSE_TIMEOUT_MS: u64 = 30_000;
 
 #[derive(Debug, Clone)]
 pub struct Libp2pNetworkConfig {
@@ -31,6 +33,7 @@ pub struct Libp2pNetworkConfig {
     pub max_error_messages: usize,
     pub max_listening_addrs: usize,
     pub peer_manager_policy: PeerManagerPolicy,
+    pub request_response_timeout: Duration,
 }
 
 impl Default for Libp2pNetworkConfig {
@@ -52,6 +55,7 @@ impl Default for Libp2pNetworkConfig {
             max_error_messages: DEFAULT_MAX_ERROR_MESSAGES,
             max_listening_addrs: DEFAULT_MAX_LISTENING_ADDRS,
             peer_manager_policy: PeerManagerPolicy::default(),
+            request_response_timeout: Duration::from_millis(DEFAULT_REQUEST_RESPONSE_TIMEOUT_MS),
         }
     }
 }

--- a/crates/oasis7_net/src/libp2p_net/swarm_behaviour.rs
+++ b/crates/oasis7_net/src/libp2p_net/swarm_behaviour.rs
@@ -105,6 +105,7 @@ pub(super) fn build_swarm(
     keypair: &Keypair,
     enable_rendezvous: bool,
     enable_autonat: bool,
+    request_response_timeout: std::time::Duration,
     wire_byte_counters: SharedLibp2pWireByteCounters,
 ) -> Swarm<Behaviour> {
     let swarm_config = libp2p::swarm::Config::with_async_std_executor()
@@ -121,8 +122,10 @@ pub(super) fn build_swarm(
         StreamProtocol::new(RR_PROTOCOL_PREFIX),
         ProtocolSupport::Full,
     )];
-    let request_response =
-        request_response::cbor::Behaviour::new(protocols, request_response::Config::default());
+    let request_response = request_response::cbor::Behaviour::new(
+        protocols,
+        request_response::Config::default().with_request_timeout(request_response_timeout),
+    );
 
     let mut store_config = MemoryStoreConfig::default();
     store_config.max_provided_keys = KAD_MAX_PROVIDED_KEYS;

--- a/crates/oasis7_net/src/libp2p_net/tests.rs
+++ b/crates/oasis7_net/src/libp2p_net/tests.rs
@@ -100,6 +100,7 @@ fn build_swarm_supports_more_than_default_max_provider_records() {
         &keypair,
         false,
         true,
+        std::time::Duration::from_secs(30),
         super::wire_bytes::init_shared_wire_byte_counters(),
     );
 
@@ -590,6 +591,7 @@ fn process_discovered_peer_record_dials_candidate_peer() {
         &Keypair::generate_ed25519(),
         false,
         true,
+        std::time::Duration::from_secs(30),
         super::wire_bytes::init_shared_wire_byte_counters(),
     );
     let peer_key = Keypair::generate_ed25519();

--- a/crates/oasis7_net/src/libp2p_net/tests/discovery_peer_record_tests.rs
+++ b/crates/oasis7_net/src/libp2p_net/tests/discovery_peer_record_tests.rs
@@ -9,6 +9,7 @@ fn routing_update_defers_bootstrap_peer_record_until_connection_exists() {
         &keypair,
         false,
         true,
+        std::time::Duration::from_secs(30),
         super::super::wire_bytes::init_shared_wire_byte_counters(),
     );
     let mut pending_dht = HashMap::new();
@@ -79,6 +80,7 @@ fn routing_update_skips_peer_record_for_unconnected_non_bootstrap_peer() {
         &keypair,
         false,
         true,
+        std::time::Duration::from_secs(30),
         super::super::wire_bytes::init_shared_wire_byte_counters(),
     );
     let mut pending_dht = HashMap::new();
@@ -125,6 +127,7 @@ fn process_discovered_peer_record_keeps_single_source_bootstrap_peer_dial_eligib
         &Keypair::generate_ed25519(),
         false,
         true,
+        std::time::Duration::from_secs(30),
         super::super::wire_bytes::init_shared_wire_byte_counters(),
     );
     let peer_key = Keypair::generate_ed25519();
@@ -210,6 +213,7 @@ fn process_discovered_peer_record_keeps_dht_only_suspect_peer_non_dialable() {
         &Keypair::generate_ed25519(),
         false,
         true,
+        std::time::Duration::from_secs(30),
         super::super::wire_bytes::init_shared_wire_byte_counters(),
     );
     let peer_key = Keypair::generate_ed25519();
@@ -248,6 +252,7 @@ fn maybe_queue_discovery_peer_record_skips_peer_with_cached_record() {
         &Keypair::generate_ed25519(),
         false,
         true,
+        std::time::Duration::from_secs(30),
         super::super::wire_bytes::init_shared_wire_byte_counters(),
     );
     let local_peer_id = PeerId::random();
@@ -296,6 +301,7 @@ fn maybe_request_cached_peer_record_does_not_use_target_peer_as_proxy() {
         &Keypair::generate_ed25519(),
         false,
         true,
+        std::time::Duration::from_secs(30),
         super::super::wire_bytes::init_shared_wire_byte_counters(),
     );
     let local_peer_id = PeerId::random();
@@ -327,6 +333,7 @@ fn maybe_request_connected_peer_record_respects_short_cooldown() {
         &Keypair::generate_ed25519(),
         false,
         true,
+        std::time::Duration::from_secs(30),
         super::super::wire_bytes::init_shared_wire_byte_counters(),
     );
     let local_peer_id = PeerId::random();
@@ -384,6 +391,7 @@ fn maybe_request_cached_peer_record_respects_short_cooldown() {
         &Keypair::generate_ed25519(),
         false,
         true,
+        std::time::Duration::from_secs(30),
         super::super::wire_bytes::init_shared_wire_byte_counters(),
     );
     let local_peer_id = PeerId::random();
@@ -445,6 +453,7 @@ fn maybe_request_cached_discovery_peers_respects_short_cooldown() {
         &Keypair::generate_ed25519(),
         false,
         true,
+        std::time::Duration::from_secs(30),
         super::super::wire_bytes::init_shared_wire_byte_counters(),
     );
     let local_peer_id = PeerId::random();
@@ -502,6 +511,7 @@ fn start_peer_discovery_query_respects_pending_query_and_cooldown() {
         &Keypair::generate_ed25519(),
         false,
         true,
+        std::time::Duration::from_secs(30),
         super::super::wire_bytes::init_shared_wire_byte_counters(),
     );
     let template = super::signed_discovery_peer_record(
@@ -568,6 +578,7 @@ fn clear_disconnected_peer_state_removes_peer_record_cooldowns() {
         &Keypair::generate_ed25519(),
         false,
         true,
+        std::time::Duration::from_secs(30),
         super::super::wire_bytes::init_shared_wire_byte_counters(),
     );
     let local_peer_id = PeerId::random();
@@ -736,6 +747,7 @@ fn cached_peer_record_not_found_retries_via_another_connected_peer() {
         &Keypair::generate_ed25519(),
         false,
         true,
+        std::time::Duration::from_secs(30),
         super::super::wire_bytes::init_shared_wire_byte_counters(),
     );
     let target_peer_id = PeerId::random();
@@ -816,6 +828,7 @@ fn cached_peer_record_not_found_stops_after_all_connected_proxies_are_tried() {
         &Keypair::generate_ed25519(),
         false,
         true,
+        std::time::Duration::from_secs(30),
         super::super::wire_bytes::init_shared_wire_byte_counters(),
     );
     let target_peer_id = PeerId::random();

--- a/crates/oasis7_net/src/libp2p_net/tests/subscribe_ack_tests.rs
+++ b/crates/oasis7_net/src/libp2p_net/tests/subscribe_ack_tests.rs
@@ -18,6 +18,7 @@ fn handle_command_subscribe_acknowledges_success() {
         &keypair,
         false,
         true,
+        std::time::Duration::from_secs(30),
         super::super::wire_bytes::init_shared_wire_byte_counters(),
     );
     let event_published = Arc::new(Mutex::new(Vec::new()));
@@ -144,12 +145,14 @@ fn handle_command_request_uses_swarm_connections_when_runtime_peers_are_empty() 
         &listener_keypair,
         false,
         true,
+        std::time::Duration::from_secs(30),
         super::super::wire_bytes::init_shared_wire_byte_counters(),
     );
     let mut dialer = super::super::swarm_behaviour::build_swarm(
         &dialer_keypair,
         false,
         true,
+        std::time::Duration::from_secs(30),
         super::super::wire_bytes::init_shared_wire_byte_counters(),
     );
     async_std::task::block_on(async {

--- a/crates/oasis7_net/src/libp2p_net/transport_retry_tests.rs
+++ b/crates/oasis7_net/src/libp2p_net/transport_retry_tests.rs
@@ -44,6 +44,7 @@ fn process_discovered_peer_record_retries_failed_candidate_dial_on_rediscovery()
         &Keypair::generate_ed25519(),
         false,
         true,
+        std::time::Duration::from_secs(30),
         super::wire_bytes::init_shared_wire_byte_counters(),
     );
     let peer_key = Keypair::generate_ed25519();
@@ -81,6 +82,7 @@ fn process_discovered_peer_record_retries_failed_candidate_dial_on_rediscovery()
         &Keypair::generate_ed25519(),
         false,
         true,
+        std::time::Duration::from_secs(30),
         super::wire_bytes::init_shared_wire_byte_counters(),
     );
 
@@ -108,6 +110,7 @@ fn request_with_providers_does_not_fallback_outside_provider_subset() {
         &keypair,
         false,
         true,
+        std::time::Duration::from_secs(30),
         super::wire_bytes::init_shared_wire_byte_counters(),
     );
     let (sender, receiver) = std::sync::mpsc::channel();
@@ -208,6 +211,7 @@ fn refresh_peer_discovery_respects_republish_and_query_budgets() {
         &keypair,
         false,
         true,
+        std::time::Duration::from_secs(30),
         super::wire_bytes::init_shared_wire_byte_counters(),
     );
     let mut subscriptions = HashSet::new();
@@ -357,6 +361,7 @@ fn refresh_peer_discovery_skips_backfill_when_connected_peers_are_already_known(
         &keypair,
         false,
         true,
+        std::time::Duration::from_secs(30),
         super::wire_bytes::init_shared_wire_byte_counters(),
     );
     let mut subscriptions = HashSet::new();

--- a/crates/oasis7_node/src/lib.rs
+++ b/crates/oasis7_node/src/lib.rs
@@ -972,8 +972,23 @@ fn register_replication_fetch_handlers_with_checkpoint_export(
                     let blob =
                         load_blob_from_root(blob_root_dir.as_path(), request.content_hash.as_str())
                             .map_err(network_internal_error)?;
+                    let (blob, range_complete) = match blob {
+                        Some(bytes) => {
+                            let (slice, range_complete) = slice_fetch_blob_response(
+                                bytes,
+                                request.offset_bytes,
+                                request.limit_bytes,
+                            );
+                            (Some(slice), range_complete)
+                        }
+                        None => (None, None),
+                    };
+                    let range_offset_bytes =
+                        request.offset_bytes.filter(|_| range_complete.is_some());
                     let response = FetchBlobResponse {
                         found: blob.is_some(),
+                        range_offset_bytes,
+                        range_complete,
                         blob,
                     };
                     serde_json::to_vec(&response).map_err(|err| {
@@ -987,6 +1002,26 @@ fn register_replication_fetch_handlers_with_checkpoint_export(
     }
 
     Ok(())
+}
+
+fn slice_fetch_blob_response(
+    bytes: Vec<u8>,
+    offset_bytes: Option<u64>,
+    limit_bytes: Option<u64>,
+) -> (Vec<u8>, Option<bool>) {
+    let Some(offset_bytes) = offset_bytes else {
+        return (bytes, None);
+    };
+    let offset = usize::try_from(offset_bytes).unwrap_or(usize::MAX);
+    if offset >= bytes.len() {
+        return (Vec::new(), Some(true));
+    }
+    let limit = limit_bytes
+        .and_then(|value| usize::try_from(value).ok())
+        .filter(|value| *value > 0)
+        .unwrap_or_else(|| bytes.len().saturating_sub(offset));
+    let end = offset.saturating_add(limit).min(bytes.len());
+    (bytes[offset..end].to_vec(), Some(end >= bytes.len()))
 }
 
 fn network_bad_request(message: impl Into<String>) -> ProtoWorldError {

--- a/crates/oasis7_node/src/libp2p_replication_network.rs
+++ b/crates/oasis7_node/src/libp2p_replication_network.rs
@@ -63,6 +63,9 @@ const REQUEST_PEER_GENERIC_PENALTY: u8 = 10;
 const REQUEST_PEER_SUCCESS_RECOVERY: u8 = 5;
 const REQUEST_TO_PEER_TIMEOUT_MS: u64 = 12_000;
 const REQUEST_RETRY_BUDGET_MS: u64 = 20_000;
+const FETCH_BLOB_REQUEST_TO_PEER_TIMEOUT_MS: u64 = 30_000;
+const FETCH_BLOB_REQUEST_RETRY_BUDGET_MS: u64 = 180_000;
+const REPLICATION_FETCH_BLOB_PROTOCOL_MARKER: &str = "/fetch-blob/";
 
 #[derive(Debug, Clone)]
 struct RequestPeerScore {
@@ -86,6 +89,8 @@ pub struct Libp2pReplicationNetworkConfig {
     pub protocol_retry_cooldown_after: Duration,
     pub request_timeout: Duration,
     pub request_retry_budget: Duration,
+    pub fetch_blob_request_timeout: Duration,
+    pub fetch_blob_request_retry_budget: Duration,
 }
 
 impl Default for Libp2pReplicationNetworkConfig {
@@ -106,6 +111,12 @@ impl Default for Libp2pReplicationNetworkConfig {
             protocol_retry_cooldown_after: Duration::from_millis(PROTOCOL_RETRY_COOLDOWN_AFTER_MS),
             request_timeout: Duration::from_millis(REQUEST_TO_PEER_TIMEOUT_MS),
             request_retry_budget: Duration::from_millis(REQUEST_RETRY_BUDGET_MS),
+            fetch_blob_request_timeout: Duration::from_millis(
+                FETCH_BLOB_REQUEST_TO_PEER_TIMEOUT_MS,
+            ),
+            fetch_blob_request_retry_budget: Duration::from_millis(
+                FETCH_BLOB_REQUEST_RETRY_BUDGET_MS,
+            ),
         }
     }
 }
@@ -119,6 +130,8 @@ pub struct Libp2pReplicationNetwork {
     protocol_retry_cooldown_after: Duration,
     request_timeout: Duration,
     request_retry_budget: Duration,
+    fetch_blob_request_timeout: Duration,
+    fetch_blob_request_retry_budget: Duration,
     protocol_retry_cooldown_peers: Arc<Mutex<HashMap<String, HashMap<PeerId, Instant>>>>,
     transport_retry_cooldown_peers: Arc<Mutex<HashMap<PeerId, Instant>>>,
     request_peer_scores: Arc<Mutex<HashMap<PeerId, RequestPeerScore>>>,
@@ -137,6 +150,9 @@ impl Libp2pReplicationNetwork {
             discovery_query_cooldown_ms: config.discovery_query_cooldown_ms,
             enable_autonat: config.enable_autonat,
             peer_manager_policy: config.peer_manager_policy,
+            request_response_timeout: config
+                .request_retry_budget
+                .max(config.fetch_blob_request_timeout),
             ..Libp2pNetworkConfig::default()
         });
 
@@ -149,6 +165,8 @@ impl Libp2pReplicationNetwork {
             protocol_retry_cooldown_after: config.protocol_retry_cooldown_after,
             request_timeout: config.request_timeout,
             request_retry_budget: config.request_retry_budget,
+            fetch_blob_request_timeout: config.fetch_blob_request_timeout,
+            fetch_blob_request_retry_budget: config.fetch_blob_request_retry_budget,
             protocol_retry_cooldown_peers: Arc::new(Mutex::new(HashMap::new())),
             transport_retry_cooldown_peers: Arc::new(Mutex::new(HashMap::new())),
             request_peer_scores: Arc::new(Mutex::new(HashMap::new())),
@@ -491,12 +509,14 @@ impl Libp2pReplicationNetwork {
         let started_at = Instant::now();
         let mut last_error = None;
         let mut attempted_peers = HashSet::new();
+        let request_timeout = self.request_timeout_for_protocol(protocol);
+        let request_retry_budget = self.request_retry_budget_for_protocol(protocol);
 
         for attempt in 0..=REQUEST_CONNECTION_REFRESH_RETRIES {
-            if started_at.elapsed() >= self.request_retry_budget {
+            if started_at.elapsed() >= request_retry_budget {
                 return Err(replication_request_budget_exhausted(
                     protocol,
-                    self.request_retry_budget,
+                    request_retry_budget,
                     last_error,
                 ));
             }
@@ -528,16 +548,16 @@ impl Libp2pReplicationNetwork {
             for peer in ordered_peers {
                 attempted_peers.insert(peer);
                 let elapsed = started_at.elapsed();
-                if elapsed >= self.request_retry_budget {
+                if elapsed >= request_retry_budget {
                     return Err(replication_request_budget_exhausted(
                         protocol,
-                        self.request_retry_budget,
+                        request_retry_budget,
                         last_error,
                     ));
                 }
-                let remaining_budget = self.request_retry_budget.saturating_sub(elapsed);
-                let request_timeout = self.request_timeout.min(remaining_budget);
-                match self.request_via_peer(protocol, payload, peer, request_timeout) {
+                let remaining_budget = request_retry_budget.saturating_sub(elapsed);
+                let peer_request_timeout = request_timeout.min(remaining_budget);
+                match self.request_via_peer(protocol, payload, peer, peer_request_timeout) {
                     Ok(reply) => {
                         self.mark_peer_request_success(peer);
                         return Ok(reply);
@@ -553,10 +573,10 @@ impl Libp2pReplicationNetwork {
                         retryable_connection_gap |=
                             peer_error_indicates_retryable_connection_gap(&err);
                         last_error = Some(err);
-                        if started_at.elapsed() >= self.request_retry_budget {
+                        if started_at.elapsed() >= request_retry_budget {
                             return Err(replication_request_budget_exhausted(
                                 protocol,
-                                self.request_retry_budget,
+                                request_retry_budget,
                                 last_error,
                             ));
                         }
@@ -590,6 +610,20 @@ impl Libp2pReplicationNetwork {
         }
 
         Err(last_error.unwrap_or_else(no_connected_error))
+    }
+
+    fn request_timeout_for_protocol(&self, protocol: &str) -> Duration {
+        if protocol.contains(REPLICATION_FETCH_BLOB_PROTOCOL_MARKER) {
+            return self.fetch_blob_request_timeout;
+        }
+        self.request_timeout
+    }
+
+    fn request_retry_budget_for_protocol(&self, protocol: &str) -> Duration {
+        if protocol.contains(REPLICATION_FETCH_BLOB_PROTOCOL_MARKER) {
+            return self.fetch_blob_request_retry_budget;
+        }
+        self.request_retry_budget
     }
 }
 

--- a/crates/oasis7_node/src/libp2p_replication_network/tests.rs
+++ b/crates/oasis7_node/src/libp2p_replication_network/tests.rs
@@ -68,6 +68,46 @@ fn libp2p_replication_network_request_rejects_without_connected_peers_by_default
 }
 
 #[test]
+fn libp2p_replication_network_uses_long_transfer_budget_for_fetch_blob() {
+    let network = Libp2pReplicationNetwork::new(Libp2pReplicationNetworkConfig {
+        request_timeout: Duration::from_millis(11),
+        request_retry_budget: Duration::from_millis(22),
+        fetch_blob_request_timeout: Duration::from_millis(333),
+        fetch_blob_request_retry_budget: Duration::from_millis(444),
+        ..Libp2pReplicationNetworkConfig::default()
+    });
+
+    assert_eq!(
+        network.request_timeout_for_protocol("/aw/node/replication/fetch-blob/1.0.0"),
+        Duration::from_millis(333)
+    );
+    assert_eq!(
+        network.request_retry_budget_for_protocol("/aw/node/replication/fetch-blob/1.0.0"),
+        Duration::from_millis(444)
+    );
+}
+
+#[test]
+fn libp2p_replication_network_keeps_short_budget_for_non_blob_protocols() {
+    let network = Libp2pReplicationNetwork::new(Libp2pReplicationNetworkConfig {
+        request_timeout: Duration::from_millis(11),
+        request_retry_budget: Duration::from_millis(22),
+        fetch_blob_request_timeout: Duration::from_millis(333),
+        fetch_blob_request_retry_budget: Duration::from_millis(444),
+        ..Libp2pReplicationNetworkConfig::default()
+    });
+
+    assert_eq!(
+        network.request_timeout_for_protocol("/aw/node/replication/fetch-commit/1.0.0"),
+        Duration::from_millis(11)
+    );
+    assert_eq!(
+        network.request_retry_budget_for_protocol("/aw/node/replication/fetch-commit/1.0.0"),
+        Duration::from_millis(22)
+    );
+}
+
+#[test]
 fn libp2p_replication_network_request_falls_back_to_local_handler_when_enabled() {
     let network = Libp2pReplicationNetwork::new(Libp2pReplicationNetworkConfig {
         allow_local_handler_fallback_when_no_peers: true,

--- a/crates/oasis7_node/src/libp2p_replication_network_wasm.rs
+++ b/crates/oasis7_node/src/libp2p_replication_network_wasm.rs
@@ -10,6 +10,8 @@ use oasis7_proto::world_error::WorldError;
 const PROTOCOL_RETRY_COOLDOWN_AFTER_MS: u64 = 5_000;
 const REQUEST_TO_PEER_TIMEOUT_MS: u64 = 12_000;
 const REQUEST_RETRY_BUDGET_MS: u64 = 20_000;
+const FETCH_BLOB_REQUEST_TO_PEER_TIMEOUT_MS: u64 = 30_000;
+const FETCH_BLOB_REQUEST_RETRY_BUDGET_MS: u64 = 180_000;
 
 // wasm32 target intentionally does not ship a full-node networking stack.
 // This stub exists only to keep API shape stable for compile-time compatibility.
@@ -29,6 +31,8 @@ pub struct Libp2pReplicationNetworkConfig {
     pub protocol_retry_cooldown_after: Duration,
     pub request_timeout: Duration,
     pub request_retry_budget: Duration,
+    pub fetch_blob_request_timeout: Duration,
+    pub fetch_blob_request_retry_budget: Duration,
 }
 
 impl Default for Libp2pReplicationNetworkConfig {
@@ -48,6 +52,12 @@ impl Default for Libp2pReplicationNetworkConfig {
             protocol_retry_cooldown_after: Duration::from_millis(PROTOCOL_RETRY_COOLDOWN_AFTER_MS),
             request_timeout: Duration::from_millis(REQUEST_TO_PEER_TIMEOUT_MS),
             request_retry_budget: Duration::from_millis(REQUEST_RETRY_BUDGET_MS),
+            fetch_blob_request_timeout: Duration::from_millis(
+                FETCH_BLOB_REQUEST_TO_PEER_TIMEOUT_MS,
+            ),
+            fetch_blob_request_retry_budget: Duration::from_millis(
+                FETCH_BLOB_REQUEST_RETRY_BUDGET_MS,
+            ),
         }
     }
 }

--- a/crates/oasis7_node/src/replication.rs
+++ b/crates/oasis7_node/src/replication.rs
@@ -1045,6 +1045,8 @@ impl ReplicationRuntime {
     ) -> Result<FetchBlobRequest, NodeError> {
         let mut request = FetchBlobRequest {
             content_hash: content_hash.to_string(),
+            offset_bytes: None,
+            limit_bytes: None,
             requester_public_key_hex: self
                 .signer
                 .as_ref()

--- a/crates/oasis7_node/src/replication/tests.rs
+++ b/crates/oasis7_node/src/replication/tests.rs
@@ -335,6 +335,8 @@ fn authorize_fetch_blob_request_rejects_requester_outside_allowlist() {
     };
     let mut request = FetchBlobRequest {
         content_hash: "hash-1".to_string(),
+        offset_bytes: None,
+        limit_bytes: None,
         requester_public_key_hex: Some(requester_public_hex),
         requester_signature_hex: None,
     };

--- a/crates/oasis7_node/src/replication_fetch.rs
+++ b/crates/oasis7_node/src/replication_fetch.rs
@@ -21,6 +21,10 @@ pub(crate) struct FetchCommitResponse {
 pub(crate) struct FetchBlobRequest {
     pub content_hash: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub offset_bytes: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub limit_bytes: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub requester_public_key_hex: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub requester_signature_hex: Option<String>,
@@ -29,6 +33,10 @@ pub(crate) struct FetchBlobRequest {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) struct FetchBlobResponse {
     pub found: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub range_offset_bytes: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub range_complete: Option<bool>,
     #[serde(
         default,
         deserialize_with = "deserialize_optional_hex_or_bytes",
@@ -77,6 +85,8 @@ mod tests {
     fn fetch_blob_response_serializes_blob_as_compact_hex_string() {
         let response = FetchBlobResponse {
             found: true,
+            range_offset_bytes: None,
+            range_complete: None,
             blob: Some(vec![0, 1, 2, 254, 255]),
         };
 

--- a/crates/oasis7_node/src/replication_probe_gate.rs
+++ b/crates/oasis7_node/src/replication_probe_gate.rs
@@ -1,5 +1,7 @@
 use super::*;
 
+const REPLICATION_FETCH_BLOB_CHUNK_BYTES: usize = 2 * 1024 * 1024;
+
 impl PosNodeEngine {
     pub(super) fn maybe_hold_proposal_for_replication_successor_probe(
         &mut self,
@@ -171,6 +173,66 @@ mod tests {
 }
 
 pub(super) fn request_fetch_blob_with_route_fallback(
+    endpoint: &ReplicationNetworkEndpoint,
+    world_id: &str,
+    content_hash: &str,
+    request: &FetchBlobRequest,
+    provider_ids: Option<&[String]>,
+) -> Result<FetchBlobResponse, NodeError> {
+    let mut offset = 0usize;
+    let mut assembled = Vec::new();
+
+    loop {
+        let mut chunk_request = request.clone();
+        chunk_request.offset_bytes = Some(offset as u64);
+        chunk_request.limit_bytes = Some(REPLICATION_FETCH_BLOB_CHUNK_BYTES as u64);
+        let response = request_fetch_blob_chunk_with_route_fallback(
+            endpoint,
+            world_id,
+            content_hash,
+            &chunk_request,
+            provider_ids,
+        )?;
+        if !response.found {
+            return Ok(response);
+        }
+        let range_aware = response.range_offset_bytes == Some(offset as u64);
+        let Some(chunk) = response.blob else {
+            return Ok(response);
+        };
+        if !range_aware {
+            return Ok(FetchBlobResponse {
+                found: true,
+                range_offset_bytes: response.range_offset_bytes,
+                range_complete: response.range_complete,
+                blob: Some(chunk),
+            });
+        }
+        if chunk.is_empty() {
+            return Ok(FetchBlobResponse {
+                found: true,
+                range_offset_bytes: None,
+                range_complete: None,
+                blob: Some(assembled),
+            });
+        }
+        let is_final_chunk = response
+            .range_complete
+            .unwrap_or(chunk.len() < REPLICATION_FETCH_BLOB_CHUNK_BYTES);
+        offset = offset.saturating_add(chunk.len());
+        assembled.extend_from_slice(chunk.as_slice());
+        if is_final_chunk {
+            return Ok(FetchBlobResponse {
+                found: true,
+                range_offset_bytes: None,
+                range_complete: None,
+                blob: Some(assembled),
+            });
+        }
+    }
+}
+
+fn request_fetch_blob_chunk_with_route_fallback(
     endpoint: &ReplicationNetworkEndpoint,
     world_id: &str,
     content_hash: &str,

--- a/crates/oasis7_node/src/tests.rs
+++ b/crates/oasis7_node/src/tests.rs
@@ -20,6 +20,34 @@ fn run_test_with_timeout(
     }
 }
 
+#[test]
+fn fetch_blob_response_slice_honors_offset_and_limit() {
+    assert_eq!(
+        super::slice_fetch_blob_response(b"abcdefgh".to_vec(), Some(2), Some(3)),
+        (b"cde".to_vec(), Some(false))
+    );
+    assert_eq!(
+        super::slice_fetch_blob_response(b"abcdefgh".to_vec(), Some(6), Some(99)),
+        (b"gh".to_vec(), Some(true))
+    );
+    assert_eq!(
+        super::slice_fetch_blob_response(b"abcdefgh".to_vec(), Some(99), Some(3)),
+        (Vec::<u8>::new(), Some(true))
+    );
+}
+
+fn test_fetch_blob_response(
+    found: bool,
+    blob: Option<Vec<u8>>,
+) -> super::replication::FetchBlobResponse {
+    super::replication::FetchBlobResponse {
+        found,
+        range_offset_bytes: None,
+        range_complete: None,
+        blob,
+    }
+}
+
 include!("tests_consensus_signatures.rs");
 include!("tests_clock_and_replication.rs");
 include!("tests_replication_gossip.rs");
@@ -27,5 +55,7 @@ include!("tests_storage_replication.rs");
 mod non_sequencer_followers;
 mod replication_state_sync;
 mod restart_reconcile;
+#[path = "tests_fetch_blob_chunking.rs"]
+mod tests_fetch_blob_chunking;
 #[path = "tests_hello_throttle.rs"]
 mod tests_hello_throttle;

--- a/crates/oasis7_node/src/tests_consensus_signatures.rs
+++ b/crates/oasis7_node/src/tests_consensus_signatures.rs
@@ -169,6 +169,8 @@ fn signed_fetch_blob_request_for_test(
     let signing_key = SigningKey::from_bytes(&signing_key_bytes);
     let mut request = super::replication::FetchBlobRequest {
         content_hash: content_hash.to_string(),
+        offset_bytes: None,
+        limit_bytes: None,
         requester_public_key_hex: Some(public_hex),
         requester_signature_hex: None,
     };
@@ -630,6 +632,8 @@ impl oasis7_proto::distributed_net::DistributedNetwork<WorldError> for ProviderA
         })?;
         let response = super::replication::FetchBlobResponse {
             found: blob.is_some(),
+            range_offset_bytes: None,
+            range_complete: None,
             blob,
         };
         serde_json::to_vec(&response).map_err(|err| WorldError::DistributedValidationFailed {
@@ -693,6 +697,8 @@ impl oasis7_proto::distributed_net::DistributedNetwork<WorldError> for ProviderF
         })?;
         let response = super::replication::FetchBlobResponse {
             found: blob.is_some(),
+            range_offset_bytes: None,
+            range_complete: None,
             blob,
         };
         serde_json::to_vec(&response).map_err(|err| WorldError::DistributedValidationFailed {
@@ -742,6 +748,8 @@ impl oasis7_proto::distributed_net::DistributedNetwork<WorldError>
                 .push(providers.to_vec());
             let response = super::replication::FetchBlobResponse {
                 found: false,
+            range_offset_bytes: None,
+            range_complete: None,
                 blob: None,
             };
             return serde_json::to_vec(&response).map_err(|err| {
@@ -764,6 +772,8 @@ impl oasis7_proto::distributed_net::DistributedNetwork<WorldError>
         })?;
         let response = super::replication::FetchBlobResponse {
             found: blob.is_some(),
+            range_offset_bytes: None,
+            range_complete: None,
             blob,
         };
         serde_json::to_vec(&response).map_err(|err| WorldError::DistributedValidationFailed {

--- a/crates/oasis7_node/src/tests_fetch_blob_chunking.rs
+++ b/crates/oasis7_node/src/tests_fetch_blob_chunking.rs
@@ -1,0 +1,89 @@
+use super::*;
+use oasis7_proto::distributed_net::NetworkSubscription;
+use oasis7_proto::world_error::WorldError;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+#[derive(Clone)]
+struct LegacyExactChunkBlobNetwork {
+    attempts: Arc<Mutex<usize>>,
+}
+
+impl oasis7_proto::distributed_net::DistributedNetwork<WorldError> for LegacyExactChunkBlobNetwork {
+    fn publish(&self, _topic: &str, _payload: &[u8]) -> Result<(), WorldError> {
+        Ok(())
+    }
+
+    fn subscribe(&self, topic: &str) -> Result<NetworkSubscription, WorldError> {
+        Ok(NetworkSubscription::new(
+            topic.to_string(),
+            Arc::new(Mutex::new(HashMap::new())),
+        ))
+    }
+
+    fn request(&self, protocol: &str, payload: &[u8]) -> Result<Vec<u8>, WorldError> {
+        *self.attempts.lock().expect("lock attempts") += 1;
+        assert_eq!(
+            protocol,
+            super::replication::REPLICATION_FETCH_BLOB_PROTOCOL
+        );
+        let request: super::replication::FetchBlobRequest =
+            serde_json::from_slice(payload).expect("decode fetch blob request");
+        assert_eq!(request.offset_bytes, Some(0));
+        assert_eq!(request.limit_bytes, Some(2 * 1024 * 1024));
+        serde_json::to_vec(&super::replication::FetchBlobResponse {
+            found: true,
+            range_offset_bytes: None,
+            range_complete: None,
+            blob: Some(vec![7; 2 * 1024 * 1024]),
+        })
+        .map_err(|err| WorldError::DistributedValidationFailed {
+            reason: format!("encode legacy blob response failed: {err}"),
+        })
+    }
+
+    fn register_handler(
+        &self,
+        _protocol: &str,
+        _handler: Box<dyn Fn(&[u8]) -> Result<Vec<u8>, WorldError> + Send + Sync>,
+    ) -> Result<(), WorldError> {
+        Ok(())
+    }
+}
+
+#[test]
+fn fetch_blob_chunking_accepts_exact_chunk_legacy_full_response_without_looping() {
+    let world_id = "world-legacy-exact-chunk";
+    let dir = temp_dir("legacy-exact-chunk-endpoint");
+    let attempts = Arc::new(Mutex::new(0usize));
+    let network = Arc::new(LegacyExactChunkBlobNetwork {
+        attempts: Arc::clone(&attempts),
+    });
+    let config = NodeConfig::new("node-b", world_id, NodeRole::Observer)
+        .expect("config")
+        .with_replication(signed_replication_config(dir, 41));
+    let handle = NodeReplicationNetworkHandle::new(network);
+    let endpoint =
+        ReplicationNetworkEndpoint::new(&handle, world_id, false, &config.network_policy)
+            .expect("endpoint");
+    let request = super::replication::FetchBlobRequest {
+        content_hash: "legacy-exact-chunk".to_string(),
+        offset_bytes: None,
+        limit_bytes: None,
+        requester_public_key_hex: None,
+        requester_signature_hex: None,
+    };
+
+    let response = super::request_fetch_blob_with_route_fallback(
+        &endpoint,
+        world_id,
+        "legacy-exact-chunk",
+        &request,
+        None,
+    )
+    .expect("fetch blob");
+
+    assert!(response.found);
+    assert_eq!(response.blob.as_ref().map(Vec::len), Some(2 * 1024 * 1024));
+    assert_eq!(*attempts.lock().expect("lock attempts"), 1);
+}

--- a/crates/oasis7_node/src/tests_network_gap_sync.rs
+++ b/crates/oasis7_node/src/tests_network_gap_sync.rs
@@ -236,10 +236,10 @@ fn successor_probe_at_genesis_syncs_height_one_before_local_proposal() {
                         .map_err(|err| WorldError::DistributedValidationFailed {
                             reason: format!("decode fetch blob request failed: {err}"),
                         })?;
-                serde_json::to_vec(&super::replication::FetchBlobResponse {
-                    found: request.content_hash == expected_hash,
-                    blob: (request.content_hash == expected_hash).then(|| expected_blob.clone()),
-                })
+                serde_json::to_vec(&test_fetch_blob_response(
+                    request.content_hash == expected_hash,
+                    (request.content_hash == expected_hash).then(|| expected_blob.clone()),
+                ))
                 .map_err(|err| WorldError::DistributedValidationFailed {
                     reason: format!("encode fetch blob response failed: {err}"),
                 })
@@ -322,11 +322,10 @@ fn runtime_network_replication_gap_sync_fetch_commit_success_cache_reuses_valida
                             .map_err(|err| WorldError::DistributedValidationFailed {
                                 reason: format!("decode fetch blob request failed: {err}"),
                             })?;
-                    serde_json::to_vec(&super::replication::FetchBlobResponse {
-                        found: request.content_hash == expected_hash,
-                        blob: (request.content_hash == expected_hash)
-                            .then(|| expected_blob.clone()),
-                    })
+                    serde_json::to_vec(&test_fetch_blob_response(
+                        request.content_hash == expected_hash,
+                        (request.content_hash == expected_hash).then(|| expected_blob.clone()),
+                    ))
                     .map_err(|err| WorldError::DistributedValidationFailed {
                         reason: format!("encode fetch blob response failed: {err}"),
                     })
@@ -412,10 +411,10 @@ fn successor_probe_cooldown_suppresses_same_height_not_found_retry() {
                         .map_err(|err| WorldError::DistributedValidationFailed {
                             reason: format!("decode fetch blob request failed: {err}"),
                         })?;
-                serde_json::to_vec(&super::replication::FetchBlobResponse {
-                    found: request.content_hash == expected_hash,
-                    blob: (request.content_hash == expected_hash).then(|| expected_blob.clone()),
-                })
+                serde_json::to_vec(&test_fetch_blob_response(
+                    request.content_hash == expected_hash,
+                    (request.content_hash == expected_hash).then(|| expected_blob.clone()),
+                ))
                 .map_err(|err| WorldError::DistributedValidationFailed {
                     reason: format!("encode fetch blob response failed: {err}"),
                 })
@@ -547,10 +546,10 @@ fn successor_probe_cooldown_preserves_waitable_hold_decision() {
                         .map_err(|err| WorldError::DistributedValidationFailed {
                             reason: format!("decode fetch blob request failed: {err}"),
                         })?;
-                serde_json::to_vec(&super::replication::FetchBlobResponse {
-                    found: request.content_hash == expected_hash,
-                    blob: (request.content_hash == expected_hash).then(|| expected_blob.clone()),
-                })
+                serde_json::to_vec(&test_fetch_blob_response(
+                    request.content_hash == expected_hash,
+                    (request.content_hash == expected_hash).then(|| expected_blob.clone()),
+                ))
                 .map_err(|err| WorldError::DistributedValidationFailed {
                     reason: format!("encode fetch blob response failed: {err}"),
                 })
@@ -667,11 +666,10 @@ fn runtime_network_replication_gap_sync_fetch_commit_success_cache_skips_invalid
                             .map_err(|err| WorldError::DistributedValidationFailed {
                                 reason: format!("decode fetch blob request failed: {err}"),
                             })?;
-                    serde_json::to_vec(&super::replication::FetchBlobResponse {
-                        found: request.content_hash == expected_hash,
-                        blob: (request.content_hash == expected_hash)
-                            .then(|| expected_blob.clone()),
-                    })
+                    serde_json::to_vec(&test_fetch_blob_response(
+                        request.content_hash == expected_hash,
+                        (request.content_hash == expected_hash).then(|| expected_blob.clone()),
+                    ))
                     .map_err(|err| WorldError::DistributedValidationFailed {
                         reason: format!("encode fetch blob response failed: {err}"),
                     })
@@ -751,10 +749,10 @@ fn runtime_network_replication_gap_sync_fetch_commit_success_cache_expires() {
                         .map_err(|err| WorldError::DistributedValidationFailed {
                             reason: format!("decode fetch blob request failed: {err}"),
                         })?;
-                serde_json::to_vec(&super::replication::FetchBlobResponse {
-                    found: request.content_hash == expected_hash,
-                    blob: (request.content_hash == expected_hash).then(|| expected_blob.clone()),
-                })
+                serde_json::to_vec(&test_fetch_blob_response(
+                    request.content_hash == expected_hash,
+                    (request.content_hash == expected_hash).then(|| expected_blob.clone()),
+                ))
                 .map_err(|err| WorldError::DistributedValidationFailed {
                     reason: format!("encode fetch blob response failed: {err}"),
                 })
@@ -1158,10 +1156,8 @@ fn runtime_network_replication_gap_sync_fetches_missing_commits() {
                         .map_err(|err| WorldError::DistributedValidationFailed {
                             reason: format!("decode fetch blob request failed: {err}"),
                         })?;
-                let response = super::replication::FetchBlobResponse {
-                    found: blob_map.contains_key(request.content_hash.as_str()),
-                    blob: blob_map.get(request.content_hash.as_str()).cloned(),
-                };
+                let blob = blob_map.get(request.content_hash.as_str()).cloned();
+                let response = test_fetch_blob_response(blob.is_some(), blob);
                 serde_json::to_vec(&response).map_err(|err| {
                     WorldError::DistributedValidationFailed {
                         reason: format!("encode fetch blob response failed: {err}"),

--- a/crates/oasis7_node/src/tests_network_gap_sync_execution_failures.rs
+++ b/crates/oasis7_node/src/tests_network_gap_sync_execution_failures.rs
@@ -113,6 +113,8 @@ fn successor_probe_does_not_advance_replication_cursor_when_execution_fails() {
                         })?;
                 serde_json::to_vec(&super::replication::FetchBlobResponse {
                     found: request.content_hash == expected_hash,
+            range_offset_bytes: None,
+            range_complete: None,
                     blob: (request.content_hash == expected_hash).then(|| expected_blob.clone()),
                 })
                 .map_err(|err| WorldError::DistributedValidationFailed {
@@ -263,6 +265,8 @@ fn gap_sync_does_not_advance_replication_cursor_when_execution_fails() {
                         })?;
                 serde_json::to_vec(&super::replication::FetchBlobResponse {
                     found: request.content_hash == expected_hash,
+            range_offset_bytes: None,
+            range_complete: None,
                     blob: (request.content_hash == expected_hash).then(|| expected_blob.clone()),
                 })
                 .map_err(|err| WorldError::DistributedValidationFailed {

--- a/crates/oasis7_node/src/tests_storage_challenge_blob_cache.rs
+++ b/crates/oasis7_node/src/tests_storage_challenge_blob_cache.rs
@@ -75,6 +75,8 @@ fn build_storage_challenge_blob_cache_fixture(
                     .expect("lock request count") += 1;
                 let response = super::replication::FetchBlobResponse {
                     found: request.content_hash == expected_hash,
+            range_offset_bytes: None,
+            range_complete: None,
                     blob: (request.content_hash == expected_hash).then(|| expected_blob.clone()),
                 };
                 serde_json::to_vec(&response).map_err(|err| {

--- a/crates/oasis7_node/src/tests_storage_challenge_gate.rs
+++ b/crates/oasis7_node/src/tests_storage_challenge_gate.rs
@@ -92,6 +92,8 @@ fn runtime_replication_storage_challenge_gate_blocks_on_network_blob_mismatch() 
                         })?;
                 let response = super::replication::FetchBlobResponse {
                     found: true,
+            range_offset_bytes: None,
+            range_complete: None,
                     blob: Some(format!("bad-{}", request.content_hash).into_bytes()),
                 };
                 serde_json::to_vec(&response).map_err(|err| {
@@ -173,6 +175,8 @@ fn runtime_replication_storage_challenge_gate_allows_when_network_matches_reach_
                 let Some(local_blob) = maybe_local else {
                     let response = super::replication::FetchBlobResponse {
                         found: false,
+            range_offset_bytes: None,
+            range_complete: None,
                         blob: None,
                     };
                     return serde_json::to_vec(&response).map_err(|err| {
@@ -198,6 +202,8 @@ fn runtime_replication_storage_challenge_gate_allows_when_network_matches_reach_
                 drop(matched_hashes);
                 let response = super::replication::FetchBlobResponse {
                     found: true,
+            range_offset_bytes: None,
+            range_complete: None,
                     blob: Some(if should_match {
                         local_blob
                     } else {
@@ -313,6 +319,8 @@ fn runtime_replication_storage_challenge_gate_falls_back_to_older_samples_during
                 let blob = remote_blobs.get(request.content_hash.as_str()).cloned();
                 let response = super::replication::FetchBlobResponse {
                     found: blob.is_some(),
+            range_offset_bytes: None,
+            range_complete: None,
                     blob,
                 };
                 serde_json::to_vec(&response).map_err(|err| {
@@ -469,6 +477,8 @@ fn runtime_replication_storage_challenge_gate_allows_single_match_during_warmup(
                 let blob = remote_blobs.get(request.content_hash.as_str()).cloned();
                 let response = super::replication::FetchBlobResponse {
                     found: blob.is_some(),
+            range_offset_bytes: None,
+            range_complete: None,
                     blob,
                 };
                 serde_json::to_vec(&response).map_err(|err| {
@@ -710,6 +720,8 @@ fn runtime_replication_storage_challenge_gate_allows_single_match_without_peer_h
                 let blob = remote_blobs.get(request.content_hash.as_str()).cloned();
                 let response = super::replication::FetchBlobResponse {
                     found: blob.is_some(),
+            range_offset_bytes: None,
+            range_complete: None,
                     blob,
                 };
                 serde_json::to_vec(&response).map_err(|err| {

--- a/crates/oasis7_node/src/tests_storage_replication_failover.rs
+++ b/crates/oasis7_node/src/tests_storage_replication_failover.rs
@@ -30,6 +30,8 @@ impl FailoverFetchCommitNetwork {
         })?;
         let response = super::replication::FetchBlobResponse {
             found: blob.is_some(),
+            range_offset_bytes: None,
+            range_complete: None,
             blob,
         };
         serde_json::to_vec(&response).map_err(|err| WorldError::DistributedValidationFailed {

--- a/crates/oasis7_node/src/tests_storage_replication_high_checkpoint_timeout.rs
+++ b/crates/oasis7_node/src/tests_storage_replication_high_checkpoint_timeout.rs
@@ -218,6 +218,8 @@ impl TimeoutThenCheckpointNetwork {
             .cloned();
         serde_json::to_vec(&replication::FetchBlobResponse {
             found: blob.is_some(),
+            range_offset_bytes: None,
+            range_complete: None,
             blob,
         })
         .map_err(|err| WorldError::DistributedValidationFailed {


### PR DESCRIPTION
## Summary
- add range-aware fetch-blob requests/responses and assemble blob transfers in 2MiB chunks
- keep non-blob replication requests on short timeouts while allowing fetch-blob a longer total retry budget
- make libp2p request-response timeout configurable and bound it to the per-chunk timeout, not the total blob budget

## Verification
- `env -u RUSTC_WRAPPER cargo test -p oasis7_node fetch_blob_chunking_accepts_exact_chunk_legacy_full_response_without_looping -- --nocapture`
- `env -u RUSTC_WRAPPER cargo test -p oasis7_node replication_fetch -- --nocapture`
- `env -u RUSTC_WRAPPER cargo test -p oasis7_node libp2p_replication_network -- --nocapture --test-threads=1`
- `env -u RUSTC_WRAPPER cargo test -p oasis7_node storage_replication_high_checkpoint -- --nocapture`
- `env -u RUSTC_WRAPPER cargo test -p oasis7_net libp2p_net -- --nocapture`
- `env -u RUSTC_WRAPPER cargo fmt --check`
- `git diff --check`
- `./scripts/check-rust-file-size.sh`
- `./scripts/pm/workflow-lint.sh --phase pr-ready --task-uid task_96c772c830e043f9b1e40b03e6f73d38`
- `./scripts/pm/workflow-behavior-eval.sh`
