### PR TITLE
Gate checkpoint export during fetch-commit

### DIFF
--- a/.pm/tasks/task_96c772c830e043f9b1e40b03e6f73d38.execution.md
+++ b/.pm/tasks/task_96c772c830e043f9b1e40b03e6f73d38.execution.md
@@ -632,3 +632,24 @@ Example:
 - Validation Command: env -u RUSTC_WRAPPER cargo fmt && env -u RUSTC_WRAPPER cargo fmt --check && git diff --check && ./scripts/check-rust-file-size.sh && ./scripts/pm/workflow-lint.sh --phase pr-ready --task-uid task_96c772c830e043f9b1e40b03e6f73d38
 - Actual Result: passed after moving helper code out of `lib.rs`; file-size gate reported oversized code files=0, test files=0, workflow-lint OK.
 - Blocker / Next Action: commit/push `codex/testnet-low-gap-high-checkpoint-fallback`, create PR, use CI package from merged main, deploy Linux + Windows, and live-verify observer advances beyond height 64.
+
+## 2026-06-14 04:55:00 CST / tpm
+- Follow-up trigger: PR #459 merged as `c58528103dc376627082db2f4d483324dc02275c`. Testnet Packages run `27478093149` (#69) produced Linux artifact `testnet-package-linux-x64-0.0.0+testnet.69.c58528103dc3`; SHA256 verification passed. Runtime hash `013faaaa7eb2374abc4b898f07fa3e3b10c0aba656188215782b6c94a08a53b3`, size `98237416`.
+- Deployment evidence: #69 Linux package was deployed with `scripts/p2p-public-testnet-package-node-upgrade.sh` to sequencer `39.104.204.172`, storage `39.104.205.67`, and observer `192.168.1.4`. All three Linux services became active and reported the #69 runtime hash/size.
+- Live verification after #69: observer still stalled at `committed_height=64`, `replication_persisted_height=64`, `replication_gap_sync_blocked_height=65`, `state_sync_fallback_required=true`. It connected to both sequencer and storage; storage had `replication_persisted_height=16715` and registered fetch-commit/fetch-blob protocols. Observer fetch-commit to storage failed with `UnexpectedEof`/`Timeout`, while storage logs showed repeated libp2p inbound timeouts from the observer.
+- Root-cause refinement: fetch-commit handler synchronously called `export_checkpoint_bundle(request.height)` for every persisted commit when an execution hook was present. That put legacy checkpoint export on the low-height gap-sync hot path; live observer requesting height 65 could force storage into checkpoint export work and miss the request-response deadline before returning the normal commit.
+- Code/design change: fetch-commit now keeps ordinary gap-sync commit fetches lightweight. It only attempts legacy checkpoint export when the requested height is the local head or a checkpoint boundary aligned to the release_default 64/32 cadence. The helper logic lives in `crates/oasis7_node/src/replication_fetch_handler_support.rs` so `lib.rs` stays under the repository file-size gate. It still publishes checkpoint descriptor providers from existing commit payloads after responding via the existing code path.
+- Validation Command: env -u RUSTC_WRAPPER cargo test -p oasis7_node storage_replication_high_checkpoint -- --nocapture
+- Actual Result: passed; 18 tests passed, including `fetch_commit_exports_checkpoints_only_for_head_or_checkpoint_boundaries`.
+- Validation Command: env -u RUSTC_WRAPPER cargo test -p oasis7_node runtime_network_replication_gap_sync -- --nocapture
+- Actual Result: passed; 10 tests passed.
+- Validation Command: env -u RUSTC_WRAPPER cargo test -p oasis7_node observer_gap_sync -- --nocapture
+- Actual Result: passed; 12 tests passed.
+- Validation Command: env -u RUSTC_WRAPPER cargo test -p oasis7_node storage_replication -- --nocapture
+- Actual Result: passed; 30 tests passed.
+- Validation Command: env -u RUSTC_WRAPPER cargo fmt && env -u RUSTC_WRAPPER cargo fmt --check && git diff --check && ./scripts/check-rust-file-size.sh && ./scripts/pm/workflow-lint.sh --phase pr-ready --task-uid task_96c772c830e043f9b1e40b03e6f73d38
+- Actual Result: passed; file-size gate reported oversized code files=0, test files=0, workflow-lint OK.
+- Intended professional slice: runtime_engineer + blockchain_ops_engineer read-only pre-PR review of fetch-commit checkpoint export gating, specifically whether ordinary low gap fetches remain lightweight and legacy high-checkpoint compatibility is preserved.
+- Actual limitation: subagent dispatch was attempted via multi_agent_v1. The first full-history explorer request was rejected because full-history forked agents must inherit parent type/model/reasoning; the corrected full-history inherited dispatch then returned `collab spawn failed: agent thread limit reached`.
+- Fallback evidence path: TPM local integration plus targeted regression and smoke tests listed above; attribution boundary: no professional-role no_findings claim is made for this follow-up until a role slice can run or GitHub review/CI covers it.
+- Blocker / Next Action: push `codex/testnet-fetch-commit-checkpoint-export-gate`, create PR, run CI/package, deploy next package to Linux + Windows, and live-verify observer advances beyond height 64.

