### PR TITLE
Fix Pages homepage claim gate

### DIFF
--- a/.pm/tasks/task_8f70a068b4864e41971de595fd3dff31.execution.md
+++ b/.pm/tasks/task_8f70a068b4864e41971de595fd3dff31.execution.md
@@ -1,0 +1,66 @@
+# task_8f70a068b4864e41971de595fd3dff31 Execution Log
+
+- task_uid: task_8f70a068b4864e41971de595fd3dff31
+- title: Check GitHub Pages deployment after story reader merge
+- owner_role: tpm
+- worktree_hint: /Users/scc/ccwork/worktrees/oasis7-site-pages-deploy-postmerge-check
+
+<!-- Append entries using:
+Example:
+  ## YYYY-MM-DD HH:MM:SS CST / role_name
+  - 完成内容: ...
+  - 遗留事项: ...
+  - Action: ...
+  - Validation Command: ...
+  - Expected Result: ...
+  - Actual Result: ...
+  - Blocker / Next Action: ...
+-->
+
+## 2026-06-15 11:00:57 CST / tpm
+- 完成内容: Checked GitHub Pages deployment status after PR #475 merge.
+- 遗留事项: Pages deployment remains blocked by `site-homepage-claim-check.sh`; fixing or updating the homepage claim gate is a separate implementation task.
+- Action: Created a read-only task worktree, inspected GitHub Actions runs, Pages workflow configuration, deployment statuses, and failed Pages logs for merge commit `b12b69aa59ac2664b14ff7ab5c422e5585e5f006`.
+- Validation Command: `gh run list --branch main --limit 30 --json ...`; `gh run view 27504216552 --json ...`; `gh run view 27504216552 --log-failed`; `gh api repos/eng-cc/oasis7/pages`; `gh api repos/eng-cc/oasis7/deployments/5055179132/statuses`; `gh run list --workflow Pages --limit 10 --json ...`; `sed -n '1,120p' .github/workflows/pages.yml`; `sed -n '1,90p' scripts/site-homepage-claim-check.sh`; `rg -n "状态：技术预览|还不能玩|site-homepage-claim" site/index.html site/en/index.html scripts/site-homepage-claim-check.sh`.
+- Expected Result: determine whether the PR #475 merge triggered Pages deployment and whether the deployment succeeded.
+- Actual Result: Pages workflow did auto-trigger on push to `main` for PR #475 merge commit `b12b69aa59ac2664b14ff7ab5c422e5585e5f006`, run `27504216552`, but failed in `Run Site Quality Gates` before artifact upload/deploy. Log error: `missing required homepage pattern in .../site/index.html: 状态：技术预览（还不能玩）`. Deployment `5055179132` for the same sha ended with status `failure`. Recent successful Pages deployment found at run `27065301388` / deployment `4958021214` on 2026-06-06, environment URL `https://oasis7.tech/`.
+- Blocker / Next Action: not a trigger problem; fix or realign `scripts/site-homepage-claim-check.sh` versus current `site/index.html` copy, then rerun Pages workflow or merge the fix.
+
+## 2026-06-15 11:22:00 CST / tpm
+- 完成内容: Fixed the stale Pages homepage claim gate that blocked the post-merge Pages deployment, and restored local cross-platform execution for the site link gate.
+- 遗留事项: needs full gate verification, closeout, review, PR, merge, and post-merge Pages confirmation.
+- Action: Updated `scripts/site-homepage-claim-check.sh` to require the current Chinese and English homepage `limited playable technical preview` strings instead of the older "not playable yet" strings. Reworked `scripts/site-link-check.sh` to avoid GNU-only `realpath -m` by performing one Python-based path scan across `site/**/*.html`. Added the fix scope to task acceptance and recorded trace in `doc/site/project.md`.
+- Validation Command: pending.
+- Expected Result: Pages quality gates match the current homepage copy and can be run locally on macOS as well as in GitHub Actions.
+- Actual Result: pending verification.
+- Blocker / Next Action: run Pages gate, doc governance, workflow lint, and task-ready verification.
+
+## 2026-06-15 11:34:00 CST / tpm
+- 完成内容: Verified the Pages gate fix and supporting governance checks.
+- 遗留事项: needs final `claim-ready`, closeout, pre-PR local role review, PR, merge, and post-merge Pages confirmation.
+- Action: Ran the same site quality gate sequence used by `.github/workflows/pages.yml`, then ran formatting, document governance, and task-scoped workflow lint checks.
+- Validation Command: `./scripts/site-link-check.sh && ./scripts/site-homepage-claim-check.sh && ./scripts/site-manual-sync-check.sh && ./scripts/site-download-check.sh`
+- Expected Result: all Pages site quality gates pass locally.
+- Actual Result: passed: `ok: site local href/src references are valid`; `ok: homepage claim/parity, metadata, and no-js navigation markers are present`; `ok: viewer manual static mirrors are synced with the current agent-browser command baseline`; `ok: site download entry and release links are present`.
+- Validation Command: `git diff --check -- .pm/roles/tpm/backlog/committed.yaml .pm/tasks/task_8f70a068b4864e41971de595fd3dff31.yaml .pm/tasks/task_8f70a068b4864e41971de595fd3dff31.execution.md doc/site/project.md scripts/site-homepage-claim-check.sh scripts/site-link-check.sh`
+- Expected Result: no whitespace or patch formatting issues.
+- Actual Result: passed with exit code 0.
+- Validation Command: `./scripts/doc-governance-check.sh`
+- Expected Result: repository doc governance remains clean after the `doc/site/project.md` trace update.
+- Actual Result: passed: `doc-governance-check: OK`.
+- Validation Command: `./scripts/pm/workflow-lint.sh --task-uid task_8f70a068b4864e41971de595fd3dff31 --phase current`
+- Expected Result: task-scoped workflow state is valid.
+- Actual Result: passed: `workflow-lint: OK (task_8f70a068b4864e41971de595fd3dff31, phase=current)`.
+- Blocker / Next Action: run `claim-ready` with the full verification bundle, then close out for PR.
+
+## 2026-06-15 12:15:00 CST / tpm
+- 完成内容: Completed fresh `claim-ready` verification and task closeout writeback for the current task.
+- 遗留事项: repo-wide `.pm/lint` still has unrelated historical execution-log failures outside this task; PR path will rely on task-scoped workflow lint plus claim-ready evidence for this slice.
+- Action: Ran `./scripts/pm/claim-ready.sh --claim-type task_complete --verify-command ...` with the full verification bundle. Then ran `./scripts/pm/task-closeout.sh --role tpm --task-uid task_8f70a068b4864e41971de595fd3dff31 --verify-command ...`; the script wrote task status `done` and verification metadata before failing its final repo-wide `.pm/lint` step on pre-existing task log issues.
+- Validation Command: `./scripts/pm/claim-ready.sh --claim-type task_complete --verify-command 'set -e; ./scripts/site-link-check.sh; ./scripts/site-homepage-claim-check.sh; ./scripts/site-manual-sync-check.sh; ./scripts/site-download-check.sh; git diff --check -- ...; ./scripts/doc-governance-check.sh; ./scripts/pm/workflow-lint.sh --task-uid task_8f70a068b4864e41971de595fd3dff31 --phase current'`
+- Expected Result: fresh verification passes and allows task completion claim.
+- Actual Result: passed; output ended with `status: verified`, `allowed_to_claim: true`, and `claim_message: Fresh verification passed; the task can now be claimed complete.`
+- Validation Command: `./scripts/pm/task-closeout.sh --role tpm --task-uid task_8f70a068b4864e41971de595fd3dff31 --verify-command ...`
+- Expected Result: closeout writes task status and preserves verification evidence.
+- Actual Result: task yaml now records `status: done`, `last_verification_status: verified`, and `last_closed_at: 2026-06-15T12:14:54+08:00`; final repo-wide `.pm/lint` step failed on unrelated historical task execution-log entries such as `task_0deb46f616874e40b147407f6b1e510b` and `task_20abeb9162c540fca74779ee7b243421`.
+- Blocker / Next Action: commit the task slice, collect pre-PR local role review, then create PR.

