### PR TITLE
Soften immersive route indicators

### DIFF
--- a/.pm/tasks/task_834078a49c334891a3193e4f303f939a.execution.md
+++ b/.pm/tasks/task_834078a49c334891a3193e4f303f939a.execution.md
@@ -212,3 +212,15 @@ Example:
 - Review Findings Disposition: addressed
 - Finding Disposition Evidence: stale packet finding addressed by this refreshed packet covering current head `5d7f4f9437808ea81115688bb1b387f03ff83a67` and changed path `doc/game/project.md`; no code/visual/QA findings remain.
 - Residual Risk: full unskipped provider-backed `scripts/run-local-letai-game-test.sh` was not completed because LetAI/provider probes timed out before UI startup; skipped-provider launcher CSS verification plus deterministic viewer visual smoke covered the CSS-only immersive route treatment. Subsequent commit after Source Head is expected to contain only this execution-log evidence.
+
+## 2026-06-13 23:52:54 CST / tpm
+- 完成内容: GitHub PR created and normal PR watch started.
+- 遗留事项: wait for required checks, inspect comments/review threads, then merge if gates pass.
+- Action: created PR #452 and checked initial PR state.
+- Validation Command: `gh pr create --base main --head task/viewer-immersive-blue-gradient-line --title "Soften immersive route indicators" --body <task summary>`
+- Expected Result: PR is created from task branch to `main`.
+- Actual Result: created `https://github.com/eng-cc/oasis7/pull/452`.
+- Validation Command: `gh pr view 452 --json number,url,state,headRefName,baseRefName,mergeStateStatus,reviewDecision,statusCheckRollup,isDraft,comments,reviews`
+- Expected Result: PR metadata, checks, review, and comments are visible for watch loop.
+- Actual Result: PR open, non-draft; `mergeStateStatus=BEHIND`, `reviewDecision=REVIEW_REQUIRED`; comments/reviews empty; `required-gate` and `plan-wasm-determinism-scope` in progress; `full-regression` and `newapi-bridge-linux-x86-64` skipped.
+- Blocker / Next Action: PR purpose `normal_pr_ci_watch`; continue watching required checks, comments/review threads, and mergeability. `BEHIND` and `REVIEW_REQUIRED` are informational under repo policy unless GitHub merge path rejects or non-approval blockers appear.

--- a/.pm/tasks/task_834078a49c334891a3193e4f303f939a.execution.md
+++ b/.pm/tasks/task_834078a49c334891a3193e4f303f939a.execution.md
@@ -138,3 +138,42 @@ Example:
 - Expected Result: no whitespace errors across current diff.
 - Actual Result: passed.
 - Blocker / Next Action: proceed to commit and pre-PR local role review; do not treat unrelated repo-wide PM lint debt as this task blocker.
