### PR TITLE
Stabilize testnet checkpoint package upgrades

### DIFF
--- a/.pm/tasks/task_96c772c830e043f9b1e40b03e6f73d38.execution.md
+++ b/.pm/tasks/task_96c772c830e043f9b1e40b03e6f73d38.execution.md
@@ -554,3 +554,58 @@ Example:
 - Comparison Ref: refs/remotes/origin/main
 - Reviewed Changed Paths: `crates/oasis7_node/src/node_engine_replication.rs`; `crates/oasis7_node/src/tests_storage_replication_high_checkpoint_retained.rs`
 - Residual Risk: CI package and deploy required to verify observer proceeds past checkpoint blob not-found and continues high-state catch-up.
+
+## 2026-06-14 02:47:26 CST / tpm
+- Follow-up trigger: after PRs #455/#456/#457 merged, Testnet Packages run `27474829822` (#67) succeeded for linux/macos/windows at commit `530b9e8d4034d3a2d84908d11faf29a808ba0ad9`. Linux artifact `testnet-package-linux-x64-0.0.0+testnet.67.530b9e8d4034` passed SHA256 verification. Windows artifact `testnet-package-windows-x64-0.0.0+testnet.67.530b9e8d4034` passed SHA256 verification.
+- Deployment finding: direct Linux package upgrade initially failed on the sequencer with `network tier runtime bundle hash mismatch` because the node-local governed bootstrap bundle still pinned the #66 runtime hash. This is a deployment-flow root cause: CI package upgrades must update the node-local `runtime_build.sha256` alongside the `current` runtime symlink before service restart.
+- Deployment mitigation applied live: the temporary deployment script was amended to rewrite the node-local governed bootstrap bundle runtime_build metadata. #67 was then deployed successfully to sequencer `39.104.204.172`, storage `39.104.205.67`, and observer `192.168.1.4`; all three Linux services became active and reported runtime hash `76262f836a82b53342d3353614792d7b97cc7c4fd3c280a35322b6a451a227a4`.
+- New live finding: observer no longer stuck in the first high-checkpoint poll after #457; after #67 it reached `tick=4,poll=4`, proving the single-probe high checkpoint change reduced the first-tick wedge. It still stalled at `replication_persisted_height=64`, `replication_gap_sync_blocked_height=65`, `state_sync_fallback_required=true`. Storage was healthy at `height=16715,repl=16715`; sequencer was active but `repl=0`. Observer connected to both peers, but storage peer score fell to 0 after `UnexpectedEof`/`Timeout` fetch-commit errors, and repair summary then showed only sequencer/generic `found=false`.
+- Read-only role slice: Poincare (`019ec247-99bb-72f2-8d50-29ea8533199b`) reported this is a code/design gap rather than a seed/state-sync/deploy-startup issue. Relevant paths: `ReplicationNetworkEndpoint::request_fetch_commit_for_gap_sync_with_policy`, `sync_missing_replication_commits_with_progress`, fetch-commit handler, and libp2p request scoring/cooldown. Slice conclusion: normal low gap sync lacks a durable full_storage preference/fallback and high checkpoint probing must avoid wasting live tick budget on non-retained candidates.
+- Code change: `high_replication_checkpoint_candidates` now probes the advertised head first, then older release_default retained 64-height checkpoint boundaries, and only then 32-height fallback boundaries. The newest aligned boundary is skipped as a retained candidate because live #67 evidence showed `16704` can be aligned but unretained/missing, while older retained windows such as `16640` are the intended release_default catch-up path.
+- Deployment-flow code change: added `scripts/p2p-public-testnet-package-node-upgrade.sh` and test coverage. The script standardizes CI Linux package upgrades by extracting `oasis7-linux-x64-bundle.tar.gz` into `releases/<package-version>`, repointing `current`, rewriting node-local governed bootstrap bundle runtime_build metadata to the installed runtime hash/size/commit/run, and optionally restarting the systemd service.
+- Validation Command: env -u RUSTC_WRAPPER cargo test -p oasis7_node high_replication_checkpoint_candidates -- --nocapture
+- Actual Result: passed; 2 tests passed.
+- Validation Command: env -u RUSTC_WRAPPER cargo test -p oasis7_node storage_replication_high_checkpoint_retained -- --nocapture
+- Actual Result: passed; 5 tests passed.
+- Validation Command: env -u RUSTC_WRAPPER cargo test -p oasis7_node runtime_network_replication_gap_sync -- --nocapture
+- Actual Result: passed; 10 tests passed.
+- Validation Command: scripts/p2p-public-testnet-package-node-upgrade.test.sh
+- Actual Result: passed.
+- Validation Command: env -u RUSTC_WRAPPER cargo fmt --check && git diff --check && scripts/p2p-public-testnet-package-node-upgrade.test.sh && ./scripts/check-rust-file-size.sh
+- Actual Result: passed.
+- Review Trigger: checkpoint retained-window ordering plus package-node-upgrade flow pre-PR local role review.
+- Review Roles: runtime_engineer, blockchain_ops_engineer, qa_engineer
+- Review Finding: P1. `scripts/p2p-public-testnet-package-node-upgrade.sh` originally replaced `releases/<package-version>` and repointed `current` before validating that the node-local governed bootstrap bundle existed and could be rewritten. On unexpected config layouts, that could leave `current` pointing to the new runtime while drift-guard metadata stayed old/missing.
+- Finding Disposition: addressed. The upgrade script now extracts and validates the runtime plus rewrites governed bootstrap bundle metadata before replacing the release dir and switching `current`. Added negative coverage proving a missing governed bootstrap bundle exits non-zero and leaves `current` pointed at the old release.
+- Review Recheck Result: addressed locally based on Hume (`019ec251-843b-7c20-bd08-1baec71a78e9`) finding; residual risk is that this helper is Linux/systemd-focused and Windows deployment remains a separate package/install path.
+- Validation Command: scripts/p2p-public-testnet-package-node-upgrade.test.sh && env -u RUSTC_WRAPPER cargo test -p oasis7_node high_replication_checkpoint_candidates -- --nocapture && env -u RUSTC_WRAPPER cargo test -p oasis7_node storage_replication_high_checkpoint_retained -- --nocapture && env -u RUSTC_WRAPPER cargo test -p oasis7_node runtime_network_replication_gap_sync -- --nocapture && env -u RUSTC_WRAPPER cargo fmt --check && git diff --check && ./scripts/check-rust-file-size.sh && ./scripts/pm/workflow-lint.sh --phase pr-ready --task-uid task_96c772c830e043f9b1e40b03e6f73d38
+- Actual Result: passed.
+- Pre-PR Local Role Review: passed
+- Task UID: task_96c772c830e043f9b1e40b03e6f73d38
+- Source Worktree: /Users/scc/ccwork/worktrees/oasis7-testnet-high-state-peer-retry
+- Source Branch: codex/testnet-fetch-commit-storage-fallback
+- Comparison Ref: refs/remotes/origin/main
+- Reviewed Changed Paths: `crates/oasis7_node/src/node_engine_replication.rs`; `crates/oasis7_node/src/tests_storage_replication_high_checkpoint_retained.rs`; `scripts/p2p-public-testnet-package-node-upgrade.sh`; `scripts/p2p-public-testnet-package-node-upgrade.test.sh`; `.pm/tasks/task_96c772c830e043f9b1e40b03e6f73d38.execution.md`
+- PR CI Finding: PR #458 first required-gate run failed three high-checkpoint tests because the first implementation skipped the latest aligned checkpoint boundary even when it was the only viable low-window boundary, e.g. network height 70 should still probe height 64.
+- Finding Disposition: addressed. Candidate generation now skips a newest aligned boundary only when there is an older retained boundary above the blocked height and the advertised head is not itself aligned. This preserves the live `16715 -> 16640` preference while keeping small-window `70 -> 64` tests valid.
+- Validation Command: env -u RUSTC_WRAPPER cargo test -p oasis7_node observer_gap_sync -- --nocapture
+- Actual Result: passed; 12 tests passed.
+- Validation Command: scripts/p2p-public-testnet-package-node-upgrade.test.sh && env -u RUSTC_WRAPPER cargo test -p oasis7_node high_replication_checkpoint_candidates -- --nocapture && env -u RUSTC_WRAPPER cargo test -p oasis7_node storage_replication_high_checkpoint_retained -- --nocapture && env -u RUSTC_WRAPPER cargo test -p oasis7_node runtime_network_replication_gap_sync -- --nocapture && env -u RUSTC_WRAPPER cargo test -p oasis7_node observer_gap_sync -- --nocapture
+- Actual Result: passed before formatting check.
+- Validation Command: env -u RUSTC_WRAPPER cargo fmt && env -u RUSTC_WRAPPER cargo fmt --check && git diff --check && ./scripts/check-rust-file-size.sh && ./scripts/pm/workflow-lint.sh --phase pr-ready --task-uid task_96c772c830e043f9b1e40b03e6f73d38
+- Actual Result: passed.
+- PR Review Finding: PR #458 inline comment `3408449268` P2 on `scripts/p2p-public-testnet-package-node-upgrade.sh`. If `<node-root>/current` is a real directory, `ln -sfn` can create the new symlink inside that directory instead of replacing it, leaving the service on the old runtime while the governed bootstrap metadata points at the new runtime.
+- Finding Disposition: addressed. The upgrade helper now records the old `current` target, moves a real `current` directory aside as `current-pre-*.dir`, removes symlink/file cases, and then creates `current -> releases/<package-version>` with `ln -s`. Added regression coverage that starts with `current` as a real directory and asserts it becomes a symlink to the new release, the old directory is backed up, and no nested `current/oasis7-linux-x64` symlink is created.
+- Validation Command: scripts/p2p-public-testnet-package-node-upgrade.test.sh
+- Actual Result: passed; includes symlink current, real-directory current, and missing-governed-bundle negative coverage.
+- Validation Command: env -u RUSTC_WRAPPER cargo test -p oasis7_node high_replication_checkpoint_candidates -- --nocapture
+- Actual Result: passed; 2 tests passed.
+- Validation Command: env -u RUSTC_WRAPPER cargo test -p oasis7_node storage_replication_high_checkpoint_retained -- --nocapture
+- Actual Result: passed; 5 tests passed.
+- Validation Command: env -u RUSTC_WRAPPER cargo test -p oasis7_node runtime_network_replication_gap_sync -- --nocapture
+- Actual Result: passed; 10 tests passed.
+- Validation Command: env -u RUSTC_WRAPPER cargo test -p oasis7_node observer_gap_sync -- --nocapture
+- Actual Result: passed; 12 tests passed.
+- Validation Command: env -u RUSTC_WRAPPER cargo fmt --check && git diff --check && ./scripts/check-rust-file-size.sh && ./scripts/pm/workflow-lint.sh --phase pr-ready --task-uid task_96c772c830e043f9b1e40b03e6f73d38
+- Actual Result: passed; file-size gate reported oversized code files=0, test files=0, workflow-lint OK.
+- Blocker / Next Action: amend/push PR #458, re-watch CI, merge, CI package, deploy #68+, and live-verify observer advances beyond height 64/high checkpoint catch-up.

