### PR TITLE
Extend fetch commit timeout for cold sync

### DIFF
--- a/.pm/tasks/task_96c772c830e043f9b1e40b03e6f73d38.execution.md
+++ b/.pm/tasks/task_96c772c830e043f9b1e40b03e6f73d38.execution.md
@@ -687,3 +687,19 @@ Example:
 - Actual limitation: subagent dispatch remains unavailable in this thread because previous full-history inherited dispatch attempts returned `collab spawn failed: agent thread limit reached`; no new professional-role conclusion is claimed here.
 - Fallback evidence path: live #71 status evidence plus focused libp2p/gap-sync tests listed above; attribution boundary: TPM integration only, pending GitHub CI/review.
 - Blocker / Next Action: commit/push `codex/testnet-provider-dial-fallback`, create PR, watch required checks, merge, package next testnet build, deploy Linux + Windows, and verify observer advances beyond height 65/66 toward high-state sync.
+
+## 2026-06-14 06:55:00 CST / tpm
+- Follow-up trigger: PR #462 merged as `186248a58c84aaf27c0dbcab052e017487d13b2d`. Testnet Packages run `27480801371` (#72) succeeded for linux/macos/windows. Linux artifact `testnet-package-linux-x64-0.0.0+testnet.72.186248a58c84` passed SHA256 verification and was deployed to sequencer, storage, and observer. All three Linux services restarted active with runtime sha256 `430c9c0c3f1f089dee360e7bd4889b238a356f919511a29268e9abfcb070c0a5`.
+- Live verification after #72: observer immediately connected to both storage `12D3KooWAuNCCEDu7CdUUDwALuAhuLekZHgVWxAYp4Ag5ti79fJj` and sequencer `12D3KooWMyPapumCaTABq27umWdHqXDr8AoTse21eMVnXeJEsbNp`, confirming the known-peer/bootstrap-provider dialing fix worked. It still remained at `committed_height=65` / `replication_persisted_height=65`. Storage was active, had `replication_persisted_height=16715`, and retained height 66 in the cold pack index with entry len `2440`, but observer repeatedly saw `Timeout` and `UnexpectedEof` for `/aw/node/replication/fetch-commit/1.0.0` against storage. Storage request score dropped to 0.
+- Root-cause refinement: the remaining blocker is no longer provider discovery or missing data. Fetch-commit serves cold commit readback and validation, but the libp2p request layer still uses the generic small-RPC budget (`12s` per peer / `20s` total). On live cold-storage repair this short budget times out before the storage provider can complete the request-response stream, penalizing the only useful full-storage peer.
+- Code/design change: fetch-commit now has an explicit cold-archive transfer budget: `30s` per peer and `120s` total retry budget. Fetch-blob keeps its existing long transfer budget, and ordinary replication RPCs keep the generic short budget.
+- Validation Command: env -u RUSTC_WRAPPER cargo test -p oasis7_node libp2p_replication_network -- --nocapture
+- Actual Result: passed; 37 tests passed, including fetch-commit cold-archive budget coverage.
+- Validation Command: env -u RUSTC_WRAPPER cargo test -p oasis7_node runtime_network_replication_gap_sync -- --nocapture
+- Actual Result: passed; 10 tests passed.
+- Validation Command: env -u RUSTC_WRAPPER cargo fmt --check && git diff --check && ./scripts/check-rust-file-size.sh && ./scripts/pm/workflow-lint.sh --phase pr-ready --task-uid task_96c772c830e043f9b1e40b03e6f73d38
+- Actual Result: passed; file-size gate reported oversized code files=0, test files=0, workflow-lint OK.
+- Intended professional slice: runtime_engineer + blockchain_ops_engineer pre-PR review of fetch-commit request-response timeout sizing for cold commit readback and peer scoring impact.
+- Actual limitation: subagent dispatch remains unavailable in this thread because previous full-history inherited dispatch attempts returned `collab spawn failed: agent thread limit reached`; no professional-role conclusion is claimed here.
+- Fallback evidence path: live #72 status evidence plus focused libp2p/gap-sync tests listed above; attribution boundary: TPM integration only, pending GitHub CI/review.
+- Blocker / Next Action: commit/push `codex/testnet-fetch-commit-cold-timeout`, create PR, watch required checks, merge, package next testnet build, deploy Linux + Windows, and verify observer advances beyond height 65.

