### PR TITLE
Harden WASM cache and identifiers

### DIFF
--- a/.pm/tasks/task_61ae4b646e994b3e91bff3141f7ef818.execution.md
+++ b/.pm/tasks/task_61ae4b646e994b3e91bff3141f7ef818.execution.md
@@ -119,3 +119,33 @@ Example:
 - Expected Result: Closeout reruns fresh verification and records done/verified metadata for this task.
 - Actual Result: The verification command passed and task metadata was updated to done/verified. The helper printed `task: ok`, then failed only on unrelated global PM lint history.
 - Blocker / Next Action: Start pre-PR local role review after committing the scoped task changes.
+
+## 2026-06-15 23:01:00 CST / tpm
+- Review Trigger: pre-PR local role review
+- Review Scope: commit `d2e963b36f35fde39ee1bdc73ad19f88542501df` on branch `task/engineering-wasm-rust-governance-review`, compared to merge-base `02d090e20325140169dcbb3b33eacbd5d8b023bf`; changed paths are this task's `.pm` files plus `crates/oasis7/src/runtime/module_store.rs`, `crates/oasis7/src/runtime/world/module_runtime.rs`, `crates/oasis7_wasm_executor/src/lib.rs`, `crates/oasis7_wasm_executor/src/tests.rs`, `crates/oasis7_wasm_router/src/lib.rs`, `crates/oasis7_wasm_router/src/metrics.rs`, `crates/oasis7_wasm_store/src/lib.rs`, `tools/wasm_build_suite/src/lib.rs`, and `tools/wasm_build_suite/tests/minimal_template.rs`.
+- Review Roles: `wasm_platform_engineer`, `runtime_engineer`, `repository_health_engineer`, `qa_engineer`.
+- Review Question: Confirm or challenge whether the implemented WASM Rust optimizations are correct, maintainable, verified enough for PR creation, and scoped to the intended task; identify any merge-blocking findings before `prepare-task-pr.sh --create`.
+- Evidence Available: `cargo fmt`; `git diff --check`; `./scripts/doc-governance-check.sh`; `./scripts/pm/workflow-lint.sh --task-uid task_61ae4b646e994b3e91bff3141f7ef818 --phase current`; targeted cargo tests for wasm store path-safe artifact keys, wasm executor bytes/hash mismatch rejection, wasm router prepared regex compile metrics, runtime prepared subscription cache identity, and wasm build suite path-shaped module ID rejection.
+- Expected Return Contract: `findings | no_findings | residual_risk`, with severity, file/line evidence, and any required follow-up verification command.
+- Formal Sink: `.pm/tasks/task_61ae4b646e994b3e91bff3141f7ef818.execution.md`.
+- Dispatch Note: actual subagent model/reasoning is inherited/unverified because the subagent tool's full-history fork path inherits parent runtime and does not report a concrete model.
+
+## 2026-06-15 23:12:00 CST / tpm
+- 完成内容: Integrated pre-PR local role review results from `wasm_platform_engineer`, `runtime_engineer`, `repository_health_engineer`, and `qa_engineer`.
+- Review Evidence / `wasm_platform_engineer`: no blocking findings. Confirmed executor hash verification before memory/disk compiled-cache lookup, shared clone watchdog controller, artifact/meta validation before store path construction, build-suite path-shaped `module_id` rejection, and prepared regex bounded cache/metrics routing. Residual risk: duplicate concurrent regex compiles remain possible under races because lookup/insert are separately locked; this is an efficiency risk, not correctness or PR-blocking.
+- Review Evidence / `runtime_engineer`: no findings. Confirmed `InvalidArtifactKey` maps to `WorldError::ModuleChangeInvalid`, prepared subscription cache key includes record identity, wasm hash, and subscription hash, and register/upgrade invalidation happens before record replacement. Residual risk: no end-to-end warmed-cache upgrade routing test, but key identity prevents stale hits; remaining risk is cache growth/coverage confidence.
+- Review Evidence / `repository_health_engineer`: one P2 PR-readiness/process finding: the pre-PR review request/results evidence was uncommitted relative to the reviewed code commit. Code maintainability had no blockers. Disposition: addressed by appending this integrated role-review evidence and the passed packet to the task execution log, then committing it before PR creation.
+- Review Evidence / `qa_engineer`: no findings. Targeted regression coverage is sufficient for PR creation; broader package-level tests are useful if CI coverage is unclear but not blocking before PR creation. Global PM lint remains noisy on unrelated historical task logs, and task-scoped workflow lint is the relevant gate for this task.
+- Review Findings Disposition: repository-health process finding addressed by evidence integration and follow-up commit; all code/verification findings are `no_findings`.
+- Residual Risk: targeted tests cover the changed hardening surfaces, but do not replace broader package/workspace regression checks; CI and PR comment/review-thread handling remain required after PR creation.
+- Pre-PR Local Role Review: passed
+- Task UID: task_61ae4b646e994b3e91bff3141f7ef818
+- Source Worktree: `/Users/scc/ccwork/worktrees/oasis7-engineering-wasm-rust-governance-review`
+- Source Branch: `task/engineering-wasm-rust-governance-review`
+- Source Head: `d2e963b36f35fde39ee1bdc73ad19f88542501df` reviewed for code changes; later changes before PR creation are limited to this task review evidence file.
+- Comparison Ref: `02d090e20325140169dcbb3b33eacbd5d8b023bf`
+- Reviewed Changed Paths: `.pm/tasks/task_61ae4b646e994b3e91bff3141f7ef818.execution.md`; `.pm/tasks/task_61ae4b646e994b3e91bff3141f7ef818.yaml`; `crates/oasis7/src/runtime/module_store.rs`; `crates/oasis7/src/runtime/world/module_runtime.rs`; `crates/oasis7_wasm_executor/src/lib.rs`; `crates/oasis7_wasm_executor/src/tests.rs`; `crates/oasis7_wasm_router/src/lib.rs`; `crates/oasis7_wasm_router/src/metrics.rs`; `crates/oasis7_wasm_store/src/lib.rs`; `tools/wasm_build_suite/src/lib.rs`; `tools/wasm_build_suite/tests/minimal_template.rs`.
+- Role Selection Basis: changed paths touch WASM executor/router/store/build-suite hardening, runtime module store/cache integration, task evidence/workflow scope, and verification readiness; selected roles were `wasm_platform_engineer`, `runtime_engineer`, `repository_health_engineer`, and `qa_engineer`.
+- Review Roles: `wasm_platform_engineer`, `runtime_engineer`, `repository_health_engineer`, `qa_engineer`.
+- Finding Disposition Evidence: repository-health process finding addressed in this log section and will be committed before `prepare-task-pr.sh --create`; no code findings required fixes.
+- Blocker / Next Action: rerun task-scoped workflow lint, commit the review evidence, then run `./scripts/prepare-task-pr.sh --create`.

--- a/.pm/tasks/task_61ae4b646e994b3e91bff3141f7ef818.execution.md
+++ b/.pm/tasks/task_61ae4b646e994b3e91bff3141f7ef818.execution.md
@@ -149,3 +149,18 @@ Example:
 - Review Roles: `wasm_platform_engineer`, `runtime_engineer`, `repository_health_engineer`, `qa_engineer`.
 - Finding Disposition Evidence: repository-health process finding addressed in this log section and will be committed before `prepare-task-pr.sh --create`; no code findings required fixes.
 - Blocker / Next Action: rerun task-scoped workflow lint, commit the review evidence, then run `./scripts/prepare-task-pr.sh --create`.
+
+## 2026-06-15 23:18:00 CST / tpm
+- Pre-PR Local Role Review: passed
+- Task UID: task_61ae4b646e994b3e91bff3141f7ef818
+- Source Worktree: /Users/scc/ccwork/worktrees/oasis7-engineering-wasm-rust-governance-review
+- Source Branch: task/engineering-wasm-rust-governance-review
+- Source Head: 85f3422268a89267f51434d4946b45e34001191a
+- Comparison Ref: refs/remotes/origin/main
+- Reviewed Changed Paths: .pm/tasks/task_61ae4b646e994b3e91bff3141f7ef818.execution.md; .pm/tasks/task_61ae4b646e994b3e91bff3141f7ef818.yaml; crates/oasis7/src/runtime/module_store.rs; crates/oasis7/src/runtime/world/module_runtime.rs; crates/oasis7_wasm_executor/src/lib.rs; crates/oasis7_wasm_executor/src/tests.rs; crates/oasis7_wasm_router/src/lib.rs; crates/oasis7_wasm_router/src/metrics.rs; crates/oasis7_wasm_store/src/lib.rs; tools/wasm_build_suite/src/lib.rs; tools/wasm_build_suite/tests/minimal_template.rs
+- Role Selection Basis: changed paths touch WASM executor/router/store/build-suite hardening, runtime module-store/cache integration, task evidence/workflow scope, and verification readiness.
+- Review Roles: wasm_platform_engineer, runtime_engineer, repository_health_engineer, qa_engineer
+- Review Evidence: wasm_platform_engineer no blocking findings; runtime_engineer no findings; repository_health_engineer process finding about uncommitted review evidence addressed by this committed packet; qa_engineer no findings and verification sufficient for PR creation.
+- Review Findings Disposition: addressed
+- Finding Disposition Evidence: appended machine-readable passed packet to task execution log and will commit it before rerunning prepare-task-pr; no code changes required by review.
+- Residual Risk: targeted tests cover changed hardening surfaces but do not replace broader package/workspace regression checks; GitHub required checks, comments, requested changes, review threads, and mergeability remain required after PR creation.

--- a/.pm/tasks/task_61ae4b646e994b3e91bff3141f7ef818.execution.md
+++ b/.pm/tasks/task_61ae4b646e994b3e91bff3141f7ef818.execution.md
@@ -155,12 +155,21 @@ Example:
 - Task UID: task_61ae4b646e994b3e91bff3141f7ef818
 - Source Worktree: /Users/scc/ccwork/worktrees/oasis7-engineering-wasm-rust-governance-review
 - Source Branch: task/engineering-wasm-rust-governance-review
-- Source Head: 85f3422268a89267f51434d4946b45e34001191a
+- Source Head: b6d42336bc5a78176fdd44a538a8995af129196f
 - Comparison Ref: refs/remotes/origin/main
