### PR TITLE
Cover replication request response transfer budgets

### DIFF
--- a/.pm/tasks/task_96c772c830e043f9b1e40b03e6f73d38.execution.md
+++ b/.pm/tasks/task_96c772c830e043f9b1e40b03e6f73d38.execution.md
@@ -722,3 +722,24 @@ Example:
 - Actual limitation: subagent dispatch remains unavailable in this thread because previous full-history inherited dispatch attempts returned `collab spawn failed: agent thread limit reached`; no professional-role conclusion is claimed here.
 - Fallback evidence path: live #73 deployment evidence, direct storage cold-pack read timings, code inspection of swarm synchronous handler path, and targeted regression tests listed above; attribution boundary: TPM integration only, pending GitHub CI/review.
 - Blocker / Next Action: commit/push `codex/testnet-fetch-commit-provider-publish`, create PR, watch required checks, merge, package #74, deploy Linux + Windows, and verify observer advances beyond height 66 into high-state catch-up.
+
+## 2026-06-14 08:05:25 CST / tpm
+- Follow-up trigger: PR #464 merged as `7497f17763fb5673ed1be53f31771263f8b486db`. Testnet Packages run `27482426041` (#74) succeeded for linux/macos/windows. Linux artifact `testnet-package-linux-x64-0.0.0+testnet.74.7497f17763fb` passed SHA256 verification and was deployed to sequencer `39.104.204.172`, storage `39.104.205.67`, and observer `192.168.1.4`; all three Linux services restarted active with runtime sha256 `3fb4ba6dd126c63b3cf21545af9c7c17f3463f5a95bc65ac296e7b751c6712ee`, size `98264256`.
+- Windows package status: #74 Windows package completed successfully. Windows host `192.168.1.3` deployment remains blocked because SSH to `Administrator@192.168.1.3:22` timed out; no Windows redeploy has been claimed.
+- Live verification after #74: observer stayed at `committed_height=66` / `replication_persisted_height=66`, `network_height=16715`, `network_height_lag=16649`, with storage and sequencer connected and active. Observer fetch-commit errors changed to `UnexpectedEof` for `/aw/node/replication/fetch-commit/1.0.0`; storage debug showed corresponding libp2p inbound `Timeout` from the observer peer.
+- Root-cause refinement: #464 removed the request-handler self-blocking provider-publish path, but the bottom libp2p request-response behavior still used a 30s stream timeout (`max(request_retry_budget=20s, fetch_blob_request_timeout=30s)`). That behavior-level inbound timeout did not cover the protocol-level high-state budgets introduced earlier: fetch-commit total retry budget 120s and fetch-blob retry budget 180s. The provider can therefore close the inbound stream at the behavior layer while the business request layer is still within its allowed high-state transfer window, surfacing to the requester as EOF.
+- Code/design change: `Libp2pReplicationNetwork` now derives the inner `Libp2pNetworkConfig.request_response_timeout` from the maximum transfer retry budget: generic request retry budget, fetch-blob retry budget, and fetch-commit cold-archive retry budget. This aligns the transport behavior lifetime with the high-state synchronization contract instead of only the short per-peer timeout.
+- Validation Command: env -u RUSTC_WRAPPER cargo test -p oasis7_node libp2p_replication_network -- --nocapture
+- Actual Result: passed; 38 tests passed, including request-response timeout coverage for long transfer budgets.
+- Validation Command: env -u RUSTC_WRAPPER cargo test -p oasis7_node storage_replication_high_checkpoint_retained -- --nocapture
+- Actual Result: passed; 7 tests passed.
+- Validation Command: env -u RUSTC_WRAPPER cargo fmt --check
+- Actual Result: passed.
+- Validation Command: git diff --check
+- Actual Result: passed.
+- Validation Command: ./scripts/check-rust-file-size.sh
+- Actual Result: passed; oversized code files=0, test files=0, structural slice files=0.
+- Intended professional slice: runtime_engineer + blockchain_ops_engineer pre-PR review of libp2p request-response behavior timeout sizing and high-state transfer budget invariants.
+- Actual limitation: subagent dispatch remains unavailable in this thread because previous full-history inherited dispatch attempts returned `collab spawn failed: agent thread limit reached`; no professional-role conclusion is claimed here.
+- Fallback evidence path: live #74 deployment evidence, storage inbound timeout evidence, code inspection of `Libp2pReplicationNetwork::new` behavior timeout sizing, and focused regression tests listed above; attribution boundary: TPM integration only, pending GitHub CI/review.
+- Blocker / Next Action: run workflow lint, commit/push `codex/testnet-replication-request-response-budget`, create PR, watch required checks, merge, package next testnet build, deploy Linux and retry Windows only if SSH becomes reachable, then verify observer advances beyond height 66.