--- a/crates/oasis7_node/src/lib.rs
+++ b/crates/oasis7_node/src/lib.rs
@@ -63,6 +63,7 @@ mod pos_state_store;
 mod pos_validation;
 mod replica_maintenance_support;
 mod replication;
+mod replication_fetch_handler_support;
 mod replication_probe_gate;
 mod replication_state_reconcile;
 mod runtime_util;
@@ -134,6 +135,9 @@ use replication::{
     FetchBlobRequest, FetchBlobResponse, FetchCommitRequest, FetchCommitResponse, FetchHeadRequest,
     FetchHeadResponse, ReplicationHeadSummary, ReplicationRuntime, REPLICATION_FETCH_BLOB_PROTOCOL,
     REPLICATION_FETCH_COMMIT_PROTOCOL, REPLICATION_GET_HEAD_PROTOCOL,
+};
+use replication_fetch_handler_support::{
+    attach_checkpoint_for_fetch_commit_if_boundary, should_export_checkpoint_for_fetch_commit,
 };
 use replication_probe_gate::{
     replication_request_waitable_connection_gap, request_fetch_blob_with_route_fallback,
@@ -831,40 +835,16 @@ fn register_replication_fetch_handlers_with_checkpoint_export(
                         request.height,
                     )
                     .map_err(network_internal_error)?;
-                    let message = match (message, commit_execution_hook.as_ref()) {
-                        (Some(message), Some(execution_hook)) => {
-                            let checkpoint = execution_hook
-                                .lock()
-                                .map_err(|_| {
-                                    network_internal_error(NodeError::Execution {
-                                        reason: "execution hook lock poisoned".to_string(),
-                                    })
-                                })?
-                                .export_checkpoint_bundle(request.height)
-                                .map_err(|reason| {
-                                    network_internal_error(NodeError::Execution { reason })
-                                })?;
-                            if let Some(checkpoint) = checkpoint {
-                                let mut runtime = ReplicationRuntime::new(
-                                    &commit_replication_config,
-                                    commit_node_id.as_str(),
-                                )
-                                .map_err(network_internal_error)?;
-                                Some(
-                                    runtime
-                                        .attach_execution_checkpoint_descriptor_to_message(
-                                            commit_node_id.as_str(),
-                                            &message,
-                                            &checkpoint,
-                                        )
-                                        .map_err(network_internal_error)?,
-                                )
-                            } else {
-                                Some(message)
-                            }
-                        }
-                        (message, _) => message,
-                    };
+                    let message = attach_checkpoint_for_fetch_commit_if_boundary(
+                        message,
+                        commit_execution_hook.as_ref(),
+                        commit_root_dir.as_path(),
+                        commit_world_id.as_str(),
+                        commit_node_id.as_str(),
+                        &commit_replication_config,
+                        request.height,
+                    )
+                    .map_err(network_internal_error)?;
                     if let Some(message) = message.as_ref() {
                         if let Some(payload) =
                             parse_replication_commit_payload(message.payload.as_slice())

--- a/crates/oasis7_node/src/replication_fetch_handler_support.rs
+++ b/crates/oasis7_node/src/replication_fetch_handler_support.rs
@@ -1,0 +1,67 @@
+use std::path::Path;
+use std::sync::{Arc, Mutex};
+
+use crate::execution_hook::NodeExecutionHook;
+use crate::replication::{
+    load_latest_commit_message_from_root, GossipReplicationMessage, NodeReplicationConfig,
+    ReplicationRuntime,
+};
+use crate::replication_state_reconcile::parse_replication_commit_payload;
+use crate::{NodeError, REPLICATION_GAP_SYNC_MAX_HEIGHTS_PER_POLL};
+
+pub(super) fn attach_checkpoint_for_fetch_commit_if_boundary(
+    message: Option<GossipReplicationMessage>,
+    execution_hook: Option<&Arc<Mutex<Box<dyn NodeExecutionHook>>>>,
+    root_dir: &Path,
+    world_id: &str,
+    node_id: &str,
+    replication: &NodeReplicationConfig,
+    request_height: u64,
+) -> Result<Option<GossipReplicationMessage>, NodeError> {
+    let Some(execution_hook) = execution_hook else {
+        return Ok(message);
+    };
+    let Some(message) = message else {
+        return Ok(None);
+    };
+    let latest_commit_height = load_latest_commit_message_from_root(
+        root_dir,
+        world_id,
+        replication.max_hot_commit_messages(),
+    )?
+    .and_then(|message| {
+        parse_replication_commit_payload(message.payload.as_slice()).map(|payload| payload.height)
+    });
+    if !latest_commit_height
+        .map(|latest_height| {
+            should_export_checkpoint_for_fetch_commit(request_height, latest_height)
+        })
+        .unwrap_or(false)
+    {
+        return Ok(Some(message));
+    }
+
+    let checkpoint = execution_hook
+        .lock()
+        .map_err(|_| NodeError::Execution {
+            reason: "execution hook lock poisoned".to_string(),
+        })?
+        .export_checkpoint_bundle(request_height)
+        .map_err(|reason| NodeError::Execution { reason })?;
+    let Some(checkpoint) = checkpoint else {
+        return Ok(Some(message));
+    };
+    let mut runtime = ReplicationRuntime::new(replication, node_id)?;
+    runtime
+        .attach_execution_checkpoint_descriptor_to_message(node_id, &message, &checkpoint)
+        .map(Some)
+}
+
+pub(super) fn should_export_checkpoint_for_fetch_commit(
+    request_height: u64,
+    latest_height: u64,
+) -> bool {
+    request_height == latest_height
+        || request_height % REPLICATION_GAP_SYNC_MAX_HEIGHTS_PER_POLL == 0
+        || request_height % (REPLICATION_GAP_SYNC_MAX_HEIGHTS_PER_POLL / 2) == 0
+}

--- a/crates/oasis7_node/src/tests_storage_replication_high_checkpoint.rs
+++ b/crates/oasis7_node/src/tests_storage_replication_high_checkpoint.rs
@@ -94,6 +94,14 @@ fn test_execution_checkpoint_bundle(
     }
 }
 
+#[test]
+fn fetch_commit_exports_checkpoints_only_for_head_or_checkpoint_boundaries() {
+    assert!(!should_export_checkpoint_for_fetch_commit(65, 16_715));
+    assert!(should_export_checkpoint_for_fetch_commit(16_715, 16_715));
+    assert!(should_export_checkpoint_for_fetch_commit(16_704, 16_715));
+    assert!(should_export_checkpoint_for_fetch_commit(16_672, 16_715));
+}
+
 fn committed_decision(height: u64, approved_stake: u64, required_stake: u64) -> PosDecision {
     PosDecision {
         height,


### PR DESCRIPTION
## Summary
- keep fetch-commit's normal gap-sync path lightweight by gating legacy checkpoint export to local head or checkpoint-aligned boundary requests
- move checkpoint attachment policy into `replication_fetch_handler_support` so `lib.rs` stays below the file-size gate
- add regression coverage for live-style height 65 requests avoiding checkpoint export while preserving head and 64/32 boundary compatibility

## Live Root Cause
After package #69, observer `192.168.1.4` still stalled at height 64. Storage was connected and registered fetch-commit/fetch-blob, but observer fetch-commit requests to storage timed out. The handler was synchronously calling `export_checkpoint_bundle(request.height)` for every persisted commit when an execution hook was present, so a low gap-sync request like height 65 could trigger checkpoint export work before returning the ordinary commit.

## Verification
- `env -u RUSTC_WRAPPER cargo test -p oasis7_node storage_replication_high_checkpoint -- --nocapture`
- `env -u RUSTC_WRAPPER cargo test -p oasis7_node runtime_network_replication_gap_sync -- --nocapture`
- `env -u RUSTC_WRAPPER cargo test -p oasis7_node observer_gap_sync -- --nocapture`
- `env -u RUSTC_WRAPPER cargo test -p oasis7_node storage_replication -- --nocapture`
- `env -u RUSTC_WRAPPER cargo fmt && env -u RUSTC_WRAPPER cargo fmt --check && git diff --check && ./scripts/check-rust-file-size.sh`
- `./scripts/pm/workflow-lint.sh --phase pr-ready --task-uid task_96c772c830e043f9b1e40b03e6f73d38`

## Workflow Note
Repo-owned pre-PR role review dispatch was attempted but the runtime returned `collab spawn failed: agent thread limit reached`; task execution log records the intended slice, actual limitation, and fallback evidence boundary.