-- Reviewed Changed Paths: .pm/tasks/task_61ae4b646e994b3e91bff3141f7ef818.execution.md; .pm/tasks/task_61ae4b646e994b3e91bff3141f7ef818.yaml; crates/oasis7/src/runtime/module_store.rs; crates/oasis7/src/runtime/world/module_runtime.rs; crates/oasis7_wasm_executor/src/lib.rs; crates/oasis7_wasm_executor/src/tests.rs; crates/oasis7_wasm_router/src/lib.rs; crates/oasis7_wasm_router/src/metrics.rs; crates/oasis7_wasm_store/src/lib.rs; tools/wasm_build_suite/src/lib.rs; tools/wasm_build_suite/tests/minimal_template.rs
+- Reviewed Changed Paths: .pm/tasks/task_61ae4b646e994b3e91bff3141f7ef818.execution.md; .pm/tasks/task_61ae4b646e994b3e91bff3141f7ef818.yaml; crates/oasis7/src/runtime/module_store.rs; crates/oasis7/src/runtime/world/module_runtime.rs; crates/oasis7_wasm_executor/src/lib.rs; crates/oasis7_wasm_executor/src/tests.rs; crates/oasis7_wasm_router/src/lib.rs; crates/oasis7_wasm_router/src/metrics.rs; crates/oasis7_wasm_store/src/lib.rs; doc/world-runtime/project.md; tools/wasm_build_suite/src/lib.rs; tools/wasm_build_suite/tests/minimal_template.rs
 - Role Selection Basis: changed paths touch WASM executor/router/store/build-suite hardening, runtime module-store/cache integration, task evidence/workflow scope, and verification readiness.
 - Review Roles: wasm_platform_engineer, runtime_engineer, repository_health_engineer, qa_engineer
 - Review Evidence: wasm_platform_engineer no blocking findings; runtime_engineer no findings; repository_health_engineer process finding about uncommitted review evidence addressed by this committed packet; qa_engineer no findings and verification sufficient for PR creation.
 - Review Findings Disposition: addressed
 - Finding Disposition Evidence: appended machine-readable passed packet to task execution log and will commit it before rerunning prepare-task-pr; no code changes required by review.
 - Residual Risk: targeted tests cover changed hardening surfaces but do not replace broader package/workspace regression checks; GitHub required checks, comments, requested changes, review threads, and mergeability remain required after PR creation.
+
+## 2026-06-15 23:21:00 CST / tpm
+- 完成内容: Added module project reference `doc/world-runtime/project.md`, added this task's Trace entry to the module project file, and ran fresh `claim-ready.sh` verification for the ready-for-PR claim.
+- 遗留事项: Global repo PM lint remains outside this task's scope due unrelated historical task logs; task-scoped workflow lint, diff check, and doc governance are the local ready-for-PR gate used here.
+- Action: Record claim-ready command/result evidence required by PR preflight.
+- Validation Command: `./scripts/pm/claim-ready.sh --claim-type ready_for_pr --verify-command "./scripts/pm/workflow-lint.sh --task-uid task_61ae4b646e994b3e91bff3141f7ef818 --phase current && git diff --check && ./scripts/doc-governance-check.sh"`
+- Expected Result: Fresh verification exits 0 and allows the ready-for-PR claim.
+- Actual Result: `workflow-lint: OK (task_61ae4b646e994b3e91bff3141f7ef818, phase=current)`, `git diff --check` exited 0 with no output, `doc-governance-check: OK`; claim verification summary reported `claim_type: ready_for_pr`, `verified_at: 2026-06-15T23:12:41+08:00`, `verification_exit_code: 0`, `status: verified`, and `allowed_to_claim: true`.
+- Blocker / Next Action: Commit doc-ref and claim-ready evidence, then rerun `./scripts/prepare-task-pr.sh --create`.

--- a/.pm/tasks/task_61ae4b646e994b3e91bff3141f7ef818.execution.md
+++ b/.pm/tasks/task_61ae4b646e994b3e91bff3141f7ef818.execution.md
@@ -182,3 +182,12 @@ Example:
 - Expected Result: Push source branch, pass pre-PR local role review gate, and create a GitHub PR.
 - Actual Result: Source branch `task/engineering-wasm-rust-governance-review` was pushed to `origin`; pre-PR local role review status was `passed`; PR URL: https://github.com/eng-cc/oasis7/pull/483.
 - Blocker / Next Action: Commit and push this PR evidence entry, then inspect GitHub required checks, mergeability, requested changes, comments, and review threads.
+
+## 2026-06-16 00:01:00 CST / tpm
+- 完成内容: Investigated and fixed PR CI `required-gate` failure from GitHub Actions job `81456359901`.
+- 遗留事项: GitHub checks must rerun after pushing the fix; remaining WASM determinism matrix checks were still in progress/pass while this fix was prepared.
+- Action: Applied the minimal CI compile fix in `crates/oasis7/src/bin/oasis7_chain_runtime/oasis7_chain_runtime_observability_tests.rs` by changing the hand-written `WasmRouterMetricsSnapshot` fixture to use `..WasmRouterMetricsSnapshot::empty()` for newly added/future metrics fields.
+- Validation Command: `env -u RUSTC_WRAPPER cargo test -p oasis7 --bin oasis7_chain_runtime observability`; `cargo fmt --check`; `git diff --check`
+- Expected Result: Reproduce surface compiles and observability tests pass locally; formatting and diff checks pass.
+- Actual Result: The targeted bin test passed with 14 passed, 0 failed, 172 filtered out. `cargo fmt --check` passed. `git diff --check` passed.
+- Blocker / Next Action: Commit and push the CI fix, then watch GitHub checks/comments/mergeability again.

--- a/.pm/tasks/task_61ae4b646e994b3e91bff3141f7ef818.execution.md
+++ b/.pm/tasks/task_61ae4b646e994b3e91bff3141f7ef818.execution.md
@@ -191,3 +191,12 @@ Example:
 - Expected Result: Reproduce surface compiles and observability tests pass locally; formatting and diff checks pass.
 - Actual Result: The targeted bin test passed with 14 passed, 0 failed, 172 filtered out. `cargo fmt --check` passed. `git diff --check` passed.
 - Blocker / Next Action: Commit and push the CI fix, then watch GitHub checks/comments/mergeability again.
+
+## 2026-06-16 00:24:00 CST / tpm
+- 完成内容: Addressed GitHub Codex review P2 on `crates/oasis7_wasm_executor/src/lib.rs` line 247 about shared epoch watchdog state across cloned executors.
+- 遗留事项: A separate long-running local `cargo-dev.sh test -p oasis7 --bin oasis7_chain_runtime observability -- --nocapture` process in the shared target cache is still compiling and can produce stale metadata for this branch's `oasis7` verification. Per repo rules, this task did not switch `CARGO_TARGET_DIR` or kill the other process; GitHub isolated checks must rerun after push.
+- Action: Changed `EpochWatchdogController` from one optional armed `(ticket, deadline)` to a ticket-indexed deadline map. The shared watchdog thread now waits on the earliest active deadline, disarms only the matching ticket, and removes only expired tickets after incrementing the engine epoch.
+- Validation Command: `env -u RUSTC_WRAPPER cargo test -p oasis7_wasm_executor --features wasmtime wasm_executor_epoch_watchdog_preempts_infinite_loop`; `cargo fmt --check`; `git diff --check`
+- Expected Result: Existing epoch watchdog timeout behavior remains intact and formatting/diff checks pass.
+- Actual Result: Executor watchdog test passed with 1 passed, 0 failed, 21 filtered out. `cargo fmt --check` passed. `git diff --check` passed.
+- Blocker / Next Action: Commit and push the GitHub review fix, then watch required checks and review thread status.