+
+## 2026-06-13 23:35:52 CST / tpm
+- Review Trigger: pre-PR local role review
+- Review Scope: `crates/oasis7_viewer/software_safe.html`; `.pm/tasks/task_834078a49c334891a3193e4f303f939a.yaml`; `.pm/tasks/task_834078a49c334891a3193e4f303f939a.execution.md`
+- Review Roles: game_visual_interaction_designer, viewer_engineer, qa_engineer
+- Review Question: confirm that commit `5b9f4baa0a9f8583b4f2562e5c796fd3b2fb816a` safely removes the abrupt immersive-mode blue gradient line, preserves viewer readability/control affordances, and has adequate verification evidence for PR creation.
+- Evidence Available: `npm --prefix crates/oasis7_viewer run test:ui -- software_safe_src/pixel_world_host.test.jsx` passed; `npm --prefix crates/oasis7_viewer run test:pixel-world:visual` passed; Browser served-CSS check on local LetAI launcher path passed; `./scripts/pm/workflow-lint.sh --task-uid task_834078a49c334891a3193e4f303f939a --phase current` passed; `git diff --check` passed.
+- Expected Return Contract: findings | no_findings | residual_risk
+- Formal Sink: `.pm/tasks/task_834078a49c334891a3193e4f303f939a.execution.md`
+- 完成内容: Pre-PR local role review request recorded before dispatch.
+- 遗留事项: await fresh review returns and record parser-friendly passed packet.
+- Action: dispatch role-specific bounded review slices.
+- Validation Command: `git diff --name-only refs/remotes/origin/main...HEAD`
+- Expected Result: review scope is limited to task PM files plus viewer CSS.
+- Actual Result: `.pm/tasks/task_834078a49c334891a3193e4f303f939a.execution.md`, `.pm/tasks/task_834078a49c334891a3193e4f303f939a.yaml`, `crates/oasis7_viewer/software_safe.html`.
+- Blocker / Next Action: dispatch reviewers and address any valid findings before `prepare-task-pr.sh --create`.
+
+## 2026-06-13 23:41:05 CST / tpm
+- 完成内容: Pre-PR local role review integrated.
+- 遗留事项: none for local role review; proceed to PR preflight/create and normal CI/comment/merge watch.
+- Action: integrate fresh review returns from `game_visual_interaction_designer`, `viewer_engineer`, and `qa_engineer`.
+- Validation Command: `multi_agent_v1.wait_agent` for reviewer agents `019ec1a0-9c97-7f73-a092-1259ccb994e7`, `019ec1a0-f4f3-7d70-9305-d9c11b36644d`, `019ec1a0-f5a1-7c00-9a35-acb3dee9bd18`
+- Expected Result: each role returns findings/no_findings plus residual risk for PR creation.
+- Actual Result: all three returned `no_findings`; residual risk limited to full unskipped provider-backed LetAI playtest timeout before UI startup, accepted as environment/provider risk for this CSS-only viewer fix.
+- Blocker / Next Action: record parser-friendly passed packet and commit review evidence.
+
+- Pre-PR Local Role Review: passed
+- Task UID: task_834078a49c334891a3193e4f303f939a
+- Source Worktree: /Users/scc/ccwork/worktrees/oasis7-viewer-immersive-blue-gradient-line
+- Source Branch: task/viewer-immersive-blue-gradient-line
+- Source Head: 5b9f4baa0a9f8583b4f2562e5c796fd3b2fb816a
+- Comparison Ref: refs/remotes/origin/main
+- Reviewed Changed Paths: .pm/tasks/task_834078a49c334891a3193e4f303f939a.execution.md; .pm/tasks/task_834078a49c334891a3193e4f303f939a.yaml; crates/oasis7_viewer/software_safe.html
+- Role Selection Basis: changed paths touch viewer CSS and task evidence; task history includes player-facing immersive visual issue, viewer implementation, visual acceptance, and verification evidence; selected game_visual_interaction_designer for visual/readability risk, viewer_engineer for CSS/viewer integration risk, qa_engineer for verification sufficiency; skipped gameplay/runtime/agent/wasm/blockchain/liveops/repository_health because no gameplay rule, runtime, agent, WASM, ops, external messaging, broad architecture, or doc/code contract changed.
+- Review Roles: game_visual_interaction_designer, viewer_engineer, qa_engineer
+- Review Evidence: game_visual_interaction_designer `019ec1a0-9c97-7f73-a092-1259ccb994e7`: no_findings; CSS removes bright blue/glowing divider treatment, preserves route readability, no mobile/fallback visual regression in reviewed evidence. viewer_engineer `019ec1a0-f4f3-7d70-9305-d9c11b36644d`: no_findings; minimal CSS-only diff, served software-safe viewer path confirmed, no DOM/state/runtime logic changed, verification adequate. qa_engineer `019ec1a0-f5a1-7c00-9a35-acb3dee9bd18`: no_findings; targeted UI test, pixel-world visual smoke, served-CSS Browser check, task-local workflow lint, and git diff check are proportionate for PR creation.
+- Review Findings Disposition: no_findings
+- Finding Disposition Evidence: no actionable findings; residual provider-backed playtest timeout documented in task evidence as external provider/environment risk, not CSS fix blocker.
+- Residual Risk: full unskipped provider-backed `scripts/run-local-letai-game-test.sh` was not completed because LetAI/provider probes timed out before UI startup; skipped-provider launcher CSS verification plus deterministic viewer visual smoke covered the CSS-only immersive route treatment.

--- a/.pm/tasks/task_834078a49c334891a3193e4f303f939a.execution.md
+++ b/.pm/tasks/task_834078a49c334891a3193e4f303f939a.execution.md
@@ -177,3 +177,15 @@ Example:
 - Review Findings Disposition: no_findings
 - Finding Disposition Evidence: no actionable findings; residual provider-backed playtest timeout documented in task evidence as external provider/environment risk, not CSS fix blocker.
 - Residual Risk: full unskipped provider-backed `scripts/run-local-letai-game-test.sh` was not completed because LetAI/provider probes timed out before UI startup; skipped-provider launcher CSS verification plus deterministic viewer visual smoke covered the CSS-only immersive route treatment.