--- a/.pm/tasks/task_8f70a068b4864e41971de595fd3dff31.execution.md
+++ b/.pm/tasks/task_8f70a068b4864e41971de595fd3dff31.execution.md
@@ -64,3 +64,41 @@ Example:
 - Expected Result: closeout writes task status and preserves verification evidence.
 - Actual Result: task yaml now records `status: done`, `last_verification_status: verified`, and `last_closed_at: 2026-06-15T12:14:54+08:00`; final repo-wide `.pm/lint` step failed on unrelated historical task execution-log entries such as `task_0deb46f616874e40b147407f6b1e510b` and `task_20abeb9162c540fca74779ee7b243421`.
 - Blocker / Next Action: commit the task slice, collect pre-PR local role review, then create PR.
+
+## 2026-06-15 12:20:00 CST / tpm
+- 完成内容: Dispatched pre-PR local role review for the fixed HEAD.
+- 遗留事项: waiting for `qa_engineer` and `repository_health_engineer` review results before PR creation.
+- Action: Spawned bounded review slices against commit `e42b7c07c8dafe437d5521077e27d3f28196647e`.
+- Review Trigger: pre-PR local role review
+- Review Scope: `.pm/tasks/task_8f70a068b4864e41971de595fd3dff31.execution.md`; `.pm/tasks/task_8f70a068b4864e41971de595fd3dff31.yaml`; `doc/site/project.md`; `scripts/site-homepage-claim-check.sh`; `scripts/site-link-check.sh`
+- Review Roles: `qa_engineer`, `repository_health_engineer`
+- Review Question: confirm the Pages deployment gate fix has sufficient QA evidence and does not introduce repository health, portability, workflow, or traceability regressions.
+- Evidence Available: Pages gate sequence passed; `git diff --check` passed; `./scripts/doc-governance-check.sh` passed; task-scoped `workflow-lint` passed; `claim-ready` passed.
+- Expected Return Contract: findings | no_findings | residual_risk
+- Formal Sink: this execution log
+- Validation Command: local role review dispatch; no shell command.
+- Expected Result: role review results are integrated before PR creation.
+- Actual Result: pending.
+- Blocker / Next Action: integrate review results and record passed packet.
+
+## 2026-06-15 12:28:00 CST / tpm
+- 完成内容: Integrated pre-PR local role review results.
+- 遗留事项: post-merge Pages deployment still needs confirmation on `main` after the PR lands.
+- Action: Reviewed `qa_engineer` and `repository_health_engineer` bounded review outputs for commit `e42b7c07c8dafe437d5521077e27d3f28196647e`; no code changes were required.
+- Validation Command: local role review result integration; no shell command.
+- Expected Result: all valid pre-PR local review findings are addressed or recorded.
+- Actual Result: `qa_engineer`: no_findings; residual risk is that Pages deployment success still requires post-merge confirmation. `repository_health_engineer`: no_findings; residual risk is that `scripts/site-link-check.sh` remains a lightweight double-quoted `href`/`src` regex gate matching the prior scope, with current site gates passing.
+- Pre-PR Local Role Review: passed
+- Task UID: task_8f70a068b4864e41971de595fd3dff31
+- Source Worktree: /Users/scc/ccwork/worktrees/oasis7-site-pages-deploy-postmerge-check
+- Source Branch: task/site-pages-deploy-postmerge-check
+- Source Head: e42b7c07c8dafe437d5521077e27d3f28196647e
+- Comparison Ref: refs/remotes/origin/main
+- Reviewed Changed Paths: `.pm/tasks/task_8f70a068b4864e41971de595fd3dff31.execution.md`; `.pm/tasks/task_8f70a068b4864e41971de595fd3dff31.yaml`; `doc/site/project.md`; `scripts/site-homepage-claim-check.sh`; `scripts/site-link-check.sh`
+- Role Selection Basis: `qa_engineer` selected because the PR claim depends on Pages quality gate verification and deployment readiness; `repository_health_engineer` selected because the diff changes shared site workflow scripts, task evidence, and docs traceability. `liveops_community` skipped because public copy was not changed, only gate patterns were aligned to already-merged copy.
+- Review Roles: qa_engineer, repository_health_engineer
+- Review Evidence: `qa_engineer` no_findings with post-merge Pages confirmation residual risk; `repository_health_engineer` no_findings with lightweight link-check regex residual risk.
+- Review Findings Disposition: no_findings
+- Finding Disposition Evidence: no valid findings required code or documentation changes.
+- Residual Risk: Pages must be observed after merge to confirm the GitHub Pages deployment succeeds; link-check remains scoped to the prior gate's HTML reference pattern.
+- Blocker / Next Action: commit review evidence, run PR preflight/create, then watch checks and Pages deployment through merge.

