### PR TITLE
Publish checkpoint blob providers for testnet sync

### DIFF
--- a/.pm/tasks/task_96c772c830e043f9b1e40b03e6f73d38.execution.md
+++ b/.pm/tasks/task_96c772c830e043f9b1e40b03e6f73d38.execution.md
@@ -609,3 +609,26 @@ Example:
 - Validation Command: env -u RUSTC_WRAPPER cargo fmt --check && git diff --check && ./scripts/check-rust-file-size.sh && ./scripts/pm/workflow-lint.sh --phase pr-ready --task-uid task_96c772c830e043f9b1e40b03e6f73d38
 - Actual Result: passed; file-size gate reported oversized code files=0, test files=0, workflow-lint OK.
 - Blocker / Next Action: amend/push PR #458, re-watch CI, merge, CI package, deploy #68+, and live-verify observer advances beyond height 64/high checkpoint catch-up.
+
+## 2026-06-14 04:30:00 CST / tpm
+- Follow-up trigger: PR #458 merged as `905e1a31d4a91c5fbe1cced70c02040309350157`. Testnet Packages run `27477014880` (#68) succeeded for linux/macos/windows. Linux artifact `testnet-package-linux-x64-0.0.0+testnet.68.905e1a31d4a9` passed SHA256 verification and was deployed with the new standard package-node-upgrade helper to sequencer `39.104.204.172`, storage `39.104.205.67`, and observer `192.168.1.4`. All three Linux services became active with runtime hash `98fb43de689e4427e764e92f170be57b6edab6f01dc4906617bbf12b18b0f3a7`. Windows artifact `testnet-package-windows-x64-0.0.0+testnet.68.905e1a31d4a9` was produced as artifact id `7614064313`; deployment is held for the next package because #68 does not include the provider-publish root fix below.
+- Live verification after #68: observer still remained at `committed_height=64`, `replication_persisted_height=64`, `replication_gap_sync_blocked_height=65`, `state_sync_fallback_required=true`. It was connected to sequencer and storage, but storage had fetch-commit `UnexpectedEof`/`Timeout` and request score 0. Runtime logs also showed repeated high-checkpoint failures such as `execution checkpoint blob not found` and `gap sync height <candidate> blob not found`.
+- Root-cause refinement: high-state catch-up had two missing design pieces. First, execution checkpoint manifest/blob content was stored locally but not consistently published as DHT provider content; commit provider publication alone did not make checkpoint state blobs routable. Second, a single missing checkpoint/commit blob could end the current high-checkpoint probe loop, wasting live catch-up time across retained checkpoint candidates.
+- Code change: checkpoint descriptor content is now first-class provider content. Local commit replication, remote commit persistence after checkpoint materialization, and fetch-commit handler on-demand checkpoint attachment publish provider records for checkpoint manifest/blob hashes only when the local blob exists and matches the descriptor size. `observer_light` still cannot publish because provider publication goes through the existing BlobState serve-lane policy.
+- Code change: high-checkpoint probing now treats `execution checkpoint blob not found` and `gap sync height ... blob not found` as continue-to-next-candidate conditions while still treating execution binding/install mismatch as fatal.
+- Intended professional slice: runtime_engineer + blockchain_ops_engineer read-only review of provider publication, role policy, fetch-handler lifecycle, and candidate-continuation semantics.
+- Actual limitation: subagent dispatch attempted via multi_agent_v1, but the runtime returned `collab spawn failed: agent thread limit reached`.
+- Fallback evidence path: TPM local code inspection plus targeted tests below; attribution boundary: no professional-role no_findings claim is made for this follow-up until a role slice can run or GitHub review/CI covers it.
+- Validation Command: env -u RUSTC_WRAPPER cargo test -p oasis7_node storage_replication_high_checkpoint_retained -- --nocapture
+- Actual Result: passed; 6 tests passed, including full_storage checkpoint provider publication and missing checkpoint blob candidate continuation.
+- Validation Command: env -u RUSTC_WRAPPER cargo test -p oasis7_node runtime_network_replication_gap_sync -- --nocapture
+- Actual Result: passed; 10 tests passed.
+- Validation Command: env -u RUSTC_WRAPPER cargo test -p oasis7_node observer_gap_sync -- --nocapture
+- Actual Result: passed; 12 tests passed.
+- Validation Command: env -u RUSTC_WRAPPER cargo test -p oasis7_node storage_replication -- --nocapture
+- Actual Result: passed; 29 tests passed.
+- Validation Command: env -u RUSTC_WRAPPER cargo test -p oasis7_node storage_replication_high_checkpoint_timeout -- --nocapture
+- Actual Result: passed; 2 tests passed.
+- Validation Command: env -u RUSTC_WRAPPER cargo fmt && env -u RUSTC_WRAPPER cargo fmt --check && git diff --check && ./scripts/check-rust-file-size.sh && ./scripts/pm/workflow-lint.sh --phase pr-ready --task-uid task_96c772c830e043f9b1e40b03e6f73d38
+- Actual Result: passed after moving helper code out of `lib.rs`; file-size gate reported oversized code files=0, test files=0, workflow-lint OK.
+- Blocker / Next Action: commit/push `codex/testnet-low-gap-high-checkpoint-fallback`, create PR, use CI package from merged main, deploy Linux + Windows, and live-verify observer advances beyond height 64.