+
+## 2026-06-13 23:43:49 CST / tpm
+- 完成内容: Ready-for-PR claim-ready evidence and project trace added.
+- 遗留事项: none for PR preflight blockers; rerun `prepare-task-pr.sh`.
+- Action: added `Trace: .pm/tasks/task_834078a49c334891a3193e4f303f939a.yaml` to `doc/game/project.md`; ran fresh `claim-ready.sh` without task-yaml persistence because the task is already closed and the helper forbids non-completion claim mutation on closed tasks.
+- Validation Command: `./scripts/pm/claim-ready.sh --claim-type ready_for_pr --verify-command "npm --prefix crates/oasis7_viewer run test:pixel-world:visual" --json`
+- Expected Result: fresh verification passes and allows ready-for-PR claim.
+- Actual Result: passed; `verification_exit_code: 0`, `status: verified`, `allowed_to_claim: true`, `verified_at: 2026-06-13T23:43:26+08:00`.
+- Validation Command: `./scripts/pm/claim-ready.sh --claim-type ready_for_pr --verify-command "npm --prefix crates/oasis7_viewer run test:pixel-world:visual" --task-uid task_834078a49c334891a3193e4f303f939a --json`
+- Expected Result: task-yaml persistence succeeds if allowed.
+- Actual Result: blocked by helper policy: `closed task claim evidence is immutable for non-completion claims`; current task already has closeout `last_claim_type: task_complete`, `last_verification_status: verified`, `last_closed_at`.
+- Blocker / Next Action: commit project trace and claim-ready evidence, then rerun PR preflight.

--- a/.pm/tasks/task_834078a49c334891a3193e4f303f939a.execution.md
+++ b/.pm/tasks/task_834078a49c334891a3193e4f303f939a.execution.md
@@ -189,3 +189,26 @@ Example:
 - Expected Result: task-yaml persistence succeeds if allowed.
 - Actual Result: blocked by helper policy: `closed task claim evidence is immutable for non-completion claims`; current task already has closeout `last_claim_type: task_complete`, `last_verification_status: verified`, `last_closed_at`.
 - Blocker / Next Action: commit project trace and claim-ready evidence, then rerun PR preflight.
+
+## 2026-06-13 23:49:57 CST / repository_health_engineer
+- 完成内容: Narrow repository-health pre-PR review returned by agent `019ec1a9-4d42-7c11-9212-b03bff6506ad`.
+- 遗留事项: stale review packet must be refreshed to cover current implementation/evidence head before PR creation.
+- Action: reviewed current HEAD `5d7f4f9437808ea81115688bb1b387f03ff83a67` for repository/task evidence alignment, especially `doc/game/project.md` Trace and `.pm` PR evidence.
+- Validation Command: repository-health review of current diff vs `refs/remotes/origin/main`.
+- Expected Result: confirm no repository-health blocker remains for project trace and task evidence alignment.
+- Actual Result: one P1 workflow finding: previous pre-PR packet was stale because it referenced Source Head `5b9f4baa0a9f8583b4f2562e5c796fd3b2fb816a` and excluded later `doc/game/project.md`; reviewer confirmed the project trace itself is semantically aligned with the task and verification path.
+- Blocker / Next Action: refresh the parser-friendly passed packet to current reviewed head `5d7f4f9437808ea81115688bb1b387f03ff83a67`; subsequent changes should be evidence-only `.pm` updates.
+
+- Pre-PR Local Role Review: passed
+- Task UID: task_834078a49c334891a3193e4f303f939a
+- Source Worktree: /Users/scc/ccwork/worktrees/oasis7-viewer-immersive-blue-gradient-line
+- Source Branch: task/viewer-immersive-blue-gradient-line
+- Source Head: 5d7f4f9437808ea81115688bb1b387f03ff83a67
+- Comparison Ref: refs/remotes/origin/main
+- Reviewed Changed Paths: .pm/tasks/task_834078a49c334891a3193e4f303f939a.execution.md; .pm/tasks/task_834078a49c334891a3193e4f303f939a.yaml; crates/oasis7_viewer/software_safe.html; doc/game/project.md
+- Role Selection Basis: changed paths touch viewer CSS, task evidence, and game project trace; task history includes player-facing immersive visual issue, viewer implementation, visual acceptance, verification evidence, and PR-evidence alignment; selected game_visual_interaction_designer for visual/readability risk, viewer_engineer for CSS/viewer integration risk, qa_engineer for verification sufficiency, repository_health_engineer for project trace / task-evidence alignment after `doc/game/project.md` was added; skipped gameplay/runtime/agent/wasm/blockchain/liveops because no gameplay rule, runtime, agent, WASM, ops, external messaging, or player promise changed.
+- Review Roles: game_visual_interaction_designer, viewer_engineer, qa_engineer, repository_health_engineer
+- Review Evidence: game_visual_interaction_designer `019ec1a0-9c97-7f73-a092-1259ccb994e7`: no_findings; CSS removes bright blue/glowing divider treatment, preserves route readability, no mobile/fallback visual regression in reviewed evidence. viewer_engineer `019ec1a0-f4f3-7d70-9305-d9c11b36644d`: no_findings; minimal CSS-only diff, served software-safe viewer path confirmed, no DOM/state/runtime logic changed, verification adequate. qa_engineer `019ec1a0-f5a1-7c00-9a35-acb3dee9bd18`: no_findings; targeted UI test, pixel-world visual smoke, served-CSS Browser check, task-local workflow lint, and git diff check are proportionate for PR creation. repository_health_engineer `019ec1a9-4d42-7c11-9212-b03bff6506ad`: finding addressed by refreshing this packet to current Source Head; project trace is semantically aligned with task and verification evidence.
+- Review Findings Disposition: addressed
+- Finding Disposition Evidence: stale packet finding addressed by this refreshed packet covering current head `5d7f4f9437808ea81115688bb1b387f03ff83a67` and changed path `doc/game/project.md`; no code/visual/QA findings remain.
+- Residual Risk: full unskipped provider-backed `scripts/run-local-letai-game-test.sh` was not completed because LetAI/provider probes timed out before UI startup; skipped-provider launcher CSS verification plus deterministic viewer visual smoke covered the CSS-only immersive route treatment. Subsequent commit after Source Head is expected to contain only this execution-log evidence.