--- a/.pm/tasks/task_61ae4b646e994b3e91bff3141f7ef818.execution.md
+++ b/.pm/tasks/task_61ae4b646e994b3e91bff3141f7ef818.execution.md
@@ -1,0 +1,121 @@
+# task_61ae4b646e994b3e91bff3141f7ef818 Execution Log
+
+- task_uid: task_61ae4b646e994b3e91bff3141f7ef818
+- title: Review wasm Rust code for optimization opportunities
+- owner_role: tpm
+- worktree_hint: /Users/scc/ccwork/worktrees/oasis7-engineering-wasm-rust-governance-review
+
+<!-- Append entries using:
+Example:
+  ## YYYY-MM-DD HH:MM:SS CST / role_name
+  - 完成内容: ...
+  - 遗留事项: ...
+  - Action: ...
+  - Validation Command: ...
+  - Expected Result: ...
+  - Actual Result: ...
+  - Blocker / Next Action: ...
+-->
+
+## 2026-06-15 21:02:02 CST / tpm
+- 完成内容: WORKFLOW BOOTSTRAP DECIDED. Repository state impact: read-only professional review request, but repository state will change for mandatory `.pm` execution evidence only. Isolation: source worktree `/Users/scc/ccwork/oasis7` was on `main` and clean; created canonical task worktree `/Users/scc/ccwork/worktrees/oasis7-engineering-wasm-rust-governance-review` on branch `task/engineering-wasm-rust-governance-review`. Task truth: owner role `tpm`, `.pm` task `task_61ae4b646e994b3e91bff3141f7ef818`, source refs `AGENTS.md`, doc refs `doc/engineering/workflow/source-of-truth.md`.
+- 完成内容: WORKFLOW ROUTE DECIDED. Current phase: task-bound read-only professional/domain judgment. Selected workflow surface: `repo-owned-workflow-router` -> bounded professional role slices. Skipped `bounded-brainstorming` because the user asks for a focused review; skipped `tdd-test-writer` and implementation skills because no code change is requested yet; skipped closeout/PR surfaces because this task is evidence-only unless findings are later promoted to code/doc changes.
+- Subagent Slice Plan: role `repository_health_engineer`; slice type `read-only governance/technical-debt review`; intended model configuration `.codex/config.toml` `[workflow.subagent_runtime]` = `gpt-5.5-medium`; actual dispatched model/reasoning to be recorded after tool call; context delivery mode full-thread/full-history fork via `fork_context=true`; mandatory context checklist includes `AGENTS.md`, `.agents/roles/repository_health_engineer.md`, `doc/engineering/workflow/source-of-truth.md`, `.pm/tasks/task_61ae4b646e994b3e91bff3141f7ef818.yaml`, this execution log, canonical worktree/branch, user request "让工程治理的同事看看wasm相关部分的rust代码，有没有需要优化的点", scoped Rust/WASM paths, third_party read-only constraint, and sibling `wasm_platform_engineer` slice. Write scope: no source edits; append findings to final response only, with TPM integrating into this execution log. Return contract: findings ordered by severity with file/line evidence, category, owner recommendation, optimization/debt suggestion, residual risk, and suggested validation command.
+- Subagent Slice Plan: role `wasm_platform_engineer`; slice type `read-only WASM platform boundary review`; intended model configuration `.codex/config.toml` `[workflow.subagent_runtime]` = `gpt-5.5-medium`; actual dispatched model/reasoning to be recorded after tool call; context delivery mode full-thread/full-history fork via `fork_context=true`; mandatory context checklist includes `AGENTS.md`, `.agents/roles/wasm_platform_engineer.md`, `doc/engineering/workflow/source-of-truth.md`, task truth files, canonical worktree/branch, user request, scoped crates `crates/oasis7_wasm_*`, `crates/oasis7_builtin_wasm_modules/*`, runtime materializer/identity paths, and sibling `repository_health_engineer` slice. Write scope: no source edits; append findings to final response only, with TPM integrating into this execution log. Return contract: ABI/executor/build/module lifecycle optimization opportunities with file/line evidence, compatibility/security/resource-governance risk, suggested owner, residual risk, and validation command.
+- Integration order: dispatch both read-only slices in parallel; TPM may gather mechanical file inventory only while waiting; TPM must not present its own analysis as professional findings unless verified by returned role slices.
+- 遗留事项: Await professional read-only slice results.
+- Action: Dispatch `repository_health_engineer` and `wasm_platform_engineer` subagent slices.
+- Validation Command: `./scripts/pm/workflow-report.sh --phase start --role tpm --task-uid task_61ae4b646e994b3e91bff3141f7ef818`
+- Expected Result: start report generated and task truth available for slice dispatch.
+- Actual Result: start report generated for task `task_61ae4b646e994b3e91bff3141f7ef818`; current stage `internal_playable_alpha_late`; gate status `draft`.
+- Blocker / Next Action: dispatch `repository_health_engineer` and `wasm_platform_engineer` read-only slices, then integrate and record findings.
+
+## 2026-06-15 21:03:00 CST / tpm
+- 完成内容: Subagent dispatch attempted with intended `.codex/config.toml` default runtime `gpt-5.5-medium` and `fork_context=true`.
+- Actual limitation: current `multi_agent_v1.spawn_agent` rejects full-history fork when `agent_type`, `model`, or `reasoning_effort` are explicitly set; tool reports full-history forked agents inherit parent agent type/model/reasoning.
+- Attribution boundary: use full-history fork as the closest workflow-equivalent context; record actual dispatched model/reasoning as `inherited/unverified` for both professional slices because the tool does not report the inherited concrete model in this mode. Returned findings remain role-slice findings, not TPM professional analysis.
+- Actual dispatch: `repository_health_engineer` slice agent `019ecb61-2845-7d92-a01e-b4d460421b24`; `wasm_platform_engineer` slice agent `019ecb61-2f5d-7082-816f-a8db2062d3c6`; both dispatched with `fork_context=true`, actual model/reasoning `inherited/unverified`.
+- 遗留事项: Slice results not yet returned.
+- Action: Wait for both dispatched professional slices.
+- Validation Command: `multi_agent_v1.spawn_agent` for both slices.
+- Expected Result: both agents start with full-history context.
+- Actual Result: both agents started successfully after omitting explicit model fields required by tool constraints.
+- Blocker / Next Action: wait for slice returns; TPM may gather mechanical file inventory only while waiting.
+
+## 2026-06-15 21:14:00 CST / wasm_platform_engineer
+- 完成内容: Read-only WASM platform slice completed; no files edited and no test commands run.
+- Finding P2 / executor / security hardening: compiled module cache is keyed only by `wasm_hash`; executor does not verify that `request.wasm_bytes` hashes to the key before memory/disk cache hits. Evidence: `crates/oasis7_wasm_executor/src/lib.rs:380`, `crates/oasis7_wasm_executor/src/lib.rs:392`, `crates/oasis7_wasm_executor/src/tests.rs:510`. Normal runtime registration validates earlier, so this is sandbox boundary hardening rather than currently proven runtime exploit.
+- Finding P2 / build + compat debt: builtin materializer still has a host-native preferred path when local rustup looks ready, while canonical build script messaging says host-native fallback is no longer supported. Evidence: `crates/oasis7/src/runtime/builtin_wasm_materializer.rs:351`, `crates/oasis7/src/runtime/builtin_wasm_materializer.rs:369`, `scripts/build-wasm-module.sh:566`.
+- Finding P3 / executor resource governance: each `WasmExecutor::clone()` creates a new epoch watchdog thread; high fan-out clone usage can create thread/resource growth. Evidence: `crates/oasis7_wasm_executor/src/lib.rs:247`, `crates/oasis7_wasm_executor/src/lib.rs:329`.
+- Finding P3 / router performance: prepared subscriptions compile regexes directly and do not reuse the bounded global regex cache used by the non-prepared path. Evidence: `crates/oasis7_wasm_router/src/lib.rs:185`, `crates/oasis7_wasm_router/src/cache.rs:4`.
+- 遗留事项: Findings require TPM integration and follow-up implementation decision.
+- Action: Return WASM platform findings to TPM.
+- Validation Command: source inspection only; suggested follow-up commands include `./scripts/cargo-dev.sh test -p oasis7_wasm_executor --features wasmtime disk_cache`, `./scripts/cargo-dev.sh test -p oasis7 builtin_wasm_materializer`, `./scripts/cargo-dev.sh test -p oasis7_wasm_executor --features wasmtime wasm_executor_epoch_watchdog_preempts_infinite_loop`, and `./scripts/cargo-dev.sh test -p oasis7_wasm_router`.
+- Expected Result: Read-only slice reports optimization candidates with evidence.
+- Actual Result: Four findings returned: executor cache hash hardening, materializer fallback debt, clone watchdog resource governance, and router prepared regex caching.
+- Residual risk: no runtime profiling or concurrency stress was run; performance/resource findings need validation before implementation prioritization.
+- Blocker / Next Action: TPM to integrate with repository-health findings.
+
+## 2026-06-15 21:15:00 CST / repository_health_engineer
+- 完成内容: Read-only repository-health slice completed; no files edited. Scope is engineering governance/maintainability and does not replace WASM platform correctness judgment.
+- Finding P2 / bug risk + test gap: artifact/build paths accept raw identifiers in filenames. Evidence: `crates/oasis7_wasm_store/src/lib.rs:132` joins raw `wasm_hash`; `tools/wasm_build_suite/src/lib.rs:295` joins raw `module_id`; validation only checks non-empty at `tools/wasm_build_suite/src/lib.rs:542`. Runtime registration computes hashes safely, but store/build APIs remain stringly typed and path-shaped input can become an out-dir escape or confusing failure mode.
+- Finding P2 / semantic ambiguity: prepared subscription cache key is only `module_id@version`. Evidence: `crates/oasis7/src/runtime/world/module_runtime.rs:121`, invalidation at `crates/oasis7/src/runtime/world/module_runtime.rs:513` and `crates/oasis7/src/runtime/world/module_runtime.rs:533`. This is maintainable only if same id/version can never carry different subscriptions/manifest content, but that invariant is not obvious at the cache boundary.
+- Finding P3 / observability test gap: regex compile metrics miss the prepared path. Evidence: unprepared path records timing via `crates/oasis7_wasm_router/src/lib.rs:41`; prepared path compiles directly at `crates/oasis7_wasm_router/src/lib.rs:185`; existing metrics test is only monotonicity-oriented at `crates/oasis7_wasm_router/src/lib.rs:835`.
+- Finding P3 / technical debt: m1/m4/m5 builtin artifact loaders are near-duplicate. Evidence: `crates/oasis7/src/runtime/m1_builtin_wasm_artifact.rs:21`, `crates/oasis7/src/runtime/m4_builtin_wasm_artifact.rs:19`, `crates/oasis7/src/runtime/m5_builtin_wasm_artifact.rs:19`.
+- 遗留事项: Findings require TPM integration and follow-up implementation decision.
+- Action: Return repository-health findings to TPM.
+- Validation Command: source inspection only; suggested follow-up commands include `env -u RUSTC_WRAPPER cargo test -p oasis7_wasm_store -p wasm_build_suite`, `env -u RUSTC_WRAPPER cargo test -p oasis7 module_action_loop`, `env -u RUSTC_WRAPPER cargo test -p oasis7_wasm_router router_metrics_track_regex_compile_time`, and `env -u RUSTC_WRAPPER cargo test -p oasis7 builtin_wasm_materializer --features wasmtime,test_tier_full`.
+- Expected Result: Read-only slice reports governance and maintainability findings with evidence.
+- Actual Result: Four findings returned: path-shaped identifiers, prepared subscription cache key ambiguity, prepared regex metric gap, and duplicate builtin artifact loaders.
+- Residual risk: findings are review findings, not verified fixes; promote P2 items into implementation tasks before changing code.
+- Blocker / Next Action: TPM to integrate with WASM platform findings.
+
+## 2026-06-15 21:16:00 CST / tpm
+- 完成内容: Integrated professional read-only slice results. Highest-priority optimization/fix candidates: (1) verify wasm bytes/hash at executor cache boundary or key cache by byte digest; (2) sanitize/validate raw wasm_hash/module_id values before filesystem joins in store/build APIs; (3) clarify prepared subscription cache identity invariant or key by manifest/subscription digest. Secondary candidates: align materializer host-native fallback wording/behavior, share or document executor watchdog clone cost, reuse/measuring prepared regex compilation, and extract duplicated builtin artifact manifest loaders.
+- 遗留事项: No source code changes requested or made. No tests were run because this task was a read-only professional review; commands above are recommended validation gates for follow-up implementation.
+- Action: report findings to user with role attribution and keep `.pm` execution log as formal sink.
+- Validation Command: source inspection integration only.
+- Expected Result: Role-attributed findings summarized for the user.
+- Actual Result: Findings summarized to user; no source changes made in read-only phase.
+- Blocker / Next Action: Await user decision on whether to implement optimizations.
+
+## 2026-06-15 21:13:03 CST / tpm
+- 完成内容: User requested implementation of the identified optimizations. Route changed from read-only professional review to implementation execution in the same canonical worktree and `.pm` task.
+- Plan-gap Review: scope is explicit enough to start. Target steps map to returned findings: (1) executor cache/hash hardening; (2) path-safe wasm store/build identifiers; (3) prepared subscription cache key/invariant hardening; (4) prepared regex cache/metrics; (5) low-risk cleanup for materializer wording/clone cost/duplicate loader only if it stays small after primary fixes.
+- Selected Workflow Skills: `executing-project-tasks` for stepwise implementation, `tdd-test-writer` because behavior-changing fixes have stable cargo test surfaces, `verification-before-completion` before any completion claim.
+- TDD RED Plan: add targeted regression tests before production edits where practical. Expected RED surfaces: executor rejects wasm_hash/bytes mismatch before memory/disk cache hit; wasm store/build suite rejects path-shaped identifiers; prepared subscription cache invalidates or keys by manifest content; prepared regex path records/reuses compile metrics.
+- Professional Slice Plan: use bounded implementation support from `wasm_platform_engineer` for executor/router behavior and `repository_health_engineer` for path/cache-key governance. Current subagent tool full-history fork inherits actual model/reasoning, so actual model remains `inherited/unverified`; TPM integrates patches and evidence in this execution log.
+- Integration Order: tests first, primary P2 fixes, P3 low-risk fixes, targeted cargo verification, PM/doc diff checks.
+- 遗留事项: Implementation and verification still pending.
+- Action: Add targeted regression tests and production fixes for the accepted optimization set.
+- Validation Command: planned targeted cargo tests plus `cargo fmt`, `git diff --check`, `./scripts/doc-governance-check.sh`.
+- Expected Result: Tests cover the fixed behavior and non-Cargo checks pass; cargo tests should pass when build lock is available.
+- Actual Result: Implementation phase started; targeted tests and production fixes to follow.
+- Blocker / Next Action: inspect target files/tests, add RED tests, then implement.
+
+## 2026-06-15 22:11:53 CST / tpm
+- 完成内容: Implemented primary accepted WASM Rust optimizations: executor verifies wasm bytes hash before compiled cache lookup and shares the epoch watchdog across clones; wasm store rejects path-shaped artifact keys and uses unique sibling temp files for atomic writes; wasm build suite rejects path-shaped module IDs before dry-run/build paths are formed; prepared subscription cache key now includes record key, wasm hash, and subscription digest; prepared regex compilation now uses the bounded regex cache and records `regex_compile_calls_total`.
+- 遗留事项: Materializer host-native fallback wording and builtin loader de-duplication were left as follow-up debt because they require broader build-chain/refactor decisions and were not necessary for the main P2 hardening fixes.
+- Action: Added targeted regression tests in `crates/oasis7_wasm_executor/src/tests.rs`, `crates/oasis7_wasm_store/src/lib.rs`, `tools/wasm_build_suite/tests/minimal_template.rs`, `crates/oasis7_wasm_router/src/lib.rs`, and `crates/oasis7/src/runtime/world/module_runtime.rs`; applied production changes in the corresponding modules.
+- Validation Command: `cargo fmt`; `git diff --check`; `./scripts/doc-governance-check.sh`; attempted `env -u RUSTC_WRAPPER cargo test -p oasis7_wasm_store artifact_paths_reject_path_shaped_wasm_hashes`.
+- Expected Result: Formatting and diff checks pass; doc governance passes; targeted cargo tests compile and pass.
+- Actual Result: `cargo fmt` passed. `git diff --check` passed. `./scripts/doc-governance-check.sh` passed. Targeted cargo tests could not run because Cargo remained blocked on `Blocking waiting for file lock on build directory` for 60 seconds while raw `ps` showed no visible cargo/rustc holder; command was interrupted with exit 130. `./scripts/pm/lint.sh` was also attempted and failed due to many pre-existing execution-log format issues across unrelated tasks, plus this task log fields that were subsequently filled.
+- Blocker / Next Action: Fresh Rust test verification remains blocked by Cargo build directory lock behavior in this environment. Next action is to rerun targeted cargo tests once the build lock is available, then perform pre-PR local role review if preparing a PR.
+
+## 2026-06-15 22:50:29 CST / tpm
+- 完成内容: Retried verification after shared Cargo locks cleared. Fixed one compile fallout from `ModuleStoreError::InvalidArtifactKey` by mapping it to `WorldError::ModuleChangeInvalid` in `crates/oasis7/src/runtime/module_store.rs`.
+- 遗留事项: Full repo PM lint still has unrelated historical execution-log failures outside this task; current task workflow lint passes.
+- Action: Ran targeted Rust tests for all new behavior plus final non-Cargo checks.
+- Validation Command: `env -u RUSTC_WRAPPER cargo test -p oasis7_wasm_store artifact_paths_reject_path_shaped_wasm_hashes`; `env -u RUSTC_WRAPPER cargo test -p oasis7_wasm_executor --features wasmtime wasm_executor_rejects_wasm_hash_bytes_mismatch_before_cache_hit`; `env -u RUSTC_WRAPPER cargo test -p oasis7_wasm_router router_metrics_track_prepared_regex_compile_count`; `env -u RUSTC_WRAPPER cargo test -p oasis7 prepared_subscription_cache_key_tracks_manifest_identity`; `env -u RUSTC_WRAPPER cargo test --manifest-path tools/wasm_build_suite/Cargo.toml minimal_template_rejects_path_shaped_module_id`; `git diff --check`; `./scripts/doc-governance-check.sh`; `./scripts/pm/workflow-lint.sh --task-uid task_61ae4b646e994b3e91bff3141f7ef818 --phase current`.
+- Expected Result: All targeted behavior tests and final non-Cargo checks pass.
+- Actual Result: All listed targeted cargo tests passed. `git diff --check` passed. `doc-governance-check: OK`. `workflow-lint: OK (task_61ae4b646e994b3e91bff3141f7ef818, phase=current)`.
+- Blocker / Next Action: Proceed to task closeout, commit, pre-PR local role review, and PR creation.
+
+## 2026-06-15 22:56:14 CST / tpm
+- 完成内容: Ran task closeout for the WASM Rust governance optimization task. Closeout updated `.pm/tasks/task_61ae4b646e994b3e91bff3141f7ef818.yaml` to `status: done`, `last_verification_status: verified`, and `last_closed_at: 2026-06-15T22:56:13+08:00`.
+- 遗留事项: `task-closeout.sh` exited nonzero after closeout because global PM lint still reports unrelated historical execution-log failures from other tasks. This task's closeout verification passed, and task-scoped workflow lint had already passed.
+- Action: Preserve closeout evidence and proceed to commit plus required pre-PR local role review.
+- Validation Command: `./scripts/pm/task-closeout.sh --role tpm --task-uid task_61ae4b646e994b3e91bff3141f7ef818 --verify-command "env -u RUSTC_WRAPPER cargo test -p oasis7_wasm_executor --features wasmtime wasm_executor_rejects_wasm_hash_bytes_mismatch_before_cache_hit"`
+- Expected Result: Closeout reruns fresh verification and records done/verified metadata for this task.
+- Actual Result: The verification command passed and task metadata was updated to done/verified. The helper printed `task: ok`, then failed only on unrelated global PM lint history.
+- Blocker / Next Action: Start pre-PR local role review after committing the scoped task changes.