--- a/crates/oasis7_node/src/libp2p_replication_network.rs
+++ b/crates/oasis7_node/src/libp2p_replication_network.rs
@@ -64,6 +64,8 @@ const REQUEST_PEER_GENERIC_PENALTY: u8 = 10;
 const REQUEST_PEER_SUCCESS_RECOVERY: u8 = 5;
 const REQUEST_TO_PEER_TIMEOUT_MS: u64 = 12_000;
 const REQUEST_RETRY_BUDGET_MS: u64 = 20_000;
+const FETCH_COMMIT_REQUEST_TO_PEER_TIMEOUT_MS: u64 = 30_000;
+const FETCH_COMMIT_REQUEST_RETRY_BUDGET_MS: u64 = 120_000;
 const FETCH_BLOB_REQUEST_TO_PEER_TIMEOUT_MS: u64 = 30_000;
 const FETCH_BLOB_REQUEST_RETRY_BUDGET_MS: u64 = 180_000;
 const REPLICATION_FETCH_BLOB_PROTOCOL_MARKER: &str = "/fetch-blob/";
@@ -641,6 +643,9 @@ impl Libp2pReplicationNetwork {
     }
 
     fn request_timeout_for_protocol(&self, protocol: &str) -> Duration {
+        if protocol == REPLICATION_FETCH_COMMIT_PROTOCOL {
+            return Duration::from_millis(FETCH_COMMIT_REQUEST_TO_PEER_TIMEOUT_MS);
+        }
         if protocol.contains(REPLICATION_FETCH_BLOB_PROTOCOL_MARKER) {
             return self.fetch_blob_request_timeout;
         }
@@ -648,6 +653,9 @@ impl Libp2pReplicationNetwork {
     }
 
     fn request_retry_budget_for_protocol(&self, protocol: &str) -> Duration {
+        if protocol == REPLICATION_FETCH_COMMIT_PROTOCOL {
+            return Duration::from_millis(FETCH_COMMIT_REQUEST_RETRY_BUDGET_MS);
+        }
         if protocol.contains(REPLICATION_FETCH_BLOB_PROTOCOL_MARKER) {
             return self.fetch_blob_request_retry_budget;
         }
@@ -1115,6 +1123,9 @@ mod bootstrap_provider_tests;
 
 #[cfg(test)]
 mod peer_selection_tests;
+
+#[cfg(test)]
+mod protocol_budget_tests;
 
 #[cfg(test)]
 mod tests;

--- a/crates/oasis7_node/src/libp2p_replication_network/protocol_budget_tests.rs
+++ b/crates/oasis7_node/src/libp2p_replication_network/protocol_budget_tests.rs
@@ -1,0 +1,62 @@
+use super::*;
+use std::time::Duration;
+
+#[test]
+fn libp2p_replication_network_uses_long_transfer_budget_for_fetch_blob() {
+    let network = Libp2pReplicationNetwork::new(Libp2pReplicationNetworkConfig {
+        request_timeout: Duration::from_millis(11),
+        request_retry_budget: Duration::from_millis(22),
+        fetch_blob_request_timeout: Duration::from_millis(333),
+        fetch_blob_request_retry_budget: Duration::from_millis(444),
+        ..Libp2pReplicationNetworkConfig::default()
+    });
+
+    assert_eq!(
+        network.request_timeout_for_protocol("/aw/node/replication/fetch-blob/1.0.0"),
+        Duration::from_millis(333)
+    );
+    assert_eq!(
+        network.request_retry_budget_for_protocol("/aw/node/replication/fetch-blob/1.0.0"),
+        Duration::from_millis(444)
+    );
+}
+
+#[test]
+fn libp2p_replication_network_uses_cold_archive_budget_for_fetch_commit() {
+    let network = Libp2pReplicationNetwork::new(Libp2pReplicationNetworkConfig {
+        request_timeout: Duration::from_millis(11),
+        request_retry_budget: Duration::from_millis(22),
+        fetch_blob_request_timeout: Duration::from_millis(333),
+        fetch_blob_request_retry_budget: Duration::from_millis(444),
+        ..Libp2pReplicationNetworkConfig::default()
+    });
+
+    assert_eq!(
+        network.request_timeout_for_protocol("/aw/node/replication/fetch-commit/1.0.0"),
+        Duration::from_millis(30_000)
+    );
+    assert_eq!(
+        network.request_retry_budget_for_protocol("/aw/node/replication/fetch-commit/1.0.0"),
+        Duration::from_millis(120_000)
+    );
+}
+
+#[test]
+fn libp2p_replication_network_keeps_short_budget_for_non_blob_protocols() {
+    let network = Libp2pReplicationNetwork::new(Libp2pReplicationNetworkConfig {
+        request_timeout: Duration::from_millis(11),
+        request_retry_budget: Duration::from_millis(22),
+        fetch_blob_request_timeout: Duration::from_millis(333),
+        fetch_blob_request_retry_budget: Duration::from_millis(444),
+        ..Libp2pReplicationNetworkConfig::default()
+    });
+
+    assert_eq!(
+        network.request_timeout_for_protocol("/aw/node/replication/ping"),
+        Duration::from_millis(11)
+    );
+    assert_eq!(
+        network.request_retry_budget_for_protocol("/aw/node/replication/ping"),
+        Duration::from_millis(22)
+    );
+}

--- a/crates/oasis7_node/src/libp2p_replication_network/tests.rs
+++ b/crates/oasis7_node/src/libp2p_replication_network/tests.rs
@@ -68,46 +68,6 @@ fn libp2p_replication_network_request_rejects_without_connected_peers_by_default
 }
 
 #[test]
-fn libp2p_replication_network_uses_long_transfer_budget_for_fetch_blob() {
-    let network = Libp2pReplicationNetwork::new(Libp2pReplicationNetworkConfig {
-        request_timeout: Duration::from_millis(11),
-        request_retry_budget: Duration::from_millis(22),
-        fetch_blob_request_timeout: Duration::from_millis(333),
-        fetch_blob_request_retry_budget: Duration::from_millis(444),
-        ..Libp2pReplicationNetworkConfig::default()
-    });
-
-    assert_eq!(
-        network.request_timeout_for_protocol("/aw/node/replication/fetch-blob/1.0.0"),
-        Duration::from_millis(333)
-    );
-    assert_eq!(
-        network.request_retry_budget_for_protocol("/aw/node/replication/fetch-blob/1.0.0"),
-        Duration::from_millis(444)
-    );
-}
-
-#[test]
-fn libp2p_replication_network_keeps_short_budget_for_non_blob_protocols() {
-    let network = Libp2pReplicationNetwork::new(Libp2pReplicationNetworkConfig {
-        request_timeout: Duration::from_millis(11),
-        request_retry_budget: Duration::from_millis(22),
-        fetch_blob_request_timeout: Duration::from_millis(333),
-        fetch_blob_request_retry_budget: Duration::from_millis(444),
-        ..Libp2pReplicationNetworkConfig::default()
-    });
-
-    assert_eq!(
-        network.request_timeout_for_protocol("/aw/node/replication/fetch-commit/1.0.0"),
-        Duration::from_millis(11)
-    );
-    assert_eq!(
-        network.request_retry_budget_for_protocol("/aw/node/replication/fetch-commit/1.0.0"),
-        Duration::from_millis(22)
-    );
-}
-
-#[test]
 fn libp2p_replication_network_request_falls_back_to_local_handler_when_enabled() {
     let network = Libp2pReplicationNetwork::new(Libp2pReplicationNetworkConfig {
         allow_local_handler_fallback_when_no_peers: true,


### PR DESCRIPTION
## Summary
- give fetch-commit its own cold-archive request budget: 30s per peer / 120s total
- keep ordinary replication RPCs on the short budget and fetch-blob on the existing long budget
- move protocol budget tests into a small module to keep the file-size gate green

## Validation
- `env -u RUSTC_WRAPPER cargo test -p oasis7_node libp2p_replication_network -- --nocapture`
- `env -u RUSTC_WRAPPER cargo test -p oasis7_node runtime_network_replication_gap_sync -- --nocapture`
- `env -u RUSTC_WRAPPER cargo fmt --check && git diff --check && ./scripts/check-rust-file-size.sh && ./scripts/pm/workflow-lint.sh --phase pr-ready --task-uid task_96c772c830e043f9b1e40b03e6f73d38`

## Live Evidence
- #72 observer now connects to storage, but fetch-commit to storage still times out and drops the storage peer score to 0.
- Storage retains height 66 in cold pack storage with a small entry, so the remaining failure is the request-response budget, not missing data or discovery.