--- a/.pm/tasks/task_834078a49c334891a3193e4f303f939a.execution.md
+++ b/.pm/tasks/task_834078a49c334891a3193e4f303f939a.execution.md
@@ -1,0 +1,140 @@
+# task_834078a49c334891a3193e4f303f939a Execution Log
+
+- task_uid: task_834078a49c334891a3193e4f303f939a
+- title: Remove immersive mode blue gradient line
+- owner_role: tpm
+- worktree_hint: /Users/scc/ccwork/worktrees/oasis7-viewer-immersive-blue-gradient-line
+
+<!-- Append entries using:
+Example:
+  ## YYYY-MM-DD HH:MM:SS CST / role_name
+  - 完成内容: ...
+  - 遗留事项: ...
+  - Action: ...
+  - Validation Command: ...
+  - Expected Result: ...
+  - Actual Result: ...
+  - Blocker / Next Action: ...
+-->
+
+## 2026-06-13 22:10:08 CST / tpm
+- 完成内容: WORKFLOW BOOTSTRAP DECIDED
+  - Repository State Impact: changes repository state; user reported a local LetAI playtest UI defect in immersive mode that needs viewer/UI correction.
+  - Isolation Decision: source workspace was `/Users/scc/ccwork/oasis7` on `main`; no explicit reuse authorization; created dedicated worktree `/Users/scc/ccwork/worktrees/oasis7-viewer-immersive-blue-gradient-line` on branch `task/viewer-immersive-blue-gradient-line`.
+  - Task Truth: owner role `tpm`; `.pm` task `task_834078a49c334891a3193e4f303f939a`; task status `committed`.
+  - Formal Docs: source/doc refs `doc/game/project.md`, `doc/testing/project.md`, `doc/game/prd.md`, `doc/testing/prd.md`.
+  - Routed Next Phase: `repo-owned-workflow-router` -> `systematic-debugging` + `executing-project-tasks`, then visual/viewer verification.
+- 完成内容: WORKFLOW ROUTE DECIDED
+  - Task Phase: reproduce and fix user-observed player-facing viewer visual defect.
+  - Selected Workflow Skills: `systematic-debugging` for observed visual regression; `executing-project-tasks` for focused implementation; `verification-before-completion` before done claim.
+  - Skipped Workflow Skills: `bounded-brainstorming` skipped because desired result is clear; `tdd-test-writer` skipped initially because defect is visual/CSS and needs reproduction before choosing stable automated coverage.
+  - Specialist Skills Considered: `agent-browser` for browser/visual reproduction; `verification-before-completion` for final evidence.
+- 完成内容: Subagent Slice Plan
+  - role: `game_visual_interaction_designer`
+  - slice type: bounded visual acceptance/readability brief.
+  - intended model configuration: `.codex/config.toml` default `gpt-5.5-medium`.
+  - actual dispatched model/reasoning: requested `gpt-5.5` / `medium`; actual model may be inherited/unverified if connector does not report final runtime.
+  - context delivery mode: full-thread/full-history fork plus this checklist.
+  - mandatory context checklist/packet: role card `.agents/roles/game_visual_interaction_designer.md`; workflow governance `AGENTS.md` and `doc/engineering/workflow/source-of-truth.md`; task truth `.pm/tasks/task_834078a49c334891a3193e4f303f939a.yaml` and this execution log; canonical worktree `/Users/scc/ccwork/worktrees/oasis7-viewer-immersive-blue-gradient-line`; branch `task/viewer-immersive-blue-gradient-line`; user intent: in `scripts/run-local-letai-game-test.sh` local playtest, immersive mode shows an abrupt blue gradient horizontal line; acceptance: remove/neutralize the line without hurting immersive readability.
+  - write scope: no code writes; return visual brief/checklist and risk notes only.
+  - return contract: findings/no_findings, recommended visual target, screenshot or DOM evidence needs, residual risk.
+  - formal sink / writeback surface: append returned conclusion to this execution log.
+  - integration owner/order: TPM integrates brief before/alongside viewer implementation; viewer implementation remains engineering owner for code.
+- 完成内容: Subagent Slice Plan
+  - role: `viewer_engineer`
+  - slice type: bounded implementation/debug slice.
+  - intended model configuration: `.codex/config.toml` default `gpt-5.5-medium`.
+  - actual dispatched model/reasoning: requested `gpt-5.5` / `medium`; actual model may be inherited/unverified if connector does not report final runtime.
+  - context delivery mode: full-thread/full-history fork plus this checklist.
+  - mandatory context checklist/packet: role card `.agents/roles/viewer_engineer.md`; workflow governance `AGENTS.md` and `doc/engineering/workflow/source-of-truth.md`; task truth `.pm/tasks/task_834078a49c334891a3193e4f303f939a.yaml` and this execution log; canonical worktree `/Users/scc/ccwork/worktrees/oasis7-viewer-immersive-blue-gradient-line`; branch `task/viewer-immersive-blue-gradient-line`; user intent: fix abrupt blue gradient horizontal line in immersive mode during local LetAI game playtest; scoped repo context: `crates/oasis7_viewer`, `scripts/run-local-letai-game-test.sh`, `testing-manual.md`; constraints: `third_party` read-only, do not modify `main`.
+  - write scope: viewer UI/CSS/JS files under `crates/oasis7_viewer` plus directly relevant tests/scripts if needed.
+  - return contract: root cause, changed files, validation command(s), residual risk, any screenshots/evidence path.
+  - formal sink / writeback surface: append returned implementation and validation evidence to this execution log.
+  - integration owner/order: TPM integrates patch, runs/coordinates verification, then closeout/PR chain if requested/appropriate.
+- 遗留事项: none at bootstrap; implementation and verification remain for later entries.
+- Action: create dedicated task worktree, bind `.pm` task, record route and subagent contracts.
+- Validation Command: `./scripts/new-task-worktree.sh viewer immersive-blue-gradient-line --base main --pm-owner-role tpm --pm-title "Remove immersive mode blue gradient line" ... --json`
+- Expected Result: isolated task worktree and committed `.pm` task are created before substantive work.
+- Actual Result: created `/Users/scc/ccwork/worktrees/oasis7-viewer-immersive-blue-gradient-line`, branch `task/viewer-immersive-blue-gradient-line`, task `task_834078a49c334891a3193e4f303f939a`.
+- Blocker / Next Action: dispatch visual and viewer slices; start local reproduction with `scripts/run-local-letai-game-test.sh` or the closest deterministic viewer harness.
+
+## 2026-06-13 22:12:00 CST / tpm
+- 完成内容: Dispatched bounded professional slices.
+  - `game_visual_interaction_designer`: agent `019ec153-3e01-7833-81d2-9dc20e63d4b2`; actual dispatch used explicit context packet with requested `gpt-5.5` / `medium` because current connector rejects simultaneous full-history fork plus model override.
+  - `viewer_engineer`: agent `019ec153-cfb7-7ce1-9ef6-0762cf9a0590`; actual dispatch used explicit context packet with requested `gpt-5.5` / `medium` because current connector rejects simultaneous full-history fork plus model override.
+- 完成内容: Attribution boundary: visual acceptance conclusion belongs to `game_visual_interaction_designer`; viewer root cause/implementation conclusion belongs to `viewer_engineer`; TPM will only integrate returned evidence, run orchestration, and record verification/PR workflow.
+- 遗留事项: none for dispatch; awaiting professional slice returns.
+- Action: dispatch `game_visual_interaction_designer` and `viewer_engineer` bounded slices.
+- Validation Command: `multi_agent_v1.spawn_agent` for the two bounded slices.
+- Expected Result: professional role slices start without creating another owner/task/worktree/PR truth.
+- Actual Result: both slices started in the canonical worktree context via explicit context packet.
+- Blocker / Next Action: TPM to reproduce/collect local playtest URL and integrate returned slice findings.
+
+## 2026-06-13 23:23:23 CST / game_visual_interaction_designer
+- 完成内容: Visual slice findings returned by agent `019ec153-3e01-7833-81d2-9dc20e63d4b2`.
+  - Finding: likely visual culprit is `.pixel-world-focus-fallback-map__route` in `crates/oasis7_viewer/software_safe.html`, a 4px horizontal green-to-blue gradient with blue glow positioned near the center of the immersive minimap; `PixelWorldFocusMinimapCard variant="immersive"` renders it whenever focus mode is active and not maximized.
+  - Secondary risk: `.pixel-world-route` is also a blue/yellow route line in the canvas route layer; target only if screenshot evidence shows the offending line is in the actual canvas route layer.
+  - Visual target: immersive mode should feel like one continuous world stage; any route cue should be thinner, lower opacity, non-blue-glowing, and subordinate to HUD/map information rather than a scene divider.
+  - Verification ask: capture Browser screenshot after `scripts/run-local-letai-game-test.sh` and enter immersive mode; prefer real renderer when available, fallback route smoke acceptable for CSS evidence.
+- 遗留事项: none for visual brief; implementation handled by viewer slice.
+- Action: integrate visual acceptance criteria into viewer CSS fix.
+- Validation Command: professional slice code/context review.
+- Expected Result: visual acceptance criteria identify the abrupt blue line source and desired treatment.
+- Actual Result: visual target and likely classes/files identified; no code edits made by this slice.
+- Blocker / Next Action: integrate with `viewer_engineer` implementation and live served CSS verification.
+
+## 2026-06-13 23:23:23 CST / viewer_engineer
+- 完成内容: Implementation slice findings and patch returned by agent `019ec153-cfb7-7ce1-9ef6-0762cf9a0590`.
+  - Root cause: immersive/fallback world focus styled route affordances like bright horizontal dividers. Main minimap route was a 4px blue-green gradient with glow; rendered world routes used saturated blue/yellow gradient.
+  - Changed file: `crates/oasis7_viewer/software_safe.html`.
+  - Patch summary: softened `.pixel-world-focus-fallback-map__route` from 4px saturated blue-green glow to 2px muted green/gold low-alpha route; softened `.pixel-world-route` from 2px saturated blue/yellow to 1px muted route with lower glow/opacity.
+  - Evidence paths: `output/playwright/pixel-world-fragment-visual/2026-06-13T15-21-51-215Z/summary.json`, `output/playwright/pixel-world-fragment-visual/2026-06-13T15-21-51-215Z/mobile-focus-overlay-visual.png`, `output/playwright/pixel-world-focus-route-probe/immersive-fallback-route-1781364068838.png`.
+- 遗留事项: TPM live served-CSS verification remains for current launcher path.
+- Action: apply focused CSS treatment in `crates/oasis7_viewer/software_safe.html`.
+- Validation Command: `npm --prefix crates/oasis7_viewer run test:ui -- software_safe_src/pixel_world_host.test.jsx`
+- Expected Result: targeted UI tests pass.
+- Actual Result: passed, 1 file / 15 tests.
+- Validation Command: `npm --prefix crates/oasis7_viewer run test:pixel-world:visual`
+- Expected Result: pixel-world visual smoke passes.
+- Actual Result: passed.
+- Validation Command: `git diff --check -- crates/oasis7_viewer/software_safe.html`
+- Expected Result: no whitespace errors.
+- Actual Result: passed.
+- Blocker / Next Action: TPM to verify current `run-local-letai-game-test.sh` served viewer after refreshing web dist; note full provider-backed smoke initially hit LetAI/provider timeouts, so UI verification uses skipped provider gates plus Browser served-CSS check.
+
+## 2026-06-13 23:25:30 CST / tpm
+- 完成内容: Fresh verification before completion.
+  - Local LetAI launcher path: `./scripts/run-local-letai-game-test.sh --skip-chat-probe --skip-bridge-smoke -- --viewer-port 4177 --live-bind 127.0.0.1:5027 --web-bind 127.0.0.1:5017 --json-ready --skip-llm-provider-preflight`.
+  - Ready URL: `http://127.0.0.1:4177/?render_mode=software_safe&ws=ws://127.0.0.1:5017&test_api=1&locale=zh`.
+  - Served asset refresh: `./scripts/copy-viewer-web-dist.sh --dist-dir crates/oasis7_viewer/dist` and `./scripts/copy-viewer-web-dist.sh --dist-dir output/local-letai-game-test/20260613-221755/launcher/web-dist`.
+  - Browser check after entering immersive mode: `.pixel-world-focus-fallback-map__route` computed style changed from old `height: 4px`, blue gradient `rgba(99, 179, 255, 0.56)`, and blue glow to `height: 2px`, muted green/gold gradient `rgba(141, 199, 170, 0.22)` -> `rgba(208, 168, 91, 0.18)`, low green glow, opacity `0.72`.
+- 遗留事项: full unskipped provider-backed playtest remains blocked by external LetAI/provider probe timeout; UI fix evidence is complete through skipped-provider launcher path and deterministic visual smoke.
+- Action: run fresh verification, refresh served web dist for live launcher check, and record provider-gate limitation.
+- Validation Command: `npm --prefix crates/oasis7_viewer run test:ui -- software_safe_src/pixel_world_host.test.jsx`
+- Expected Result: targeted UI tests pass.
+- Actual Result: passed, 1 file / 15 tests.
+- Validation Command: `npm --prefix crates/oasis7_viewer run test:pixel-world:visual`
+- Expected Result: pixel-world visual smoke passes and records screenshot evidence.
+- Actual Result: passed; evidence summary `output/playwright/pixel-world-fragment-visual/2026-06-13T15-25-03-020Z/summary.json`; mobile focus overlay screenshot `output/playwright/pixel-world-fragment-visual/2026-06-13T15-25-03-020Z/mobile-focus-overlay-visual.png`.
+- Validation Command: `git diff --check -- crates/oasis7_viewer/software_safe.html .pm/tasks/task_834078a49c334891a3193e4f303f939a.execution.md`
+- Expected Result: no whitespace errors.
+- Actual Result: passed.
+- Blocker / Next Action: no UI/code blocker found. Full unskipped provider-backed playtest was not completed because LetAI chat probe/provider bridge smoke timed out before UI startup; this is recorded as external provider gate instability rather than the visual fix evidence path.
+
+## 2026-06-13 23:34:43 CST / tpm
+- 完成内容: Task closeout and PM-lint boundary recorded for PR flow.
+- 遗留事项: repo-wide `.pm lint` still has unrelated historical execution-log debt in tasks such as `task_20abeb9162c540fca74779ee7b243421`, `task_56f67be67a5a43c09027cb224f1416ad`, `task_96c772c830e043f9b1e40b03e6f73d38`, and others; current task-local workflow lint passes.
+- Action: ran standard `task-closeout.sh`, then confirmed current task status and task-local workflow lint.
+- Validation Command: `./scripts/pm/task-closeout.sh --role tpm --task-uid task_834078a49c334891a3193e4f303f939a --verify-command "npm --prefix crates/oasis7_viewer run test:pixel-world:visual" --claim-type task_complete`
+- Expected Result: fresh visual smoke runs, task closes to `done`, final PM lint passes or reports blockers.
+- Actual Result: verification passed and task YAML is `status: done` with `last_verification_exit_code: 0`; final repo-wide PM lint failed on unrelated historical tasks plus pre-field-fix entries in this task log.
+- Validation Command: `./scripts/pm/task-closeout.sh --role tpm --task-uid task_834078a49c334891a3193e4f303f939a --verify-command "npm --prefix crates/oasis7_viewer run test:pixel-world:visual" --claim-type task_complete --no-lint`
+- Expected Result: no-lint closeout completes if needed after separating global lint noise.
+- Actual Result: no-op failure `task already closed with status=done`, confirming prior closeout already changed current task status.
+- Validation Command: `./scripts/pm/workflow-lint.sh --task-uid task_834078a49c334891a3193e4f303f939a --phase current`
+- Expected Result: current task workflow lint passes.
+- Actual Result: passed.
+- Validation Command: `git diff --check`
+- Expected Result: no whitespace errors across current diff.
+- Actual Result: passed.
+- Blocker / Next Action: proceed to commit and pre-PR local role review; do not treat unrelated repo-wide PM lint debt as this task blocker.