--- a/.pm/tasks/task_61ae4b646e994b3e91bff3141f7ef818.execution.md
+++ b/.pm/tasks/task_61ae4b646e994b3e91bff3141f7ef818.execution.md
@@ -173,3 +173,12 @@ Example:
 - Expected Result: Fresh verification exits 0 and allows the ready-for-PR claim.
 - Actual Result: `workflow-lint: OK (task_61ae4b646e994b3e91bff3141f7ef818, phase=current)`, `git diff --check` exited 0 with no output, `doc-governance-check: OK`; claim verification summary reported `claim_type: ready_for_pr`, `verified_at: 2026-06-15T23:12:41+08:00`, `verification_exit_code: 0`, `status: verified`, and `allowed_to_claim: true`.
 - Blocker / Next Action: Commit doc-ref and claim-ready evidence, then rerun `./scripts/prepare-task-pr.sh --create`.
+
+## 2026-06-15 23:25:00 CST / tpm
+- 完成内容: Created GitHub PR for the task branch after PR preflight passed.
+- 遗留事项: `prepare-task-pr.sh` reported branch behind base by 13 commits and suggested branch sync before merge if GitHub later requires it. Per repo policy, behind status is informational unless GitHub merge path/checks require branch sync.
+- Action: Push PR evidence and continue PR CI/comment/mergeability watch.
+- Validation Command: `./scripts/prepare-task-pr.sh --create`
+- Expected Result: Push source branch, pass pre-PR local role review gate, and create a GitHub PR.
+- Actual Result: Source branch `task/engineering-wasm-rust-governance-review` was pushed to `origin`; pre-PR local role review status was `passed`; PR URL: https://github.com/eng-cc/oasis7/pull/483.
+- Blocker / Next Action: Commit and push this PR evidence entry, then inspect GitHub required checks, mergeability, requested changes, comments, and review threads.

--- a/.pm/tasks/task_61ae4b646e994b3e91bff3141f7ef818.yaml
+++ b/.pm/tasks/task_61ae4b646e994b3e91bff3141f7ef818.yaml
@@ -1,0 +1,24 @@
+task_uid: task_61ae4b646e994b3e91bff3141f7ef818
+title: "Review wasm Rust code for optimization opportunities"
+owner_role: tpm
+worktree_hint: /Users/scc/ccwork/worktrees/oasis7-engineering-wasm-rust-governance-review
+execution_log_path: .pm/tasks/task_61ae4b646e994b3e91bff3141f7ef818.execution.md
+status: done
+priority: P2
+source_signal: null
+source_refs:
+  - AGENTS.md
+doc_refs:
+  - doc/engineering/workflow/source-of-truth.md
+related_prd: []
+acceptance:
+  - "Bounded wasm/repository-health review records scoped evidence and optimization opportunities in the task execution log."
+handoff_to: []
+updated_at: 2026-06-15T22:56:14+08:00
+last_started_at: 2026-06-15T21:01:44+08:00
+last_claim_type: task_complete
+last_verify_command: "env -u RUSTC_WRAPPER cargo test -p oasis7_wasm_executor --features wasmtime wasm_executor_rejects_wasm_hash_bytes_mismatch_before_cache_hit"
+last_verified_at: 2026-06-15T22:56:05+08:00
+last_verification_exit_code: 0
+last_verification_status: verified
+last_closed_at: 2026-06-15T22:56:13+08:00