--- a/crates/oasis7_node/src/lib.rs
+++ b/crates/oasis7_node/src/lib.rs
@@ -798,6 +798,8 @@ fn register_replication_fetch_handlers_with_checkpoint_export(
         let commit_world_id = world_id.to_string();
         let commit_replication_config = replication.clone();
         let commit_execution_hook = execution_hook.clone();
+        let commit_handle = handle.clone();
+        let commit_network_policy = network_policy.clone();
         network
             .register_handler(
                 REPLICATION_FETCH_COMMIT_PROTOCOL,
@@ -863,6 +865,20 @@ fn register_replication_fetch_handlers_with_checkpoint_export(
                         }
                         (message, _) => message,
                     };
+                    if let Some(message) = message.as_ref() {
+                        if let Some(payload) =
+                            parse_replication_commit_payload(message.payload.as_slice())
+                        {
+                            commit_handle
+                                .publish_checkpoint_descriptor_providers_from_root(
+                                    &commit_network_policy,
+                                    commit_root_dir.as_path(),
+                                    commit_world_id.as_str(),
+                                    payload.execution_checkpoint.as_ref(),
+                                )
+                                .map_err(network_internal_error)?;
+                        }
+                    }
                     let response = FetchCommitResponse {
                         found: message.is_some(),
                         message,

--- a/crates/oasis7_node/src/network_bridge.rs
+++ b/crates/oasis7_node/src/network_bridge.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::fmt;
+use std::path::Path;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
@@ -18,10 +19,11 @@ use crate::gossip_udp::{
     GossipAttestationMessage, GossipCommitMessage, GossipMessage, GossipProposalMessage,
 };
 use crate::replication::{
-    FetchCommitRequest, FetchCommitResponse, FetchHeadRequest, FetchHeadResponse,
-    GossipReplicationMessage, REPLICATION_FETCH_COMMIT_PROTOCOL, REPLICATION_GET_HEAD_PROTOCOL,
+    load_blob_from_root, FetchCommitRequest, FetchCommitResponse, FetchHeadRequest,
+    FetchHeadResponse, GossipReplicationMessage, REPLICATION_FETCH_COMMIT_PROTOCOL,
+    REPLICATION_GET_HEAD_PROTOCOL,
 };
-use crate::{NodeError, NodeNetworkPolicy};
+use crate::{NodeError, NodeExecutionCheckpointDescriptor, NodeNetworkPolicy};
 
 pub(crate) const DEFAULT_REPLICATION_TOPIC_PREFIX: &str = "aw";
 pub(crate) const DEFAULT_CONSENSUS_PROPOSAL_TOPIC_SUFFIX: &str = "consensus.proposal";
@@ -177,6 +179,80 @@ impl NodeReplicationNetworkHandle {
 
     pub fn clone_network(&self) -> Arc<dyn DistributedNetwork<WorldError> + Send + Sync> {
         Arc::clone(&self.network)
+    }
+
+    pub(crate) fn publish_local_content_provider(
+        &self,
+        network_policy: &NodeNetworkPolicy,
+        world_id: &str,
+        content_hash: &str,
+    ) -> Result<(), NodeError> {
+        let Some(dht) = self.dht.as_ref() else {
+            return Ok(());
+        };
+        let Some(local_provider_id) = self.local_provider_id.as_deref() else {
+            return Ok(());
+        };
+        if !network_policy
+            .allows_lane_operation(NetworkLane::BlobState, NetworkLaneOperation::Serve)
+        {
+            return Ok(());
+        }
+        dht.publish_provider(world_id, content_hash, local_provider_id)
+            .map_err(network_err)
+    }
+
+    pub(crate) fn publish_checkpoint_descriptor_providers_from_root(
+        &self,
+        network_policy: &NodeNetworkPolicy,
+        root_dir: &Path,
+        world_id: &str,
+        descriptor: Option<&NodeExecutionCheckpointDescriptor>,
+    ) -> Result<(), NodeError> {
+        let Some(descriptor) = descriptor else {
+            return Ok(());
+        };
+        self.publish_checkpoint_blob_provider_from_root(
+            network_policy,
+            root_dir,
+            world_id,
+            descriptor.manifest_ref.as_str(),
+            descriptor.manifest_size_bytes,
+        )?;
+        for blob_ref in &descriptor.blobs {
+            self.publish_checkpoint_blob_provider_from_root(
+                network_policy,
+                root_dir,
+                world_id,
+                blob_ref.content_hash.as_str(),
+                blob_ref.size_bytes,
+            )?;
+        }
+        Ok(())
+    }
+
+    fn publish_checkpoint_blob_provider_from_root(
+        &self,
+        network_policy: &NodeNetworkPolicy,
+        root_dir: &Path,
+        world_id: &str,
+        content_hash: &str,
+        expected_size_bytes: u64,
+    ) -> Result<(), NodeError> {
+        let Some(bytes) = load_blob_from_root(root_dir, content_hash)? else {
+            return Ok(());
+        };
+        if bytes.len() as u64 != expected_size_bytes {
+            return Err(NodeError::Replication {
+                reason: format!(
+                    "checkpoint provider publish local blob size mismatch hash={} expected={} actual={}",
+                    content_hash,
+                    expected_size_bytes,
+                    bytes.len()
+                ),
+            });
+        }
+        self.publish_local_content_provider(network_policy, world_id, content_hash)
     }
 
     fn resolved_topic(&self, world_id: &str) -> String {
@@ -638,20 +714,13 @@ impl ReplicationNetworkEndpoint {
         world_id: &str,
         content_hash: &str,
     ) -> Result<(), NodeError> {
-        let Some(dht) = self.dht.as_ref() else {
-            return Ok(());
+        let handle = NodeReplicationNetworkHandle {
+            network: Arc::clone(&self.network),
+            dht: self.dht.clone(),
+            local_provider_id: self.local_provider_id.clone(),
+            topic: Some(self.topic.clone()),
         };
-        let Some(local_provider_id) = self.local_provider_id.as_deref() else {
-            return Ok(());
-        };
-        if !self
-            .network_policy
-            .allows_lane_operation(NetworkLane::BlobState, NetworkLaneOperation::Serve)
-        {
-            return Ok(());
-        }
-        dht.publish_provider(world_id, content_hash, local_provider_id)
-            .map_err(network_err)
+        handle.publish_local_content_provider(&self.network_policy, world_id, content_hash)
     }
 
     fn cached_fetch_commit_success_response(

--- a/crates/oasis7_node/src/node_engine_replication.rs
+++ b/crates/oasis7_node/src/node_engine_replication.rs
@@ -45,7 +45,42 @@ impl PosNodeEngine {
         let fetch_commit_route_error = reason.contains(REPLICATION_FETCH_COMMIT_PROTOCOL)
             && (reason.contains("NetworkProtocolUnavailable")
                 || reason.contains("request failed: Timeout"));
-        fetch_commit_route_error
+        let checkpoint_blob_missing = reason.contains("execution checkpoint blob not found hash=")
+            || (reason.contains("gap sync height ")
+                && reason.contains(" blob not found for hash "));
+        fetch_commit_route_error || checkpoint_blob_missing
+    }
+
+    pub(super) fn publish_execution_checkpoint_descriptor_providers(
+        endpoint: &ReplicationNetworkEndpoint,
+        world_id: &str,
+        replication_runtime: &ReplicationRuntime,
+        descriptor: &NodeExecutionCheckpointDescriptor,
+    ) -> Result<(), NodeError> {
+        let publish_if_present = |content_hash: &str, expected_size_bytes: u64| {
+            let Some(bytes) = replication_runtime.load_blob_by_hash(content_hash)? else {
+                return Ok(());
+            };
+            if bytes.len() as u64 != expected_size_bytes {
+                return Err(NodeError::Replication {
+                    reason: format!(
+                        "execution checkpoint provider publish local blob size mismatch hash={} expected={} actual={}",
+                        content_hash,
+                        expected_size_bytes,
+                        bytes.len()
+                    ),
+                });
+            }
+            endpoint.publish_local_content_provider(world_id, content_hash)
+        };
+        publish_if_present(
+            descriptor.manifest_ref.as_str(),
+            descriptor.manifest_size_bytes,
+        )?;
+        for blob_ref in &descriptor.blobs {
+            publish_if_present(blob_ref.content_hash.as_str(), blob_ref.size_bytes)?;
+        }
+        Ok(())
     }
 
     fn clear_replication_gap_sync_blocked_if_unblocked(&mut self) {
@@ -171,6 +206,17 @@ impl PosNodeEngine {
             execution_checkpoint,
         )? {
             if let Some(endpoint) = network_endpoint {
+                if let Some(payload) = parse_replication_commit_payload(message.payload.as_slice())
+                {
+                    if let Some(descriptor) = payload.execution_checkpoint.as_ref() {
+                        Self::publish_execution_checkpoint_descriptor_providers(
+                            endpoint,
+                            world_id,
+                            replication,
+                            descriptor,
+                        )?;
+                    }
+                }
                 endpoint.publish_local_content_provider(
                     world_id,
                     message.record.content_hash.as_str(),
@@ -427,6 +473,18 @@ impl PosNodeEngine {
                         world_id,
                         message.record.content_hash.as_str(),
                     )?;
+                    if let Some(full_payload) =
+                        parse_replication_commit_payload(message.payload.as_slice())
+                    {
+                        if let Some(descriptor) = full_payload.execution_checkpoint.as_ref() {
+                            Self::publish_execution_checkpoint_descriptor_providers(
+                                endpoint,
+                                world_id,
+                                replication_runtime,
+                                descriptor,
+                            )?;
+                        }
+                    }
                     if let Some(payload) = payload_view {
                         self.advance_contiguous_replication_persisted_height(
                             replication_runtime,
@@ -666,6 +724,12 @@ impl PosNodeEngine {
             )?;
         }
         replication_runtime.pin_execution_checkpoint_descriptor(descriptor)?;
+        Self::publish_execution_checkpoint_descriptor_providers(
+            endpoint,
+            world_id,
+            replication_runtime,
+            descriptor,
+        )?;
         replication_runtime
             .load_execution_checkpoint_bundle(descriptor)?
             .ok_or_else(|| NodeError::Replication {

--- a/crates/oasis7_node/src/tests_storage_replication_high_checkpoint_retained.rs
+++ b/crates/oasis7_node/src/tests_storage_replication_high_checkpoint_retained.rs
@@ -102,9 +102,13 @@ fn high_replication_checkpoint_probe_continues_after_fetch_commit_timeout() {
 }
 
 #[test]
-fn high_replication_checkpoint_probe_does_not_continue_after_blob_or_execution_errors() {
+fn high_replication_checkpoint_probe_continues_after_missing_checkpoint_blob() {
     let blob_err = NodeError::Replication {
         reason: "execution checkpoint blob not found hash=missing-blob".to_string(),
+    };
+    let commit_blob_err = NodeError::Replication {
+        reason: "gap sync height 16640 blob not found for hash missing-commit-payload"
+            .to_string(),
     };
     let execution_err = NodeError::Execution {
         reason: "execution checkpoint install returned mismatched binding at height 16640"
@@ -116,8 +120,11 @@ fn high_replication_checkpoint_probe_does_not_continue_after_blob_or_execution_e
                 .to_string(),
     };
 
-    assert!(!PosNodeEngine::high_replication_checkpoint_probe_can_continue(
+    assert!(PosNodeEngine::high_replication_checkpoint_probe_can_continue(
         &blob_err
+    ));
+    assert!(PosNodeEngine::high_replication_checkpoint_probe_can_continue(
+        &commit_blob_err
     ));
     assert!(!PosNodeEngine::high_replication_checkpoint_probe_can_continue(
         &execution_err
@@ -125,6 +132,69 @@ fn high_replication_checkpoint_probe_does_not_continue_after_blob_or_execution_e
     assert!(!PosNodeEngine::high_replication_checkpoint_probe_can_continue(
         &protocol_omitted_blob_timeout
     ));
+}
+
+#[test]
+fn full_storage_publishes_execution_checkpoint_blob_providers() {
+    let world_id = "world-checkpoint-provider-publish";
+    let dir = temp_dir("checkpoint-provider-publish");
+    let (_, public_key) = deterministic_keypair_hex(252);
+    let config = NodeConfig::new("node-storage", world_id, NodeRole::Storage)
+        .expect("config")
+        .with_replication(
+            signed_replication_config(dir.clone(), 252)
+                .with_fetch_requester_allowlist(vec![public_key])
+                .expect("fetch allowlist"),
+        );
+    let replication =
+        ReplicationRuntime::new(config.replication.as_ref().expect("replication"), "node-storage")
+            .expect("runtime");
+    let bundle = test_execution_checkpoint_bundle(64, "exec-block-64", "exec-state-64");
+    let manifest_hash = oasis7_distfs::blake3_hex(bundle.manifest_json.as_slice());
+    let blob_hash = bundle
+        .blobs
+        .first()
+        .expect("checkpoint blob")
+        .content_hash
+        .clone();
+    let descriptor = replication
+        .store_execution_checkpoint_bundle(&bundle)
+        .expect("store checkpoint");
+    let network: Arc<
+        dyn oasis7_proto::distributed_net::DistributedNetwork<WorldError> + Send + Sync,
+    > = Arc::new(TestInMemoryNetwork::default());
+    let dht = Arc::new(TestReplicaMaintenanceDht::new(
+        "remote-provider",
+        "storage-provider",
+    ));
+    let handle = NodeReplicationNetworkHandle::new(Arc::clone(&network))
+        .with_dht(dht.clone())
+        .with_local_provider_id("storage-provider");
+    let endpoint =
+        ReplicationNetworkEndpoint::new(&handle, world_id, false, &config.network_policy)
+            .expect("endpoint");
+
+    PosNodeEngine::publish_execution_checkpoint_descriptor_providers(
+        &endpoint,
+        world_id,
+        &replication,
+        &descriptor,
+    )
+    .expect("publish checkpoint providers");
+
+    let published = dht.published_records();
+    for hash in [manifest_hash, blob_hash] {
+        assert!(
+            published.iter().any(
+                |(published_world, published_hash, provider)| published_world == world_id
+                    && published_hash == &hash
+                    && provider == "storage-provider"
+            ),
+            "expected checkpoint content hash={hash} to be published, published={published:?}"
+        );
+    }
+
+    let _ = fs::remove_dir_all(&dir);
 }
 
 #[test]
@@ -231,7 +301,7 @@ fn observer_gap_sync_probes_retained_checkpoint_window_below_non_checkpoint_head
         dht.seed_provider(hash, "node-a-provider");
     }
     let handle_b = NodeReplicationNetworkHandle::new(Arc::clone(&network))
-        .with_dht(dht)
+        .with_dht(dht.clone())
         .with_local_provider_id("node-b-provider");
     let endpoint_b =
         ReplicationNetworkEndpoint::new(&handle_b, world_id, false, &config_b.network_policy)
@@ -271,7 +341,6 @@ fn observer_gap_sync_probes_retained_checkpoint_window_below_non_checkpoint_head
             .any(|provider| provider == "node-a-provider")),
         "expected retained checkpoint sync to route blob fetches through DHT providers, attempts={provider_attempts:?}"
     );
-
     let _ = fs::remove_dir_all(&dir_a);
     let _ = fs::remove_dir_all(&dir_b);
 }


### PR DESCRIPTION
## Summary
- Publish execution checkpoint manifest/blob provider records when the local node actually has the checkpoint blobs.
- Let fetch-commit handler publish checkpoint blob providers after on-demand checkpoint descriptor attachment.
- Continue high-checkpoint candidate probing when one candidate is missing a checkpoint/commit blob, while preserving fatal execution mismatch errors.

## Validation
- `env -u RUSTC_WRAPPER cargo test -p oasis7_node storage_replication_high_checkpoint_retained -- --nocapture`
- `env -u RUSTC_WRAPPER cargo test -p oasis7_node runtime_network_replication_gap_sync -- --nocapture`
- `env -u RUSTC_WRAPPER cargo test -p oasis7_node observer_gap_sync -- --nocapture`
- `env -u RUSTC_WRAPPER cargo test -p oasis7_node storage_replication -- --nocapture`
- `env -u RUSTC_WRAPPER cargo test -p oasis7_node storage_replication_high_checkpoint_timeout -- --nocapture`
- `env -u RUSTC_WRAPPER cargo fmt --check && git diff --check && ./scripts/check-rust-file-size.sh && ./scripts/pm/workflow-lint.sh --phase pr-ready --task-uid task_96c772c830e043f9b1e40b03e6f73d38`

## Review note
Repo-owned role review dispatch was attempted, but the local subagent runtime returned `agent thread limit reached`; the task execution log records the attribution boundary and fallback evidence. GitHub review/CI should be treated as the external review gate for this follow-up.