--- a/.pm/tasks/task_834078a49c334891a3193e4f303f939a.yaml
+++ b/.pm/tasks/task_834078a49c334891a3193e4f303f939a.yaml
@@ -1,0 +1,27 @@
+task_uid: task_834078a49c334891a3193e4f303f939a
+title: "Remove immersive mode blue gradient line"
+owner_role: tpm
+worktree_hint: /Users/scc/ccwork/worktrees/oasis7-viewer-immersive-blue-gradient-line
+execution_log_path: .pm/tasks/task_834078a49c334891a3193e4f303f939a.execution.md
+status: done
+priority: P2
+source_signal: null
+source_refs:
+  - doc/game/project.md
+  - doc/testing/project.md
+doc_refs:
+  - doc/game/prd.md
+  - doc/testing/prd.md
+related_prd: []
+acceptance:
+  - "Immersive mode no longer shows the abrupt blue gradient horizontal line during local LetAI game playtest."
+  - "Relevant viewer/UI checks or visual reproduction evidence are recorded."
+handoff_to: []
+updated_at: 2026-06-13T23:33:23+08:00
+last_started_at: 2026-06-13T22:07:27+08:00
+last_claim_type: task_complete
+last_verify_command: "npm --prefix crates/oasis7_viewer run test:pixel-world:visual"
+last_verified_at: 2026-06-13T23:33:22+08:00
+last_verification_exit_code: 0
+last_verification_status: verified
+last_closed_at: 2026-06-13T23:33:23+08:00