--- a/.pm/tasks/task_8f70a068b4864e41971de595fd3dff31.yaml
+++ b/.pm/tasks/task_8f70a068b4864e41971de595fd3dff31.yaml
@@ -1,0 +1,29 @@
+task_uid: task_8f70a068b4864e41971de595fd3dff31
+title: "Check GitHub Pages deployment after story reader merge"
+owner_role: tpm
+worktree_hint: /Users/scc/ccwork/worktrees/oasis7-site-pages-deploy-postmerge-check
+execution_log_path: .pm/tasks/task_8f70a068b4864e41971de595fd3dff31.execution.md
+status: done
+priority: P2
+source_signal: null
+source_refs:
+  - site/story/index.html
+  - scripts/site-homepage-claim-check.sh
+  - site/index.html
+  - site/en/index.html
+doc_refs:
+  - site/story/project.md
+  - doc/site/project.md
+related_prd: []
+acceptance:
+  - "Determine whether PR #475 merge automatically triggered GitHub Pages deployment and report evidence"
+  - "Fix the Pages homepage claim gate if the deployment was blocked by stale claim patterns"
+handoff_to: []
+updated_at: 2026-06-15T12:14:55+08:00
+last_started_at: 2026-06-15T10:57:22+08:00
+last_claim_type: task_complete
+last_verify_command: "set -e\n./scripts/site-link-check.sh\n./scripts/site-homepage-claim-check.sh\n./scripts/site-manual-sync-check.sh\n./scripts/site-download-check.sh\ngit diff --check -- .pm/roles/tpm/backlog/committed.yaml .pm/tasks/task_8f70a068b4864e41971de595fd3dff31.yaml .pm/tasks/task_8f70a068b4864e41971de595fd3dff31.execution.md doc/site/project.md scripts/site-homepage-claim-check.sh scripts/site-link-check.sh\n./scripts/doc-governance-check.sh\n./scripts/pm/workflow-lint.sh --task-uid task_8f70a068b4864e41971de595fd3dff31 --phase current"
+last_verified_at: 2026-06-15T12:14:51+08:00
+last_verification_exit_code: 0
+last_verification_status: verified
+last_closed_at: 2026-06-15T12:14:54+08:00