--- a/crates/oasis7_node/src/libp2p_replication_network.rs
+++ b/crates/oasis7_node/src/libp2p_replication_network.rs
@@ -145,6 +145,7 @@ impl Libp2pReplicationNetwork {
     pub fn new(config: Libp2pReplicationNetworkConfig) -> Self {
         let bootstrap_addrs_by_peer_id =
             bootstrap_peer_addrs_by_peer_id(config.bootstrap_peers.as_slice());
+        let request_response_timeout = request_response_timeout_for_config(&config);
         let inner = Libp2pNetwork::new(Libp2pNetworkConfig {
             keypair: config.keypair,
             peer_record: config.peer_record,
@@ -156,9 +157,7 @@ impl Libp2pReplicationNetwork {
             discovery_query_cooldown_ms: config.discovery_query_cooldown_ms,
             enable_autonat: config.enable_autonat,
             peer_manager_policy: config.peer_manager_policy,
-            request_response_timeout: config
-                .request_retry_budget
-                .max(config.fetch_blob_request_timeout),
+            request_response_timeout,
             ..Libp2pNetworkConfig::default()
         });
 
@@ -661,6 +660,13 @@ impl Libp2pReplicationNetwork {
         }
         self.request_retry_budget
     }
+}
+
+fn request_response_timeout_for_config(config: &Libp2pReplicationNetworkConfig) -> Duration {
+    config
+        .request_retry_budget
+        .max(config.fetch_blob_request_retry_budget)
+        .max(Duration::from_millis(FETCH_COMMIT_REQUEST_RETRY_BUDGET_MS))
 }
 
 fn bootstrap_peer_addrs_by_peer_id(addrs: &[Multiaddr]) -> HashMap<PeerId, Multiaddr> {

--- a/crates/oasis7_node/src/libp2p_replication_network/protocol_budget_tests.rs
+++ b/crates/oasis7_node/src/libp2p_replication_network/protocol_budget_tests.rs
@@ -42,6 +42,32 @@ fn libp2p_replication_network_uses_cold_archive_budget_for_fetch_commit() {
 }
 
 #[test]
+fn libp2p_replication_network_inner_timeout_covers_long_transfer_budgets() {
+    assert_eq!(
+        request_response_timeout_for_config(&Libp2pReplicationNetworkConfig::default()),
+        Duration::from_millis(180_000)
+    );
+
+    assert_eq!(
+        request_response_timeout_for_config(&Libp2pReplicationNetworkConfig {
+            request_retry_budget: Duration::from_millis(22),
+            fetch_blob_request_retry_budget: Duration::from_millis(444),
+            ..Libp2pReplicationNetworkConfig::default()
+        }),
+        Duration::from_millis(120_000)
+    );
+
+    assert_eq!(
+        request_response_timeout_for_config(&Libp2pReplicationNetworkConfig {
+            request_retry_budget: Duration::from_millis(22),
+            fetch_blob_request_retry_budget: Duration::from_millis(240_000),
+            ..Libp2pReplicationNetworkConfig::default()
+        }),
+        Duration::from_millis(240_000)
+    );
+}
+
+#[test]
 fn libp2p_replication_network_keeps_short_budget_for_non_blob_protocols() {
     let network = Libp2pReplicationNetwork::new(Libp2pReplicationNetworkConfig {
         request_timeout: Duration::from_millis(11),


### PR DESCRIPTION
## Summary
- align libp2p replication request-response behavior timeout with high-state transfer retry budgets
- cover generic, fetch-commit, and fetch-blob budget invariants with a focused regression test
- record #74 deployment evidence and remaining Windows SSH blocker in the task execution log

## Verification
- env -u RUSTC_WRAPPER cargo test -p oasis7_node libp2p_replication_network -- --nocapture
- env -u RUSTC_WRAPPER cargo test -p oasis7_node storage_replication_high_checkpoint_retained -- --nocapture
- env -u RUSTC_WRAPPER cargo fmt --check
- git diff --check
- ./scripts/check-rust-file-size.sh
- ./scripts/pm/workflow-lint.sh --phase pr-ready --task-uid task_96c772c830e043f9b1e40b03e6f73d38

## Notes
- Professional subagent dispatch remains unavailable in this thread because the runtime returned agent thread limit reached; fallback evidence is recorded in the task execution log.