--- a/crates/oasis7_viewer/software_safe.html
+++ b/crates/oasis7_viewer/software_safe.html
@@ -842,14 +842,15 @@
         left: 29%;
         right: 29%;
         top: 49%;
-        height: 4px;
+        height: 2px;
         border-radius: 999px;
-        background: linear-gradient(90deg, rgba(141, 199, 170, 0.62), rgba(99, 179, 255, 0.56));
-        box-shadow: 0 0 20px rgba(99, 179, 255, 0.14);
+        background: linear-gradient(90deg, rgba(141, 199, 170, 0.22), rgba(208, 168, 91, 0.18));
+        box-shadow: 0 0 14px rgba(141, 199, 170, 0.08);
+        opacity: 0.72;
       }
       .pixel-world-focus-fallback-map__route[data-routes="0"] {
-        opacity: 0.26;
-        background: rgba(152, 177, 150, 0.34);
+        opacity: 0.2;
+        background: rgba(152, 177, 150, 0.22);
       }
       .pixel-world-focus-fallback-map__node {
         position: absolute;
@@ -1242,11 +1243,12 @@
       .pixel-world-route {
         position: absolute;
         z-index: 2;
-        height: 2px;
+        height: 1px;
         pointer-events: none;
         border-radius: 999px;
-        background: linear-gradient(90deg, rgba(99, 179, 255, 0.72), rgba(250, 204, 21, 0.5));
-        box-shadow: 0 0 12px rgba(99, 179, 255, 0.16);
+        background: linear-gradient(90deg, rgba(141, 199, 170, 0.24), rgba(208, 168, 91, 0.2));
+        box-shadow: 0 0 10px rgba(141, 199, 170, 0.08);
+        opacity: 0.78;
       }
       .pixel-world-entity {
         position: absolute;

--- a/doc/game/project.md
+++ b/doc/game/project.md
@@ -3,6 +3,7 @@
 审计轮次: 17
 
 ## 任务拆解（含 PRD-ID 映射）
+- [x] viewer-immersive-blue-gradient-line (PRD-GAME-012) [test_tier_required]: `viewer_engineer` 已收口沉浸模式中突兀的蓝色渐变横线，把 minimap route 与 canvas route 从高饱和蓝色 glow 降为更细、更低透明的路线提示，并通过 targeted UI、pixel-world visual smoke、local launcher served-CSS 检查与 pre-PR 本地角色 review。 Trace: .pm/tasks/task_834078a49c334891a3193e4f303f939a.yaml
 - [x] TASK-GAME-001 (PRD-GAME-001) [test_tier_required]: 完成 game PRD 改写，建立玩法设计总入口。
 - Legacy `TASK-GAME-002` (PRD-GAME-001/002): 补齐核心玩法循环（新手/经济/协作治理）验收矩阵；战争/政治只保留为历史 runtime primitive 与未来受控重启参考，不作为当前玩家-facing 主循环承诺。
 - [x] TASK-GAME-003 (PRD-GAME-002/003) [test_tier_required]: 建立可玩性问题分级与修复闭环模板。


### PR DESCRIPTION
## Summary
- soften the immersive/fallback route indicator that appeared as a bright blue horizontal divider
- reduce canvas route emphasis to keep route affordance readable without stealing focus
- add task trace and PR evidence for task_834078a49c334891a3193e4f303f939a

## Verification
- npm --prefix crates/oasis7_viewer run test:ui -- software_safe_src/pixel_world_host.test.jsx
- npm --prefix crates/oasis7_viewer run test:pixel-world:visual
- ./scripts/pm/workflow-lint.sh --task-uid task_834078a49c334891a3193e4f303f939a --phase pr-ready
- git diff --check

## Residual Risk
- Full unskipped provider-backed run-local-letai-game-test hit LetAI/provider probe timeouts before UI startup; skipped-provider launcher CSS verification and deterministic viewer visual smoke covered this CSS-only viewer fix.