--- a/.pm/tasks/task_61ae4b646e994b3e91bff3141f7ef818.yaml
+++ b/.pm/tasks/task_61ae4b646e994b3e91bff3141f7ef818.yaml
@@ -10,6 +10,7 @@ source_refs:
   - AGENTS.md
 doc_refs:
   - doc/engineering/workflow/source-of-truth.md
+  - doc/world-runtime/project.md
 related_prd: []
 acceptance:
   - "Bounded wasm/repository-health review records scoped evidence and optimization opportunities in the task execution log."

--- a/PR.md
+++ b/PR.md
@@ -8,6 +8,7 @@
 
 - `env -u RUSTC_WRAPPER cargo test -p oasis7_wasm_store artifact_paths_reject_path_shaped_wasm_hashes`
 - `env -u RUSTC_WRAPPER cargo test -p oasis7_wasm_executor --features wasmtime wasm_executor_rejects_wasm_hash_bytes_mismatch_before_cache_hit`
+- `env -u RUSTC_WRAPPER cargo test -p oasis7_wasm_executor --features wasmtime wasm_executor_epoch_watchdog_preempts_infinite_loop`
 - `env -u RUSTC_WRAPPER cargo test -p oasis7_wasm_router router_metrics_track_prepared_regex_compile_count`
 - `env -u RUSTC_WRAPPER cargo test -p oasis7 prepared_subscription_cache_key_tracks_manifest_identity`
 - `env -u RUSTC_WRAPPER cargo test --manifest-path tools/wasm_build_suite/Cargo.toml minimal_template_rejects_path_shaped_module_id`

--- a/PR.md
+++ b/PR.md
@@ -11,6 +11,7 @@
 - `env -u RUSTC_WRAPPER cargo test -p oasis7_wasm_router router_metrics_track_prepared_regex_compile_count`
 - `env -u RUSTC_WRAPPER cargo test -p oasis7 prepared_subscription_cache_key_tracks_manifest_identity`
 - `env -u RUSTC_WRAPPER cargo test --manifest-path tools/wasm_build_suite/Cargo.toml minimal_template_rejects_path_shaped_module_id`
+- `env -u RUSTC_WRAPPER cargo test -p oasis7 --bin oasis7_chain_runtime observability`
 - `./scripts/pm/workflow-lint.sh --task-uid task_61ae4b646e994b3e91bff3141f7ef818 --phase pr-ready`
 - `./scripts/doc-governance-check.sh`
 - `git diff --check`

--- a/PR.md
+++ b/PR.md
@@ -1,19 +1,26 @@
 ## Summary
 
-- Refresh the simulation cleanup audit evidence for the current task.
-- Reclassify the old world-simulator PRD review checklist as a historical 2026-03-05 snapshot instead of current active truth.
-- Record follow-up reflection signals for the larger `oasis7_init_demo` and `oasis7_llm_agent_demo*` retirement candidates, leaving direct code deletion out of this governance-only patch.
+- Harden WASM executor compiled-cache use by verifying request bytes against `wasm_hash` before any memory or disk cache hit.
+- Validate path-sensitive WASM artifact/module identifiers before filesystem joins, and map invalid store keys into module-change validation errors.
+- Strengthen prepared subscription and regex cache behavior with manifest-aware subscription keys plus prepared regex cache/metrics coverage.
 
 ## Verification
 
-- `./scripts/pm/workflow-lint.sh --task-uid task_41b18b1a7fef4d7b95e5d51aac64974f --phase current`
+- `env -u RUSTC_WRAPPER cargo test -p oasis7_wasm_store artifact_paths_reject_path_shaped_wasm_hashes`
+- `env -u RUSTC_WRAPPER cargo test -p oasis7_wasm_executor --features wasmtime wasm_executor_rejects_wasm_hash_bytes_mismatch_before_cache_hit`
+- `env -u RUSTC_WRAPPER cargo test -p oasis7_wasm_router router_metrics_track_prepared_regex_compile_count`
+- `env -u RUSTC_WRAPPER cargo test -p oasis7 prepared_subscription_cache_key_tracks_manifest_identity`
+- `env -u RUSTC_WRAPPER cargo test --manifest-path tools/wasm_build_suite/Cargo.toml minimal_template_rejects_path_shaped_module_id`
+- `./scripts/pm/workflow-lint.sh --task-uid task_61ae4b646e994b3e91bff3141f7ef818 --phase pr-ready`
 - `./scripts/doc-governance-check.sh`
 - `git diff --check`
 
 ## PR Evidence
 
-- task_uid: task_41b18b1a7fef4d7b95e5d51aac64974f
-- Source worktree: `/Users/scc/ccwork/worktrees/oasis7-engineering-simulation-cleanup-audit`
-- Branch: `task/engineering-simulation-cleanup-audit`
-- Repository-health conclusion: no active simulation core code/docs are safe to delete immediately; only governance/evidence cleanup and future retirement follow-ups are in scope.
-- Residual risk: demo/bin retirement still needs runtime, agent, and QA replacement evidence before any code deletion. Repo-wide `./scripts/pm/lint.sh` was run and still fails on unrelated historical task-log structure debt; task-local workflow lint passes for this task.
+- task_uid: task_61ae4b646e994b3e91bff3141f7ef818
+- PR URL: https://github.com/eng-cc/oasis7/pull/483
+- Source worktree: `/Users/scc/ccwork/worktrees/oasis7-engineering-wasm-rust-governance-review`
+- Branch: `task/engineering-wasm-rust-governance-review`
+- Pre-PR Local Role Review: passed
+- Review roles: `wasm_platform_engineer`, `runtime_engineer`, `repository_health_engineer`, `qa_engineer`
+- Residual risk: targeted local tests cover the changed hardening surfaces; broader package/workspace checks, GitHub required checks, comments, requested changes, review threads, and mergeability remain required after PR creation.

--- a/crates/oasis7/src/bin/oasis7_chain_runtime/oasis7_chain_runtime_observability_tests.rs
+++ b/crates/oasis7/src/bin/oasis7_chain_runtime/oasis7_chain_runtime_observability_tests.rs
@@ -79,6 +79,7 @@ pub(super) fn sample_wasm_status() -> super::wasm_status::ChainWasmStatus {
             regex_compile_ms_total: 1,
             prepare_ms_buckets: BTreeMap::from([("le_0005_ms".to_string(), 2)]),
             match_ms_buckets: BTreeMap::from([("le_0005_ms".to_string(), 8)]),
+            ..oasis7_wasm_router::WasmRouterMetricsSnapshot::empty()
         },
     }
 }

--- a/crates/oasis7/src/runtime/module_store.rs
+++ b/crates/oasis7/src/runtime/module_store.rs
@@ -63,6 +63,9 @@ fn map_store_error(error: ModuleStoreError) -> WorldError {
         ModuleStoreError::VersionMismatch { expected, found } => {
             WorldError::ModuleStoreVersionMismatch { expected, found }
         }
+        ModuleStoreError::InvalidArtifactKey(key) => WorldError::ModuleChangeInvalid {
+            reason: format!("invalid module artifact key: {key}"),
+        },
         ModuleStoreError::Io(message) => WorldError::Io(message),
         ModuleStoreError::Serde(message) => WorldError::Serde(message),
     }

