### PR TITLE
Route checkpoint blobs through providers

### DIFF
--- a/.pm/tasks/task_96c772c830e043f9b1e40b03e6f73d38.execution.md
+++ b/.pm/tasks/task_96c772c830e043f9b1e40b03e6f73d38.execution.md
@@ -425,3 +425,32 @@ Example:
 - Review Findings Disposition: addressed
 - Residual Risk: live CI package/deployment still required for Linux storage, Linux observer, and reachable Windows host; verify chunked fetch-blob transfer, final size/hash checks, and worker tick progress.
 - Blocker / Next Action: commit, push PR, then use CI package for Linux/Windows deployment.
+
+## 2026-06-14 00:22:00 CST / tpm
+- Follow-up trigger: PR #450 merged and Testnet Packages run `27470938203` (#64) succeeded for linux/macos/windows. Linux artifact `testnet-package-linux-x64-0.0.0+testnet.64.16b21b7faad9` passed SHA256 verification and was deployed to `39.104.205.67` storage, `192.168.1.4` observer, and then `39.104.204.172` sequencer after live state showed the sequencer was also part of the active public testnet source set.
+- Live verification: all three Linux services run `oasis7-public-testnet-governed-20260606` with runtime hash `54605b61aff8662e2a995953defbbd7aa8629e5696ce5b858930e251d8ce683a`. The old `shared-devnet-ecs-v1` observer path is no longer the active testnet observer path. Windows package `testnet-package-windows-x64-0.0.0+testnet.64.16b21b7faad9` downloaded and passed SHA256 verification; host deployment remains separate/reachability dependent.
+- New live finding after #450 deploy: observer progressed beyond the large `/fetch-blob/` EOF/timeout class and transferred about 4MiB over `/aw/node/replication/fetch-blob/1.0.0`, but then stopped at `node replication error: execution checkpoint blob not found hash=bc25ba53ac3b08e162e8c7641bcb937ff2e1e40025a525ed66cb6eabd76ab948`. This shows automatic peer join and chunked transfer now work far enough to materialize checkpoint metadata, but checkpoint install still used generic blob route selection and could land on a peer missing a specific checkpoint blob.
+- Code change: `ensure_execution_checkpoint_blob` now looks up DHT provider ids for each checkpoint manifest/blob content hash and passes them into `request_fetch_blob_with_route_fallback`, matching existing gap sync and storage challenge provider-aware fetch behavior. If provider lookup fails and generic fallback still returns not found, the checkpoint error preserves the provider lookup failure context.
+- Test change: retained high-checkpoint gap-sync coverage now seeds DHT providers for commit payload blobs, checkpoint manifest blob, and checkpoint data blobs, then asserts provider-aware blob fetch attempts include the selected provider.
+- Review Trigger: checkpoint provider-aware fallback fix pre-PR local role review.
+- Review Roles: blockchain_ops_engineer, runtime_engineer
+- Review Finding: P2 on silently dropping DHT provider lookup failures with `unwrap_or(None)`, which could hide a real lookup issue behind a generic `execution checkpoint blob not found`.
+- Finding Disposition: addressed by preserving provider lookup failure in the final not-found error while still allowing generic fallback to recover when possible.
+- Review Recheck Result: no further findings after local integration of the P2 fix by TPM; residual risk is live provider record availability for both manifest and checkpoint blobs.
+- Validation Command: env -u RUSTC_WRAPPER cargo test -p oasis7_node storage_replication_high_checkpoint_retained -- --nocapture
+- Actual Result: passed; 4 tests passed.
+- Validation Command: env -u RUSTC_WRAPPER cargo test -p oasis7_node runtime_network_replication_gap_sync -- --nocapture
+- Actual Result: passed; 10 tests passed.
+- Validation Command: env -u RUSTC_WRAPPER cargo fmt --check && git diff --check
+- Actual Result: passed.
+- Validation Command: ./scripts/check-rust-file-size.sh
+- Actual Result: passed; oversized code files=0, test files=0.
+- Validation Command: ./scripts/pm/workflow-behavior-eval.sh
+- Actual Result: passed.
+- Pre-PR Local Role Review: passed
+- Task UID: task_96c772c830e043f9b1e40b03e6f73d38
+- Source Worktree: /Users/scc/ccwork/worktrees/oasis7-testnet-high-state-peer-retry
+- Source Branch: codex/testnet-checkpoint-provider-fallback
+- Comparison Ref: refs/remotes/origin/main
+- Reviewed Changed Paths: `crates/oasis7_node/src/node_engine_replication.rs`; `crates/oasis7_node/src/tests_storage_replication_high_checkpoint_retained.rs`
+- Residual Risk: CI package and deploy required to verify observer proceeds past checkpoint blob not-found and continues high-state catch-up.

--- a/crates/oasis7_node/src/node_engine_replication.rs
+++ b/crates/oasis7_node/src/node_engine_replication.rs
@@ -691,14 +691,33 @@ impl PosNodeEngine {
             return Ok(());
         }
         let request = replication_runtime.build_fetch_blob_request(content_hash)?;