--- a/crates/oasis7_node/src/node_engine_replication.rs
+++ b/crates/oasis7_node/src/node_engine_replication.rs
@@ -6,8 +6,9 @@ use crate::replication_state_reconcile::ReplicationCommitPayload;
 use oasis7_proto::distributed::WorldHeadAnnounce;
 
 impl PosNodeEngine {
-    // Mirrors release_default.execution_checkpoint_keep. The inclusive range probes the
-    // latest aligned boundary plus eight older retained-window boundaries.
+    // Mirrors release_default.execution_checkpoint_keep. Probe the advertised head first, then
+    // the older retained-window boundaries. The newest aligned boundary can still be in-flight
+    // or unretained on live testnet nodes, so retained-window probing starts one interval back.
     const HIGH_REPLICATION_CHECKPOINT_LOOKBACK_WINDOWS: u64 = 8;
 
     pub(super) fn high_replication_checkpoint_candidates(
@@ -23,11 +24,17 @@ impl PosNodeEngine {
         push_candidate(advertised_network_height);
         for interval in [64_u64, 32_u64] {
             let aligned = advertised_network_height - (advertised_network_height % interval);
-            for lookback in 0..=Self::HIGH_REPLICATION_CHECKPOINT_LOOKBACK_WINDOWS {
+            let first_lookback = if aligned.saturating_sub(interval) > blocked_height
+                && aligned != advertised_network_height
+            {
+                1
+            } else {
+                0
+            };
+            for lookback in first_lookback..=Self::HIGH_REPLICATION_CHECKPOINT_LOOKBACK_WINDOWS {
                 push_candidate(aligned.saturating_sub(interval.saturating_mul(lookback)));
             }
         }
-        candidates.sort_unstable_by(|a, b| b.cmp(a));
         candidates
     }
 

--- a/crates/oasis7_node/src/tests_storage_replication_high_checkpoint_retained.rs
+++ b/crates/oasis7_node/src/tests_storage_replication_high_checkpoint_retained.rs
@@ -68,6 +68,29 @@ fn high_replication_checkpoint_candidates_cover_release_default_retained_window(
 }
 
 #[test]
+fn high_replication_checkpoint_candidates_prefer_release_retained_boundaries() {
+    let candidates = PosNodeEngine::high_replication_checkpoint_candidates(16_715, 64);
+
+    assert_eq!(
+        &candidates[..4],
+        &[16_715, 16_640, 16_576, 16_512],
+        "release_default 64-height retained checkpoint boundaries should be probed before 32-height fallback boundaries"
+    );
+    let retained_index = candidates
+        .iter()
+        .position(|height| *height == 16_640)
+        .expect("retained boundary candidate");
+    let fallback_index = candidates
+        .iter()
+        .position(|height| *height == 16_672)
+        .expect("32-height fallback boundary candidate");
+    assert!(
+        retained_index < fallback_index,
+        "retained boundary should be preferred over nearer 32-height fallback boundary; candidates={candidates:?}"
+    );
+}
+
+#[test]
 fn high_replication_checkpoint_probe_continues_after_fetch_commit_timeout() {
     let err = NodeError::Replication {
         reason:

--- a/scripts/p2p-public-testnet-package-node-upgrade.sh
+++ b/scripts/p2p-public-testnet-package-node-upgrade.sh
@@ -1,0 +1,219 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  ./scripts/p2p-public-testnet-package-node-upgrade.sh \
+    --node-root <path> \
+    --bundle-tar <oasis7-linux-x64-bundle.tar.gz> \
+    --package-version <version> \
+    --commit <sha> \
+    --run-id <github-actions-run-id> \
+    [--artifact-ref <ref>] \
+    [--systemd-service <name>] \
+    [--restart-service]
+
+Description:
+  Upgrade an installed public testnet Linux node from a CI package bundle.
+  The script extracts the bundle into <node-root>/releases/<package-version>,
+  repoints <node-root>/current, and rewrites the node-local governed bootstrap
+  bundle runtime_build hash to the installed runtime binary. This keeps the
+  network-tier runtime drift guard aligned with the deployed artifact.
+EOF
+}
+
+die() {
+  printf 'error: %s\n' "$*" >&2
+  exit 1
+}
+
+require_non_empty() {
+  local flag=$1
+  local value=$2
+  [[ -n "$value" ]] || die "missing required option: $flag"
+}
+
+abs_path() {
+  python3 -c 'import pathlib,sys; print(pathlib.Path(sys.argv[1]).expanduser().resolve())' "$1"
+}
+
+node_root=""
+bundle_tar=""
+package_version=""
+commit=""
+run_id=""
+artifact_ref=""
+systemd_service=""
+restart_service=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --node-root)
+      node_root=${2:-}
+      shift 2
+      ;;
+    --bundle-tar)
+      bundle_tar=${2:-}
+      shift 2
+      ;;
+    --package-version)
+      package_version=${2:-}
+      shift 2
+      ;;
+    --commit)
+      commit=${2:-}
+      shift 2
+      ;;
+    --run-id)
+      run_id=${2:-}
+      shift 2
+      ;;
+    --artifact-ref)
+      artifact_ref=${2:-}
+      shift 2
+      ;;
+    --systemd-service)
+      systemd_service=${2:-}
+      shift 2
+      ;;
+    --restart-service)
+      restart_service=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      die "unknown option: $1"
+      ;;
+  esac
+done
+
+require_non_empty "--node-root" "$node_root"
+require_non_empty "--bundle-tar" "$bundle_tar"
+require_non_empty "--package-version" "$package_version"
+require_non_empty "--commit" "$commit"
+require_non_empty "--run-id" "$run_id"
+[[ -f "$bundle_tar" ]] || die "missing bundle tar: $bundle_tar"
+if [[ "$restart_service" -eq 1 ]]; then
+  require_non_empty "--systemd-service" "$systemd_service"
+fi
+
+node_root=$(abs_path "$node_root")
+bundle_tar=$(abs_path "$bundle_tar")
+artifact_ref=${artifact_ref:-"oasis7-linux-x64-bundle.tar.gz!/bin/oasis7_chain_runtime"}
+
+release_dir="$node_root/releases/$package_version"
+tmp_dir="$node_root/releases/.${package_version}.tmp.$$"
+backup_suffix="pre-${package_version//[^A-Za-z0-9_.-]/_}-$(date -u +%Y%m%dT%H%M%SZ)"
+
+mkdir -p "$node_root/releases"
+rm -rf "$tmp_dir"
+mkdir -p "$tmp_dir"
+tar -xzf "$bundle_tar" -C "$tmp_dir"
+bundle_root="$tmp_dir/oasis7-linux-x64"
+runtime_bin="$bundle_root/bin/oasis7_chain_runtime"
+[[ -x "$runtime_bin" ]] || die "bundle missing executable runtime: $runtime_bin"
+
+python3 - "$node_root" "$bundle_root" "$package_version" "$commit" "$run_id" "$artifact_ref" <<'PY'
+from __future__ import annotations
+
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+node_root = Path(sys.argv[1])
+bundle_root = Path(sys.argv[2])
+package_version = sys.argv[3]
+commit = sys.argv[4]
+run_id = sys.argv[5]
+artifact_ref = sys.argv[6]
+runtime_bin = bundle_root / "bin" / "oasis7_chain_runtime"
+
+digest = hashlib.sha256()
+with runtime_bin.open("rb") as fh:
+    for chunk in iter(lambda: fh.read(1024 * 1024), b""):
+        digest.update(chunk)
+runtime_sha = digest.hexdigest()
+runtime_size = runtime_bin.stat().st_size
+updated_by = (
+    "p2p-public-testnet-package-node-upgrade "
+    f"{package_version} (run {run_id}, commit {commit})"
+)
+
+bundle_paths = sorted((node_root / "config").rglob(
+    "public-testnet-governed-bootstrap-bundle-2026-06-06.json"
+))
+if not bundle_paths:
+    raise SystemExit(
+        f"no governed bootstrap bundle found under {node_root / 'config'}"
+    )
+
+for bundle_path in bundle_paths:
+    data = json.loads(bundle_path.read_text(encoding="utf-8"))
+    runtime = data.setdefault("runtime_build", {})
+    runtime["git_commit"] = commit
+    runtime["kind"] = "file"
+    installed_runtime = node_root / "current" / "bin" / "oasis7_chain_runtime"
+    runtime["path"] = str(installed_runtime)
+    runtime["resolved_path"] = str(installed_runtime)
+    runtime["ref"] = artifact_ref
+    runtime["sha256"] = runtime_sha
+    runtime["size_bytes"] = runtime_size
+    runtime["updated_by"] = updated_by
+    data["git_commit"] = commit
+    data["updated_by"] = updated_by
+    bundle_path.write_text(
+        json.dumps(data, ensure_ascii=True, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+(node_root / "CURRENT_VERSION").write_text(package_version + "\n", encoding="utf-8")
+(node_root / "DEPLOYED_BUILDINFO").write_text(
+    "\n".join(
+        [
+            "workflow=Testnet Packages",
+            f"run_id={run_id}",
+            f"repository=eng-cc/oasis7",
+            f"commit={commit}",
+            f"package_version={package_version}",
+            "platform=linux-x64",
+            f"runtime_sha256={runtime_sha}",
+            f"runtime_size={runtime_size}",
+            "",
+        ]
+    ),
+    encoding="utf-8",
+)
+print(f"runtime_sha256={runtime_sha}")
+print(f"runtime_size={runtime_size}")
+print(f"updated_bundle_count={len(bundle_paths)}")
+PY
+
+rm -rf "$release_dir"
+mv "$bundle_root" "$release_dir"
+rm -rf "$tmp_dir"
+
+current_path="$node_root/current"
+if [[ -L "$current_path" || -e "$current_path" ]]; then
+  readlink -f "$current_path" >"$node_root/last-$backup_suffix.txt" || true
+  if [[ -d "$current_path" && ! -L "$current_path" ]]; then
+    mv "$current_path" "$node_root/current-$backup_suffix.dir"
+  else
+    rm -f "$current_path"
+  fi
+fi
+ln -s "$release_dir" "$current_path"
+
+if [[ "$restart_service" -eq 1 ]]; then
+  systemctl daemon-reload
+  systemctl restart "$systemd_service"
+  sleep 3
+  systemctl is-active --quiet "$systemd_service"
+  systemctl --no-pager --full status "$systemd_service" | sed -n '1,18p'
+fi
+
+echo "upgraded $node_root to $package_version"

--- a/scripts/p2p-public-testnet-package-node-upgrade.test.sh
+++ b/scripts/p2p-public-testnet-package-node-upgrade.test.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/oasis7-package-node-upgrade-test.XXXXXX")"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+node_root="$TMP_DIR/node"
+bundle_root="$TMP_DIR/bundle/oasis7-linux-x64"
+package_version="0.0.0+testnet.test.abcdef123456"
+commit="abcdef1234567890abcdef1234567890abcdef12"
+run_id="12345"
+
+mkdir -p "$bundle_root/bin" "$node_root/config/doc/testing/evidence" "$node_root/releases/old/bin"
+printf 'runtime-v2\n' >"$bundle_root/bin/oasis7_chain_runtime"
+chmod +x "$bundle_root/bin/oasis7_chain_runtime"
+printf 'runtime-v1\n' >"$node_root/releases/old/bin/oasis7_chain_runtime"
+chmod +x "$node_root/releases/old/bin/oasis7_chain_runtime"
+ln -s "$node_root/releases/old" "$node_root/current"
+
+cat >"$node_root/config/doc/testing/evidence/public-testnet-governed-bootstrap-bundle-2026-06-06.json" <<'EOF'
+{
+  "schema_version": "oasis7.release_candidate_bundle.v1",
+  "git_commit": "old",
+  "runtime_build": {
+    "path": "old",
+    "ref": "old",
+    "resolved_path": "old",
+    "sha256": "0000000000000000000000000000000000000000000000000000000000000000",
+    "size_bytes": 1
+  }
+}
+EOF
+
+tar -czf "$TMP_DIR/oasis7-linux-x64-bundle.tar.gz" -C "$TMP_DIR/bundle" oasis7-linux-x64
+
+"$ROOT_DIR/scripts/p2p-public-testnet-package-node-upgrade.sh" \
+  --node-root "$node_root" \
+  --bundle-tar "$TMP_DIR/oasis7-linux-x64-bundle.tar.gz" \
+  --package-version "$package_version" \
+  --commit "$commit" \
+  --run-id "$run_id" \
+  --artifact-ref "testnet-package-linux-x64-$package_version/oasis7-linux-x64-bundle.tar.gz!/bin/oasis7_chain_runtime" \
+  >/dev/null
+
+node_root_abs=$(python3 -c 'import pathlib,sys; print(pathlib.Path(sys.argv[1]).resolve())' "$node_root")
+expected_sha=$(shasum -a 256 "$node_root_abs/current/bin/oasis7_chain_runtime" | awk '{print $1}')
+
+test "$(readlink "$node_root_abs/current")" = "$node_root_abs/releases/$package_version"
+test -x "$node_root_abs/releases/$package_version/bin/oasis7_chain_runtime"
+test -f "$node_root_abs/CURRENT_VERSION"
+test -f "$node_root_abs/DEPLOYED_BUILDINFO"
+grep -q "^package_version=$package_version$" "$node_root_abs/DEPLOYED_BUILDINFO"
+grep -q "^commit=$commit$" "$node_root_abs/DEPLOYED_BUILDINFO"
+
+jq -e \
+  --arg expected "$expected_sha" \
+  --arg commit "$commit" \
+  --arg runtime "$node_root_abs/current/bin/oasis7_chain_runtime" \
+  '.git_commit == $commit
+    and .runtime_build.git_commit == $commit
+    and .runtime_build.sha256 == $expected
+    and .runtime_build.path == $runtime
+    and .runtime_build.resolved_path == $runtime
+    and (.runtime_build.ref | contains("testnet-package-linux-x64-"))' \
+  "$node_root_abs/config/doc/testing/evidence/public-testnet-governed-bootstrap-bundle-2026-06-06.json" >/dev/null
+
+directory_current_node="$TMP_DIR/directory-current-node"
+mkdir -p "$directory_current_node/current/bin" "$directory_current_node/config/doc/testing/evidence"
+printf 'runtime-v1\n' >"$directory_current_node/current/bin/oasis7_chain_runtime"
+chmod +x "$directory_current_node/current/bin/oasis7_chain_runtime"
+cp \
+  "$node_root_abs/config/doc/testing/evidence/public-testnet-governed-bootstrap-bundle-2026-06-06.json" \
+  "$directory_current_node/config/doc/testing/evidence/public-testnet-governed-bootstrap-bundle-2026-06-06.json"
+
+"$ROOT_DIR/scripts/p2p-public-testnet-package-node-upgrade.sh" \
+  --node-root "$directory_current_node" \
+  --bundle-tar "$TMP_DIR/oasis7-linux-x64-bundle.tar.gz" \
+  --package-version "$package_version" \
+  --commit "$commit" \
+  --run-id "$run_id" \
+  --artifact-ref "testnet-package-linux-x64-$package_version/oasis7-linux-x64-bundle.tar.gz!/bin/oasis7_chain_runtime" \
+  >/dev/null
+
+directory_current_node_abs=$(python3 -c 'import pathlib,sys; print(pathlib.Path(sys.argv[1]).resolve())' "$directory_current_node")
+test -L "$directory_current_node_abs/current"
+test "$(readlink "$directory_current_node_abs/current")" = "$directory_current_node_abs/releases/$package_version"
+test -x "$directory_current_node_abs/current/bin/oasis7_chain_runtime"
+test "$(find "$directory_current_node_abs" -maxdepth 1 -type d -name 'current-pre-*.dir' | wc -l | tr -d ' ')" = "1"
+test ! -e "$directory_current_node_abs/current/oasis7-linux-x64"
+
+missing_bundle_node="$TMP_DIR/missing-bundle-node"
+mkdir -p "$missing_bundle_node/releases/old/bin" "$missing_bundle_node/config"
+printf 'runtime-v1\n' >"$missing_bundle_node/releases/old/bin/oasis7_chain_runtime"
+chmod +x "$missing_bundle_node/releases/old/bin/oasis7_chain_runtime"
+ln -s "$missing_bundle_node/releases/old" "$missing_bundle_node/current"
+missing_bundle_node_abs=$(python3 -c 'import pathlib,sys; print(pathlib.Path(sys.argv[1]).resolve())' "$missing_bundle_node")
+set +e
+"$ROOT_DIR/scripts/p2p-public-testnet-package-node-upgrade.sh" \
+  --node-root "$missing_bundle_node" \
+  --bundle-tar "$TMP_DIR/oasis7-linux-x64-bundle.tar.gz" \
+  --package-version "$package_version" \
+  --commit "$commit" \
+  --run-id "$run_id" \
+  >/tmp/oasis7-package-node-upgrade-negative.out 2>&1
+negative_status=$?
+set -e
+test "$negative_status" -ne 0
+grep -q "no governed bootstrap bundle found" /tmp/oasis7-package-node-upgrade-negative.out
+negative_current=$(python3 -c 'import pathlib,sys; print(pathlib.Path(sys.argv[1]).resolve())' "$missing_bundle_node_abs/current")
+test "$negative_current" = "$missing_bundle_node_abs/releases/old"
+
+echo "ok: package node upgrade pins current runtime hash into governed bootstrap bundle"


### PR DESCRIPTION
## Summary
- Prefer older release_default retained checkpoint boundaries before 32-height fallback candidates during high replication checkpoint catch-up.
- Add a standard Linux testnet package node upgrade helper that updates node-local governed bootstrap bundle runtime metadata before switching `current`.
- Cover the package upgrade flow, including a negative case that leaves `current` unchanged when the governed bootstrap bundle is missing.

## Validation
- `scripts/p2p-public-testnet-package-node-upgrade.test.sh`
- `env -u RUSTC_WRAPPER cargo test -p oasis7_node high_replication_checkpoint_candidates -- --nocapture`
- `env -u RUSTC_WRAPPER cargo test -p oasis7_node storage_replication_high_checkpoint_retained -- --nocapture`
- `env -u RUSTC_WRAPPER cargo test -p oasis7_node runtime_network_replication_gap_sync -- --nocapture`
- `env -u RUSTC_WRAPPER cargo fmt --check && git diff --check && ./scripts/check-rust-file-size.sh && ./scripts/pm/workflow-lint.sh --phase pr-ready --task-uid task_96c772c830e043f9b1e40b03e6f73d38`

## Live Context
#67 deployment proved the previous single-probe fix avoids the first high-checkpoint tick wedge, but also surfaced two remaining issues: node-local governed bundle hash drift during package upgrade, and high checkpoint probing wasting budget on a newest aligned boundary that can be unretained on live public testnet nodes.