--- a/crates/oasis7/src/runtime/world/module_runtime.rs
+++ b/crates/oasis7/src/runtime/world/module_runtime.rs
@@ -30,6 +30,63 @@ fn count_exceeds_limit(count: usize, limit: u32) -> bool {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::{
+        ModuleAbiContract, ModuleRole, ModuleSubscription, ModuleSubscriptionStage,
+    };
+
+    fn manifest_with_subscription(wasm_hash: &str, event_kind: &str) -> ModuleManifest {
+        ModuleManifest {
+            module_id: "m.cache".to_string(),
+            name: "Cache".to_string(),
+            version: "0.1.0".to_string(),
+            kind: ModuleKind::Reducer,
+            role: ModuleRole::Domain,
+            wasm_hash: wasm_hash.to_string(),
+            interface_version: "wasm-1".to_string(),
+            abi_contract: ModuleAbiContract::default(),
+            exports: vec!["reduce".to_string()],
+            subscriptions: vec![ModuleSubscription {
+                event_kinds: vec![event_kind.to_string()],
+                action_kinds: Vec::new(),
+                stage: Some(ModuleSubscriptionStage::PostEvent),
+                filters: None,
+            }],
+            required_caps: Vec::new(),
+            artifact_identity: None,
+            limits: ModuleLimits::unbounded(),
+        }
+    }
+
+    #[test]
+    fn prepared_subscription_cache_key_tracks_manifest_identity() {
+        let base = manifest_with_subscription("hash-a", "world.tick");
+        let changed_hash = manifest_with_subscription("hash-b", "world.tick");
+        let changed_subscription = manifest_with_subscription("hash-a", "world.event");
+
+        let base_key = prepared_subscription_cache_key(&base).expect("base key");
+        assert_ne!(
+            base_key,
+            prepared_subscription_cache_key(&changed_hash).expect("hash key")
+        );
+        assert_ne!(
+            base_key,
+            prepared_subscription_cache_key(&changed_subscription).expect("subscription key")
+        );
+    }
+}
+
+fn prepared_subscription_cache_key(manifest: &ModuleManifest) -> Result<String, WorldError> {
+    let record_key = ModuleRegistry::record_key(&manifest.module_id, &manifest.version);
+    let subscription_hash = hash_json(&manifest.subscriptions)?;
+    Ok(format!(
+        "{record_key}|wasm={}|subs={subscription_hash}",
+        manifest.wasm_hash
+    ))
+}
+
 #[derive(Debug, Clone)]
 pub(super) struct ActiveModuleInvocation {
     pub(super) instance_id: String,
@@ -42,6 +99,12 @@ impl World {
     // ---------------------------------------------------------------------
     // Module artifact and limits
     // ---------------------------------------------------------------------
+
+    fn remove_prepared_subscription_cache_entries(&mut self, module_id: &str, version: &str) {
+        let prefix = format!("{}|", ModuleRegistry::record_key(module_id, version));
+        self.prepared_subscription_cache
+            .retain(|key, _| !key.starts_with(&prefix));
+    }
 
     pub fn register_module_artifact(
         &mut self,
@@ -118,7 +181,7 @@ impl World {
         &mut self,
         manifest: &ModuleManifest,
     ) -> Result<Arc<[PreparedSubscription]>, WorldError> {
-        let key = ModuleRegistry::record_key(&manifest.module_id, &manifest.version);
+        let key = prepared_subscription_cache_key(manifest)?;
         if let Some(prepared) = self.prepared_subscription_cache.get(&key) {
             return Ok(prepared.clone());
         }
@@ -511,7 +574,7 @@ impl World {
                 registered_by,
             } => {
                 let key = ModuleRegistry::record_key(&module.module_id, &module.version);
-                self.prepared_subscription_cache.remove(&key);
+                self.remove_prepared_subscription_cache_entries(&module.module_id, &module.version);
                 self.module_registry.records.insert(
                     key,
                     super::super::ModuleRecord {
@@ -531,7 +594,7 @@ impl World {
                 ..
             } => {
                 let key = ModuleRegistry::record_key(module_id, to_version);
-                self.prepared_subscription_cache.remove(&key);
+                self.remove_prepared_subscription_cache_entries(module_id, to_version);
                 self.module_registry.records.insert(
                     key,
                     super::super::ModuleRecord {

--- a/crates/oasis7_wasm_executor/src/lib.rs
+++ b/crates/oasis7_wasm_executor/src/lib.rs
@@ -244,7 +244,7 @@ impl Clone for WasmExecutor {
             metrics: Arc::clone(&self.metrics),
             compiled_cache: Arc::clone(&self.compiled_cache),
             compiled_disk_cache: self.compiled_disk_cache.clone(),
-            watchdog: Arc::new(EpochWatchdogController::new(engine.clone())),
+            watchdog: Arc::clone(&self.watchdog),
             engine,
         }
     }
@@ -377,6 +377,22 @@ impl WasmExecutor {
         wasm_hash: &str,
         wasm_bytes: &[u8],
     ) -> Result<CompileModuleOutcome, ModuleCallFailure> {
+        let actual_hash = sha256_hex(wasm_bytes);
+        if actual_hash != wasm_hash {
+            return Err(self.failure(
+                &ModuleCallRequest {
+                    module_id: wasm_hash.to_string(),
+                    wasm_hash: wasm_hash.to_string(),
+                    trace_id: "compile".to_string(),
+                    entrypoint: "call".to_string(),
+                    input: Vec::new(),
+                    limits: ModuleLimits::default(),
+                    wasm_bytes: Arc::<[u8]>::from([]),
+                },
+                ModuleCallErrorCode::Trap,
+                format!("wasm hash mismatch expected {wasm_hash} found {actual_hash}"),
+            ));
+        }
         let mut cache = self.compiled_cache.lock().expect("compiled cache poisoned");
         if let Some(module) = cache.get(wasm_hash) {
             return Ok(CompileModuleOutcome {
@@ -928,6 +944,17 @@ struct CompileModuleOutcome {
 
 fn elapsed_ms(started: Instant) -> u64 {
     started.elapsed().as_millis().try_into().unwrap_or(u64::MAX)
+}
+
+#[cfg(feature = "wasmtime")]
+fn sha256_hex(bytes: &[u8]) -> String {
+    let digest = Sha256::digest(bytes);
+    let mut out = String::with_capacity(digest.len() * 2);
+    for byte in digest {
+        use std::fmt::Write as _;
+        let _ = write!(&mut out, "{byte:02x}");
+    }
+    out
 }
 
 #[cfg(feature = "wasmtime")]

--- a/crates/oasis7_wasm_executor/src/lib.rs
+++ b/crates/oasis7_wasm_executor/src/lib.rs
@@ -142,35 +142,34 @@ impl EpochWatchdogController {
     fn new(engine: wasmtime::Engine) -> Self {
         let (command_tx, command_rx) = mpsc::channel::<WatchdogCommand>();
         let join_handle = std::thread::spawn(move || {
-            let mut armed: Option<(u64, std::time::Instant)> = None;
+            let mut armed: BTreeMap<u64, std::time::Instant> = BTreeMap::new();
             loop {
-                match armed {
-                    Some((ticket, deadline)) => {
+                match armed.values().min().copied() {
+                    Some(deadline) => {
                         let timeout = deadline.saturating_duration_since(std::time::Instant::now());
                         match command_rx.recv_timeout(timeout) {
                             Ok(command) => match command {
                                 WatchdogCommand::Arm { ticket, timeout } => {
-                                    armed = Some((ticket, std::time::Instant::now() + timeout));
+                                    armed.insert(ticket, std::time::Instant::now() + timeout);
                                 }
                                 WatchdogCommand::Disarm {
                                     ticket: disarm_ticket,
                                 } => {
-                                    if disarm_ticket == ticket {
-                                        armed = None;
-                                    }
+                                    armed.remove(&disarm_ticket);
                                 }
                                 WatchdogCommand::Shutdown => break,
                             },
                             Err(mpsc::RecvTimeoutError::Timeout) => {
                                 engine.increment_epoch();
-                                armed = None;
+                                let now = std::time::Instant::now();
+                                armed.retain(|_, deadline| *deadline > now);
                             }
                             Err(mpsc::RecvTimeoutError::Disconnected) => break,
                         }
                     }
                     None => match command_rx.recv() {
                         Ok(WatchdogCommand::Arm { ticket, timeout }) => {
-                            armed = Some((ticket, std::time::Instant::now() + timeout));
+                            armed.insert(ticket, std::time::Instant::now() + timeout);
                         }
                         Ok(WatchdogCommand::Disarm { .. }) => {}
                         Ok(WatchdogCommand::Shutdown) | Err(_) => break,

--- a/crates/oasis7_wasm_executor/src/tests.rs
+++ b/crates/oasis7_wasm_executor/src/tests.rs
@@ -78,6 +78,17 @@ fn invalid_cbor_output_wasm() -> Vec<u8> {
     wat::parse_str(wat).expect("compile invalid cbor wat")
 }
 
+#[cfg(feature = "wasmtime")]
+fn sha256_hex_for_test(bytes: &[u8]) -> String {
+    let digest = <sha2::Sha256 as sha2::Digest>::digest(bytes);
+    let mut out = String::with_capacity(digest.len() * 2);
+    for byte in digest {
+        use std::fmt::Write as _;
+        let _ = write!(&mut out, "{byte:02x}");
+    }
+    out
+}
+
 #[test]
 fn fixed_sandbox_succeed_returns_cloned_output() {
     let output = ModuleOutput {
@@ -323,9 +334,10 @@ fn wasm_executor_epoch_watchdog_preempts_infinite_loop() {
                i64.const 0))"#,
     )
     .expect("compile test wat");
+    let wasm_hash = sha256_hex_for_test(&wasm);
     let request = ModuleCallRequest {
         module_id: "m.loop".to_string(),
-        wasm_hash: "hash-loop".to_string(),
+        wasm_hash,
         trace_id: "trace-loop".to_string(),
         entrypoint: "call".to_string(),
         input: Vec::new(),
@@ -357,9 +369,10 @@ fn wasm_executor_metrics_track_compile_call_and_failure_paths() {
     let metrics = init_shared_wasm_executor_metrics();
     let mut executor = test_executor_with_metrics(WasmExecutorConfig::default(), metrics.clone());
     let wasm = trivial_success_wasm();
+    let wasm_hash = sha256_hex_for_test(&wasm);
     let request = ModuleCallRequest {
         module_id: "m.metrics".to_string(),
-        wasm_hash: "hash-metrics".to_string(),
+        wasm_hash,
         trace_id: "trace-metrics".to_string(),
         entrypoint: "call".to_string(),
         input: Vec::new(),
@@ -412,9 +425,11 @@ fn wasm_executor_metrics_track_compile_call_and_failure_paths() {
 fn wasm_executor_metrics_track_decode_timing_for_invalid_output() {
     let metrics = init_shared_wasm_executor_metrics();
     let mut executor = test_executor_with_metrics(WasmExecutorConfig::default(), metrics.clone());
+    let wasm = invalid_cbor_output_wasm();
+    let wasm_hash = sha256_hex_for_test(&wasm);
     let request = ModuleCallRequest {
         module_id: "m.invalid-output".to_string(),
-        wasm_hash: "hash-invalid-output".to_string(),
+        wasm_hash,
         trace_id: "trace-invalid-output".to_string(),
         entrypoint: "call".to_string(),
         input: Vec::new(),
@@ -426,7 +441,7 @@ fn wasm_executor_metrics_track_decode_timing_for_invalid_output() {
             max_effects: 0,
             max_emits: 0,
         },
-        wasm_bytes: Arc::<[u8]>::from(invalid_cbor_output_wasm()),
+        wasm_bytes: Arc::<[u8]>::from(wasm),
     };
 
     let failure = executor
@@ -459,12 +474,18 @@ fn wasm_executor_compiled_cache_evicts_old_entries() {
         ..WasmExecutorConfig::default()
     });
     let wasm_a = [0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00];
-    let wasm_b = [0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00];
+    let wasm_b = trivial_success_wasm();
+    let wasm_a_hash = sha256_hex_for_test(&wasm_a);
+    let wasm_b_hash = sha256_hex_for_test(&wasm_b);
 
-    executor.compile_module_cached("hash-a", &wasm_a).unwrap();
+    executor
+        .compile_module_cached(wasm_a_hash.as_str(), &wasm_a)
+        .unwrap();
     assert_eq!(executor.compiled_cache_len(), 1);
 
-    executor.compile_module_cached("hash-b", &wasm_b).unwrap();
+    executor
+        .compile_module_cached(wasm_b_hash.as_str(), &wasm_b)
+        .unwrap();
     assert_eq!(executor.compiled_cache_len(), 1);
 }
 
@@ -476,11 +497,16 @@ fn wasm_executor_compiled_cache_zero_capacity_stays_empty() {
         ..WasmExecutorConfig::default()
     });
     let wasm = [0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00];
+    let wasm_hash = sha256_hex_for_test(&wasm);
 
-    executor.compile_module_cached("hash-a", &wasm).unwrap();
+    executor
+        .compile_module_cached(wasm_hash.as_str(), &wasm)
+        .unwrap();
     assert_eq!(executor.compiled_cache_len(), 0);
 
-    executor.compile_module_cached("hash-b", &wasm).unwrap();
+    executor
+        .compile_module_cached(wasm_hash.as_str(), &wasm)
+        .unwrap();
     assert_eq!(executor.compiled_cache_len(), 0);
 }
 
@@ -505,14 +531,41 @@ fn wasm_executor_disk_cache_hits_when_memory_cache_disabled() {
         ..WasmExecutorConfig::default()
     });
     let wasm = [0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00];
-    let invalid_wasm = [0x01, 0x02, 0x03];
+    let wasm_hash = sha256_hex_for_test(&wasm);
 
     executor
-        .compile_module_cached("hash-disk-hit", &wasm)
+        .compile_module_cached(wasm_hash.as_str(), &wasm)
         .unwrap();
     executor
-        .compile_module_cached("hash-disk-hit", &invalid_wasm)
+        .compile_module_cached(wasm_hash.as_str(), &wasm)
         .expect("load compiled module from disk cache");
+
+    let _ = fs::remove_dir_all(cache_dir);
+}
+
+#[cfg(feature = "wasmtime")]
+#[test]
+fn wasm_executor_rejects_wasm_hash_bytes_mismatch_before_cache_hit() {
+    let cache_dir = unique_temp_cache_dir("hash-mismatch");
+    let executor = test_executor(WasmExecutorConfig {
+        compiled_cache_dir: Some(cache_dir.clone()),
+        ..WasmExecutorConfig::default()
+    });
+    let wasm = trivial_success_wasm();
+    let wasm_hash = sha256_hex_for_test(&wasm);
+    executor
+        .compile_module_cached(wasm_hash.as_str(), &wasm)
+        .expect("populate compiled cache");
+
+    let err = executor
+        .compile_module_cached(wasm_hash.as_str(), &[0x01, 0x02, 0x03])
+        .expect_err("mismatched bytes must not hit compiled cache");
+    assert_eq!(err.code, ModuleCallErrorCode::Trap);
+    assert!(
+        err.detail.contains("wasm hash mismatch"),
+        "unexpected error detail: {}",
+        err.detail
+    );
 
     let _ = fs::remove_dir_all(cache_dir);
 }
@@ -527,12 +580,14 @@ fn wasm_executor_disk_cache_persists_serialized_compiled_artifact() {
         ..WasmExecutorConfig::default()
     });
     let wasm = trivial_success_wasm();
-    let wasm_hash = "hash-disk-serialized";
+    let wasm_hash = sha256_hex_for_test(&wasm);
 
-    executor.compile_module_cached(wasm_hash, &wasm).unwrap();
+    executor
+        .compile_module_cached(wasm_hash.as_str(), &wasm)
+        .unwrap();
 
     let cache_file = executor
-        .compiled_disk_cache_path_for_test(wasm_hash)
+        .compiled_disk_cache_path_for_test(wasm_hash.as_str())
         .expect("cache path");
     let cached_bytes = fs::read(&cache_file).expect("read serialized cache");
     assert_ne!(cached_bytes, wasm);
@@ -554,16 +609,18 @@ fn wasm_executor_disk_cache_recovers_from_corruption() {
         ..WasmExecutorConfig::default()
     });
     let wasm = [0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00];
-    let wasm_hash = "hash-disk-corrupt";
+    let wasm_hash = sha256_hex_for_test(&wasm);
 
-    executor.compile_module_cached(wasm_hash, &wasm).unwrap();
+    executor
+        .compile_module_cached(wasm_hash.as_str(), &wasm)
+        .unwrap();
     let cache_file = executor
-        .compiled_disk_cache_path_for_test(wasm_hash)
+        .compiled_disk_cache_path_for_test(wasm_hash.as_str())
         .expect("cache path");
     fs::write(&cache_file, b"corrupt-bytes").expect("write corrupt cache");
 
     executor
-        .compile_module_cached(wasm_hash, &wasm)
+        .compile_module_cached(wasm_hash.as_str(), &wasm)
         .expect("recompile after corrupt cache");
 
     let repaired = fs::read(&cache_file).expect("read repaired cache");
@@ -581,10 +638,11 @@ fn perf_probe_executor_call_and_watchdog_overhead() {
         ..WasmExecutorConfig::default()
     });
     let wasm = trivial_success_wasm();
+    let wasm_hash = sha256_hex_for_test(&wasm);
     let expected_output_bytes = trivial_output_bytes().len() as u64;
     let request = ModuleCallRequest {
         module_id: "m.perf".to_string(),
-        wasm_hash: "hash-perf".to_string(),
+        wasm_hash,
         trace_id: "trace-perf".to_string(),
         entrypoint: "call".to_string(),
         input: Vec::new(),

--- a/crates/oasis7_wasm_router/src/lib.rs
+++ b/crates/oasis7_wasm_router/src/lib.rs
@@ -38,15 +38,15 @@ fn parsed_subscription_filters(
     Ok(Arc::new(parsed))
 }
 
-fn cached_regex(pattern: &str) -> Option<Arc<regex::Regex>> {
+fn cached_regex(pattern: &str) -> Result<Arc<regex::Regex>, regex::Error> {
     if let Some(cached) = lock_recover(regex_cache()).get_cloned(pattern) {
-        return Some(cached);
+        return Ok(cached);
     }
     let compile_started = Instant::now();
-    let compiled = Arc::new(regex::Regex::new(pattern).ok()?);
+    let compiled = Arc::new(regex::Regex::new(pattern)?);
     metrics::observe_wasm_router_regex_compile(elapsed_ms(compile_started));
     lock_recover(regex_cache()).insert(pattern.to_string(), compiled.clone());
-    Some(compiled)
+    Ok(compiled)
 }
 
 #[derive(Debug, Clone)]
@@ -89,7 +89,7 @@ enum PreparedMatchOperator {
     Gte(f64),
     Lt(f64),
     Lte(f64),
-    Re(regex::Regex),
+    Re(Arc<regex::Regex>),
 }
 
 pub fn prepare_subscriptions(
@@ -183,7 +183,7 @@ fn prepare_rule(rule: &MatchRule, module_id: &str) -> Result<PreparedMatchRule, 
     } else if let Some(threshold) = rule.lte {
         PreparedMatchOperator::Lte(threshold)
     } else if let Some(pattern) = &rule.re {
-        PreparedMatchOperator::Re(regex::Regex::new(pattern).map_err(|err| {
+        PreparedMatchOperator::Re(cached_regex(pattern).map_err(|err| {
             format!("module {module_id} subscription filter regex invalid: {err}")
         })?)
     } else {
@@ -857,6 +857,35 @@ mod tests {
         assert!(
             latest.regex_compile_ms_total >= baseline.regex_compile_ms_total,
             "regex compile counter should be monotonic"
+        );
+    }
+
+    #[test]
+    fn router_metrics_track_prepared_regex_compile_count() {
+        let baseline = snapshot_global_wasm_router_metrics();
+        let unique = format!(
+            "^prepared-metrics-{}$",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("unix epoch")
+                .as_nanos()
+        );
+        let subscription = event_subscription(
+            &["world.tick"],
+            Some(json!({
+                "event": [
+                    { "path": "/status", "re": unique }
+                ]
+            })),
+        );
+
+        let _ = prepare_subscriptions(&[subscription], "m.prepared.metrics")
+            .expect("prepare regex subscription");
+
+        let latest = snapshot_global_wasm_router_metrics();
+        assert!(
+            latest.regex_compile_calls_total >= baseline.regex_compile_calls_total + 1,
+            "prepared regex compilation should be counted"
         );
     }
 }

--- a/crates/oasis7_wasm_router/src/metrics.rs
+++ b/crates/oasis7_wasm_router/src/metrics.rs
@@ -27,6 +27,7 @@ pub struct WasmRouterMetricsSnapshot {
     pub match_ms_total: u64,
     pub parse_fallbacks: u64,
     pub prepared_hits: u64,
+    pub regex_compile_calls_total: u64,
     pub regex_compile_ms_total: u64,
     pub prepare_ms_buckets: BTreeMap<String, u64>,
     pub match_ms_buckets: BTreeMap<String, u64>,
@@ -44,6 +45,7 @@ impl WasmRouterMetricsSnapshot {
             match_ms_total: 0,
             parse_fallbacks: 0,
             prepared_hits: 0,
+            regex_compile_calls_total: 0,
             regex_compile_ms_total: 0,
             prepare_ms_buckets: empty_bucket_map(),
             match_ms_buckets: empty_bucket_map(),
@@ -100,6 +102,7 @@ pub fn observe_wasm_router_regex_compile(regex_compile_ms: u64) {
     locked.regex_compile_ms_total = locked
         .regex_compile_ms_total
         .saturating_add(regex_compile_ms);
+    locked.regex_compile_calls_total = locked.regex_compile_calls_total.saturating_add(1);
 }
 
 fn global_wasm_router_metrics() -> SharedWasmRouterMetrics {

--- a/crates/oasis7_wasm_store/src/lib.rs
+++ b/crates/oasis7_wasm_store/src/lib.rs
@@ -68,6 +68,7 @@ const MODULES_DIR: &str = "modules";
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ModuleStoreError {
     VersionMismatch { expected: u64, found: u64 },
+    InvalidArtifactKey(String),
     Io(String),
     Serde(String),
 }
@@ -128,6 +129,7 @@ impl ModuleStore {
         wasm_hash: &str,
         bytes: &[u8],
     ) -> Result<PathBuf, ModuleStoreError> {
+        validate_artifact_key(wasm_hash)?;
         self.ensure_dirs()?;
         let path = self.modules_dir.join(format!("{wasm_hash}.wasm"));
         write_bytes_atomic(&path, bytes)?;
@@ -135,11 +137,13 @@ impl ModuleStore {
     }
 
     pub fn read_artifact(&self, wasm_hash: &str) -> Result<Vec<u8>, ModuleStoreError> {
+        validate_artifact_key(wasm_hash)?;
         let path = self.modules_dir.join(format!("{wasm_hash}.wasm"));
         Ok(fs::read(path)?)
     }
 
     pub fn write_meta(&self, manifest: &ModuleManifest) -> Result<PathBuf, ModuleStoreError> {
+        validate_artifact_key(&manifest.wasm_hash)?;
         self.ensure_dirs()?;
         let path = self
             .modules_dir
@@ -149,6 +153,7 @@ impl ModuleStore {
     }
 
     pub fn read_meta(&self, wasm_hash: &str) -> Result<ModuleManifest, ModuleStoreError> {
+        validate_artifact_key(wasm_hash)?;
         let path = self.modules_dir.join(format!("{wasm_hash}.meta.json"));
         read_json_from_path(&path)
     }
@@ -195,18 +200,46 @@ fn now_unix() -> i64 {
         .unwrap_or(0)
 }
 
+fn validate_artifact_key(value: &str) -> Result<(), ModuleStoreError> {
+    let trimmed = value.trim();
+    let valid = !trimmed.is_empty()
+        && trimmed == value
+        && trimmed != "."
+        && trimmed != ".."
+        && trimmed
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.'));
+    if valid {
+        Ok(())
+    } else {
+        Err(ModuleStoreError::InvalidArtifactKey(value.to_string()))
+    }
+}
+
 fn write_json_atomic<T: Serialize>(value: &T, path: &Path) -> Result<(), ModuleStoreError> {
-    let tmp = path.with_extension("tmp");
+    let tmp = unique_tmp_path(path);
     write_json_to_path(value, &tmp)?;
     fs::rename(tmp, path)?;
     Ok(())
 }
 
 fn write_bytes_atomic(path: &Path, bytes: &[u8]) -> Result<(), ModuleStoreError> {
-    let tmp = path.with_extension("tmp");
+    let tmp = unique_tmp_path(path);
     fs::write(&tmp, bytes)?;
     fs::rename(tmp, path)?;
     Ok(())
+}
+
+fn unique_tmp_path(path: &Path) -> PathBuf {
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or(0);
+    let file_name = path
+        .file_name()
+        .and_then(|value| value.to_str())
+        .unwrap_or("module-store");
+    path.with_file_name(format!("{file_name}.{}.{}.tmp", std::process::id(), nonce))
 }
 
 fn write_json_to_path<T: Serialize>(value: &T, path: &Path) -> Result<(), ModuleStoreError> {
@@ -289,6 +322,33 @@ mod tests {
 
         store.save_registry(&registry).expect("save registry");
         assert_eq!(store.load_registry().expect("load registry"), registry);
+
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn artifact_paths_reject_path_shaped_wasm_hashes() {
+        let dir = temp_dir("oasis7-wasm-store-path-safe");
+        let store = ModuleStore::new(&dir);
+
+        assert!(matches!(
+            store.write_artifact("../escape", &[1, 2, 3]),
+            Err(ModuleStoreError::InvalidArtifactKey(_))
+        ));
+        assert!(matches!(
+            store.read_artifact("../escape"),
+            Err(ModuleStoreError::InvalidArtifactKey(_))
+        ));
+
+        let manifest = sample_manifest("abc/def");
+        assert!(matches!(
+            store.write_meta(&manifest),
+            Err(ModuleStoreError::InvalidArtifactKey(_))
+        ));
+        assert!(matches!(
+            store.read_meta("abc/def"),
+            Err(ModuleStoreError::InvalidArtifactKey(_))
+        ));
 
         let _ = fs::remove_dir_all(dir);
     }

--- a/doc/world-runtime/project.md
+++ b/doc/world-runtime/project.md
@@ -3,6 +3,7 @@
 审计轮次: 6
 
 ## 任务拆解（含 PRD-ID 映射）
+- [x] wasm-rust-governance-hardening (PRD-WORLD_RUNTIME-001/002) [test_tier_required]: 加固 WASM executor cache hash 边界、artifact/module_id 路径安全、prepared subscription cache identity 与 prepared regex cache/metrics，并记录工程治理复查证据。 Trace: .pm/tasks/task_61ae4b646e994b3e91bff3141f7ef818.yaml
 - [x] oc-letai-bridge-test-coverage (PRD-WORLD_RUNTIME-040) [test_tier_required]: 补齐 `OC -> LetAI token_key/quota` 运行链的自动化覆盖，至少包含 remote provider bridge 从 `bridge-state.json` 解析 active binding/token_key 的正向用例，以及 `letai_provider_cli.py` 从 NewAPI bridge state 自动取 `token_key` 后调用 mock `/v1/chat/completions` 的脚本级 smoke。 Trace: .pm/tasks/task_962b35abbe284804a0ca983cee0779d8.yaml
 - [x] viewer-live-integration-flake-burn-down (PRD-WORLD_RUNTIME-001) [test_tier_full]: 移除 `scripts/ci-tests.sh` 对 `live_server_accepts_client_and_emits_snapshot_and_event` 的历史 `skip + 单测重跑 + retry` 特殊路径，确认该 full-tier 集成回归在当前代码上已可直接并入 `cargo test -p oasis7 --tests --features "test_tier_full,wasmtime,viewer_live_integration"` 单次入口。 Trace: .pm/tasks/task_0a012bf9b85b417bb56d591969a07d36.yaml
 - [x] first-agent-claim-auto-grant (PRD-WORLD_RUNTIME-040) [test_tier_required]: 将首个 agent `slot-1` claim 从“申请/审核/批准后再发 grant”改为“专用池余额足够时在 `ClaimAgent` 路径自动补足 restricted starter funding 并原子完成认领”；viewer / API 同步移除旧审批 surface，只保留 dedicated pool auto-funding 直连 claim 真值。 Trace: .pm/tasks/task_313368c409c54cc2bcf8ef4f47919b65.yaml

--- a/tools/wasm_build_suite/src/lib.rs
+++ b/tools/wasm_build_suite/src/lib.rs
@@ -545,6 +545,12 @@ fn validate_request(request: &BuildRequest) -> Result<(), BuildError> {
             "module_id is empty".to_string(),
         ));
     }
+    if !is_path_safe_module_id(&request.module_id) {
+        return Err(BuildError::InvalidArgument(format!(
+            "module_id must be path-safe, got {}",
+            request.module_id
+        )));
+    }
     if request.target.trim().is_empty() {
         return Err(BuildError::InvalidArgument("target is empty".to_string()));
     }
@@ -560,6 +566,17 @@ fn validate_request(request: &BuildRequest) -> Result<(), BuildError> {
         ));
     }
     Ok(())
+}
+
+fn is_path_safe_module_id(value: &str) -> bool {
+    let trimmed = value.trim();
+    !trimmed.is_empty()
+        && trimmed == value
+        && trimmed != "."
+        && trimmed != ".."
+        && trimmed
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.'))
 }
 
 fn read_cargo_metadata(manifest_path: &Path) -> Result<CargoMetadata, BuildError> {

--- a/tools/wasm_build_suite/tests/minimal_template.rs
+++ b/tools/wasm_build_suite/tests/minimal_template.rs
@@ -79,6 +79,25 @@ fn minimal_template_dry_run_resolves_paths() {
 }
 
 #[test]
+fn minimal_template_rejects_path_shaped_module_id() {
+    let out_dir = unique_temp_dir("wasm-build-suite-path-safe");
+    let request = BuildRequest {
+        module_id: "../escape".to_string(),
+        manifest_path: template_manifest_path(),
+        out_dir,
+        target: DEFAULT_TARGET.to_string(),
+        profile: "dev".to_string(),
+        dry_run: true,
+    };
+
+    let err = run_build(&request).expect_err("path-shaped module_id must be rejected");
+    assert!(
+        err.to_string().contains("module_id"),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
 fn minimal_template_real_build_writes_wasm_and_metadata() {
     if !has_target_installed(DEFAULT_TARGET) {
         eprintln!(


### PR DESCRIPTION
## Summary

- Harden WASM executor compiled-cache use by verifying request bytes against `wasm_hash` before any memory or disk cache hit.
- Validate path-sensitive WASM artifact/module identifiers before filesystem joins, and map invalid store keys into module-change validation errors.
- Strengthen prepared subscription and regex cache behavior with manifest-aware subscription keys plus prepared regex cache/metrics coverage.

## Verification

- `env -u RUSTC_WRAPPER cargo test -p oasis7_wasm_store artifact_paths_reject_path_shaped_wasm_hashes`
- `env -u RUSTC_WRAPPER cargo test -p oasis7_wasm_executor --features wasmtime wasm_executor_rejects_wasm_hash_bytes_mismatch_before_cache_hit`
- `env -u RUSTC_WRAPPER cargo test -p oasis7_wasm_executor --features wasmtime wasm_executor_epoch_watchdog_preempts_infinite_loop`
- `env -u RUSTC_WRAPPER cargo test -p oasis7_wasm_router router_metrics_track_prepared_regex_compile_count`
- `env -u RUSTC_WRAPPER cargo test -p oasis7 prepared_subscription_cache_key_tracks_manifest_identity`
- `env -u RUSTC_WRAPPER cargo test --manifest-path tools/wasm_build_suite/Cargo.toml minimal_template_rejects_path_shaped_module_id`
- `env -u RUSTC_WRAPPER cargo test -p oasis7 --bin oasis7_chain_runtime observability`
- `./scripts/pm/workflow-lint.sh --task-uid task_61ae4b646e994b3e91bff3141f7ef818 --phase pr-ready`
- `./scripts/doc-governance-check.sh`
- `git diff --check`

## PR Evidence

- task_uid: task_61ae4b646e994b3e91bff3141f7ef818
- PR URL: https://github.com/eng-cc/oasis7/pull/483
- Source worktree: `/Users/scc/ccwork/worktrees/oasis7-engineering-wasm-rust-governance-review`
- Branch: `task/engineering-wasm-rust-governance-review`
- Pre-PR Local Role Review: passed
- Review roles: `wasm_platform_engineer`, `runtime_engineer`, `repository_health_engineer`, `qa_engineer`
- Residual risk: targeted local tests cover the changed hardening surfaces; broader package/workspace checks, GitHub required checks, comments, requested changes, review threads, and mergeability remain required after PR creation.
