### PR TITLE
Fallback blob fetches through connected peers

### DIFF
--- a/.pm/tasks/task_96c772c830e043f9b1e40b03e6f73d38.execution.md
+++ b/.pm/tasks/task_96c772c830e043f9b1e40b03e6f73d38.execution.md
@@ -238,6 +238,66 @@ Example:
 - Formal Sink: `.pm/tasks/task_96c772c830e043f9b1e40b03e6f73d38.execution.md`
 - Blocker / Next Action: dispatch runtime_engineer and qa_engineer review slices, integrate findings, create follow-up PR, run CI package again, then redeploy Linux/storage/local/Windows from the v2 package.
 
+## 2026-06-14 01:22:00 CST / tpm
+- 完成内容: Post-PR #455/testnet.65 live smoke showed the prior checkpoint-provider route fix succeeded for the specific checkpoint install path, but observer still hit gap-sync blob misses while connected to both sequencer and storage. Observer logs after the #65 restart included `gap sync height 16576 blob not found for hash 5d8dcc970510559a811693ca4f1e0801b224098ffe5547f4701e4616f65da2b3`; storage `39.104.205.67` had that blob and the earlier missed hashes on disk, while sequencer `39.104.204.172` did not.
+- 设计结论: Public testnet high-state sync cannot treat an application-level `FetchBlobResponse { found: false }` from one routed peer as final when other connected peers may hold the blob. DHT provider records remain an accelerator, but a newly started observer should be able to make progress without seed/state-sync once it is connected to a storage/full-storage peer.
+- 代码改动: Added `ReplicationNetworkEndpoint::connected_peer_ids()` and updated `request_fetch_blob_chunk_with_route_fallback` to try provider routes, then one generic route, then each deduplicated connected peer as a provider-directed route before spending the remaining generic retry budget. Retryable route/availability errors still fall back; non-retryable errors still fail closed.
+- 回归测试: Added `fetch_blob_route_fallback_tries_connected_peers_after_not_found_routes`, which reproduces the live topology: stale provider miss, generic `found=false`, sequencer connected-peer miss, storage connected-peer hit.
+- Validation Command: env -u RUSTC_WRAPPER cargo test -p oasis7_node fetch_blob_route_fallback_tries_connected_peers_after_not_found_routes -- --nocapture
+- Expected Result: new regression proves blob sync can recover from stale/generic not-found routes through connected storage.
+- Actual Result: passed; 1 test passed.
+- Validation Command: env -u RUSTC_WRAPPER cargo test -p oasis7_node storage_replication_high_checkpoint_retained -- --nocapture
+- Actual Result: passed; 4 tests passed.
+- Validation Command: env -u RUSTC_WRAPPER cargo test -p oasis7_node runtime_network_replication_gap_sync -- --nocapture
+- Actual Result: passed; 10 tests passed.
+- Validation Command: env -u RUSTC_WRAPPER cargo fmt --check && git diff --check && ./scripts/check-rust-file-size.sh
+- Actual Result: passed; format, whitespace, and Rust file-size gates clean.
+- Review Trigger: post-testnet.65 gap-sync blob route follow-up pre-PR local role review
+- Review Roles: runtime_engineer, qa_engineer
+- Review Question: confirm whether connected-peer blob fallback is the correct code-level root fix for live `blob not found` misses where storage has the blob but provider/generic routing can hit a sequencer without the blob, and whether the regression coverage is sufficient for CI package/deploy.
+- Expected Return Contract: findings | no_findings | residual_risk
+- Formal Sink: `.pm/tasks/task_96c772c830e043f9b1e40b03e6f73d38.execution.md`
+- Blocker / Next Action: dispatch runtime_engineer and qa_engineer review slices, integrate findings, run workflow lint, commit, create PR, use CI package, and redeploy Linux/local/Windows where reachable.
+
+## 2026-06-14 01:34:00 CST / tpm
+- runtime_engineer: no_findings. A `found=false` blob response is an application-level miss from a reachable peer, so generic libp2p routing can stop on the wrong peer without surfacing a retryable transport error. The new route order in `replication_probe_gate.rs` correctly tries DHT providers, one generic route, deduplicated connected peers as explicit provider routes, then remaining generic budget.
+- runtime_engineer semantic review: retryable availability/route-unavailable errors still fall through to alternate routes; decode, policy, validation, and other non-retryable errors still return immediately. The connected-peer sweep is bounded by the current connected peer list and the generic retry constant, so no unbounded loop behavior was found.
+- runtime_engineer residual_risk: large checkpoint blobs may amplify requests as `chunks * connected_peers` because each chunk can re-probe non-holder peers before reaching storage. Acceptable for this root fix; a later polish can cache/prioritize the peer that returned the previous successful chunk. This also does not replace provider-record hygiene if the holder is neither connected nor discoverable.
+- qa_engineer: no_findings. The regression test sufficiently covers the live failure mode for PR/CI packaging: provider-aware route returns `found=false`, generic route returns `found=false`, and a connected storage peer satisfies the blob through targeted provider routing.
+- qa_engineer suggestion: make the stale provider in the test be `sequencer-peer` instead of a separate name to match the live topology more literally. Disposition: addressed by changing the test provider route to `sequencer-peer`; the expected attempts are now sequencer miss followed by storage hit.
+- qa_engineer residual_risk: fix depends on `connected_peer_ids()` including storage when blob fetch happens and does not replace broader DHT provider republish hygiene; live deployment must confirm observer clears the gap-sync blob-not-found loop.
+- Validation Command: env -u RUSTC_WRAPPER cargo test -p oasis7_node fetch_blob_route_fallback_tries_connected_peers_after_not_found_routes -- --nocapture
+- Actual Result: passed after QA topology-fidelity adjustment; 1 test passed.
+- Validation Command: env -u RUSTC_WRAPPER cargo fmt --check && git diff --check
+- Actual Result: passed after QA topology-fidelity adjustment.
+- Pre-PR Local Role Review: passed
+- Task UID: task_96c772c830e043f9b1e40b03e6f73d38
+- Source Worktree: /Users/scc/ccwork/worktrees/oasis7-testnet-high-state-peer-retry
+- Source Branch: codex/testnet-blob-provider-republish
+- Comparison Ref: refs/remotes/origin/main
+- Reviewed Changed Paths: `crates/oasis7_node/src/network_bridge.rs`; `crates/oasis7_node/src/replication_probe_gate.rs`; `crates/oasis7_node/src/tests_fetch_blob_chunking.rs`; `.pm/tasks/task_96c772c830e043f9b1e40b03e6f73d38.execution.md`
+- Role Selection Basis: runtime replication blob route semantics, public testnet high-state sync behavior, and regression/release-readiness verification.
+- Review Roles: runtime_engineer, qa_engineer
+- Review Evidence: runtime_engineer no_findings and qa_engineer no_findings recorded above.
+- Review Findings Disposition: addressed
+- Finding Disposition Evidence: QA topology-fidelity suggestion addressed and target test reran cleanly.
+- Residual Risk: packaged CI artifact and live Linux/storage/local/Windows redeploy smoke remain required after merge; deployment smoke should verify observer leaves the gap-sync blob-not-found loop.
+
+## 2026-06-14 01:49:00 CST / tpm
+- PR Review Finding: P2 automated PR review found that a connected peer returning `ErrUnsupported` for fetch-blob would abort the new connected-peer sweep before later connected storage peers were tried.
+- Finding Disposition: addressed. `should_fallback_provider_aware_replication_request` now treats fetch-blob `ErrUnsupported` as a fallbackable peer-level miss, scoped to `REPLICATION_FETCH_BLOB_PROTOCOL`.
+- 回归测试: Added `fetch_blob_route_fallback_skips_unsupported_connected_peers`, proving a legacy connected peer can return `ErrUnsupported` and the route sweep still reaches storage. Added helper coverage `provider_aware_fallback_treats_fetch_blob_unsupported_as_retryable`.
+- Validation Command: env -u RUSTC_WRAPPER cargo test -p oasis7_node fetch_blob_route_fallback -- --nocapture
+- Actual Result: passed; 2 tests passed.
+- Validation Command: env -u RUSTC_WRAPPER cargo test -p oasis7_node provider_aware_fallback_treats_fetch_blob_unsupported_as_retryable -- --nocapture
+- Actual Result: passed; 1 test passed.
+- Validation Command: env -u RUSTC_WRAPPER cargo test -p oasis7_node storage_replication_high_checkpoint_retained -- --nocapture && env -u RUSTC_WRAPPER cargo test -p oasis7_node runtime_network_replication_gap_sync -- --nocapture
+- Actual Result: passed; 4 retained checkpoint tests and 10 gap-sync tests passed.
+- Validation Command: env -u RUSTC_WRAPPER cargo fmt --check && git diff --check && ./scripts/check-rust-file-size.sh
+- Actual Result: passed.
+- Validation Command: ./scripts/pm/workflow-lint.sh --phase pr-ready --task-uid task_96c772c830e043f9b1e40b03e6f73d38
+- Actual Result: passed.
+
 ## 2026-06-13 18:02:00 CST / tpm
 - runtime_engineer: no_findings. `request_to_peer` now uses `std::sync::mpsc::channel` and `recv_timeout`, so it no longer blocks on a futures oneshot executor path; this directly addresses the packaged observer gdb backtrace.
 - runtime_engineer semantic review: runtime loop still sends success or the original `Err(WorldError)` unchanged; API helper preserves `Ok(result) => result` and only maps channel closed/timeout to `NetworkProtocolUnavailable`. DHT pending query outcomes keep their original Kademlia result semantics.

