### PR TITLE
Use single probes for high checkpoint scans

### DIFF
--- a/.pm/tasks/task_96c772c830e043f9b1e40b03e6f73d38.execution.md
+++ b/.pm/tasks/task_96c772c830e043f9b1e40b03e6f73d38.execution.md
@@ -298,6 +298,46 @@ Example:
 - Validation Command: ./scripts/pm/workflow-lint.sh --phase pr-ready --task-uid task_96c772c830e043f9b1e40b03e6f73d38
 - Actual Result: passed.
 
+## 2026-06-14 02:08:00 CST / tpm
+- 完成内容: PR #456 merged as `92bf6aca25420107f2a97bcbdac600166cef55ce`; Testnet Packages run #66 produced Linux/macOS/Windows artifacts. Linux artifact `testnet-package-linux-x64-0.0.0+testnet.66.92bf6aca2542` passed SHA256 verification and was deployed to sequencer `39.104.204.172`, storage `39.104.205.67`, and observer `192.168.1.4`.
+- 部署验证: all three Linux nodes run `/current/bin/oasis7_chain_runtime` with sha256 `1f279dc981225a9820e29527b0fdfda4b216c7615e8aa40fe3060fe0e4d1d52c`. Observer progressed from height/replication `0` to `64`, proving checkpoint install and blob route fallback moved past the earlier `blob not found` blocker.
+- 新根因证据: observer then remained on first tick (`tick_count=1`, `worker_poll_count=1`, `last_error=null`, `replication_persisted_height=64`) for several minutes. Live gdb backtrace showed thread `aw-node-triad-t` inside `request_fetch_commit_for_gap_sync_with_policy` called by `try_sync_high_replication_checkpoint_boundary`, waiting in `request_to_peer_with_timeout` for fetch-commit.
+- 设计结论: high checkpoint candidate scanning should not spend full gap-sync fetch-commit retry budget for every candidate. The retained-window scan may probe many candidate heights; using the full policy can make one runtime tick spend many minutes in candidate misses/timeouts, which looks like another worker wedge and blocks automatic attach.
+- 代码改动: Added `sync_replication_height_once_for_high_checkpoint_probe` using the existing single-probe fetch-commit policy and changed `try_sync_high_replication_checkpoint_boundary` to use it. The full gap-sync retry policy remains for contiguous height sync.
+- 回归测试: Added `tests_network_gap_sync_high_checkpoint_probe.rs::high_checkpoint_probe_uses_single_fetch_commit_probe_for_not_found_candidate`, proving a not-found high checkpoint candidate uses one generic fetch-commit probe instead of the full retry budget.
+- Validation Command: env -u RUSTC_WRAPPER cargo test -p oasis7_node high_checkpoint_probe_uses_single_fetch_commit_probe_for_not_found_candidate -- --nocapture
+- Actual Result: passed; 1 test passed.
+- Validation Command: env -u RUSTC_WRAPPER cargo test -p oasis7_node storage_replication_high_checkpoint_retained -- --nocapture && env -u RUSTC_WRAPPER cargo test -p oasis7_node runtime_network_replication_gap_sync -- --nocapture
+- Actual Result: passed; 4 retained checkpoint tests and 10 gap-sync tests passed.
+- Validation Command: env -u RUSTC_WRAPPER cargo fmt --check && git diff --check && ./scripts/check-rust-file-size.sh
+- Actual Result: passed.
+- Review Trigger: post-testnet.66 first-tick long high-checkpoint candidate scan follow-up pre-PR local role review
+- Review Roles: runtime_engineer, qa_engineer
+- Review Question: confirm whether high checkpoint candidate scans should use single-probe fetch-commit to preserve node worker liveness while leaving full retry budget for contiguous gap sync, and whether the regression coverage is sufficient for CI package/deploy.
+- Expected Return Contract: findings | no_findings | residual_risk
+- Formal Sink: `.pm/tasks/task_96c772c830e043f9b1e40b03e6f73d38.execution.md`
+- Blocker / Next Action: dispatch runtime_engineer and qa_engineer review slices, integrate findings, run workflow lint, commit, PR, CI package, redeploy observer/Linux/Windows.
+
+## 2026-06-14 02:16:00 CST / tpm
+- runtime_engineer: no_findings. Single-probe fetch-commit is semantically correct for high checkpoint candidate scans; full retry budget remains on normal contiguous gap sync. If a candidate is found, checkpoint bundle fetch/install validation and persisted-height advancement still run unchanged, so the change only trims candidate discovery cost.
+- runtime_engineer residual_risk: a transient miss on the only valid retained checkpoint candidate can defer checkpoint catch-up to a later tick, but this is preferable to spending full retry budget per candidate and does not remove the normal full retry path. Live validation must confirm observer no longer sits inside one tick for minutes while scanning retained-window candidates.
+- qa_engineer: no_findings. The regression exercises the live risk directly by invoking `try_sync_high_replication_checkpoint_boundary` and asserting a not-found candidate consumes exactly one generic fetch-commit attempt through `request_fetch_commit_for_gap_sync_single_probe`.
+- qa_engineer residual_risk: coverage targets not-found candidate stall, not the duration of one slow transport timeout. Live deployment should still confirm tick responsiveness after deployment.
+- Validation Command: ./scripts/pm/workflow-lint.sh --phase pr-ready --task-uid task_96c772c830e043f9b1e40b03e6f73d38
+- Actual Result: passed.
+- Pre-PR Local Role Review: passed
+- Task UID: task_96c772c830e043f9b1e40b03e6f73d38
+- Source Worktree: /Users/scc/ccwork/worktrees/oasis7-testnet-high-state-peer-retry
+- Source Branch: codex/testnet-high-checkpoint-single-probe
+- Comparison Ref: refs/remotes/origin/main
+- Reviewed Changed Paths: `crates/oasis7_node/src/node_engine_network.rs`; `crates/oasis7_node/src/node_engine_replication.rs`; `crates/oasis7_node/src/tests_clock_and_replication.rs`; `crates/oasis7_node/src/tests_network_gap_sync_high_checkpoint_probe.rs`; `.pm/tasks/task_96c772c830e043f9b1e40b03e6f73d38.execution.md`
+- Role Selection Basis: runtime replication high checkpoint candidate scan behavior, public testnet observer tick liveness, and regression/release-readiness verification.
+- Review Roles: runtime_engineer, qa_engineer
+- Review Evidence: runtime_engineer no_findings and qa_engineer no_findings recorded above.
+- Review Findings Disposition: no_findings
+- Finding Disposition Evidence: none required.
+- Residual Risk: packaged CI artifact and live Linux/storage/local/Windows redeploy smoke remain required after merge; deployment smoke should verify observer first tick returns and continues beyond retained checkpoint height 64.
+
 ## 2026-06-13 18:02:00 CST / tpm
 - runtime_engineer: no_findings. `request_to_peer` now uses `std::sync::mpsc::channel` and `recv_timeout`, so it no longer blocks on a futures oneshot executor path; this directly addresses the packaged observer gdb backtrace.
 - runtime_engineer semantic review: runtime loop still sends success or the original `Err(WorldError)` unchanged; API helper preserves `Ok(result) => result` and only maps channel closed/timeout to `NetworkProtocolUnavailable`. DHT pending query outcomes keep their original Kademlia result semantics.