--- a/doc/site/project.md
+++ b/doc/site/project.md
@@ -3,6 +3,16 @@
 审计轮次: 6
 
 ## 任务拆解（含 PRD-ID 映射）
+- [x] pages-homepage-claim-gate-refresh (PRD-SITE-003/004) [test_tier_required]: 对齐 Pages 质量门禁与当前中英首页 `limited playable technical preview` 口径，并把 site local link check 从 GNU `realpath -m` 改为跨平台批量路径校验，恢复本地与 CI 的 Pages gate 验证链路。 Trace: .pm/tasks/task_8f70a068b4864e41971de595fd3dff31.yaml
+  - 产物文件:
+    - `scripts/site-homepage-claim-check.sh`
+    - `scripts/site-link-check.sh`
+    - `.pm/tasks/task_8f70a068b4864e41971de595fd3dff31.yaml`
+  - 验收命令 (`test_tier_required`):
+    - `./scripts/site-link-check.sh && ./scripts/site-homepage-claim-check.sh && ./scripts/site-manual-sync-check.sh && ./scripts/site-download-check.sh`
+    - `git diff --check`
+    - `./scripts/doc-governance-check.sh`
+    - `./scripts/pm/workflow-lint.sh --task-uid task_8f70a068b4864e41971de595fd3dff31 --phase current`
 - [x] html-roadshow-deck (PRD-SITE-001/003/012) [test_tier_required]: 在公开站点新增 HTML 路演 deck，使用适配静态 Pages 的演示库承载固定 slide 叙事，不把首页改成 PPT，也不引入必需的 SPA 构建链；同时从 docs hub 暴露清晰入口，并保留回到首页/文档中心的导航。 Trace: .pm/tasks/task_edb2d067d4774fddaa528bf7046326b5.yaml
   - 产物文件:
     - `doc/site/prd.md`