--- a/crates/oasis7_node/src/network_bridge.rs
+++ b/crates/oasis7_node/src/network_bridge.rs
@@ -595,6 +595,10 @@ impl ReplicationNetworkEndpoint {
         })
     }
 
+    pub(crate) fn connected_peer_ids(&self) -> Vec<String> {
+        self.network.connected_peer_ids()
+    }
+
     pub(crate) fn lookup_provider_ids_for_content_hash(
         &self,
         world_id: &str,

--- a/crates/oasis7_node/src/replication_probe_gate.rs
+++ b/crates/oasis7_node/src/replication_probe_gate.rs
@@ -115,6 +115,8 @@ fn should_fallback_provider_aware_replication_request(err: &NodeError) -> bool {
     };
     reason.starts_with(crate::network_bridge::REPLICATION_NETWORK_AVAILABILITY_GAP_PREFIX)
         || reason.starts_with(crate::network_bridge::REPLICATION_NETWORK_ROUTE_UNAVAILABLE_PREFIX)
+        || (reason.contains("ErrUnsupported")
+            && reason.contains(super::replication::REPLICATION_FETCH_BLOB_PROTOCOL))
 }
 
 pub(super) fn replication_request_waitable_connection_gap(err: &NodeError) -> bool {
@@ -156,6 +158,16 @@ mod tests {
                 "{}simulated provider route unavailable",
                 crate::network_bridge::REPLICATION_NETWORK_ROUTE_UNAVAILABLE_PREFIX
             ),
+        };
+        assert!(should_fallback_provider_aware_replication_request(&err));
+        assert!(!replication_request_waitable_connection_gap(&err));
+    }
+
+    #[test]
+    fn provider_aware_fallback_treats_fetch_blob_unsupported_as_retryable() {
+        let err = NodeError::Replication {
+            reason: "replication network error: NetworkRequestFailed { code: ErrUnsupported, message: \"/aw/node/replication/fetch-blob/1.0.0\", retryable: false }"
+                .to_string(),
         };
         assert!(should_fallback_provider_aware_replication_request(&err));
         assert!(!replication_request_waitable_connection_gap(&err));
@@ -241,10 +253,15 @@ fn request_fetch_blob_chunk_with_route_fallback(
 ) -> Result<FetchBlobResponse, NodeError> {
     let mut last_not_found: Option<FetchBlobResponse> = None;
     let mut last_retryable_error: Option<NodeError> = None;
+    let mut attempted_provider_ids = std::collections::BTreeSet::new();
 
     if let Some(provider_ids) = provider_ids {
         for provider_id in provider_ids {
-            let provider_route = [provider_id.clone()];
+            let provider_id = provider_id.trim();
+            if provider_id.is_empty() || !attempted_provider_ids.insert(provider_id.to_string()) {
+                continue;
+            }
+            let provider_route = [provider_id.to_string()];
             match endpoint.request_json_with_providers::<FetchBlobRequest, FetchBlobResponse>(
                 REPLICATION_FETCH_BLOB_PROTOCOL,
                 request,
@@ -264,7 +281,8 @@ fn request_fetch_blob_chunk_with_route_fallback(
         }
     }
 
-    for _ in 0..REPLICATION_FETCH_BLOB_GENERIC_ROUTE_ATTEMPTS {
+    let mut generic_attempts = 0usize;
+    if generic_attempts < REPLICATION_FETCH_BLOB_GENERIC_ROUTE_ATTEMPTS {
         match endpoint.request_json::<FetchBlobRequest, FetchBlobResponse>(
             REPLICATION_FETCH_BLOB_PROTOCOL,
             request,
@@ -280,6 +298,53 @@ fn request_fetch_blob_chunk_with_route_fallback(
             }
             Err(err) => return Err(err),
         }
+        generic_attempts += 1;
+    }
+
+    let mut connected_peer_ids = endpoint.connected_peer_ids();
+    connected_peer_ids.sort();
+    connected_peer_ids.dedup();
+    for peer_id in connected_peer_ids {
+        let peer_id = peer_id.trim();
+        if peer_id.is_empty() || !attempted_provider_ids.insert(peer_id.to_string()) {
+            continue;
+        }
+        let provider_route = [peer_id.to_string()];
+        match endpoint.request_json_with_providers::<FetchBlobRequest, FetchBlobResponse>(
+            REPLICATION_FETCH_BLOB_PROTOCOL,
+            request,
+            provider_route.as_slice(),
+        ) {
+            Ok(response) => {
+                if response.found {
+                    return Ok(response);
+                }
+                last_not_found = Some(response);
+            }
+            Err(err) if should_fallback_provider_aware_replication_request(&err) => {
+                last_retryable_error = Some(err);
+            }
+            Err(err) => return Err(err),
+        }
+    }
+
+    while generic_attempts < REPLICATION_FETCH_BLOB_GENERIC_ROUTE_ATTEMPTS {
+        match endpoint.request_json::<FetchBlobRequest, FetchBlobResponse>(
+            REPLICATION_FETCH_BLOB_PROTOCOL,
+            request,
+        ) {
+            Ok(response) => {
+                if response.found {
+                    return Ok(response);
+                }
+                last_not_found = Some(response);
+            }
+            Err(err) if should_fallback_provider_aware_replication_request(&err) => {
+                last_retryable_error = Some(err);
+            }
+            Err(err) => return Err(err),
+        }
+        generic_attempts += 1;
     }
 
     if let Some(response) = last_not_found {

--- a/crates/oasis7_node/src/tests_fetch_blob_chunking.rs
+++ b/crates/oasis7_node/src/tests_fetch_blob_chunking.rs
@@ -1,4 +1,5 @@
 use super::*;
+use oasis7_proto::distributed::DistributedErrorCode;
 use oasis7_proto::distributed_net::NetworkSubscription;
 use oasis7_proto::world_error::WorldError;
 use std::collections::HashMap;
@@ -7,6 +8,16 @@ use std::sync::{Arc, Mutex};
 #[derive(Clone)]
 struct LegacyExactChunkBlobNetwork {
     attempts: Arc<Mutex<usize>>,
+}
+
+#[derive(Clone)]
+struct ConnectedPeerBlobFallbackNetwork {
+    blob_provider_id: String,
+    blob: Vec<u8>,
+    generic_attempts: Arc<Mutex<usize>>,
+    provider_attempts: Arc<Mutex<Vec<Vec<String>>>>,
+    connected_peer_ids: Vec<String>,
+    unsupported_provider_ids: Vec<String>,
 }
 
 impl oasis7_proto::distributed_net::DistributedNetwork<WorldError> for LegacyExactChunkBlobNetwork {
@@ -39,6 +50,104 @@ impl oasis7_proto::distributed_net::DistributedNetwork<WorldError> for LegacyExa
         })
         .map_err(|err| WorldError::DistributedValidationFailed {
             reason: format!("encode legacy blob response failed: {err}"),
+        })
+    }
+
+    fn register_handler(
+        &self,
+        _protocol: &str,
+        _handler: Box<dyn Fn(&[u8]) -> Result<Vec<u8>, WorldError> + Send + Sync>,
+    ) -> Result<(), WorldError> {
+        Ok(())
+    }
+}
+
+impl oasis7_proto::distributed_net::DistributedNetwork<WorldError>
+    for ConnectedPeerBlobFallbackNetwork
+{
+    fn publish(&self, _topic: &str, _payload: &[u8]) -> Result<(), WorldError> {
+        Ok(())
+    }
+
+    fn subscribe(&self, topic: &str) -> Result<NetworkSubscription, WorldError> {
+        Ok(NetworkSubscription::new(
+            topic.to_string(),
+            Arc::new(Mutex::new(HashMap::new())),
+        ))
+    }
+
+    fn request(&self, protocol: &str, _payload: &[u8]) -> Result<Vec<u8>, WorldError> {
+        *self.generic_attempts.lock().expect("lock generic attempts") += 1;
+        assert_eq!(
+            protocol,
+            super::replication::REPLICATION_FETCH_BLOB_PROTOCOL
+        );
+        serde_json::to_vec(&super::replication::FetchBlobResponse {
+            found: false,
+            range_offset_bytes: None,
+            range_complete: None,
+            blob: None,
+        })
+        .map_err(|err| WorldError::DistributedValidationFailed {
+            reason: format!("encode generic blob response failed: {err}"),
+        })
+    }
+
+    fn connected_peer_ids(&self) -> Vec<String> {
+        self.connected_peer_ids.clone()
+    }
+
+    fn request_with_providers(
+        &self,
+        protocol: &str,
+        payload: &[u8],
+        providers: &[String],
+    ) -> Result<Vec<u8>, WorldError> {
+        self.provider_attempts
+            .lock()
+            .expect("lock provider attempts")
+            .push(providers.to_vec());
+        assert_eq!(
+            protocol,
+            super::replication::REPLICATION_FETCH_BLOB_PROTOCOL
+        );
+        let request: super::replication::FetchBlobRequest =
+            serde_json::from_slice(payload).expect("decode fetch blob request");
+        assert_eq!(request.offset_bytes, Some(0));
+        assert_eq!(request.limit_bytes, Some(2 * 1024 * 1024));
+        if providers.iter().any(|provider_id| {
+            self.unsupported_provider_ids
+                .iter()
+                .any(|unsupported| unsupported == provider_id)
+        }) {
+            return Err(WorldError::NetworkRequestFailed {
+                code: DistributedErrorCode::ErrUnsupported,
+                message: super::replication::REPLICATION_FETCH_BLOB_PROTOCOL.to_string(),
+                retryable: false,
+            });
+        }
+        if providers
+            .iter()
+            .any(|provider_id| provider_id == &self.blob_provider_id)
+        {
+            return serde_json::to_vec(&super::replication::FetchBlobResponse {
+                found: true,
+                range_offset_bytes: Some(0),
+                range_complete: Some(true),
+                blob: Some(self.blob.clone()),
+            })
+            .map_err(|err| WorldError::DistributedValidationFailed {
+                reason: format!("encode provider blob response failed: {err}"),
+            });
+        }
+        serde_json::to_vec(&super::replication::FetchBlobResponse {
+            found: false,
+            range_offset_bytes: None,
+            range_complete: None,
+            blob: None,
+        })
+        .map_err(|err| WorldError::DistributedValidationFailed {
+            reason: format!("encode provider blob miss failed: {err}"),
         })
     }
 
@@ -86,4 +195,125 @@ fn fetch_blob_chunking_accepts_exact_chunk_legacy_full_response_without_looping(
     assert!(response.found);
     assert_eq!(response.blob.as_ref().map(Vec::len), Some(2 * 1024 * 1024));
     assert_eq!(*attempts.lock().expect("lock attempts"), 1);
+}
+
+#[test]
+fn fetch_blob_route_fallback_tries_connected_peers_after_not_found_routes() {
+    let world_id = "world-blob-connected-peer-fallback";
+    let dir = temp_dir("blob-connected-peer-fallback-endpoint");
+    let generic_attempts = Arc::new(Mutex::new(0usize));
+    let provider_attempts = Arc::new(Mutex::new(Vec::<Vec<String>>::new()));
+    let network = Arc::new(ConnectedPeerBlobFallbackNetwork {
+        blob_provider_id: "storage-peer".to_string(),
+        blob: b"checkpoint-payload-from-storage".to_vec(),
+        generic_attempts: Arc::clone(&generic_attempts),
+        provider_attempts: Arc::clone(&provider_attempts),
+        connected_peer_ids: vec![
+            "sequencer-peer".to_string(),
+            "storage-peer".to_string(),
+            "sequencer-peer".to_string(),
+        ],
+        unsupported_provider_ids: Vec::new(),
+    });
+    let config = NodeConfig::new("node-b", world_id, NodeRole::Observer)
+        .expect("config")
+        .with_replication(signed_replication_config(dir, 42));
+    let handle = NodeReplicationNetworkHandle::new(network);
+    let endpoint =
+        ReplicationNetworkEndpoint::new(&handle, world_id, false, &config.network_policy)
+            .expect("endpoint");
+    let request = super::replication::FetchBlobRequest {
+        content_hash: "checkpoint-payload".to_string(),
+        offset_bytes: None,
+        limit_bytes: None,
+        requester_public_key_hex: None,
+        requester_signature_hex: None,
+    };
+
+    let response = super::request_fetch_blob_with_route_fallback(
+        &endpoint,
+        world_id,
+        "checkpoint-payload",
+        &request,
+        Some(&["sequencer-peer".to_string()]),
+    )
+    .expect("fetch blob");
+
+    assert!(response.found);
+    assert_eq!(
+        response.blob.as_deref(),
+        Some(b"checkpoint-payload-from-storage".as_slice())
+    );
+    assert_eq!(
+        *generic_attempts.lock().expect("lock generic attempts"),
+        1,
+        "expected one generic miss before connected-peer fallback"
+    );
+    assert_eq!(
+        provider_attempts
+            .lock()
+            .expect("lock provider attempts")
+            .as_slice(),
+        &[
+            vec!["sequencer-peer".to_string()],
+            vec!["storage-peer".to_string()],
+        ],
+        "expected stale provider miss, then each connected peer until storage returns the blob"
+    );
+}
+
+#[test]
+fn fetch_blob_route_fallback_skips_unsupported_connected_peers() {
+    let world_id = "world-blob-connected-peer-unsupported-fallback";
+    let dir = temp_dir("blob-connected-peer-unsupported-fallback-endpoint");
+    let generic_attempts = Arc::new(Mutex::new(0usize));
+    let provider_attempts = Arc::new(Mutex::new(Vec::<Vec<String>>::new()));
+    let network = Arc::new(ConnectedPeerBlobFallbackNetwork {
+        blob_provider_id: "storage-peer".to_string(),
+        blob: b"checkpoint-payload-from-storage".to_vec(),
+        generic_attempts: Arc::clone(&generic_attempts),
+        provider_attempts: Arc::clone(&provider_attempts),
+        connected_peer_ids: vec!["legacy-peer".to_string(), "storage-peer".to_string()],
+        unsupported_provider_ids: vec!["legacy-peer".to_string()],
+    });
+    let config = NodeConfig::new("node-b", world_id, NodeRole::Observer)
+        .expect("config")
+        .with_replication(signed_replication_config(dir, 43));
+    let handle = NodeReplicationNetworkHandle::new(network);
+    let endpoint =
+        ReplicationNetworkEndpoint::new(&handle, world_id, false, &config.network_policy)
+            .expect("endpoint");
+    let request = super::replication::FetchBlobRequest {
+        content_hash: "checkpoint-payload".to_string(),
+        offset_bytes: None,
+        limit_bytes: None,
+        requester_public_key_hex: None,
+        requester_signature_hex: None,
+    };
+
+    let response = super::request_fetch_blob_with_route_fallback(
+        &endpoint,
+        world_id,
+        "checkpoint-payload",
+        &request,
+        None,
+    )
+    .expect("fetch blob");
+
+    assert!(response.found);
+    assert_eq!(
+        response.blob.as_deref(),
+        Some(b"checkpoint-payload-from-storage".as_slice())
+    );
+    assert_eq!(
+        provider_attempts
+            .lock()
+            .expect("lock provider attempts")
+            .as_slice(),
+        &[
+            vec!["legacy-peer".to_string()],
+            vec!["storage-peer".to_string()],
+        ],
+        "expected unsupported legacy peer to be skipped before trying storage"
+    );
 }


### PR DESCRIPTION
## Summary
- make fetch-blob fallback try connected peers after provider/generic `found=false` routes
- expose connected peer ids through `ReplicationNetworkEndpoint` for replication route fallback
- add a regression covering sequencer miss + storage connected-peer hit, matching the live testnet.65 failure shape

## Live Root Cause
After #455/testnet.65, the observer progressed past the specific checkpoint provider lookup path but still failed gap sync with `blob not found` while connected to both sequencer and storage. The missing blobs existed on storage but not on sequencer, so a generic fetch-blob response from a non-holder peer could return `found=false` and stop the blob fetch before trying the connected storage peer.

## Validation
- `env -u RUSTC_WRAPPER cargo test -p oasis7_node fetch_blob_route_fallback_tries_connected_peers_after_not_found_routes -- --nocapture`
- `env -u RUSTC_WRAPPER cargo test -p oasis7_node storage_replication_high_checkpoint_retained -- --nocapture`
- `env -u RUSTC_WRAPPER cargo test -p oasis7_node runtime_network_replication_gap_sync -- --nocapture`
- `env -u RUSTC_WRAPPER cargo fmt --check && git diff --check && ./scripts/check-rust-file-size.sh`
- `./scripts/pm/workflow-lint.sh --phase pr-ready --task-uid task_96c772c830e043f9b1e40b03e6f73d38`

## Review
Pre-PR local role review passed for runtime_engineer and qa_engineer.

## Residual Risk
Live deployment still needs CI packaging and redeploy smoke. This fix requires the blob holder to be connected or discoverable; broader provider-record republish hygiene can still improve convergence later.