+        let mut provider_lookup_failure = None;
+        let provider_lookup = match endpoint
+            .lookup_provider_ids_for_content_hash(world_id, content_hash)
+        {
+            Ok(provider_ids) => provider_ids,
+            Err(err) => {
+                provider_lookup_failure = Some(format!(
+                    "provider lookup failed for execution checkpoint blob hash={content_hash}: {err:?}"
+                ));
+                None
+            }
+        };
         let response = request_fetch_blob_with_route_fallback(
             endpoint,
             world_id,
             content_hash,
             &request,
-            None,
+            provider_lookup.as_deref(),
         )?;
         if !response.found {
+            if let Some(provider_lookup_failure) = provider_lookup_failure {
+                return Err(NodeError::Replication {
+                    reason: format!(
+                        "execution checkpoint blob not found hash={content_hash}; {provider_lookup_failure}"
+                    ),
+                });
+            }
             return Err(NodeError::Replication {
                 reason: format!("execution checkpoint blob not found hash={content_hash}"),
             });

--- a/crates/oasis7_node/src/tests_storage_replication_high_checkpoint_retained.rs
+++ b/crates/oasis7_node/src/tests_storage_replication_high_checkpoint_retained.rs
@@ -142,6 +142,7 @@ fn observer_gap_sync_probes_retained_checkpoint_window_below_non_checkpoint_head
     let mut replication_a =
         ReplicationRuntime::new(config_a.replication.as_ref().expect("repl a"), "node-a")
             .expect("runtime a");
+    let mut provider_hashes = Vec::<String>::new();
     for height in [64_u64, 300_u64] {
         let decision = PosDecision {
             height,
@@ -161,7 +162,16 @@ fn observer_gap_sync_probes_retained_checkpoint_window_below_non_checkpoint_head
         let checkpoint = (height == 64).then(|| {
             test_execution_checkpoint_bundle(height, &execution_block_hash, &execution_state_root)
         });
-        replication_a
+        if let Some(bundle) = checkpoint.as_ref() {
+            provider_hashes.push(oasis7_distfs::blake3_hex(bundle.manifest_json.as_slice()));
+            provider_hashes.extend(
+                bundle
+                    .blobs
+                    .iter()
+                    .map(|blob| blob.content_hash.clone()),
+            );
+        }
+        let message = replication_a
             .build_local_commit_message_with_checkpoint(
                 "node-a",
                 world_id,
@@ -173,11 +183,16 @@ fn observer_gap_sync_probes_retained_checkpoint_window_below_non_checkpoint_head
             )
             .expect("build local message")
             .expect("message");
+        provider_hashes.push(message.record.content_hash);
     }
 
+    let network_impl = Arc::new(ProviderAwareTestNetwork::new(
+        dir_a.clone(),
+        "node-a-provider",
+    ));
     let network: Arc<
         dyn oasis7_proto::distributed_net::DistributedNetwork<WorldError> + Send + Sync,
-    > = Arc::new(TestInMemoryNetwork::default());
+    > = network_impl.clone();
     register_replication_fetch_handlers(
         &NodeReplicationNetworkHandle::new(Arc::clone(&network)),
         &replication_config_a,
@@ -185,7 +200,16 @@ fn observer_gap_sync_probes_retained_checkpoint_window_below_non_checkpoint_head
         &config_a.network_policy,
     )
     .expect("register fetch handlers");
-    let handle_b = NodeReplicationNetworkHandle::new(Arc::clone(&network));
+    let dht = Arc::new(TestReplicaMaintenanceDht::new(
+        "node-a-provider",
+        "node-b-provider",
+    ));
+    for hash in &provider_hashes {
+        dht.seed_provider(hash, "node-a-provider");
+    }
+    let handle_b = NodeReplicationNetworkHandle::new(Arc::clone(&network))
+        .with_dht(dht)
+        .with_local_provider_id("node-b-provider");
     let endpoint_b =
         ReplicationNetworkEndpoint::new(&handle_b, world_id, false, &config_b.network_policy)
             .expect("endpoint b");
@@ -217,6 +241,13 @@ fn observer_gap_sync_probes_retained_checkpoint_window_below_non_checkpoint_head
         Some(("exec-block-64", "exec-state-64"))
     );
     assert_eq!(engine_b.last_replication_gap_sync_blocked_height, None);
+    let provider_attempts = network_impl.provider_attempts();
+    assert!(
+        provider_attempts.iter().any(|providers| providers
+            .iter()
+            .any(|provider| provider == "node-a-provider")),
+        "expected retained checkpoint sync to route blob fetches through DHT providers, attempts={provider_attempts:?}"
+    );
 
     let _ = fs::remove_dir_all(&dir_a);
     let _ = fs::remove_dir_all(&dir_b);


### PR DESCRIPTION
## Summary
- route execution checkpoint manifest/blob fetches through DHT provider ids before generic fallback
- preserve provider lookup failure context if the generic fallback still returns blob not found
- add retained high-checkpoint coverage proving checkpoint blob fetches use DHT-selected providers

## Live context
After PR #450 deployed from Testnet Packages run `27470938203`, Linux sequencer/storage/observer all ran `oasis7-public-testnet-governed-20260606` and the observer progressed beyond the large `/fetch-blob/` EOF/timeout class. The next live blocker became `execution checkpoint blob not found hash=bc25...`, with traffic showing checkpoint blob fetches had begun. This patch fixes the missing provider-aware route selection in checkpoint install.

## Verification
- `env -u RUSTC_WRAPPER cargo test -p oasis7_node storage_replication_high_checkpoint_retained -- --nocapture`
- `env -u RUSTC_WRAPPER cargo test -p oasis7_node runtime_network_replication_gap_sync -- --nocapture`
- `env -u RUSTC_WRAPPER cargo fmt --check && git diff --check`
- `./scripts/check-rust-file-size.sh`
- `./scripts/pm/workflow-lint.sh --phase pr-ready --task-uid task_96c772c830e043f9b1e40b03e6f73d38`
- `./scripts/pm/workflow-behavior-eval.sh`

Pre-PR Local Role Review: passed