--- a/crates/oasis7_node/src/node_engine_network.rs
+++ b/crates/oasis7_node/src/node_engine_network.rs
@@ -129,6 +129,24 @@ impl PosNodeEngine {
         )
     }
 
+    pub(super) fn sync_replication_height_once_for_high_checkpoint_probe(
+        &self,
+        endpoint: &ReplicationNetworkEndpoint,
+        node_id: &str,
+        world_id: &str,
+        replication_runtime: &mut ReplicationRuntime,
+        height: u64,
+    ) -> Result<GapSyncHeightOutcome, NodeError> {
+        self.sync_replication_height_once_with_fetch(
+            endpoint,
+            node_id,
+            world_id,
+            replication_runtime,
+            height,
+            |endpoint, request| endpoint.request_fetch_commit_for_gap_sync_single_probe(request),
+        )
+    }
+
     fn sync_replication_height_once_with_fetch(
         &self,
         endpoint: &ReplicationNetworkEndpoint,

--- a/crates/oasis7_node/src/node_engine_replication.rs
+++ b/crates/oasis7_node/src/node_engine_replication.rs
@@ -505,7 +505,7 @@ impl PosNodeEngine {
         )
     }
 
-    fn try_sync_high_replication_checkpoint_boundary(
+    pub(super) fn try_sync_high_replication_checkpoint_boundary(
         &mut self,
         endpoint: &ReplicationNetworkEndpoint,
         node_id: &str,
@@ -523,7 +523,7 @@ impl PosNodeEngine {
         {
             return Ok(false);
         }
-        let checkpoint = match self.sync_replication_height_once(
+        let checkpoint = match self.sync_replication_height_once_for_high_checkpoint_probe(
             endpoint,
             node_id,
             world_id,

--- a/crates/oasis7_node/src/tests_clock_and_replication.rs
+++ b/crates/oasis7_node/src/tests_clock_and_replication.rs
@@ -6,6 +6,8 @@ mod network_gap_sync_not_found_tests;
 mod network_gap_sync_provider_routing_tests;
 #[path = "tests_network_gap_sync.rs"]
 mod network_gap_sync_tests;
+#[path = "tests_network_gap_sync_high_checkpoint_probe.rs"]
+mod network_gap_sync_high_checkpoint_probe_tests;
 #[path = "tests_network_gap_sync_successor_probe.rs"]
 mod network_gap_sync_successor_probe_tests;
 #[path = "tests_storage_challenge_blob_cache.rs"]

--- a/crates/oasis7_node/src/tests_network_gap_sync_high_checkpoint_probe.rs
+++ b/crates/oasis7_node/src/tests_network_gap_sync_high_checkpoint_probe.rs
@@ -1,0 +1,67 @@
+use std::collections::HashMap;
+use std::fs;
+use std::sync::{Arc, Mutex};
+
+use oasis7_proto::world_error::WorldError;
+
+use super::*;
+use super::network_gap_sync_tests::{
+    build_fetch_commit_success_cache_fixture, PeerDirectedFetchCommitTestNetwork,
+};
+
+#[test]
+fn high_checkpoint_probe_uses_single_fetch_commit_probe_for_not_found_candidate() {
+    let dir_remote = temp_dir("high-checkpoint-single-probe-remote");
+    let dir_local = temp_dir("high-checkpoint-single-probe-local");
+    let world_id = "world-high-checkpoint-single-probe";
+    let generic_attempts = Arc::new(Mutex::new(0usize));
+    let provider_attempts = Arc::new(Mutex::new(Vec::<Vec<String>>::new()));
+    let peer_responses = Arc::new(Mutex::new(HashMap::new()));
+    let network: Arc<
+        dyn oasis7_proto::distributed_net::DistributedNetwork<WorldError> + Send + Sync,
+    > = Arc::new(PeerDirectedFetchCommitTestNetwork {
+        generic_response: super::replication::FetchCommitResponse {
+            found: false,
+            message: None,
+        },
+        generic_unsupported: false,
+        peer_responses,
+        connected_peer_ids: Vec::new(),
+        generic_attempts: Arc::clone(&generic_attempts),
+        provider_attempts,
+    });
+    let (mut engine, mut replication, endpoint, _) = build_fetch_commit_success_cache_fixture(
+        world_id,
+        dir_remote.as_path(),
+        dir_local.as_path(),
+        146,
+        147,
+        network,
+    );
+    let mut execution_hook = None;
+    let mut progress_callback = None;
+
+    let synced = engine
+        .try_sync_high_replication_checkpoint_boundary(
+            &endpoint,
+            "node-b",
+            world_id,
+            &mut replication,
+            16_640,
+            64,
+            None,
+            &mut execution_hook,
+            &mut progress_callback,
+        )
+        .expect("high checkpoint probe not-found response");
+
+    assert!(!synced);
+    assert_eq!(
+        *generic_attempts.lock().expect("lock generic attempts"),
+        1,
+        "high checkpoint candidate scans should not spend the full gap-sync retry budget"
+    );
+
+    let _ = fs::remove_dir_all(&dir_remote);
+    let _ = fs::remove_dir_all(&dir_local);
+}


### PR DESCRIPTION
## Summary
- use the existing single-probe fetch-commit policy for high checkpoint candidate scans
- keep the full fetch-commit retry budget on normal contiguous gap sync
- add a regression proving a not-found high checkpoint candidate consumes one generic fetch-commit probe, not the full gap-sync retry budget

## Live Root Cause
After #456/testnet.66, the observer progressed from height 0 to retained checkpoint height 64, proving the checkpoint/blob route fixes worked. It then stayed inside the first runtime tick for minutes. A live gdb backtrace showed the worker in `request_fetch_commit_for_gap_sync_with_policy` via `try_sync_high_replication_checkpoint_boundary`, waiting on fetch-commit for retained-window checkpoint candidates.

The retained-window scan may probe many candidate heights. Spending full gap-sync retry budget for every candidate can make one tick run for minutes and look like a worker wedge.

## Validation
- `env -u RUSTC_WRAPPER cargo test -p oasis7_node high_checkpoint_probe_uses_single_fetch_commit_probe_for_not_found_candidate -- --nocapture`
- `env -u RUSTC_WRAPPER cargo test -p oasis7_node storage_replication_high_checkpoint_retained -- --nocapture`
- `env -u RUSTC_WRAPPER cargo test -p oasis7_node runtime_network_replication_gap_sync -- --nocapture`
- `env -u RUSTC_WRAPPER cargo fmt --check && git diff --check && ./scripts/check-rust-file-size.sh`
- `./scripts/pm/workflow-lint.sh --phase pr-ready --task-uid task_96c772c830e043f9b1e40b03e6f73d38`

## Review
Pre-PR local role review passed for runtime_engineer and qa_engineer.

## Residual Risk
A transient miss on the only valid retained checkpoint can defer catch-up to a later tick. Live deployment should confirm the observer first tick returns and continues beyond retained checkpoint height 64.