--- a/scripts/site-homepage-claim-check.sh
+++ b/scripts/site-homepage-claim-check.sh
@@ -39,7 +39,7 @@ check_required_patterns() {
 ZH_PATTERNS=(
   "class=\"skip-link\""
   "data-homepage-claim=\"preview-status\""
-  "状态：技术预览（还不能玩）"
+  "状态：limited playable technical preview"
   "data-homepage-claim=\"default-web-entry\""
   "默认网页验证入口：viewer"
   "data-homepage-claim=\"future-platform-boundary\""
@@ -55,7 +55,7 @@ ZH_PATTERNS=(
 EN_PATTERNS=(
   "class=\"skip-link\""
   "data-homepage-claim=\"preview-status\""
-  "Status: technical preview, not playable yet"
+  "Status: limited playable technical preview"
   "data-homepage-claim=\"default-web-entry\""
   "Default web verification entry: viewer"
   "data-homepage-claim=\"future-platform-boundary\""

--- a/scripts/site-link-check.sh
+++ b/scripts/site-link-check.sh
@@ -10,37 +10,40 @@ if [[ ! -d "${SITE_ROOT}" ]]; then
   exit 1
 fi
 
-fail_count=0
+python3 - "${SITE_ROOT}" <<'PY'
+from __future__ import annotations
 
-while IFS= read -r html_file; do
-  while IFS= read -r attr; do
-    ref="${attr#*=}"
-    ref="${ref#\"}"
-    ref="${ref%\"}"
+import os
+import re
+import sys
+from pathlib import Path
 
-    case "${ref}" in
-      ""|\#*|http:*|https:*|mailto:*|javascript:*|tel:*)
-        continue
-        ;;
-    esac
+site_root = Path(sys.argv[1])
+attr_re = re.compile(r'(href|src)="([^"]+)"')
+skip_prefixes = ("#", "http:", "https:", "mailto:", "javascript:", "tel:")
+failures: list[tuple[Path, str, Path]] = []
 
-    clean="${ref%%\#*}"
-    clean="${clean%%\?*}"
-    if [[ -z "${clean}" ]]; then
-      continue
-    fi
+for html_file in sorted(site_root.rglob("*.html")):
+    text = html_file.read_text(encoding="utf-8")
+    for _attr, ref in attr_re.findall(text):
+        if not ref or ref.startswith(skip_prefixes):
+            continue
+        clean = ref.split("#", 1)[0].split("?", 1)[0]
+        if not clean:
+            continue
+        target = Path(os.path.normpath(os.path.abspath(html_file.parent / clean)))
+        if not target.exists():
+            failures.append((html_file, ref, target))
 
-    target="$(realpath -m "$(dirname "${html_file}")/${clean}")"
-    if [[ ! -e "${target}" ]]; then
-      echo "error: broken local reference in ${html_file}: ${ref} -> ${target}" >&2
-      fail_count=$((fail_count + 1))
-    fi
-  done < <(grep -Eo '(href|src)="[^"]+"' "${html_file}" || true)
-done < <(find "${SITE_ROOT}" -type f -name '*.html' | sort)
+for html_file, ref, target in failures:
+    print(f"error: broken local reference in {html_file}: {ref} -> {target}", file=sys.stderr)
 
-if [[ "${fail_count}" -gt 0 ]]; then
-  echo "error: site link check failed with ${fail_count} broken local reference(s)" >&2
-  exit 1
-fi
+if failures:
+    print(
+        f"error: site link check failed with {len(failures)} broken local reference(s)",
+        file=sys.stderr,
+    )
+    raise SystemExit(1)
 
-echo "ok: site local href/src references are valid"
+print("ok: site local href/src references are valid")
+PY


### PR DESCRIPTION
## Summary
- Align the Pages homepage claim gate with the already-merged `limited playable technical preview` homepage copy.
- Make `scripts/site-link-check.sh` portable on macOS by replacing GNU-only `realpath -m` with a single Python path scan.
- Record task trace, closeout evidence, and pre-PR local role review.

## Verification
- `./scripts/site-link-check.sh && ./scripts/site-homepage-claim-check.sh && ./scripts/site-manual-sync-check.sh && ./scripts/site-download-check.sh`
- `git diff --check`
- `./scripts/doc-governance-check.sh`
- `./scripts/pm/workflow-lint.sh --task-uid task_8f70a068b4864e41971de595fd3dff31 --phase current`
- `./scripts/pm/claim-ready.sh --claim-type task_complete --verify-command ...`

## Notes
- PR #475 did trigger Pages automatically, but run 27504216552 failed in `site-homepage-claim-check.sh` before upload/deploy.
- Repo-wide `.pm/lint` still reports unrelated historical execution-log issues; this task's scoped workflow lint and claim-ready checks passed.
- Post-merge Pages deployment still needs confirmation.