### PR TITLE
Slim testing documentation surfaces

### DIFF
--- a/.pm/tasks/task_0af93d9ebb8c45df8cf013e11840cc9b.execution.md
+++ b/.pm/tasks/task_0af93d9ebb8c45df8cf013e11840cc9b.execution.md
@@ -134,3 +134,25 @@ Example:
 - Expected Result: ready_for_pr claim verification passes; closeout provenance is visible to workflow-lint; task YAML remains `status: done` with `last_closed_at`.
 - Actual Result: `claim-ready.sh` returned `status=verified`, `verification_exit_code=0`, `allowed_to_claim=true`, `verified_at=2026-06-16T20:36:41+08:00`; earlier `task-closeout.sh` exited 0 with `claim_verification_status: verified`, `final_status: done`, `last_closed_at=2026-06-16T20:22:44+08:00`, and `pm_lint: skipped` due unrelated repo-wide historical PM lint debt.
 - Blocker / Next Action: Commit workflow-lint evidence repair, rerun `prepare-task-pr.sh --create`.
+
+## 2026-06-16 20:58:00 CST / tpm
+- 完成内容: Integrated narrow repository-health re-review after `prepare-task-pr.sh --create` detected post-review non-evidence change `doc/testing/project.md`. The only non-`.pm` post-review change was the one-line task Trace added for PR-readiness provenance.
+- Pre-PR Local Role Review: passed
+- Task UID: task_0af93d9ebb8c45df8cf013e11840cc9b
+- Source Worktree: /Users/scc/ccwork/worktrees/oasis7-testing-testing-doc-default-surface-slimming
+- Source Branch: task/testing-testing-doc-default-surface-slimming
+- Source Head: a8cd055431bbebf498d25cd0572c5d4581219217
+- Comparison Ref: refs/remotes/origin/main
+- Reviewed Changed Paths: .pm/tasks/task_0af93d9ebb8c45df8cf013e11840cc9b.execution.md; doc/testing/project.md
+- Role Selection Basis: narrow repository-health re-review required because post-review PR-readiness provenance touched the testing project trace surface.
+- Review Roles: repository_health_engineer
+- Review Evidence: repository_health_engineer no_findings for commit a8cd055431bbebf498d25cd0572c5d4581219217; inspected only the readiness evidence additions and the one-line `doc/testing/project.md` Trace addition; confirmed no repository-health/doc-governance issue, traceability regression, or non-evidence content change requiring docs fixes before PR creation.
+- Review Findings Disposition: no_findings
+- Finding Disposition Evidence: No fixes required after narrow re-review; subsequent commit is expected to contain only this execution-log evidence.
+- Residual Risk: Repo-wide PM lint remains known-red on unrelated historical task logs; this narrow re-review ran `workflow-lint --phase pr-ready` and `git diff --check` against the scoped commit successfully.
+- 遗留事项: None for pre-PR local role review.
+- Action: Commit this re-review evidence-only update and rerun `./scripts/prepare-task-pr.sh --create`.
+- Validation Command: repository_health_engineer narrow re-review; `./scripts/pm/workflow-lint.sh --task-uid task_0af93d9ebb8c45df8cf013e11840cc9b --phase pr-ready`; `git diff --check a8cd055431bbebf498d25cd0572c5d4581219217^ a8cd055431bbebf498d25cd0572c5d4581219217`
+- Expected Result: Pre-PR packet source head covers the `doc/testing/project.md` Trace addition; later changes are evidence-only.
+- Actual Result: repository_health_engineer returned `no_findings`; workflow-lint and diff check passed in the narrow review evidence.
+- Blocker / Next Action: Commit evidence-only update, then create PR.

--- a/.pm/tasks/task_0af93d9ebb8c45df8cf013e11840cc9b.execution.md
+++ b/.pm/tasks/task_0af93d9ebb8c45df8cf013e11840cc9b.execution.md
@@ -125,3 +125,12 @@ Example:
 - Expected Result: Preflight recognizes passed local role review packet.
 - Actual Result: Pending rerun.
 - Blocker / Next Action: Commit evidence formatting fix.
+
+## 2026-06-16 20:41:00 CST / tpm
+- 完成内容: Added workflow-lint PR-readiness provenance after prepare-task-pr preflight found missing project Trace / claim-ready / closeout markers.
+- 遗留事项: Repo-wide PM lint remains known-red on unrelated historical task logs; current task workflow lint is the governing PM check for this PR path.
+- Action: Added `testing-doc-default-surface-slimming` Trace to `doc/testing/project.md`; recorded explicit `claim-ready.sh` and `task-closeout.sh` evidence markers.
+- Validation Command: `./scripts/pm/claim-ready.sh --claim-type ready_for_pr --verify-command "./scripts/pm/workflow-lint.sh --task-uid task_0af93d9ebb8c45df8cf013e11840cc9b --phase current && git diff --check" --json`; `./scripts/pm/task-closeout.sh --role tpm --task-uid task_0af93d9ebb8c45df8cf013e11840cc9b --verify-command "<doc-governance timeout-wrapper + workflow-lint + git diff --check>" --no-lint`
+- Expected Result: ready_for_pr claim verification passes; closeout provenance is visible to workflow-lint; task YAML remains `status: done` with `last_closed_at`.
+- Actual Result: `claim-ready.sh` returned `status=verified`, `verification_exit_code=0`, `allowed_to_claim=true`, `verified_at=2026-06-16T20:36:41+08:00`; earlier `task-closeout.sh` exited 0 with `claim_verification_status: verified`, `final_status: done`, `last_closed_at=2026-06-16T20:22:44+08:00`, and `pm_lint: skipped` due unrelated repo-wide historical PM lint debt.
+- Blocker / Next Action: Commit workflow-lint evidence repair, rerun `prepare-task-pr.sh --create`.

--- a/.pm/tasks/task_0af93d9ebb8c45df8cf013e11840cc9b.execution.md
+++ b/.pm/tasks/task_0af93d9ebb8c45df8cf013e11840cc9b.execution.md
@@ -60,3 +60,46 @@ Example:
 - Expected Result: Current task workflow lint passes; repo-wide PM lint emits no current-task matches; doc governance passes; whitespace diff check passes.
 - Actual Result: `workflow-lint: OK (task_0af93d9ebb8c45df8cf013e11840cc9b, phase=current)`; filtered PM lint command exited 0 with no current-task matches; `doc-governance-check: OK`; `git diff --check` passed with no output.
 - Blocker / Next Action: No current-task blocker. If preparing PR, next phase is pre-PR local role review and normal PR closeout flow.
+
+## 2026-06-16 20:25:00 CST / tpm
+- Review Trigger: pre-PR local role review.
+- Review Scope: `.pm/tasks/task_0af93d9ebb8c45df8cf013e11840cc9b.*`; `doc/testing/README.md`; `doc/testing/prd.index.md`; `doc/testing/project.md`; `doc/testing/performance/performance-coverage-gap-matrix-2026-06-09.md`; `doc/testing/manual/systematic-application-testing-manual.{prd,design,project}.md`.
+- Review Roles: `repository_health_engineer`, `qa_engineer`.
+- Review Question: Confirm the committed diff `1b4a63c582cc0ebb58fbe85b4e618443e69bd4c4` safely slims testing documentation default surfaces, preserves traceability, and does not misstate QA / required-gate semantics.
+- Evidence Available: commit `1b4a63c582cc0ebb58fbe85b4e618443e69bd4c4`; closeout verified `doc-governance-check: OK`, `workflow-lint: OK`, `git diff --check` clean; repo-wide PM lint remains red only on unrelated historical task logs with current-task filtered check clean.
+- Expected Return Contract: `findings | no_findings | residual_risk`.
+- Formal Sink: `.pm/tasks/task_0af93d9ebb8c45df8cf013e11840cc9b.execution.md`.
+- 完成内容: Pre-PR local role review request recorded before dispatching role slices.
+- 遗留事项: Await role findings before recording `Pre-PR Local Role Review: passed`.
+- Action: Dispatch `repository_health_engineer` and `qa_engineer` pre-PR review slices.
+- Validation Command: N/A for review request entry; verification evidence listed above.
+- Expected Result: Both role slices return findings/no_findings with residual risk.
+- Actual Result: Pending.
+- Blocker / Next Action: Integrate role review results.
+
+## 2026-06-16 20:33:00 CST / tpm
+- 完成内容: Integrated pre-PR local role review results.
+- Review Evidence:
+  - `repository_health_engineer`: `no_findings`. Confirmed the diff narrows default testing-doc reading surface while preserving traceability via README landing scope, `prd.index.md` file-level table, and `project.md` current-window plus historical trace pointers. Confirmed static count drift is controlled, `test-coverage-gate-fill` is the active blocker, Viewer perf wording matches report-only gate behavior, and the manual triplet is clearly historical with canonical redirects. Reviewer ran fresh `./scripts/doc-governance-check.sh`, current-task workflow lint, `git diff --check origin/main...HEAD`, and current-task filtered PM lint clean.
+  - `qa_engineer`: `no_findings`. Confirmed no QA gate-semantic regressions: Viewer perf smoke is explicitly report-only and not PR/release blocking; the compressed project page preserves active blocker/caveats; the manual triplet redirects current execution to `testing-manual.md`.
+- Review Findings Disposition: no_findings.
+- Finding Disposition Evidence: No code/doc changes required after role review; only this review evidence was appended.
+- Residual Risk: Repo-wide PM lint remains known-red on unrelated historical task logs; current-task workflow lint and current-task filtered PM lint are clean. Review request/result evidence is appended after reviewed commit and will be included as review-evidence-only commit before PR creation.
+- Pre-PR Local Role Review: passed
+- Task UID: task_0af93d9ebb8c45df8cf013e11840cc9b
+- Source Worktree: `/Users/scc/ccwork/worktrees/oasis7-testing-testing-doc-default-surface-slimming`
+- Source Branch: `task/testing-testing-doc-default-surface-slimming`
+- Source Head: `1b4a63c582cc0ebb58fbe85b4e618443e69bd4c4` (reviewed implementation commit; later change is this task review evidence only)
+- Comparison Ref: `refs/remotes/origin/main`
+- Reviewed Changed Paths: `.pm/tasks/task_0af93d9ebb8c45df8cf013e11840cc9b.execution.md`; `.pm/tasks/task_0af93d9ebb8c45df8cf013e11840cc9b.yaml`; `doc/testing/README.md`; `doc/testing/prd.index.md`; `doc/testing/project.md`; `doc/testing/performance/performance-coverage-gap-matrix-2026-06-09.md`; `doc/testing/manual/systematic-application-testing-manual.prd.md`; `doc/testing/manual/systematic-application-testing-manual.design.md`; `doc/testing/manual/systematic-application-testing-manual.project.md`
+- Role Selection Basis: testing documentation governance diff touches default reading surfaces, doc traceability, QA blocker wording, and required-gate/report-only semantics; selected `repository_health_engineer` for doc governance/traceability and `qa_engineer` for gate/release semantic correctness.
+- Review Roles: `repository_health_engineer`, `qa_engineer`
+- Review Findings Disposition: no_findings
+- Finding Disposition Evidence: Both roles returned no findings; no fixes required.
+- Residual Risk: Same as above; repo-wide PM lint historical failures unrelated to this task remain out of scope.
+- 遗留事项: None for pre-PR local role review.
+- Action: Commit review evidence and run `./scripts/prepare-task-pr.sh --create`.
+- Validation Command: role review subagent returns + task execution log evidence packet.
+- Expected Result: Required pre-PR local role review packet exists before PR creation.
+- Actual Result: Passed packet recorded in this entry.
+- Blocker / Next Action: Commit evidence-only update, then run PR preflight/create.

--- a/.pm/tasks/task_0af93d9ebb8c45df8cf013e11840cc9b.execution.md
+++ b/.pm/tasks/task_0af93d9ebb8c45df8cf013e11840cc9b.execution.md
@@ -103,3 +103,25 @@ Example:
 - Expected Result: Required pre-PR local role review packet exists before PR creation.
 - Actual Result: Passed packet recorded in this entry.
 - Blocker / Next Action: Commit evidence-only update, then run PR preflight/create.
+
+## 2026-06-16 20:39:00 CST / tpm
+- Pre-PR Local Role Review: passed
+- Task UID: task_0af93d9ebb8c45df8cf013e11840cc9b
+- Source Worktree: /Users/scc/ccwork/worktrees/oasis7-testing-testing-doc-default-surface-slimming
+- Source Branch: task/testing-testing-doc-default-surface-slimming
+- Source Head: 7d8c65bd67f1d2d88df1adf1cbac42fa37d00422
+- Comparison Ref: refs/remotes/origin/main
+- Reviewed Changed Paths: .pm/tasks/task_0af93d9ebb8c45df8cf013e11840cc9b.execution.md; .pm/tasks/task_0af93d9ebb8c45df8cf013e11840cc9b.yaml; doc/testing/README.md; doc/testing/prd.index.md; doc/testing/project.md; doc/testing/performance/performance-coverage-gap-matrix-2026-06-09.md; doc/testing/manual/systematic-application-testing-manual.prd.md; doc/testing/manual/systematic-application-testing-manual.design.md; doc/testing/manual/systematic-application-testing-manual.project.md
+- Role Selection Basis: testing documentation governance diff touches default reading surfaces, doc traceability, QA blocker wording, and required-gate/report-only semantics; selected repository_health_engineer and qa_engineer.
+- Review Roles: repository_health_engineer, qa_engineer
+- Review Evidence: repository_health_engineer no_findings; qa_engineer no_findings; both reviewed commit 1b4a63c582cc0ebb58fbe85b4e618443e69bd4c4 and accepted later review-evidence-only execution log change.
+- Review Findings Disposition: no_findings
+- Finding Disposition Evidence: No fixes required; both role reviews returned no findings; this entry reformats the already recorded passed review packet for prepare-task-pr parser compatibility.
+- Residual Risk: Repo-wide PM lint remains known-red on unrelated historical task logs; current-task workflow lint and current-task filtered PM lint are clean.
+- 完成内容: Added parser-compatible pre-PR local role review packet after prepare-task-pr preflight rejected the human-readable packet formatting.
+- 遗留事项: None.
+- Action: Commit parser-compatible review packet and rerun prepare-task-pr.
+- Validation Command: ./scripts/prepare-task-pr.sh --create
+- Expected Result: Preflight recognizes passed local role review packet.
+- Actual Result: Pending rerun.
+- Blocker / Next Action: Commit evidence formatting fix.

--- a/.pm/tasks/task_0af93d9ebb8c45df8cf013e11840cc9b.execution.md
+++ b/.pm/tasks/task_0af93d9ebb8c45df8cf013e11840cc9b.execution.md
@@ -1,0 +1,62 @@
+# task_0af93d9ebb8c45df8cf013e11840cc9b Execution Log
+
+- task_uid: task_0af93d9ebb8c45df8cf013e11840cc9b
+- title: testing doc default surface slimming
+- owner_role: tpm
+- worktree_hint: /Users/scc/ccwork/worktrees/oasis7-testing-testing-doc-default-surface-slimming
+
+<!-- Append entries using:
+Example:
+  ## YYYY-MM-DD HH:MM:SS CST / role_name
+  - 完成内容: ...
+  - 遗留事项: ...
+  - Action: ...
+  - Validation Command: ...
+  - Expected Result: ...
+  - Actual Result: ...
+  - Blocker / Next Action: ...
+-->
+
+## 2026-06-16 17:50:00 CST / tpm
+- 完成内容: WORKFLOW BOOTSTRAP DECIDED. Repository state impact: documentation governance edits are expected. Isolation decision: created dedicated worktree `/Users/scc/ccwork/worktrees/oasis7-testing-testing-doc-default-surface-slimming` from clean main using `./scripts/new-task-worktree.sh testing testing-doc-default-surface-slimming --pm-owner-role tpm`. Task truth: `.pm/tasks/task_0af93d9ebb8c45df8cf013e11840cc9b.yaml`, owner_role `tpm`, title `testing doc default surface slimming`.
+- 完成内容: WORKFLOW ROUTE DECIDED. Current phase: implementation from prior repository-health audit findings. Selected workflow surface: `executing-project-tasks`; skipped TDD because this is documentation governance without a behavior-changing test harness. Specialist slice required: `repository_health_engineer` for documentation slimming implementation and repository-health judgment.
+- 完成内容: TPM TODO decomposition:
+  - Step 1: slim default testing reading surfaces while preserving traceability, primarily `doc/testing/project.md`, `doc/testing/README.md`, and `doc/testing/prd.index.md`.
+  - Step 2: refresh stale performance coverage wording in `doc/testing/performance/performance-coverage-gap-matrix-2026-06-09.md` to current report-only scoped gate state.
+  - Step 3: compact completed manual planning triplet references for `doc/testing/manual/systematic-application-testing-manual.{prd,design,project}.md` without breaking governance traceability.
+  - Step 4: run documentation/governance verification and record evidence.
+- 完成内容: Subagent Slice Contract. role: `repository_health_engineer`; slice type: bounded docs implementation; intended model configuration: workflow source-of-truth default subagent runtime / inherited parent model; actual dispatched model/reasoning: to be recorded after dispatch, expected inherited/unverified if connector does not report exact runtime; context delivery mode: full-thread/full-history fork by default, explicit context packet fallback if tool limitations apply; mandatory context checklist/packet: identity and authority from `AGENTS.md` and `.agents/roles/repository_health_engineer.md`; workflow governance from `doc/engineering/workflow/source-of-truth.md`; task truth from `.pm/tasks/task_0af93d9ebb8c45df8cf013e11840cc9b.*`; user intent "做治理"; scoped repo context from prior audit plus `doc/testing/**`; collaboration boundary: repository_health owns docs slimming edits and findings, TPM integrates and verifies. write scope: `doc/testing/project.md`, `doc/testing/README.md`, `doc/testing/prd.index.md`, `doc/testing/performance/performance-coverage-gap-matrix-2026-06-09.md`, `doc/testing/manual/systematic-application-testing-manual.{prd,design,project}.md`, and necessary index/checklist references only. return contract: changed files, rationale, verification commands run or recommended, residual risk. formal sink: this execution log. integration owner/order: TPM dispatch -> repository_health edits -> TPM inspect diff and run verification.
+- Validation Command: `./scripts/new-task-worktree.sh testing testing-doc-default-surface-slimming --pm-owner-role tpm --pm-title "testing doc default surface slimming" ... --json`
+- Expected Result: Dedicated task worktree and committed `.pm` task exist before edits.
+- Actual Result: Created branch `task/testing-testing-doc-default-surface-slimming`, worktree `/Users/scc/ccwork/worktrees/oasis7-testing-testing-doc-default-surface-slimming`, task `task_0af93d9ebb8c45df8cf013e11840cc9b`.
+- 遗留事项: None at bootstrap; implementation and verification still pending.
+- Action: Dispatch bounded `repository_health_engineer` implementation slice, integrate returned diff, then run fresh documentation governance verification.
+- Blocker / Next Action: Dispatch bounded `repository_health_engineer` implementation slice.
+
+## 2026-06-16 18:12:00 CST / repository_health_engineer
+- 完成内容: Implemented bounded documentation slimming for the testing default reading surface. Changed docs: `doc/testing/project.md`, `doc/testing/README.md`, `doc/testing/prd.index.md`, `doc/testing/performance/performance-coverage-gap-matrix-2026-06-09.md`, and `doc/testing/manual/systematic-application-testing-manual.{prd,design,project}.md`.
+- 完成内容: Slimming decisions: compressed `doc/testing/project.md` from a long accumulated task log into a current execution window plus historical traceability pointers; removed static drift-prone file counts from README/index default surfaces; updated Viewer performance matrix language to reflect current required-gate report-only scoped smoke; converted the completed systematic testing manual triplet into compact historical redirect/decision records while preserving PRD/project traceability.
+- 遗留事项: `doc/testing/prd.index.md` intentionally still contains the full topic table for file-level traceability, so the default reading surface is slimmer but the index is not aggressively reduced.
+- Action: TPM integration review should confirm no stale current-state contradictions remain, then run fresh verification.
+- Validation Command: `git diff --check`; `./scripts/doc-governance-check.sh`
+- Expected Result: Whitespace diff check and doc governance check pass after the manual triplet compaction.
+- Actual Result: Subagent reported both checks passing after fixing an initial doc-governance schema marker issue; TPM reran fresh verification in the next entry.
+- Blocker / Next Action: No implementation blocker; TPM to run fresh checks and record current observed results.
+
+## 2026-06-16 18:18:00 CST / tpm
+- 完成内容: Integrated repository-health edits, inspected the compressed `doc/testing/project.md`, and corrected one stale status contradiction from old `TASK-TESTING-002/003` wording to the current `test-coverage-gate-fill` blocker.
+- 遗留事项: Repo-wide `./scripts/pm/lint.sh` still reports unrelated historical execution-log format failures outside this task; current task-specific lint must be checked separately.
+- Action: Run fresh documentation and PM verification, then report local verification status with the repo-wide historical PM lint caveat.
+- Validation Command: `./scripts/doc-governance-check.sh`; `git diff --check`; `./scripts/pm/lint.sh`
+- Expected Result: Doc governance and whitespace pass; repo-wide PM lint may fail only on unrelated historical tasks or must be fixed if it reports current task issues.
+- Actual Result: `./scripts/doc-governance-check.sh` -> `doc-governance-check: OK`; `git diff --check` -> passed with no output; `./scripts/pm/lint.sh` -> failed, including current task entry missing `遗留事项` and `Action` plus many unrelated historical task log format failures. Current task log fields were then patched in this entry.
+- Blocker / Next Action: Rerun current-task PM lint/filtered PM lint after this patch.
+
+## 2026-06-16 18:24:00 CST / tpm
+- 完成内容: Fresh verification completed after execution-log field patch.
+- 遗留事项: Repo-wide `./scripts/pm/lint.sh` remains red on unrelated historical task logs, so this task is verified with current-task workflow lint and current-task filtered PM lint evidence.
+- Action: Report implementation status and residual repo-wide PM lint caveat to the user.
+- Validation Command: `./scripts/pm/workflow-lint.sh --task-uid task_0af93d9ebb8c45df8cf013e11840cc9b --phase current`; `./scripts/pm/lint.sh 2>&1 | rg 'task_0af93d9ebb8c45df8cf013e11840cc9b'; test $? -eq 1`; `./scripts/doc-governance-check.sh`; `git diff --check`
+- Expected Result: Current task workflow lint passes; repo-wide PM lint emits no current-task matches; doc governance passes; whitespace diff check passes.
+- Actual Result: `workflow-lint: OK (task_0af93d9ebb8c45df8cf013e11840cc9b, phase=current)`; filtered PM lint command exited 0 with no current-task matches; `doc-governance-check: OK`; `git diff --check` passed with no output.
+- Blocker / Next Action: No current-task blocker. If preparing PR, next phase is pre-PR local role review and normal PR closeout flow.

--- a/.pm/tasks/task_0af93d9ebb8c45df8cf013e11840cc9b.yaml
+++ b/.pm/tasks/task_0af93d9ebb8c45df8cf013e11840cc9b.yaml
@@ -1,0 +1,29 @@
+task_uid: task_0af93d9ebb8c45df8cf013e11840cc9b
+title: "testing doc default surface slimming"
+owner_role: tpm
+worktree_hint: /Users/scc/ccwork/worktrees/oasis7-testing-testing-doc-default-surface-slimming
+execution_log_path: .pm/tasks/task_0af93d9ebb8c45df8cf013e11840cc9b.execution.md
+status: done
+priority: P2
+source_signal: null
+source_refs:
+  - doc/testing/project.md
+doc_refs:
+  - doc/testing/README.md
+  - doc/testing/prd.index.md
+  - doc/testing/performance/performance-coverage-gap-matrix-2026-06-09.md
+  - doc/testing/manual/systematic-application-testing-manual.prd.md
+related_prd: []
+acceptance:
+  - "Slim testing default reading surfaces while preserving traceability"
+  - "Refresh stale performance gate wording to current report-only scoped gate state"
+  - "Record repository_health_engineer implementation findings and verification evidence"
+handoff_to: []
+updated_at: 2026-06-16T20:22:46+08:00
+last_started_at: 2026-06-16T17:46:41+08:00
+last_claim_type: task_complete
+last_verify_command: "python3 - <<'PY'\nimport subprocess\nsubprocess.run(['./scripts/doc-governance-check.sh'], timeout=600, check=True)\nPY\n./scripts/pm/workflow-lint.sh --task-uid task_0af93d9ebb8c45df8cf013e11840cc9b --phase current\ngit diff --check"
+last_verified_at: 2026-06-16T20:22:40+08:00
+last_verification_exit_code: 0
+last_verification_status: verified
+last_closed_at: 2026-06-16T20:22:44+08:00

--- a/doc/testing/README.md
+++ b/doc/testing/README.md
@@ -42,19 +42,19 @@
 - 汇总 CI、启动器、长稳、性能、人工手册与治理专题。
 - 承接跨模块测试范围定义、证据归档与趋势基线建设。
 
-## 热点子域导航（2026-05-06 快照）
-- `evidence/`（49）：发布证据、趋势基线与审计留痕；当前已补 `evidence/README.md` 作为热点子域入口。
-- `ci/`（33）：CI、wasm determinism、tiering 与 gate 保护。
-- `longrun/`（24）：长稳、chaos、soak 与在线稳定性。
-- `launcher/`（18）：启动器链路测试、playtest 与配置自动接线。
-- `governance/`（28）：质量趋势、release-gate 指标、审计检查、好玩性证据栈、L4 synthetic/human 分层、subagent 评审系统与 simulated player personas。
-- `templates/`（16）：证据包、报告、模型视觉评审卡与检查清单模板；默认按需进入。
-- `performance/`（12）：runtime / viewer 性能观测与方法学。
-- `manual/`（7）：系统测试手册分册与 Web UI 闭环 manual。
-- `chaos-plans/`（1）：专项 chaos plan 入口。
+## 热点子域导航
+- `evidence/`：发布证据、趋势基线与审计留痕；当前已补 `evidence/README.md` 作为热点子域入口。
+- `ci/`：CI、wasm determinism、tiering 与 gate 保护。
+- `longrun/`：长稳、chaos、soak 与在线稳定性。
+- `launcher/`：启动器链路测试、playtest 与配置自动接线。
+- `governance/`：质量趋势、release-gate 指标、审计检查、好玩性证据栈、L4 synthetic/human 分层、subagent 评审系统与 simulated player personas。
+- `templates/`：证据包、报告、模型视觉评审卡与检查清单模板；默认按需进入。
+- `performance/`：runtime / viewer 性能观测与方法学。
+- `manual/`：系统测试手册分册与 Web UI 闭环 manual。
+- `chaos-plans/`：专项 chaos plan 入口。
 
 ## 高密度提示
-- `doc/testing/` 当前共有 194 份文件；这一层入口不再尝试把热点专题直接摊平展示。
+- 本页不维护静态文件数量；这些数字容易随任务流转漂移，不能作为默认阅读面的判断依据。
 - 需要完整活跃专题清单时，进入 `doc/testing/prd.index.md`；进入 `evidence/` 时，优先先读 `doc/testing/evidence/README.md` 再继续下钻；需要 template / blocker 留痕时，再按具体子域进入。
 
 ## 共享约定

--- a/doc/testing/manual/systematic-application-testing-manual.design.md
+++ b/doc/testing/manual/systematic-application-testing-manual.design.md
@@ -1,29 +1,21 @@
-# oasis7：系统性应用测试手册工程化收口（2026-02-26）设计
+# oasis7：系统性应用测试手册工程化收口（历史设计记录）
 
+- 当前 canonical 手册: `testing-manual.md`
 - 对应需求文档: `doc/testing/manual/systematic-application-testing-manual.prd.md`
 - 对应项目管理文档: `doc/testing/manual/systematic-application-testing-manual.project.md`
 
-## 1. 设计定位
-定义测试手册专题设计，统一系统性测试、Web UI Playwright 闭环与工程化维护方式。
+## 状态
+- 当前状态: completed / historical
+- 默认阅读面: 不作为当前执行设计入口；测试手册结构、执行步骤、工具链对齐与维护约定以 `testing-manual.md` 及 Web UI 分册为准。
 
-## 2. 设计结构
-- 手册结构层：明确入口、章节组织与适用范围。
-- 执行方法层：沉淀测试步骤、命令模板与证据要求。
-- 工具链对齐层：把 Playwright、系统测试与门禁口径统一到手册。
-- 维护治理层：建立版本更新、引用互链与长期维护约定。
+## 历史设计摘要
+- 手册结构层: 明确入口、章节组织与适用范围。
+- 执行方法层: 沉淀测试步骤、命令模板与证据要求。
+- 工具链对齐层: 把系统测试、Web 闭环与门禁口径统一到手册。
+- 维护治理层: 建立版本更新、引用互链与长期维护约定。
 
-## 3. 关键接口 / 入口
-- 测试手册入口
-- 步骤/命令模板
-- Playwright / 系统测试链接点
-- 手册维护约定
-
-## 4. 约束与边界
-- 手册必须服务真实测试流程而非重复 PRD。
-- 命令与步骤需可直接执行或映射。
-- 不在本专题扩展新的测试框架。
-
-## 5. 设计演进计划
-- 先固化手册目录与范围。
-- 再补步骤模板和工具链对齐。
-- 最后沉淀维护约定。
+## Current References
+- 标准测试手册: `testing-manual.md`
+- Web UI 闭环分册: `doc/testing/manual/web-ui-agent-browser-closure-manual.manual.md`
+- Web UI 闭环 PRD: `doc/testing/manual/web-ui-agent-browser-closure-manual.prd.md`
+- CI 入口: `scripts/ci-tests.sh`

--- a/doc/testing/manual/systematic-application-testing-manual.prd.md
+++ b/doc/testing/manual/systematic-application-testing-manual.prd.md
@@ -1,113 +1,62 @@
-# oasis7：系统性应用测试手册工程化收口（2026-02-26）
+# oasis7：系统性应用测试手册工程化收口（历史决策记录）
 
+- 当前 canonical 手册: `testing-manual.md`
 - 对应设计文档: `doc/testing/manual/systematic-application-testing-manual.design.md`
 - 对应项目管理文档: `doc/testing/manual/systematic-application-testing-manual.project.md`
 
-审计轮次: 4
+审计轮次: 5
 
+## 状态
+- 当前状态: completed / historical
+- 默认阅读面: 不作为当前测试执行入口；当前测试层级、套件矩阵、Web 闭环与证据口径以 `testing-manual.md` 为准。
+- 保留原因: 记录 2026-02-26 手册工程化收口的需求决策，维持 PRD/project traceability。
 
-## 1. Executive Summary
+## 历史决策摘要
 - Problem Statement: 测试分层模型、触发矩阵与证据标准若分散在多处文档/脚本，容易出现执行口径漂移，导致“通过门禁但风险未覆盖”。
-- Proposed Solution: 以 `testing-manual.md` 作为统一入口，配套 Web 闭环分册与脚本入口，固化 Human/AI 共用的可审计测试流程。
+- Selected Solution: 以 `testing-manual.md` 作为统一入口，配套 Web 闭环分册与脚本入口，固化 Human/AI 共用的可审计测试流程。
 - Success Criteria:
-  - SC-1: `testing-manual.md` 稳定承载分层模型（L0~L5）与套件映射（S0~S10）。
-  - SC-2: 手册、脚本入口与 CI 门禁口径一致，不出现冲突说明。
-  - SC-3: Web 闭环分册与主手册引用稳定，执行路径唯一。
-  - SC-4: 改动路径到必跑套件映射可复用，发布前可直接判定 required/full 组合。
-  - SC-5: 文档迁移后命名统一为 `.prd.md/.project.md`，并通过文档治理检查。
+  - `testing-manual.md` 稳定承载分层模型与套件映射。
+  - 手册、脚本入口与 CI 门禁口径一致。
+  - Web 闭环分册与主手册引用稳定，执行路径唯一。
+  - 改动路径到必跑套件映射可复用，发布前可直接判定 required/full 组合。
+  - 文档迁移后命名统一为 `.prd.md/.project.md`，并通过文档治理检查。
 
-## 2. User Experience & Functionality
-- User Personas:
-  - 测试维护者：负责维护分层模型、触发矩阵与证据标准。
-  - 功能开发者：根据改动路径选择最小必跑套件。
-  - 发布负责人：基于证据包进行放行判断。
-- User Scenarios & Frequency:
-  - 每次核心功能改动后：执行 required 路径并核对证据。
-  - 每次发布前：执行 required + full，并回收审计证据。
-  - 每次测试体系变更后：同步手册与脚本入口，避免口径漂移。
-- User Stories:
-  - PRD-TESTING-MANUAL-001: As a 测试维护者, I want one canonical manual, so that test rules stay consistent.
-  - PRD-TESTING-MANUAL-002: As a 开发者, I want clear suite mapping, so that I can run the right tests efficiently.
-  - PRD-TESTING-MANUAL-003: As a 发布负责人, I want auditable test evidence, so that release decisions are traceable.
-- Critical User Flows:
-  1. Flow-TMAN-001: `识别改动范围 -> 对照 L0~L5/S0~S10 -> 生成必跑清单`
-  2. Flow-TMAN-002: `执行脚本入口 -> 收集命令/日志/截图 -> 填写结论`
-  3. Flow-TMAN-003: `发布前复核证据包 -> 校验缺失项 -> 放行或阻断`
-  4. Flow-TMAN-004: `更新 Web 分册或门禁脚本 -> 回写主手册引用 -> 重新校验`
-- Functional Specification Matrix:
-| 功能点 | 字段定义 | 按钮/动作行为 | 状态转换 | 排序/计算规则 | 权限逻辑 |
-| --- | --- | --- | --- | --- | --- |
-| 手册主入口维护 | `testing-manual.md`、章节索引、版本日期 | 更新主手册并发布统一口径 | `draft -> active -> archived` | 主手册优先级最高 | 测试维护者维护 |
-| 分层与套件映射 | `L0~L5`、`S0~S10`、触发条件 | 按改动路径选择 required/full | `planned -> running -> verified` | required 为默认下限，发布叠加 full | 开发/测试共用 |
-| 证据规范 | 命令、日志、截图、结论、责任人 | 执行后归档证据包并审阅 | `collecting -> reviewed -> accepted/rejected` | 缺字段即不通过 | 发布负责人审核 |
-| Web 分册联动 | 分册路径、脚本入口、GPU/headed 约束 | 按分册执行 Web 闭环并回填结果 | `linked -> executed -> traced` | 主手册引用必须可达 | 测试维护者与执行人 |
-- Acceptance Criteria:
-  - AC-1: 主手册包含分层模型、套件矩阵、执行与证据规则。
-  - AC-2: Web 闭环细节以分册维护，主手册保留唯一引用入口。
-  - AC-3: `scripts/ci-tests.sh` 与发布脚本在手册中可追踪到对应章节。
-  - AC-4: required/full 判定标准可直接用于任务收口。
-  - AC-5: 本专题迁移后命名统一且引用无断链。
-- Non-Goals:
-  - 不在本专题新增业务功能测试代码。
-  - 不在本专题引入新的测试框架。
-  - 不在本专题重写所有历史 devlog。
+## Traceability
+| PRD-ID | 历史目标 | 当前权威入口 |
+| --- | --- | --- |
+| PRD-TESTING-MANUAL-001 | one canonical manual | `testing-manual.md` |
+| PRD-TESTING-MANUAL-002 | clear suite mapping | `testing-manual.md` 的 L0-L5 / S0-S10 与 required/full 章节 |
+| PRD-TESTING-MANUAL-003 | auditable test evidence | `testing-manual.md`、`doc/testing/templates/release-evidence-bundle-template.md`、`doc/testing/evidence/README.md` |
 
-## 3. AI System Requirements (If Applicable)
-- Tool Requirements: 不适用（本专题为测试手册工程化与执行口径收口，不涉及 AI 推理系统改造）。
-- Evaluation Strategy: 不适用。
+## 目标
+- 历史目标已完成：统一分层测试模型、触发矩阵与证据标准，并把当前执行入口收口到 `testing-manual.md`。
+- 本文件现在只保留历史决策和 traceability，不再重复当前手册正文。
 
-## 4. Technical Specifications
-- Architecture Overview: 以 `testing-manual.md` 为主入口，`doc/testing/manual/web-ui-agent-browser-closure-manual.manual.md` 为 Web 闭环操作分册，`doc/testing/manual/web-ui-agent-browser-closure-manual.prd.md` 为需求/验收权威源，脚本入口负责执行层闭环，四者通过引用关系保持一致。
-- Integration Points:
-  - `testing-manual.md`
-  - `doc/testing/manual/web-ui-agent-browser-closure-manual.manual.md`
-  - `doc/testing/manual/web-ui-agent-browser-closure-manual.prd.md`
-  - `scripts/ci-tests.sh`
-  - `scripts/viewer-primary-web-entry-regression.sh`
-  - `scripts/viewer-software-safe-step-regression.sh`
-  - `scripts/viewer-software-safe-chat-regression.sh`
-- Edge Cases & Error Handling:
-  - 文档与脚本不同步：以主手册为准，变更同批次修复引用。
-  - 套件入口分散：强制通过主手册索引归并，避免重复入口。
-  - 证据缺失：判定为测试未完成，禁止发布放行。
-  - Web 闭环环境异常：按分册 fail-fast 分级归档并阻断。
-- Non-Functional Requirements:
-  - NFR-TMAN-1: 手册更新后 1 个工作日内完成相关入口引用修正。
-  - NFR-TMAN-2: 发布证据字段完整率维持 100%。
-  - NFR-TMAN-3: 主手册与分册引用检查零断链。
-  - NFR-TMAN-4: required 路径说明应在 10 分钟内可定位执行命令。
-- Security & Privacy: 文档与证据包不得记录密钥/凭据，日志需遵循最小暴露原则。
+## 范围
+- In scope: 保留手册工程化收口的历史需求、决策、PRD-ID 映射和 canonical redirect。
+- Out of scope: 不新增测试框架、不重写当前 `testing-manual.md`、不替代 Web UI 闭环分册。
 
-## 5. Risks & Roadmap
-- Phased Rollout:
-  - MVP (TMAN-1): 完成手册迁移与命名统一。
-  - v1.1 (TMAN-2): 收口分层模型（L0~L5）与套件矩阵（S0~S10）。
-  - v2.0 (TMAN-3): 完成 Web 分册拆分、引用与门禁口径对齐。
-  - v2.1 (TMAN-4): 持续维护增量规则并同步 CI 变更。
-  - v2.2 (TMAN-5): 本专题 strict schema 人工迁移与命名统一收口。
-- Technical Risks:
-  - 风险-1: 手册更新滞后于脚本变更，导致执行失败。
-  - 风险-2: Web 分册与主手册引用漂移，造成双口径。
-  - 风险-3: 团队绕过手册直接执行脚本，证据质量下降。
+## 接口 / 数据
+- 当前手册入口: `testing-manual.md`
+- Web UI 闭环分册: `doc/testing/manual/web-ui-agent-browser-closure-manual.manual.md`
+- 发布证据模板: `doc/testing/templates/release-evidence-bundle-template.md`
+- evidence 分流入口: `doc/testing/evidence/README.md`
 
-## 6. Validation & Decision Record
-- Test Plan & Traceability:
-| PRD-ID | 对应任务 | 测试层级 | 验证方法 | 回归影响范围 |
-| --- | --- | --- | --- | --- |
-| PRD-TESTING-MANUAL-001 | TMAN-1/2/5 | `test_tier_required` | 手册章节与触发矩阵人工审阅 + 文档治理检查 | 测试主入口一致性 |
-| PRD-TESTING-MANUAL-002 | TMAN-2/3/4 | `test_tier_required` | 分层模型与套件映射抽样校验 | 改动路径必跑集合判定 |
-| PRD-TESTING-MANUAL-003 | TMAN-3/4/5 | `test_tier_required` | 证据规范字段核验 + 引用回归扫描 | 发布放行与审计追溯 |
-- Decision Log:
+## 里程碑
+- TMAN-1: 完成手册迁移与主入口命名统一。
+- TMAN-2: 收口分层模型与套件矩阵。
+- TMAN-3: 完成 Web 闭环分册拆分并建立主手册引用入口。
+- TMAN-4: 持续补齐 fail-fast、GPU/headed 门禁与运行约束。
+- TMAN-5: 专题文档人工迁移到 strict schema 并统一命名。
+
+## 风险
+- 当前主要风险是历史规划文档被误读为当前执行入口；本文件通过 `completed / historical` 状态和 canonical 手册 redirect 降低该风险。
+- 若 `testing-manual.md` 与脚本/CI 入口漂移，应更新当前 canonical 手册和对应 task evidence，而不是在本历史 PRD 中复制新规则。
+
+## Historical Decisions
 | 决策ID | 选定方案 | 备选方案（否决） | 依据 |
 | --- | --- | --- | --- |
 | DEC-TMAN-001 | 主手册 + 分册双层结构 | 所有细节堆叠在单文档 | 保持可读性并降低维护冲突。 |
 | DEC-TMAN-002 | required/full 分层执行策略 | 每次全量执行 | 兼顾执行效率与发布覆盖。 |
 | DEC-TMAN-003 | 证据包作为发布门禁硬要求 | 仅口头确认结果 | 无法支撑审计与追溯。 |
 | DEC-TMAN-004 | legacy 文档逐篇人工迁移 | 脚本批量改写 | 保证内容语义与约束完整保真。 |
-
-## 原文约束点映射（内容保真）
-- 原“目标：统一分层测试模型、触发矩阵、证据标准” -> 第 1 章 Problem/Solution/SC 与第 2 章功能矩阵。
-- 原“In Scope/Out of Scope” -> 第 2 章 AC/Non-Goals。
-- 原“接口/数据（主手册、分册、脚本入口）” -> 第 4 章 Integration Points。
-- 原“M1~M4 里程碑” -> 第 5 章 phased rollout（TMAN-1~TMAN-5）。
-- 原“风险（手册脚本不同步、入口分散）” -> 第 4 章边界处理 + 第 5 章风险。

--- a/doc/testing/manual/systematic-application-testing-manual.project.md
+++ b/doc/testing/manual/systematic-application-testing-manual.project.md
@@ -1,9 +1,10 @@
-# 系统性应用测试手册工程化收口（项目管理文档）
+# 系统性应用测试手册工程化收口（历史项目记录）
 
+- 当前 canonical 手册: `testing-manual.md`
 - 对应设计文档: `doc/testing/manual/systematic-application-testing-manual.design.md`
 - 对应需求文档: `doc/testing/manual/systematic-application-testing-manual.prd.md`
 
-审计轮次: 4
+审计轮次: 5
 
 ## 任务拆解（含 PRD-ID 映射）
 - [x] TMAN-1 (PRD-TESTING-MANUAL-001): 完成手册迁移与主入口命名统一（`testing-manual.md`）。
@@ -12,19 +13,15 @@
 - [x] TMAN-4 (PRD-TESTING-MANUAL-002/003): 按 CI 与执行经验持续补齐 fail-fast、GPU/headed 门禁与运行约束。
 - [x] TMAN-5 (PRD-TESTING-004): 专题文档人工迁移到 strict schema 并统一 `.prd.md/.project.md` 命名。
 
+## 状态
+- 更新日期: 2026-06-16
+- 当前阶段: 已完成 / 历史追溯
+- 阻塞项: 无
+- 下一步: 无；当前测试执行与维护请进入 `testing-manual.md`、`doc/testing/prd.md`、`doc/testing/project.md`。
+
 ## 依赖
-- doc/testing/manual/systematic-application-testing-manual.prd.md
 - `testing-manual.md`
 - `doc/testing/manual/web-ui-agent-browser-closure-manual.prd.md`
 - `scripts/ci-tests.sh`
-- `scripts/viewer-primary-web-entry-regression.sh`
-- `scripts/viewer-software-safe-step-regression.sh`
-- `scripts/viewer-software-safe-chat-regression.sh`
 - `doc/testing/prd.md`
 - `doc/testing/project.md`
-
-## 状态
-- 更新日期：2026-03-03
-- 当前阶段：已完成
-- 阻塞项：无
-- 下一步：无（manual 批次迁移已收口）

--- a/doc/testing/performance/performance-coverage-gap-matrix-2026-06-09.md
+++ b/doc/testing/performance/performance-coverage-gap-matrix-2026-06-09.md
@@ -16,7 +16,7 @@
 ## 补测矩阵
 | Surface | 当前已有覆盖 | 当前缺口 | 建议补充 | 建议 tier | 优先级 |
 | --- | --- | --- | --- | --- | --- |
-| Viewer Web 帧率 / frame time | `./scripts/viewer-performance-probe.sh --profile smoke|release`；`test:perf-harness` 覆盖部分前端性能指标 contract | PR 默认 gate 不盯 FPS / frame p95 / long task，Viewer 改动可能到人工验收才暴露卡顿 | 把 `viewer-performance-probe.sh --profile smoke` 做成 `crates/oasis7_viewer/**` 命中时的 changed-path scoped gate，保留 `release` profile 给更高风险改动 | `required-scoped` | P1 |
+| Viewer Web 帧率 / frame time | `./scripts/viewer-performance-probe.sh --profile smoke|release`；`test:perf-harness` 覆盖部分前端性能指标 contract；`testing-manual.md` / `scripts/ci-tests.sh` 已将 `smoke` profile 接入 `crates/oasis7_viewer/**` 命中时的 required-gate report-only scoped smoke | 当前缺口不再是“没有 scoped gate 入口”，而是阈值、环境噪音和 blocking rollout 尚未稳定；report-only failure 会被记录为 warning，不阻断 required-gate | 继续收集 `summary.json` / `summary.md`，稳定 `readyMs`、FPS、frame p95、long task count 的基线与噪音边界，再决定是否从 report-only 升级为 blocking | `required-scoped` report-only | P1 |
 | Viewer headed Web 真环境渲染 | 有 `agent-browser` 闭环、software-safe contract、build/UI tests | 当前缺少“真实 headed + GPU 路径”的轻量性能回归，容易只测 DOM/contract 不测渲染体感 | 补一条 headed smoke profile，记录 `readyMs`、FPS、frame p95、long task count，并把 SwiftShader/软件渲染继续当环境阻断处理 | `full-scoped` | P2 |
 | Viewer 移动端 / 窄屏性能 | 现有手册强调 desktop/mobile 截图与 visual review，但性能 probe 主要围绕当前默认 Viewer Web 入口 | 缺少移动布局下 DOM 规模、ready time、交互响应的独立预算 | 给 `viewer-performance-probe.mjs` 增加 mobile viewport profile，至少落 `readyMs + frame p95 + DOM size` | `on-demand`，稳定后可升 `required-scoped` | P2 |
 | Runtime tick / step 热路径 | `test_tier_required/full` 覆盖正确性；`llm-longrun-stress.sh` 会产出 `runtime_perf.tick.p95_ms` 等指标；`./scripts/runtime-module-routing-perf-harness.sh` 已补上稳定内环 module routing micro harness，并已有首个 `release` baseline（`event_avg_ms=5.591`、`action_avg_ms=6.992`、`modules=192`、`iterations=80`） | 现阶段轻量 harness 只覆盖 runtime module routing 内环，尚未扩到更完整 tick/step 预算；冷 `release` 编译耗时仍偏高 | 下一步把更多稳定热路径收进同一 summary/checklist，并评估哪些指标适合变成 scoped gate | `required-scoped`（仅限稳定 harness 命中路径）候选 | P1 |
@@ -29,7 +29,7 @@
 | 跨 surface 统一预算口径 | 局部有 compile closure/size、Viewer probe、release soak 阈值 | 缺少统一的 surface budget 表，导致哪些指标算退化依赖人记忆 | 建一份 repo-level perf budget 表，只维护少量核心指标：Viewer FPS/frame p95、runtime tick p95、launcher build/size、soak stall/lag | 先文档化，后逐步接 gate | P2 |
 
 ## 建议优先顺序
-1. 先补 Viewer changed-path scoped 性能 gate，因为这是最容易感知、也最容易退化的用户面。
+1. 继续收敛 Viewer changed-path scoped 性能 gate，因为 report-only 入口已经存在，下一步风险在阈值、噪音与 blocking rollout。
 2. 再补 runtime tick/step 的轻量 deterministic perf harness，减少只能靠长跑发现性能退化的问题。
 3. 然后补 P2P/存储/共识的短窗 scoped soak，把一部分 release 才暴露的问题前移。
 4. 最后再考虑 launcher runtime startup perf、LLM/provider latency 预算和 WASM ignored probes 的标准化。
@@ -37,12 +37,12 @@
 ## 先做哪三项
 | Rank | Item | Why now | Minimum deliverable | Gate recommendation | Rollout caution |
 | --- | --- | --- | --- | --- | --- |
-| 1 | Viewer changed-path scoped 性能 gate | Viewer 是最直接的用户面，掉帧/卡顿最容易被感知；现有 `viewer-performance-probe.sh` 已经存在，补 gate 的改造成本最低 | 在 `crates/oasis7_viewer/**` 命中时运行 `./scripts/viewer-performance-probe.sh --profile smoke`，先稳定产出 `summary.json`/`summary.md` 与基础阈值结果 | 先做 `required-scoped` 候选 | 前几轮建议 `report-only`，先稳定阈值和环境噪音，再转 blocking |
+| 1 | Viewer changed-path scoped 性能 gate | Viewer 是最直接的用户面，掉帧/卡顿最容易被感知；现有 `viewer-performance-probe.sh` 已经进入 required-gate report-only scoped smoke | 已在 `crates/oasis7_viewer/**` 命中时运行 `./scripts/viewer-performance-probe.sh --profile smoke`，并稳定产出 `summary.json`/`summary.md`；下一步是积累基线与阈值噪音样本 | `required-scoped` report-only，blocking 仍待决策 | 不要在阈值和环境噪音稳定前转 blocking；report-only warning 不是 release/PR 阻断结论 |
 | 2 | Runtime tick/step 轻量 deterministic perf harness | 当前 runtime 性能更多靠 longrun/stress 暴露，反馈太晚；需要一条能日常回归的热路径预算 | 第一阶段已落 `./scripts/runtime-module-routing-perf-harness.sh`，固定输入输出 `event/action avg ms`；首个 `release` baseline 为 `event_avg_ms=5.591`、`action_avg_ms=6.992`；后续再扩到更接近 tick/step 的稳定指标 | 先保持本地/reporting 入口，再评估 `required-scoped` 候选 | 不要一开始就拿整场景总耗时做 gate，优先选最稳定的内环指标，避免 flaky；冷 `release` 编译成本也要一起纳入 gate 设计 |
 | 3 | P2P/存储/共识短窗 scoped soak | 这类退化现在太容易拖到 release soak 才暴露，修复成本高；需要前移一条便宜但有代表性的短窗检查 | 为 `oasis7_node/**`、`oasis7_net/**`、复制/存储高风险改动准备一个 reduced-duration soak 命令和统一 summary 判读 | 开发期先 `on-demand`，高风险合流或 release 前强制 | 必须按 changed paths 和风险等级触发，不能把 release 级长跑成本扩散到普通 PR |
 
 ## 实施顺序建议
-1. 先做第 1 项，因为脚本和指标基础已经存在，最容易快速落成一条可见收益高的 gate。
+1. 继续推进第 1 项，因为脚本、指标基础和 report-only scoped gate 已存在，最需要补的是基线样本与 blocking 决策。
 2. 再做第 2 项，因为 runtime 缺的不是“有没有长跑”，而是“有没有日常可回归的小预算”。
 3. 第 3 项随后做，因为它收益很高，但执行成本和 CI 时长影响也更大，需要在 scoped 触发条件上更谨慎。
 
@@ -50,7 +50,7 @@
 - Viewer changed-path scoped 性能 gate:
   - changed-path planner 能识别 `crates/oasis7_viewer/**`
   - smoke profile 能稳定落 summary 产物
-  - 至少完成一轮 report-only 基线收集
+  - 当前状态为 required-gate report-only scoped smoke；后续完成定义是积累足够基线，明确哪些阈值可升级为 blocking
 - Runtime tick/step harness:
   - 至少 1 个稳定 hot path 场景
   - 指标输出可机读

--- a/doc/testing/prd.index.md
+++ b/doc/testing/prd.index.md
@@ -2,7 +2,7 @@
 
 审计轮次: 10
 
-更新时间：2026-05-06
+更新时间：2026-06-16
 
 ## 入口
 - 模块 PRD：`doc/testing/prd.md`
@@ -24,30 +24,22 @@
 - 想先进入 `evidence` 热点子域，并按 release gate / hosted-world / p2p-shared-network / governance drill / claim-audit 问题分流：先读 `doc/testing/evidence/README.md`
 - 想继续按子域或文件名下钻：使用下方热点子域导航，再跳到对应清单区域
 
-## 密度快照（2026-05-06）
-- `doc/testing/`：194 份文件
-- `doc/testing/evidence/`：49 份文件
-- `doc/testing/ci/`：33 份文件
-- `doc/testing/longrun/`：24 份文件
-- `doc/testing/launcher/`：18 份文件
-- `doc/testing/governance/`：28 份文件
-- `doc/testing/templates/`：16 份文件
-- `doc/testing/performance/`：12 份文件
-- `doc/testing/manual/`：7 份文件
-- `doc/testing/chaos-plans/`：1 份文件
+## 密度说明
+- 本索引不维护静态文件数量；数量快照容易漂移，只能作为历史审计材料，不作为默认阅读顺序或覆盖完整性的依据。
+- 需要重新统计时，使用 `find doc/testing -type f` / `rg --files doc/testing` 等当前命令输出，并把结果写入具体审计任务，而不是手工更新本页。
 
 ## 热点子域导航
-| 子域 | 文件数 | 适合回答的问题 |
-| --- | --- | --- |
-| `evidence/` | 49 | 发布证据、趋势基线与审计留痕；当前已补 `evidence/README.md` 作为热点子域入口 |
-| `ci/` | 33 | CI、wasm determinism、tiering、required check 保护 |
-| `longrun/` | 24 | 长稳、chaos、soak 与在线稳定性 |
-| `launcher/` | 18 | 启动器链路测试、playtest 与配置自动接线 |
-| `governance/` | 28 | 质量趋势、release-gate 指标、审计检查、好玩性证据栈、L4 synthetic/human 分层、subagent 评审系统与 simulated personas |
-| `templates/` | 12 | 证据包、报告、模型视觉评审卡与检查清单模板；默认按需进入 |
-| `performance/` | 12 | runtime / viewer 性能观测与方法学 |
-| `manual/` | 7 | 系统测试手册分册与 Web UI 闭环 manual |
-| `chaos-plans/` | 1 | 专项 chaos plan 入口 |
+| 子域 | 适合回答的问题 |
+| --- | --- |
+| `evidence/` | 发布证据、趋势基线与审计留痕；当前已补 `evidence/README.md` 作为热点子域入口 |
+| `ci/` | CI、wasm determinism、tiering、required check 保护 |
+| `longrun/` | 长稳、chaos、soak 与在线稳定性 |
+| `launcher/` | 启动器链路测试、playtest 与配置自动接线 |
+| `governance/` | 质量趋势、release-gate 指标、审计检查、好玩性证据栈、L4 synthetic/human 分层、subagent 评审系统与 simulated personas |
+| `templates/` | 证据包、报告、模型视觉评审卡与检查清单模板；默认按需进入 |
+| `performance/` | runtime / viewer 性能观测与方法学 |
+| `manual/` | 系统测试手册分册与 Web UI 闭环 manual |
+| `chaos-plans/` | 专项 chaos plan 入口 |
 
 ## 活跃补充文档
 - `doc/testing/evidence/README.md`：`evidence/` 热点子域 landing page，按 release gate、hosted-world、p2p/shared-network、governance drill 与 claim/audit 分流读者。
@@ -59,7 +51,7 @@
 
 ## 默认阅读面边界
 - 本页首屏只负责分流，不再要求读者从第一行开始顺扫完整长表。
-- README 不再平铺“近期专题”；完整清单继续保留在下方，用于精确文件名检索和互链可达性。
+- README 不再平铺“近期专题”；专题清单继续保留在下方，用于精确文件名检索和互链可达性。
 - `evidence/README.md` 负责最高密度热点子域的首读分流；完整长表继续由本页与目标 evidence 文件承担。
 - 手册、blocker、evidence 与 template 等 supporting / 审计材料继续保留可检索性，但不并入模块 PRD 三件套长表。
 
@@ -69,7 +61,9 @@
 - 排除规则：不纳入 `doc/devlog/**`、`doc/testing/evidence/**`、`doc/testing/templates/**` 与其他非 PRD 配对文档。
 - 按需进入：evidence、template、blocker、closure 说明与历史归档继续保留可检索性；除非它们重新成为当前 operator 或 owner 的直接入口，否则不进入默认首屏。
 
-## 完整活跃专题清单（按文件名精确检索）
+## 专题清单（含历史完成项，按文件名精确检索）
+本表用于互链可达性和 traceability，不代表每一行都是默认首读或当前活跃执行面；已完成的规划三件套应先读其 redirect / historical status，再进入当前 canonical 手册或 topic 文档。
+
 | 专题 PRD | 专题设计文档 | 专题项目文档 |
 | --- | --- | --- |
 | `doc/testing/ci/ci-builtin-wasm-determinism-gate-m1.prd.md` | `doc/testing/ci/ci-builtin-wasm-determinism-gate-m1.design.md` | `doc/testing/ci/ci-builtin-wasm-determinism-gate-m1.project.md` |

--- a/doc/testing/project.md
+++ b/doc/testing/project.md
@@ -1,455 +1,58 @@
 # testing PRD Project
 
-审计轮次: 9
+审计轮次: 10
 
-## 任务拆解（含 PRD-ID 映射）
-- [x] viewer-world-tick-readout (PRD-TESTING-002/003) [test_tier_required]: 在 Viewer 的 persistent readout 与 World Focus HUD 中显示当前世界 tick，并为 DTO/readout/runtime-derived render-state 路径补 UI 回归测试。 Trace: .pm/tasks/task_8c585fc8ac964a3bbc197946f843e2ba.yaml
-- [x] local-playtest-entrypoint-slimming (PRD-TESTING-002/003) [test_tier_required]: 将本地游戏试玩入口收敛成 `2 + 1` 操作菜单：真实本地 LetAI、producer/release bundle-first 人工试玩、QA/subagent evidence，并把底层 launcher bootstrap / A-B sentinel 降级为高级或自动化路径。 Trace: .pm/tasks/task_b7c7e7e3a3474eb9bf5379fe65c7387c.yaml
-- [ ] test-coverage-gate-fill (PRD-TESTING-002/PRD-TESTING-003) [test_tier_required] + [test_tier_full]: 补齐 Rust CI 测试覆盖缺口，让 `full-support` 直接触达 workspace support crates，并为 `required-gate` changed-path planner 增加 regression，防止未分类代码路径绕过 full fallback。 Trace: .pm/tasks/task_ce44b8a269824fbcb718febd2140c425.yaml
-- [x] playability-governance-stack-2026-05-06 (PRD-TESTING-007/008/009/010) [test_tier_required]: 本页将“好玩性证据栈 / subagent 评审系统 / 模拟玩家 persona 面板 / L4 synthetic-agent 分层”四个 2026-05-06 专题收口为单个 bundle 入口，便于浏览；当前同批 follow-up 已补 repo-local `L4` scaffold/wrapper + `L4B` runner，使同一 worktree 内可以直接准备 packet、role/persona cards、summary、`L4B` agent 卡，并执行一次会自动落 summary/state/screenshot 的 embodied-agent run，以及可选内部真人佐证 notes。 Trace: .pm/tasks/task_efe1a5f949e84160a1237302c9064168.yaml
-  - Bundle includes: `playability-subagent-review-system-2026-05-06`、`playability-simulated-player-persona-panel-2026-05-06`、`playability-l4-synthetic-human-split-2026-05-06`
-  - Related traces: `.pm/tasks/task_9a6bbbc3022f4d4e8a3f5f99fab4d1b2.yaml`、`.pm/tasks/task_a9d3c884a3074ab2b0f3b10dab7bb86e.yaml`、`.pm/tasks/task_a68decb0a2c8460aa7d989df7370c901.yaml`
-- [x] model-visual-review-sop (PRD-TESTING-011) [test_tier_required]: 建立截图加模型视觉评审的 canonical SOP 与输出模板，把 routine 人工视觉 review 收敛为模型默认评审，并明确 `pass/watch/block/human_escalation`、低置信升级、GitHub required review 与对外 claim 边界。 Trace: .pm/tasks/task_0f9cda4621c14812861639d597e0b6b5.yaml
-- [x] shared-player-gameplay-contract-parity (PRD-TESTING-003) [test_tier_required]: 收口 `software_safe` / `pure_api` 共享 `snapshot.player_gameplay` 的玩家可读语义 contract，补 active-LLM scope、旧 no-LLM 口径退役说明，以及 pure API parity smoke 对“同一组玩家问题”的显式摘要。 Trace: .pm/tasks/task_ebf98fe337b44bd8b10e7574316dee67.yaml
-- [x] TASK-TESTING-001 (PRD-TESTING-001) [test_tier_required]: 完成 testing PRD 改写，建立分层测试设计入口。
-- [x] TASK-TESTING-002 (PRD-TESTING-001/002) [test_tier_required]: 对齐 S0~S10 与改动路径触发矩阵。
-  - 产物文件:
-    - `testing-manual.md`
-  - 验收命令 (`test_tier_required`):
-    - `rg -n "套件触发总表|改动路径矩阵|选择规则|S0|S10" testing-manual.md`
-- [x] TASK-TESTING-003 (PRD-TESTING-002/003) [test_tier_required]: 建立发布证据包模板（命令、日志、截图、结论）。
-  - 产物文件:
-    - `doc/testing/templates/release-evidence-bundle-template.md`
-  - 验收命令 (`test_tier_required`):
-    - `test -f doc/testing/templates/release-evidence-bundle-template.md`
-    - `rg -n "执行命令|UI / 体验证据|长跑 / 在线证据|结论摘要|PRD-ID" doc/testing/templates/release-evidence-bundle-template.md`
-- [x] TASK-TESTING-004 (PRD-TESTING-003) [test_tier_required]: 建立测试质量趋势跟踪（通过率/逃逸率/修复时长）。
-  - 产物文件:
-    - `doc/testing/governance/testing-quality-trend-tracking-2026-03-11.prd.md`
-    - `doc/testing/governance/testing-quality-trend-tracking-2026-03-11.design.md`
-    - `doc/testing/governance/testing-quality-trend-tracking-2026-03-11.project.md`
-    - `doc/testing/evidence/testing-quality-trend-baseline-2026-03-11.md`
-  - 验收命令 (`test_tier_required`):
-    - `test -f doc/testing/governance/testing-quality-trend-tracking-2026-03-11.prd.md`
-    - `test -f doc/testing/evidence/testing-quality-trend-baseline-2026-03-11.md`
-    - `rg -n "首次通过率|阶段内逃逸率|平均修复时长|红黄绿阈值" doc/testing/governance/testing-quality-trend-tracking-2026-03-11.prd.md doc/testing/evidence/testing-quality-trend-baseline-2026-03-11.md`
-- [x] playability-player-leverage-evidence-rubric (PRD-TESTING-003) [test_tier_required]: 要求正式 gameplay/trust evidence packet 显式回答“玩家做了什么、世界因此变了什么”，并补 `world_activity_only` 防误报字段与 trust-gate 样例回写。 Trace: .pm/tasks/task_ca4ecaf214c4430eb93a0f7e9bae9493.yaml
-- [x] TASK-TESTING-005 (PRD-TESTING-002/003) [test_tier_required]: 建立模块级专题任务映射索引（2026-03-02 批次）。
-- [x] TASK-TESTING-006 (PRD-TESTING-001/002/003) [test_tier_required]: 对齐 strict PRD schema，补齐关键流程/规格矩阵/边界异常/NFR/验证与决策记录。
-- [x] TASK-TESTING-007 (PRD-TESTING-004) [test_tier_required]: 完成 `ci-wasm32-target-install` 专题文档逐篇人工迁移到 strict schema，并统一 `.prd` 命名。
-- [x] TASK-TESTING-008 (PRD-TESTING-004) [test_tier_required]: 继续按批次迁移 testing 活跃 legacy 专题文档（优先 `governance/launcher/longrun/performance/manual`）。
-- [x] TASK-TESTING-009 (PRD-TESTING-004) [test_tier_required]: 完成 `ci-testcase-tiering` 专题文档逐篇人工迁移到 strict schema，并统一 `.prd` 命名。
-- [x] TASK-TESTING-010 (PRD-TESTING-004) [test_tier_required]: 完成 `ci-tiered-execution` 专题文档逐篇人工迁移到 strict schema，并统一 `.prd` 命名。
-- [x] TASK-TESTING-011 (PRD-TESTING-004) [test_tier_required]: 完成 `ci-test-coverage` 专题文档逐篇人工迁移到 strict schema，并统一 `.prd` 命名。
-- [x] TASK-TESTING-012 (PRD-TESTING-004) [test_tier_required]: 完成 `ci-builtin-wasm-determinism-gate-m1` 专题文档逐篇人工迁移到 strict schema，并统一 `.prd` 命名。
-- [x] TASK-TESTING-013 (PRD-TESTING-004) [test_tier_required]: 完成 `ci-builtin-wasm-determinism-gate-required-check-protection` 专题文档逐篇人工迁移到 strict schema，并统一 `.prd` 命名。
-- [x] TASK-TESTING-014 (PRD-TESTING-004) [test_tier_required]: 完成 `ci-remove-builtin-wasm-hash-checks-from-base-gate` 专题文档逐篇人工迁移到 strict schema，并统一 `.prd` 命名。
-- [x] TASK-TESTING-015 (PRD-TESTING-004) [test_tier_required]: 完成 `wasm-build-determinism-guard` 专题文档逐篇人工迁移到 strict schema，并统一 `.prd` 命名。
-- [x] TASK-TESTING-016 (PRD-TESTING-004) [test_tier_required]: 完成 `release-gate-metric-policy-alignment-2026-02-28` 专题文档逐篇人工迁移到 strict schema，并统一 `.prd` 命名。
-- [x] TASK-TESTING-017 (PRD-TESTING-004) [test_tier_required]: 完成 `llm-skip-tick-ratio-metric` 专题文档逐篇人工迁移到 strict schema，并统一 `.prd` 命名。
-- [x] TASK-TESTING-018 (PRD-TESTING-004) [test_tier_required]: 完成 `launcher-chain-script-migration-2026-02-28` 专题文档逐篇人工迁移到 strict schema，并统一 `.prd` 命名。
-- [x] TASK-TESTING-019 (PRD-TESTING-004) [test_tier_required]: 完成 `launcher-lifecycle-hardening-2026-03-01` 专题文档逐篇人工迁移到 strict schema，并统一 `.prd` 命名。
-- [x] TASK-TESTING-020 (PRD-TESTING-004) [test_tier_required]: 完成 `launcher-viewer-auth-node-config-autowire-2026-03-02` 专题文档逐篇人工迁移到 strict schema，并统一 `.prd` 命名。
-- [x] TASK-TESTING-021 (PRD-TESTING-004) [test_tier_required]: 完成 `chain-runtime-feedback-replication-network-autowire-2026-03-02` 专题文档逐篇人工迁移到 strict schema，并统一 `.prd` 命名。
-- [x] TASK-TESTING-022 (PRD-TESTING-004) [test_tier_required]: 完成 `chain-runtime-soak-script-reactivation-2026-02-28` 专题文档逐篇人工迁移到 strict schema，并统一 `.prd` 命名。
-- [x] TASK-TESTING-023 (PRD-TESTING-004) [test_tier_required]: 完成 `p2p-longrun-continuous-chaos-injection-2026-02-24` 专题文档逐篇人工迁移到 strict schema，并统一 `.prd` 命名。
-- [x] TASK-TESTING-024 (PRD-TESTING-004) [test_tier_required]: 完成 `p2p-longrun-endurance-chaos-template-2026-02-25` 专题文档逐篇人工迁移到 strict schema，并统一 `.prd` 命名。
-- [x] TASK-TESTING-025 (PRD-TESTING-004) [test_tier_required]: 完成 `p2p-storage-consensus-longrun-online-stability-2026-02-24` 专题文档逐篇人工迁移到 strict schema，并统一 `.prd` 命名。
-- [x] TASK-TESTING-026 (PRD-TESTING-004) [test_tier_required]: 完成 `p2p-longrun-feedback-event-injection-2026-03-02` 专题文档逐篇人工迁移到 strict schema，并统一 `.prd` 命名。
-- [x] TASK-TESTING-027 (PRD-TESTING-004) [test_tier_required]: 完成 `s10-distfs-probe-bootstrap-2026-02-28` 专题文档逐篇人工迁移到 strict schema，并统一 `.prd` 命名。
-- [x] TASK-TESTING-028 (PRD-TESTING-004) [test_tier_required]: 完成 `s10-five-node-real-game-soak` 专题文档逐篇人工迁移到 strict schema，并统一 `.prd` 命名。
-- [x] TASK-TESTING-029 (PRD-TESTING-004) [test_tier_required]: 完成 `runtime-performance-observability-foundation-2026-02-25` 专题文档逐篇人工迁移到 strict schema，并统一 `.prd` 命名。
-- [x] TASK-TESTING-030 (PRD-TESTING-004) [test_tier_required]: 完成 `runtime-performance-observability-llm-api-decoupling-2026-02-25` 专题文档逐篇人工迁移到 strict schema，并统一 `.prd` 命名。
-- [x] TASK-TESTING-031 (PRD-TESTING-004) [test_tier_required]: 完成 `viewer-perf-bottleneck-observability-2026-02-25` 专题文档逐篇人工迁移到 strict schema，并统一 `.prd` 命名。
-- [x] TASK-TESTING-032 (PRD-TESTING-004) [test_tier_required]: 完成 `viewer-performance-methodology-closure-2026-02-25` 专题文档逐篇人工迁移到 strict schema，并统一 `.prd` 命名。
-- [x] TASK-TESTING-033 (PRD-TESTING-004) [test_tier_required]: 完成 `systematic-application-testing-manual` 专题文档逐篇人工迁移到 strict schema，并统一 `.prd` 命名。
-- [x] TASK-TESTING-034 (PRD-TESTING-004) [test_tier_required]: 完成 `web-ui-agent-browser-closure-manual` 专题文档逐篇人工迁移到 strict schema，并补齐 `.project.md` 管理文档。
-- [x] TASK-TESTING-042 (PRD-TESTING-002/003/004) [test_tier_required]: 将 Web UI 闭环默认工具口径统一收口到 `agent-browser`，同步主手册、专题分册、Viewer 手册、站内镜像与门禁脚本。
-- [x] TASK-TESTING-043 (PRD-TESTING-002/003) [test_tier_required]: 修正文档边界歧义，明确 `Viewer` 页面默认走 `agent-browser`，`oasis7_web_launcher` / launcher Web 控制面默认走 GUI Agent，再用页面做状态与字段校验。
-- [x] TASK-TESTING-044 (PRD-TESTING-LAUNCHER-BUNDLE-001) [test_tier_required]: 完成“启动器 bundle-first 试玩入口收敛（2026-03-12）”专题 PRD / design / project 建档，并同步 testing 索引与 README。
-- [x] TASK-TESTING-045 (PRD-TESTING-LAUNCHER-BUNDLE-001/002) [test_tier_required]: 为 `run-game-test.sh` 增加 `--bundle-dir`，同步主手册/人工清单帮助口径，并完成 bundle 产物闭环验证与 blocker 归档。
-- [x] TASK-TESTING-046 (PRD-TESTING-LAUNCHER-BUNDLE-002) [test_tier_required]: 查明 `run-game-test-ab.sh --headless` 的阻断根因是 `SwiftShader` software renderer，并新增环境快失败与 `browser_env.json` 证据落盘，避免把环境问题误判成 fresh Web 回归。
-- [x] TASK-TESTING-047 (PRD-TESTING-LAUNCHER-BUNDLE-001/002) [test_tier_required]: 新增 `run-producer-playtest.sh`，把制作人 bundle-first 试玩收敛成单命令入口，并同步主手册与人工清单。
-- [x] TASK-TESTING-048 (PRD-TESTING-LAUNCHER-BUNDLE-001/002) [test_tier_required]: 为 `run-producer-playtest.sh` 增加 `--open-headed`，使制作人可在起栈后自动打开 headed 浏览器，并同步主手册/日志口径。
-- [x] TASK-TESTING-049 (PRD-TESTING-LAUNCHER-BUNDLE-001/002) [test_tier_required]: 修复 `run-producer-playtest.sh --open-headed` 退出后残留浏览器窗口的问题，为脚本补充自动关会话收尾，并同步手册/日志口径。
-- [x] TASK-TESTING-050 (PRD-TESTING-LAUNCHER-BUNDLE-001/002) [test_tier_required]: 固化 headed Viewer Web 的默认硬件 WebGL 启动参数，并把 headed 命中 `SwiftShader` / software renderer 统一收口为环境阻断，同步脚本/手册/专题文档。
-- [x] TASK-TESTING-051 (PRD-TESTING-LAUNCHER-BUNDLE-001/002) [test_tier_required]: 为 bundle-first 试玩入口增加 freshness manifest 守卫，默认阻断或自动重建 stale bundle，避免旧 Viewer Web 产物与新 runtime 二进制混跑。
-- [x] TASK-TESTING-035 (PRD-TESTING-004) [test_tier_required]: 完成 archive 专题 `ci-required-m1-wasm-hash-check` 文档迁移到 strict schema，并统一 `.prd` 命名。
-- [x] TASK-TESTING-036 (PRD-TESTING-004) [test_tier_required]: 完成 archive 专题 `wasm-platform-canonical-hash-manifest` 文档迁移到 strict schema，并统一 `.prd` 命名。
-- [x] TASK-TESTING-037 (PRD-TESTING-005) [test_tier_required]: 完成 `ci-builtin-wasm-docker-canonical-gate` 专题 PRD 与项目管理文档建档，建立 1-6 治理项映射。
-- [x] TASK-TESTING-038 (PRD-TESTING-005) [test_tier_required]: 落地 m4/m5 keyed hash manifest 迁移与 sync strict 模式（禁 legacy 写回）。
-- [x] TASK-TESTING-039 (PRD-TESTING-005) [test_tier_required]: 收敛 builtin wasm identity 的 `source_hash` 输入范围并移除 workspace 根 `Cargo.lock` 依赖。
-- [x] TASK-TESTING-040 (PRD-TESTING-005) [test_tier_required]: 收敛 builtin wasm 独立 gate 到 `wasm-determinism-gate` / required checks 保护与本地只读校验策略；GitHub-hosted 默认 runner 为 Linux，外部 Docker-capable macOS summary 作为 full-tier 补充证据。
-- [x] wasm-determinism-gate-ondemand-scope (PRD-TESTING-005) [test_tier_required]: 为 `wasm-determinism-gate` 补 changed-path scope planner，保持 `verify-wasm-determinism (m1|m4|m5)` required contexts 稳定，同时把 docs-only / 无关 PR 收口为 job 内 no-op success。 Trace: .pm/tasks/task_3db20911d0a141cda3f990ea75bc5ea7.yaml
-- [x] rust-required-gate-ondemand-scope (PRD-TESTING-002/003) [test_tier_required]: 为 `.github/workflows/rust.yml` 的 `required-gate` 补 changed-path scope planner，保持 `required-gate` check context 稳定，同时把 docs-only / `.pm` / 无关元数据 PR 收口为 governance/fmt-only。 Trace: .pm/tasks/task_67ace00b259d423a8569f52a2f58c1fd.yaml
-- [x] TASK-TESTING-041 (PRD-TESTING-002/003) [test_tier_required]: 完成“启动器全功能可用性审查与闭环验收（2026-03-08）”专题执行（脚本审查 + agent-browser 真闭环 + 风险分级结论）。
+## 当前执行窗口
+- 当前状态: active
+- 当前权威入口: `doc/testing/prd.md`、`testing-manual.md`、`doc/testing/prd.index.md`
+- 当前阻断摘要: `doc/testing/provider-dual-mode-t4-blocker-2026-03-16.md`
+- 活跃任务:
+  - [ ] `test-coverage-gate-fill` (PRD-TESTING-002/003) [test_tier_required] + [test_tier_full]: 补齐 Rust CI 测试覆盖缺口，让 `full-support` 直接触达 workspace support crates，并为 `required-gate` changed-path planner 增加 regression，防止未分类代码路径绕过 full fallback。Trace: `.pm/tasks/task_ce44b8a269824fbcb718febd2140c425.yaml`
+  - [ ] token genesis allocation audit follow-up: 等待 `producer_system_designer` / `runtime_engineer` 提供真实创世账户表后，用 `doc/testing/governance/token-genesis-allocation-audit-checklist-2026-03-22.project.md` 与对应模板执行首轮正式审计。
+- 当前门禁/治理摘要:
+  - `required-gate-ondemand-launcher-web-build`、`rust-required-gate-ondemand-scope` 与 `wasm-determinism-gate-ondemand-scope` 已把 GitHub required gate 收口为 stable context + changed-path on-demand 执行；launcher/shared runtime 命中时会额外补跑 launcher Web `trunk build`。
+  - `engineering-code-quality-performance-baselines` 已为 `required-gate` 增补 Viewer changed-path perf smoke scope；`viewer-performance-probe.sh --profile smoke` 当前是 report-only scoped gate，不作为 blocking failure。
+  - `playability-governance-stack-2026-05-06` 已把好玩性证据栈、标准角色 subagent 评审系统、模拟玩家 persona panel，以及 `L4A synthetic` / `L4B embodied-agent` / `L5` 真实人类与线上验证边界收口为单个 bundle 视图。
+  - `playability-player-leverage-evidence-rubric` 已为 trust/playability 证据补单独的 `player leverage` 审查层，避免再用 world activity 代替玩家有效参与。
+  - `shared-network-ecs-triad-chain-status-metrics-rollout` 已冻结本机 observer + 两台阿里云 ECS 的 same-window triad snapshot、最近 `10` 分钟 traffic window，以及 `/v1/chain/status` 新增 live contract 证据。
 
-## 专题任务映射（2026-03-02 批次）
-- [x] SUBTASK-TESTING-20260302-001 (PRD-TESTING-002/003) [test_tier_required]: `doc/testing/longrun/chain-runtime-feedback-replication-network-autowire-2026-03-02.project.md`
-- [x] SUBTASK-TESTING-20260302-002 (PRD-TESTING-002/003) [test_tier_required]: `doc/testing/launcher/launcher-viewer-auth-node-config-autowire-2026-03-02.project.md`
-- [x] SUBTASK-TESTING-20260302-003 (PRD-TESTING-002/003) [test_tier_required]: `doc/testing/longrun/p2p-longrun-feedback-event-injection-2026-03-02.project.md`
+## 历史追溯索引
+本页不再按时间顺序手工追加完成项长表；历史 trace 仍保留在对应 topic `*.project.md`、证据文件与 `.pm/tasks/task_<32hex>.yaml` / `.execution.md` 中。
 
-## 专题任务映射（2026-03-03 批次）
-- [x] SUBTASK-TESTING-20260303-001 (PRD-TESTING-004) [test_tier_required]: `doc/testing/ci/ci-wasm32-target-install.project.md`
-- [x] SUBTASK-TESTING-20260303-002 (PRD-TESTING-004) [test_tier_required]: `doc/testing/ci/ci-testcase-tiering.project.md`
-- [x] SUBTASK-TESTING-20260303-003 (PRD-TESTING-004) [test_tier_required]: `doc/testing/ci/ci-tiered-execution.project.md`
-- [x] SUBTASK-TESTING-20260303-004 (PRD-TESTING-004) [test_tier_required]: `doc/testing/ci/ci-test-coverage.project.md`
-- [x] SUBTASK-TESTING-20260303-005 (PRD-TESTING-004) [test_tier_required]: `doc/testing/ci/ci-builtin-wasm-determinism-gate-m1.project.md`
-- [x] SUBTASK-TESTING-20260303-006 (PRD-TESTING-004) [test_tier_required]: `doc/testing/ci/ci-builtin-wasm-determinism-gate-required-check-protection.project.md`
-- [x] SUBTASK-TESTING-20260303-007 (PRD-TESTING-004) [test_tier_required]: `doc/testing/ci/ci-remove-builtin-wasm-hash-checks-from-base-gate.project.md`
-- [x] SUBTASK-TESTING-20260303-008 (PRD-TESTING-004) [test_tier_required]: `doc/testing/governance/wasm-build-determinism-guard.project.md`
-- [x] SUBTASK-TESTING-20260303-009 (PRD-TESTING-004) [test_tier_required]: `doc/testing/governance/release-gate-metric-policy-alignment-2026-02-28.project.md`
-- [x] SUBTASK-TESTING-20260303-010 (PRD-TESTING-004) [test_tier_required]: `doc/testing/governance/llm-skip-tick-ratio-metric.project.md`
-- [x] SUBTASK-TESTING-20260303-011 (PRD-TESTING-004) [test_tier_required]: `doc/testing/launcher/launcher-chain-script-migration-2026-02-28.project.md`
-- [x] SUBTASK-TESTING-20260303-012 (PRD-TESTING-004) [test_tier_required]: `doc/testing/launcher/launcher-lifecycle-hardening-2026-03-01.project.md`
-- [x] SUBTASK-TESTING-20260303-013 (PRD-TESTING-004) [test_tier_required]: `doc/testing/launcher/launcher-viewer-auth-node-config-autowire-2026-03-02.project.md`
-- [x] SUBTASK-TESTING-20260303-014 (PRD-TESTING-004) [test_tier_required]: `doc/testing/longrun/chain-runtime-feedback-replication-network-autowire-2026-03-02.project.md`
-- [x] SUBTASK-TESTING-20260303-015 (PRD-TESTING-004) [test_tier_required]: `doc/testing/longrun/chain-runtime-soak-script-reactivation-2026-02-28.project.md`
-- [x] SUBTASK-TESTING-20260303-016 (PRD-TESTING-004) [test_tier_required]: `doc/testing/longrun/p2p-longrun-continuous-chaos-injection-2026-02-24.project.md`
-- [x] SUBTASK-TESTING-20260303-017 (PRD-TESTING-004) [test_tier_required]: `doc/testing/longrun/p2p-longrun-endurance-chaos-template-2026-02-25.project.md`
-- [x] SUBTASK-TESTING-20260303-018 (PRD-TESTING-004) [test_tier_required]: `doc/testing/longrun/p2p-storage-consensus-longrun-online-stability-2026-02-24.project.md`
-- [x] SUBTASK-TESTING-20260303-019 (PRD-TESTING-004) [test_tier_required]: `doc/testing/longrun/p2p-longrun-feedback-event-injection-2026-03-02.project.md`
-- [x] SUBTASK-TESTING-20260303-020 (PRD-TESTING-004) [test_tier_required]: `doc/testing/longrun/s10-distfs-probe-bootstrap-2026-02-28.project.md`
-- [x] SUBTASK-TESTING-20260303-021 (PRD-TESTING-004) [test_tier_required]: `doc/testing/longrun/s10-five-node-real-game-soak.project.md`
-- [x] SUBTASK-TESTING-20260303-022 (PRD-TESTING-004) [test_tier_required]: `doc/testing/performance/runtime-performance-observability-foundation-2026-02-25.project.md`
-- [x] SUBTASK-TESTING-20260303-023 (PRD-TESTING-004) [test_tier_required]: `doc/testing/performance/runtime-performance-observability-llm-api-decoupling-2026-02-25.project.md`
-- [x] SUBTASK-TESTING-20260303-024 (PRD-TESTING-004) [test_tier_required]: `doc/testing/performance/viewer-perf-bottleneck-observability-2026-02-25.project.md`
-- [x] SUBTASK-TESTING-20260303-025 (PRD-TESTING-004) [test_tier_required]: `doc/testing/performance/viewer-performance-methodology-closure-2026-02-25.project.md`
-- [x] SUBTASK-TESTING-20260303-026 (PRD-TESTING-004) [test_tier_required]: `doc/testing/manual/systematic-application-testing-manual.project.md`
-- [x] SUBTASK-TESTING-20260303-027 (PRD-TESTING-004) [test_tier_required]: `doc/testing/manual/web-ui-agent-browser-closure-manual.project.md`
+| 历史批次 / 专题 | 追溯入口 |
+| --- | --- |
+| 基础 testing PRD、S0~S10、证据包、趋势 baseline 与 strict schema 迁移 (`TASK-TESTING-001` 至 `TASK-TESTING-034`) | `doc/testing/prd.index.md` 的专题三件套清单；对应 `.pm/tasks/task_<32hex>.*` |
+| Archive / CI / wasm determinism / required-gate 保护批次 (`TASK-TESTING-035` 至 `TASK-TESTING-040`) | `doc/testing/ci/*.project.md`、`doc/testing/governance/*.project.md` |
+| Launcher / Web UI / release gate hardening 批次 (`TASK-TESTING-041` 至 `TASK-TESTING-065`) | `doc/testing/launcher/*.project.md`、`doc/testing/manual/web-ui-agent-browser-closure-manual.project.md`、相关 `.pm/tasks/task_<32hex>.*` |
+| 2026-03-02 / 2026-03-03 / 2026-03-06 专题任务映射 | `doc/testing/prd.index.md` 按文件名检索对应 `*.project.md`；旧 `SUBTASK-TESTING-*` 映射保留在专题 project 文档与 task evidence 中 |
+| Playability evidence stack / L4A-L4B / model visual review | `doc/testing/governance/playability-*.project.md`、`doc/testing/manual/model-visual-review-sop-2026-05-29.manual.md`、`doc/testing/templates/model-visual-review-card-template.md` |
+| Shared network / hosted-world / release evidence | `doc/testing/evidence/README.md` 先分流，再进入具体 evidence 文件 |
+| Performance coverage and baselines | `doc/testing/performance/performance-coverage-gap-matrix-2026-06-09.md`、`testing-manual.md` 的 required-gate / Viewer performance probe 段落 |
 
-## 专题任务映射（2026-03-06 批次）
-- [x] SUBTASK-TESTING-20260306-001 (PRD-TESTING-005) [test_tier_required]: `doc/testing/ci/ci-builtin-wasm-docker-canonical-gate.project.md`
-
-## 专题任务映射（2026-03-08 批次）
-- [x] SUBTASK-TESTING-20260308-001 (PRD-TESTING-002/003) [test_tier_required]: `doc/testing/launcher/launcher-full-usability-closure-audit-2026-03-08.project.md`
-
-## 专题任务映射（2026-03-10 批次）
-- [x] SUBTASK-TESTING-20260310-001 (PRD-TESTING-LAUNCHER-MANUAL-001/002/003) [test_tier_required]: `doc/testing/launcher/launcher-manual-test-checklist-2026-03-10.project.md`
-- [x] TASK-TESTING-006 (PRD-TESTING-001) [test_tier_required]: 同步 `doc/testing/README.md` 的模块入口索引，补齐近期专题、模块职责与根目录收口口径。
-- [x] TASK-TESTING-052 (PRD-TESTING-002/003) [test_tier_required]: 把前期工业引导的 required-tier 人工回归链路挂入 `testing-manual.md`，并与 playability 专题卡组互链，覆盖 `首个制成品 / 停机恢复 / 首座工厂单元`。
-  - 产物文件:
-    - `testing-manual.md`
-    - `doc/playability_test_result/topics/industrial-onboarding-required-tier-cards-2026-03-15.md`
-  - 验收命令 (`test_tier_required`):
-    - `rg -n 'industrial-onboarding-required-tier-cards-2026-03-15|首个制成品|停机恢复|首座工厂单元' testing-manual.md doc/playability_test_result/topics/industrial-onboarding-required-tier-cards-2026-03-15.md`
-- [x] TASK-TESTING-053 (PRD-TESTING-002/003) [test_tier_required]: 优化 release packaging Web 资产复用链路，在 `build-web-dist` 一次性产出 viewer/launcher 两份静态包，并让 `package-native` 直接复用 artifact，避免每个平台重复 `trunk install` / `trunk build`。
-  - 产物文件:
-    - `.github/workflows/release-packages.yml`
-    - `scripts/release-prepare-bundle.sh`
-    - `scripts/build-game-launcher-bundle.sh`
-  - 验收命令 (`test_tier_required`):
-    - `bash -n scripts/release-prepare-bundle.sh scripts/build-game-launcher-bundle.sh`
-    - `python -c "import pathlib, yaml; yaml.safe_load(pathlib.Path('.github/workflows/release-packages.yml').read_text())"`
-    - `tmpdir=$(mktemp -d) && mkdir -p "$tmpdir/viewer" "$tmpdir/launcher" "$tmpdir/out" && printf "<html></html>" > "$tmpdir/viewer/index.html" && printf "<html></html>" > "$tmpdir/launcher/index.html" && ./scripts/build-game-launcher-bundle.sh --dry-run --out-dir "$tmpdir/out" --web-dist "$tmpdir/viewer" --web-launcher-dist "$tmpdir/launcher" >/dev/null`
-- [x] TASK-TESTING-054 (PRD-TESTING-002/003) [test_tier_required]: 继续压缩 release 关键路径，让 `release-gate-web` 与 `build-web-dist` 共享同一组 Web wasm/cargo cache，并把 bundle 原生二进制构建收敛到单次 cargo 调用，减少重复 bootstrap 与 metadata 解析。
-  - 产物文件:
-    - `.github/workflows/release-packages.yml`
-    - `scripts/build-game-launcher-bundle.sh`
-    - `doc/testing/prd.md`
-  - 验收命令 (`test_tier_required`):
-    - `bash -n scripts/build-game-launcher-bundle.sh`
-    - `python -c "import pathlib, yaml; yaml.safe_load(pathlib.Path('.github/workflows/release-packages.yml').read_text())"`
-    - `rg -n "release-packages-web-wasm-v2|BUNDLE_NATIVE_BUILD_ARGS|oasis7_client_launcher" .github/workflows/release-packages.yml scripts/build-game-launcher-bundle.sh doc/testing/prd.md`
-- [x] TASK-TESTING-055 (PRD-TESTING-002/003) [test_tier_required]: 继续拆分 `release-gate-runtime`，把 `ci-tests.sh full` 收敛为 `full-core` / `full-support` 两个 shard，并把 builtin wasm sync 检查独立成第三个并行 job，由聚合 gate 统一裁决放行，压缩 runtime 关键路径。
-  - 产物文件:
-    - `.github/workflows/release-packages.yml`
-    - `scripts/ci-tests.sh`
-    - `doc/testing/prd.md`
-  - 验收命令 (`test_tier_required`):
-    - `bash -n scripts/ci-tests.sh`
-    - `python -c "import pathlib, yaml; yaml.safe_load(pathlib.Path('.github/workflows/release-packages.yml').read_text())"`
-    - `rg -n "full-core|full-support|release-gate-runtime-core|release-gate-runtime-support|release-gate-runtime-sync" scripts/ci-tests.sh .github/workflows/release-packages.yml doc/testing/prd.md`
-- [x] TASK-TESTING-056 (PRD-TESTING-002/003) [test_tier_required]: 基于 `runtime-core` 热点复盘重平衡 shard，把 `oasis7 --features wasmtime --lib --bins` 从 `full-core` 挪到 `full-support`，降低最长 runtime shard。
-  - 产物文件:
-    - `scripts/ci-tests.sh`
-    - `doc/testing/prd.md`
-  - 验收命令 (`test_tier_required`):
-    - `bash -n scripts/ci-tests.sh`
-    - `rg -n "full-core|full-support|oasis7 --features wasmtime --lib --bins" scripts/ci-tests.sh doc/testing/prd.md doc/testing/project.md`
-- [x] release-windows-invalid-path-blocker (PRD-TESTING-002) [test_tier_required]: 修复会让 `windows-2022` 在 `actions/checkout@v6` 直接失败的 tracked path，补充 `scripts/check-windows-paths.sh` 并接入 `scripts/ci-tests.sh` 的 required gate，让 release 在进入 Windows `package-native` 前就能阻断非法路径。 Trace: .pm/tasks/task_a3d359ee14df4460922aca14907dfdc8.yaml
-  - 产物文件:
-    - `.github/instructions/pr-review.instructions.md`
-    - `scripts/check-windows-paths.sh`
-    - `scripts/ci-tests.sh`
-    - `doc/testing/prd.md`
-    - `doc/testing/project.md`
-  - 验收命令 (`test_tier_required`):
-    - `bash -n scripts/check-windows-paths.sh scripts/ci-tests.sh`
-    - `./scripts/check-windows-paths.sh`
-    - `git ls-files '.github/instructions/*'`
-    - `git diff --check`
-- [x] release-script-executable-mode-gate (PRD-TESTING-002/003) [test_tier_required]: 修复 `release-gate-web` 只在 GitHub Linux runner 上暴露的 shell 执行位漂移，补 `scripts/check-script-executable-bits.sh` 并接入 `scripts/ci-tests.sh` 的 commit/required gate，让 release 关键脚本在进入 `release-gate-web` / `package-native` 前就能阻断 `Permission denied`。 Trace: .pm/tasks/task_81b8b3dfddd3487e9733600aad78806d.yaml
-  - 产物文件:
-    - `scripts/check-script-executable-bits.sh`
-    - `scripts/ci-tests.sh`
-    - `scripts/release-gate-web-strict.sh`
-    - `testing-manual.md`
-    - `doc/testing/prd.md`
-    - `doc/testing/project.md`
-  - 验收命令 (`test_tier_required`):
-    - `bash -n scripts/check-script-executable-bits.sh scripts/ci-tests.sh scripts/release-gate-web-strict.sh`
-    - `./scripts/check-script-executable-bits.sh`
-    - `git ls-files --stage scripts/check-script-executable-bits.sh scripts/release-gate-web-strict.sh`
-    - `rg -n "check-script-executable-bits|release-script-executable-mode-gate|AC-9C" scripts/ci-tests.sh testing-manual.md doc/testing/prd.md doc/testing/project.md`
-- [x] p2p-path-behavior-matrix-taxonomy-doc-freeze (PRD-TESTING-002/003) [test_tier_required]: 在 `testing-manual.md` 冻结 P2P mixed-topology path behavior taxonomy，明确 `evidence_class/path_expectation/reachability_pair/degradation_class/claim_boundary` 字段、`proxy != physical NAT/CGNAT proof` 边界，以及 reachability/status observability 只能消费 bounded status projection。 Trace: .pm/tasks/task_43a21163092541809de36036403d7c97.yaml
-  - 产物文件:
-    - `testing-manual.md`
-    - `doc/testing/project.md`
-    - `doc/p2p/network/p2p-mainnet-private-reachability-architecture-2026-04-01.*`
-    - `doc/p2p/node/node-triad-observability-stack-2026-04-23.*`
-  - 后续实现入口:
-    - `scripts/p2p-mixed-topology-matrix.sh` 应输出 taxonomy fields。
-    - `scripts/p2p-mixed-topology-matrix-smoke.sh` 应验证 required tier 只含 `evidence_class=exact`。
-    - `scripts/p2p-real-env-observability-monitor.sh` / summary helper 应从 status truth 消费 reachability path summary，缺字段时输出 `not_reported`。
-  - 验收命令 (`test_tier_required`):
-    - `rg -n "evidence_class|path_expectation|reachability_pair|degradation_class|claim_boundary|physical NAT|not_reported|selected_path_kind" testing-manual.md doc/testing/project.md`
-    - `./scripts/doc-governance-check.sh`
-    - `git diff --check`
-- [x] TASK-TESTING-057 (PRD-TESTING-WEB-001/002/003) [test_tier_required]: 为 `renderMode=software_safe` 补专用 prompt/chat 回归方案与 `viewer-software-safe-chat-regression.sh`，覆盖 apply/rollback/chat ack、消息流采样以及 `agent_spoke` 缺失签名。
-  - 产物文件:
-    - `scripts/viewer-software-safe-chat-regression.sh`
-    - `testing-manual.md`
-    - `doc/testing/manual/web-ui-agent-browser-closure-manual.prd.md`
-    - `doc/testing/manual/web-ui-agent-browser-closure-manual.project.md`
-  - 验收命令 (`test_tier_required`):
-    - `bash -n scripts/viewer-software-safe-chat-regression.sh`
-    - `./scripts/viewer-software-safe-chat-regression.sh --help`
-    - `./scripts/viewer-software-safe-chat-regression.sh --viewer-static-dir /tmp/aw-viewer-dist-promptchat3 --viewer-port 4373 --live-bind 127.0.0.1:5323 --web-bind 127.0.0.1:5311`
-- [x] TASK-TESTING-058 (PRD-TESTING-WEB-001/002/003) [test_tier_required]: 为 software-safe 消息流回归补 `agent_chat -> AgentSpoke` 的 env-gated runtime echo 验证路径，并修正 runtime 事件形状兼容解析。
-  - 产物文件:
-    - `crates/oasis7/src/viewer/runtime_live/control_plane.rs`
-    - `crates/oasis7/src/viewer/runtime_live/tests.rs`
-    - `crates/oasis7_viewer/software_safe.js`
-    - `doc/testing/manual/web-ui-agent-browser-closure-manual.prd.md`
-  - 验收命令 (`test_tier_required`):
-    - `env -u RUSTC_WRAPPER cargo test -p oasis7 runtime_agent_chat_echo_env_enqueues_agent_spoke_virtual_event -- --nocapture`
-    - `node --check crates/oasis7_viewer/software_safe.js`
-    - `agent-browser` 手工链路：`open software_safe -> sendAgentChat -> runSteps -> getState().chatHistory` 观察 `source=event` 的 `AgentSpoke` 记录
-- [x] TASK-TESTING-059 (PRD-TESTING-004) [test_tier_required]: 对 `doc/testing/**` 的仍可读历史专题执行 title-only cleanup，将首行 `oasis7*` 公开标题统一切到 `oasis7*`，保留正文历史证据原文不动。
-- [x] TASK-TESTING-060 (PRD-TESTING-004) [test_tier_required]: 清理 `doc/testing/launcher/**` 活跃专题里仍作为当前真值出现的旧品牌 crate/path/env/command，引文统一到 `oasis7*` / `OASIS7_*`。
-  - 产物文件:
-    - `doc/testing/prd.md`
-    - `doc/testing/project.md`
-    - `doc/testing/ci/*.md`
-    - `doc/testing/governance/*.md`
-    - `doc/testing/launcher/*.md`
-    - `doc/testing/longrun/*.md`
-    - `doc/testing/manual/*.md`
-    - `doc/testing/performance/*.md`
-    - `doc/devlog/README.md`
-  - 验收命令 (`test_tier_required`):
-    - `rg -n "^# oasis7|^# oasis7 Runtime|^# oasis7 Simulator|^# oasis7 Viewer" doc/testing --glob '!third_party/**'`
-    - `./scripts/doc-governance-check.sh`
-    - `git diff --check`
-- [x] TASK-TESTING-061 (PRD-TESTING-004) [test_tier_required]: 清理 `doc/testing/{longrun,governance,performance,ci,manual}` 活跃专题里已完成改名但文档仍残留的旧品牌 crate/path/env 当前真值。
-- [x] TASK-TESTING-062 (PRD-TESTING-006) [test_tier_required]: 新增“Token 创世分配审计清单（2026-03-22）”专题 PRD / design / project 与执行模板，覆盖比例、custody/treasury 语义、个人上限、创世流通与首年释放门禁，并同步 `testing` / `p2p token` 追踪。
-  - 产物文件:
-    - `doc/testing/governance/token-genesis-allocation-audit-checklist-2026-03-22.prd.md`
-    - `doc/testing/governance/token-genesis-allocation-audit-checklist-2026-03-22.design.md`
-    - `doc/testing/governance/token-genesis-allocation-audit-checklist-2026-03-22.project.md`
-    - `doc/testing/evidence/token-genesis-allocation-audit-template-2026-03-22.md`
-    - `doc/testing/prd.md`
-    - `doc/testing/project.md`
-    - `doc/testing/prd.index.md`
-    - `doc/testing/README.md`
-    - `doc/p2p/token/mainchain-token-initial-allocation-and-early-contribution-reward-2026-03-22.project.md`
-    - `doc/devlog/README.md`
-  - 验收命令 (`test_tier_required`):
-    - `rg -n "sum=10000 bps|genesis_liquid|1500 bps|5000 bps|custody|treasury|verdict" doc/testing/governance/token-genesis-allocation-audit-checklist-2026-03-22.prd.md doc/testing/evidence/token-genesis-allocation-audit-template-2026-03-22.md doc/p2p/token/mainchain-token-initial-allocation-and-early-contribution-reward-2026-03-22.project.md`
-    - `./scripts/doc-governance-check.sh`
-    - `git diff --check`
-- [x] TASK-TESTING-063 (PRD-TESTING-004) [test_tier_required]: 执行 ROUND-009 首批手册载体规范化，为 Web UI 闭环补 canonical `*.manual.md` 操作手册，并同步主手册、模块入口与 PRD/project 职责边界。
-- [x] TASK-TESTING-064 (PRD-TESTING-002/003) [test_tier_required]: 修复 `release-gate-soak` 的 S10 误阻断，补齐 `scripts/s10-five-node-game-soak.sh` 的显式 replication listen/peer 拓扑，并把 `s10-sequencer` 上极少量 bootstrap `fetch-commit` protocol unavailable 收口为有上限的 warning（`>2` 仍然 fail），恢复 canonical 300 秒发布样本通过。
-  - 产物文件:
-    - `scripts/s10-five-node-game-soak.sh`
-    - `.pm/tasks/task_0abc42e0aa7c47d39972300f9ef9027b.yaml`
-    - `.pm/tasks/task_0abc42e0aa7c47d39972300f9ef9027b.execution.md`
-    - `doc/testing/project.md`
-    - `doc/world-runtime/project.md`
-  - 验收命令 (`test_tier_required`):
-    - `bash -n scripts/s10-five-node-game-soak.sh`
-    - `env -u RUSTC_WRAPPER cargo build -p oasis7 --bin oasis7_chain_runtime`
-    - `./scripts/s10-five-node-game-soak.sh --duration-secs 300 --base-port 7510 --no-prewarm --max-stall-secs 240 --max-lag-p95 50 --out-dir .tmp/release_gate_s10_fix_full_v5`
-- [x] TASK-TESTING-065 (PRD-TESTING-002/003) [test_tier_required]: 修复 `build-web-dist` 的 `oasis7_client_launcher` wasm 编译兼容性，避免 release tag 路径在 `crates/oasis7_viewer` 通过后仍因 launcher 引用 native-only `ProviderCompatibilityStatus` 而阻断 web dist 打包。
-  - 产物文件:
-    - `crates/oasis7_client_launcher/src/main.rs`
-    - `crates/oasis7_client_launcher/src/launcher_core.rs`
-    - `doc/testing/project.md`
-    - `.pm/tasks/task_1d90a16ad56f4c4e96bfa5370199b3d7.yaml`
-    - `.pm/tasks/task_1d90a16ad56f4c4e96bfa5370199b3d7.execution.md`
-  - 验收命令 (`test_tier_required`):
-    - `env -u RUSTC_WRAPPER cargo build --target wasm32-unknown-unknown --manifest-path crates/oasis7_client_launcher/Cargo.toml --release --bin oasis7_client_launcher`
-    - `cd crates/oasis7_client_launcher && env -u NO_COLOR trunk build --release --dist ../../output/release/web-launcher-dist`
-- [x] release-gate-web-soak-hardening (PRD-TESTING-002/003) [test_tier_required]: 修复 `Release Packages` run `26276289822` 的多层假阴性：移除 `viewer-software-safe-step-regression.sh` 对未使用 `rg` 的硬依赖；补齐 `release-gate-web-strict -> viewer-software-safe-step-regression -> run-game-test` 的 `--scenario` 参数 contract；恢复 software-safe step 回归在“无自然推进”时主动发 canonical `step` 并接受 `completed_advanced` + 正向 world delta 的正式判据；同时让 `p2p-longrun-soak.sh` 在 restart/pause chaos 后等待节点恢复到健康态再恢复采样，并把实际恢复窗口计入 `chaos_exempt_secs`，避免把预期瞬态记成 `last_error_samples` / `http_failure_samples`。 Trace: .pm/tasks/task_1aef6daff1ef4e81bbc3a6a34531a828.yaml
-  - 产物文件:
-    - `scripts/run-launcher-stack.sh`
-    - `scripts/viewer-software-safe-step-regression.sh`
-    - `scripts/p2p-longrun-soak.sh`
-    - `doc/testing/prd.md`
-    - `doc/testing/project.md`
-    - `.pm/tasks/task_1aef6daff1ef4e81bbc3a6a34531a828.execution.md`
-  - 验收命令 (`test_tier_required`):
-    - `bash -n scripts/viewer-software-safe-step-regression.sh scripts/run-launcher-stack.sh scripts/p2p-longrun-soak.sh`
-    - `./scripts/viewer-software-safe-step-regression.sh --help >/dev/null`
-    - `! rg -n "\\brg\\b" scripts/viewer-software-safe-step-regression.sh`
-    - `env -u RUSTC_WRAPPER cargo build -p oasis7 --bin oasis7_chain_runtime`
-    - `./scripts/p2p-longrun-soak.sh --profile soak_release --topologies triad_distributed --duration-secs 300 --no-prewarm --max-stall-secs 240 --max-lag-p95 50 --max-distfs-failure-ratio 0.1 --chaos-continuous-enable --chaos-continuous-interval-secs 30 --chaos-continuous-start-sec 30 --chaos-continuous-max-events 8 --chaos-continuous-actions restart,pause --chaos-continuous-seed 1772284566 --chaos-continuous-restart-down-secs 1 --chaos-continuous-pause-duration-secs 2 --out-dir .tmp/release_gate_p2p_v051_fix`
-    - `./scripts/release-gate.sh --out-dir .tmp/release_gate_web_v051_fix_rerun3 --skip-ci-full --skip-sync --skip-s9 --skip-s10`
-- [x] release-web-preflight-config-shadow (PRD-TESTING-002/003) [test_tier_required]: 修复 `Release Packages` run `26290255692` 的 `release-gate-web` 假阴性：`viewer-primary-web-entry-regression.sh` 在 root 缺失 canonical `config.toml` 时，会让 launcher/chain runtime 自动生成一份只含 `[node]` keypair 的 ignored `config.toml`；同一 workflow 后续 `viewer-software-safe-step-regression.sh` 再走 `run-game-test` 时，`release-gate-web-strict.sh` 需要显式传 `--skip-llm-provider-preflight`，把 software-safe phase 收口为“stack bootstrap 后的 UI/blocker contract 验证”而不是外部 LLM provider 活性检查，同时 primary-entry 必须在退出时清理自己生成的 node-only `config.toml`，避免把前一阶段遗留副作用误判成 Web 回归。 Trace: .pm/tasks/task_b7097f476e674a429469a98d6ae36794.yaml
-  - 产物文件:
-    - `scripts/release-gate-web-strict.sh`
-    - `scripts/viewer-primary-web-entry-regression.sh`
-    - `doc/testing/prd.md`
-    - `doc/testing/project.md`
-    - `.pm/tasks/task_b7097f476e674a429469a98d6ae36794.execution.md`
-  - 验收命令 (`test_tier_required`):
-    - `bash -n scripts/release-gate-web-strict.sh scripts/viewer-primary-web-entry-regression.sh`
-    - `./scripts/viewer-primary-web-entry-regression.sh --help >/dev/null`
-    - `./scripts/release-gate-web-strict.sh --scenario llm_bootstrap --out-dir .tmp/release_gate_web_preflight_shadow --headed`
-- [x] release-web-strict-live-progress-retry (PRD-TESTING-002/003) [test_tier_required]: 修复 `Release Packages` run `26297891385` 的 `release-gate-web` 串行假阴性：`release-gate-web-strict.sh` 先跑 headed `viewer-primary-web-entry-regression`，再跑 `viewer-software-safe-step-regression` 时，不再复用同一组 launcher/web/viewer 端口；software-safe step phase 改为独立端口 + headless 浏览器，并在 `step` 长时间停留 `queued` 且无 world delta 时补发一次 canonical `play` fallback，避免把前一阶段残留 listener 或 headed live-control stall 误判成 release 回归。 Trace: .pm/tasks/task_bca86dc8b045420baf35b7e28414818c.yaml
-  - 产物文件:
-    - `scripts/release-gate-web-strict.sh`
-    - `scripts/viewer-software-safe-step-regression.sh`
-    - `doc/testing/prd.md`
-    - `doc/testing/project.md`
-    - `.pm/tasks/task_bca86dc8b045420baf35b7e28414818c.execution.md`
-  - 验收命令 (`test_tier_required`):
-    - `bash -n scripts/release-gate-web-strict.sh scripts/viewer-software-safe-step-regression.sh`
-    - `xvfb-run -a ./scripts/release-gate-web-strict.sh --scenario llm_bootstrap --out-dir /tmp/release-gate-web-strict-xvfb-mixed-clean --headed`
-- [x] release-node24-actions (PRD-TESTING-002/003) [test_tier_required]: 升级 `Release Packages` workflow 中触发 Node.js 20 deprecation warning 的 GitHub Actions runtime，确保 `release-gate-*` / `build-web-dist` / `package-native` 产物上传不再依赖 Node 20，并保持 release 资产链路语义不变。 Trace: .pm/tasks/task_62acc2d0e69649dc81eeae2c3954bd67.yaml
-  - 产物文件:
-    - `.github/workflows/release-packages.yml`
-    - `doc/testing/project.md`
-    - `.pm/tasks/task_62acc2d0e69649dc81eeae2c3954bd67.execution.md`
-  - 验收命令 (`test_tier_required`):
-    - `python -c "import pathlib, yaml; yaml.safe_load(pathlib.Path('.github/workflows/release-packages.yml').read_text())"`
-    - `rg -n "actions/setup-node@v6|actions/upload-artifact@v7|actions/download-artifact@v5" .github/workflows/release-packages.yml`
-    - `git diff --check`
-- [x] required-gate-ondemand-launcher-web-build (PRD-TESTING-002/003) [test_tier_required]: 为 PR `required-gate` 补 launcher Web `trunk build` 的 changed-path 按需覆盖，在保持 stable check context 的前提下，仅对 launcher/shared runtime 相关路径安装 `trunk` 并执行 `oasis7_client_launcher` Web dist 构建，避免 release `build-web-dist` 才暴露编译错误。 Trace: .pm/tasks/task_3778b0e747b249bc85b92b942a32b3fd.yaml
-  - 产物文件:
-    - `scripts/plan-rust-required-scope.sh`
-    - `scripts/ci-tests.sh`
-    - `.github/workflows/rust.yml`
-    - `doc/testing/prd.md`
-    - `doc/testing/project.md`
-    - `doc/testing/ci/ci-tiered-execution.prd.md`
-    - `doc/testing/ci/ci-tiered-execution.project.md`
-    - `.pm/tasks/task_3778b0e747b249bc85b92b942a32b3fd.yaml`
-    - `.pm/tasks/task_3778b0e747b249bc85b92b942a32b3fd.execution.md`
-  - 验收命令 (`test_tier_required`):
-    - `bash -n scripts/plan-rust-required-scope.sh scripts/ci-tests.sh`
-    - `python -c "import pathlib, yaml; yaml.safe_load(pathlib.Path('.github/workflows/rust.yml').read_text())"`
-    - `./scripts/plan-rust-required-scope.sh --event-name pull_request --changed-path crates/oasis7_client_launcher/src/app_process_web.rs`
-    - `./scripts/plan-rust-required-scope.sh --event-name pull_request --changed-path crates/oasis7/src/lib.rs`
-    - `./scripts/plan-rust-required-scope.sh --event-name pull_request --changed-path .pm/tasks/example.yaml`
-    - `OASIS7_CI_RUN_OASIS7_REQUIRED_TESTS=false OASIS7_CI_RUN_CONSENSUS_TESTS=false OASIS7_CI_RUN_DISTFS_TESTS=false OASIS7_CI_RUN_VIEWER_TESTS=false OASIS7_CI_RUN_VIEWER_CONTRACT_TESTS=false OASIS7_CI_RUN_VIEWER_WASM_CHECK=false OASIS7_CI_RUN_LAUNCHER_WEB_BUILD=true ./scripts/ci-tests.sh required`
-- [x] release-build-web-dist-launcher-wasm-regression (PRD-TESTING-002/003) [test_tier_required]: 修复 `Release Packages` 再次卡在 `build-web-dist` 的 launcher wasm 回归，恢复 `launcher_core_http` 里跨目标 URL helper 在 wasm32 构建下的可见性，避免 `parse_http_base_url` / `normalize_host_for_url` / `host_for_url` 被 native-only `cfg` 意外屏蔽。 Trace: .pm/tasks/task_9a300593735d419ba7de7f95bd67bead.yaml
-  - 产物文件:
-    - `crates/oasis7_client_launcher/src/launcher_core.rs`
-    - `doc/testing/project.md`
-    - `.pm/tasks/task_9a300593735d419ba7de7f95bd67bead.yaml`
-    - `.pm/tasks/task_9a300593735d419ba7de7f95bd67bead.execution.md`
-  - 验收命令 (`test_tier_required`):
-    - `env -u RUSTC_WRAPPER cargo build --target wasm32-unknown-unknown --manifest-path crates/oasis7_client_launcher/Cargo.toml --release --bin oasis7_client_launcher`
-    - `cd crates/oasis7_viewer && env -u NO_COLOR trunk build --release --dist ../../output/release/web-dist`
-    - `cd crates/oasis7_client_launcher && env -u NO_COLOR trunk build --release --dist ../../output/release/web-launcher-dist`
-- [x] release-web-semantic-gate-drift (PRD-TESTING-002/003) [test_tier_required]: 修复 `release-gate-web` 对 `software_safe` live-control 旧语义的误判，改为接受 `play/pause` 的 `queued` 契约，并以后续 `step -> completed_advanced` + 正向 world delta 作为 formal progress gate。 Trace: .pm/tasks/task_f59a3d14ebcd47dcacbee3a7aa725675.yaml
-  - 产物文件:
-    - 历史已删除：`scripts/viewer-release-qa-loop.sh`
-    - `doc/testing/prd.md`
-    - `doc/testing/project.md`
-    - `.pm/tasks/task_f59a3d14ebcd47dcacbee3a7aa725675.yaml`
-    - `.pm/tasks/task_f59a3d14ebcd47dcacbee3a7aa725675.execution.md`
-  - 验收命令 (`test_tier_required`):
-    - 历史验收记录：`bash -n scripts/viewer-release-qa-loop.sh`
-    - `node crates/oasis7_viewer/scripts/software-safe-feedback-contract.test.mjs`
-    - 历史验收记录：`./scripts/viewer-release-qa-loop.sh --scenario llm_bootstrap --out-dir .tmp/release_gate_web_fix --headed`
-- [x] release-web-entry-text-casefold (PRD-TESTING-002/003) [test_tier_required]: 修复 `release-gate-web` 的 primary entry 文案断言假阴性；当 `agent-browser get text body` 因渲染层/CSS `text-transform` 返回全大写文本时，`viewer-primary-web-entry-regression.sh` 仍需识别 `Formal Gameplay Summary` 与 action handoff surface，不得把已存在内容误判成缺失。 Trace: .pm/tasks/task_a720e2fb03dd44369766bb4aa43cdf03.yaml
-  - 产物文件:
-    - `scripts/viewer-primary-web-entry-regression.sh`
-    - `doc/testing/prd.md`
-    - `doc/testing/project.md`
-    - `.pm/tasks/task_a720e2fb03dd44369766bb4aa43cdf03.yaml`
-    - `.pm/tasks/task_a720e2fb03dd44369766bb4aa43cdf03.execution.md`
-  - 验收命令 (`test_tier_required`):
-    - `bash -n scripts/viewer-primary-web-entry-regression.sh`
-    - `./scripts/viewer-primary-web-entry-regression.sh --help`
-    - `printf 'FORMAL GAMEPLAY SUMMARY\nACTIONS NOT EXPOSED ON THIS PAGE\n' | grep -qi 'Formal Gameplay Summary'`
-    - `printf 'FORMAL GAMEPLAY SUMMARY\nACTIONS NOT EXPOSED ON THIS PAGE\n' | grep -Eqi 'Missing Action Handoff|Actions Not Exposed On This Page'`
-- [x] shared-network-ecs-triad-chain-status-metrics-rollout (PRD-TESTING-002/003) [test_tier_required]: 归档三节点链状态指标部署与采样证据，冻结 `8e605366` release/sha256、same-window triad snapshot、最近 `10` 分钟 traffic window，以及新增 `/v1/chain/status` `transactions` / `consensus.recent_finality_latency` / `pending_proposal` / `pending_consensus_actions` contract 的 live 三节点证据。 Trace: .pm/tasks/task_c2def8d52baa4fe5a1b1df64e19a6305.yaml
-  - 产物文件:
-    - `doc/testing/evidence/shared-network-ecs-triad-chain-status-metrics-rollout-2026-04-23.md`
-    - `doc/testing/evidence/README.md`
-    - `doc/testing/project.md`
-    - `.pm/tasks/task_c2def8d52baa4fe5a1b1df64e19a6305.execution.md`
-  - 验收命令 (`test_tier_required`):
-    - `./scripts/doc-governance-check.sh`
-    - `git diff --check`
-- [x] lightweight-web-ui-automation-smoke (PRD-TESTING-002/003) [test_tier_required]: 新增 `scripts/viewer-software-safe-step-regression-smoke.sh`，通过临时 fixture 页面复用真 `agent-browser` 回归 `viewer-software-safe-step-regression.sh` 的最小浏览器链路与 summary/state 产物契约，作为正式 S6 前的快预检。 Trace: .pm/tasks/task_08478a657e554c5f9b0031f0b86bed2f.yaml
-  - 产物文件:
-    - `scripts/viewer-software-safe-step-regression-smoke.sh`
-    - `testing-manual.md`
-    - `doc/testing/prd.md`
-    - `doc/testing/project.md`
-    - `.pm/tasks/task_08478a657e554c5f9b0031f0b86bed2f.yaml`
-    - `.pm/tasks/task_08478a657e554c5f9b0031f0b86bed2f.execution.md`
-  - 验收命令 (`test_tier_required`):
-    - `bash -n scripts/viewer-software-safe-step-regression-smoke.sh scripts/viewer-software-safe-step-regression.sh`
-    - `./scripts/viewer-software-safe-step-regression-smoke.sh`
-    - `./scripts/doc-governance-check.sh`
-    - `git diff --check`
-- [x] engineering-code-quality-performance-baselines (PRD-TESTING-002/003) [test_tier_required]: 为 `required-gate` 增补 Viewer changed-path perf smoke scope，并新增本地 report-only runtime module routing micro harness、覆盖缺口矩阵与首个 dev/release baseline，补齐“哪些性能面该补、哪些只保留本地观测”的当前执行依据。 Trace: .pm/tasks/task_35657c5f0a5543dda5d57f51fc4b8841.yaml
-  - 产物文件:
-    - `.github/workflows/rust.yml`
-    - `scripts/ci-tests.sh`
-    - `scripts/plan-rust-required-scope.sh`
-    - `scripts/plan-rust-required-scope.test.sh`
-    - `crates/oasis7/src/runtime/tests/modules.rs`
-    - `crates/oasis7/src/bin/oasis7_runtime_module_routing_perf.rs`
-    - `scripts/runtime-module-routing-perf-harness.sh`
-    - `testing-manual.md`
-    - `doc/testing/performance/performance-coverage-gap-matrix-2026-06-09.md`
-    - `doc/testing/project.md`
-    - `.pm/tasks/task_35657c5f0a5543dda5d57f51fc4b8841.execution.md`
-  - 验收命令 (`test_tier_required`):
-    - `git diff --check`
-    - `./scripts/doc-governance-check.sh`
-    - `env -u RUSTC_WRAPPER cargo check -p oasis7 --bin oasis7_runtime_module_routing_perf`
-    - `./scripts/plan-rust-required-scope.test.sh`
-    - `./scripts/plan-rust-required-scope.sh --event-name pull_request --changed-path crates/oasis7_viewer/src/lib.rs | grep -q '^run_viewer_perf_smoke=true$'`
-
-- 当前阻断摘要：`doc/testing/provider-dual-mode-t4-blocker-2026-03-16.md`
+## 最近高价值完成摘要
+- `engineering-code-quality-performance-baselines` (Trace: `.pm/tasks/task_35657c5f0a5543dda5d57f51fc4b8841.execution.md`): Viewer changed-path perf smoke 已接入 required-gate report-only scope；runtime module routing perf harness 已有首个 dev/release baseline。
+- `required-gate-ondemand-launcher-web-build` (Trace: `.pm/tasks/task_3778b0e747b249bc85b92b942a32b3fd.yaml`): launcher Web `trunk build` 已按 changed-path 注入 required gate，避免 release `build-web-dist` 才暴露编译错误。
+- `release-web-*` hardening 系列 (Trace examples: `.pm/tasks/task_b7097f476e674a429469a98d6ae36794.execution.md`、`.pm/tasks/task_bca86dc8b045420baf35b7e28414818c.execution.md`、`.pm/tasks/task_f59a3d14ebcd47dcacbee3a7aa725675.execution.md`): release Web gate 已收口 preflight shadow、独立端口、software-safe live-control 语义与 headed/headless evidence 边界。
+- `TASK-TESTING-065/064/063/062`: 已依次收口 launcher `build-web-dist` wasm 兼容性、`release-gate-soak` S10 样本修复、Web UI 闭环 canonical manual，以及 Token 创世分配 QA 审计清单；详细验收命令回到对应 `.pm/tasks/task_<32hex>.execution.md`。
 
 ## 依赖
-- 模块设计总览：`doc/testing/design.md`
-- doc/testing/prd.index.md
-- `testing-manual.md`
-- `doc/testing/manual/web-ui-agent-browser-closure-manual.manual.md`
-- `doc/testing/manual/web-ui-agent-browser-closure-manual.prd.md`
-- `scripts/ci-tests.sh`
-- `.github/workflows/*`
-- `.agents/skills/prd/check.md`
+- 模块设计总览: `doc/testing/design.md`
+- 文件级索引: `doc/testing/prd.index.md`
+- 标准测试手册: `testing-manual.md`
+- Web UI 闭环 manual: `doc/testing/manual/web-ui-agent-browser-closure-manual.manual.md`
+- Web UI 闭环 PRD: `doc/testing/manual/web-ui-agent-browser-closure-manual.prd.md`
+- CI 入口: `scripts/ci-tests.sh`
+- GitHub workflow: `.github/workflows/*`
+- PRD governance check: `.agents/skills/prd/check.md`
 
 ## 状态
-- 更新日期: 2026-05-06
+- 更新日期: 2026-06-16
 - 当前状态: active
-- 当前窗口摘要: `playability-governance-stack-2026-05-06` 已把“自动化不能单独保证好玩”的治理结论、标准角色 subagent 评审系统、模拟玩家 persona panel，以及 `L4A synthetic` / `L4B embodied-agent` / `L5` 真实人类与线上验证边界收口为单个 bundle 视图；同批 follow-up 已补 `scripts/prepare-playability-l4-review.sh`、`scripts/run-playability-l4b-agent.sh` 与 `playability-l4-*` 模板，让单个 worktree 内可以直接准备完整 `L4A + L4B` 执行包，并把内部真人试玩降为 `L4B` 可选校准附录。`--with-l4a-stack` 入口继承 formal gameplay 的 active LLM provider preflight；若当前环境缺少 `OASIS7_LLM_MODEL` / 等价 `config.toml`，会在 harness 启动前 `blocked`，这属于环境前置而不是 scaffold 缺项。
-- 当前窗口摘要: `playability-player-leverage-evidence-rubric` 已为 trust/playability 证据补单独的 `player leverage` 审查层，避免再用 world activity 代替玩家有效参与。
-- 下一任务: 等待 `producer_system_designer` / `runtime_engineer` 提供真实创世账户表后，用 `token-genesis-allocation-audit-template-2026-03-22` 执行首轮正式审计。
-- 当前窗口摘要: `shared-network-ecs-triad-chain-status-metrics-rollout` 已冻结本机 observer + 两台阿里云 ECS 的 same-window triad snapshot、最近 `10` 分钟 traffic window，以及 `/v1/chain/status` 新增 `transactions` / `recent_finality_latency` / `pending_proposal` / `pending_consensus_actions` live contract 证据。
-- 当前窗口摘要: `required-gate-ondemand-launcher-web-build`、`rust-required-gate-ondemand-scope` 与 `wasm-determinism-gate-ondemand-scope` 已把 GitHub required gate 收口为 stable context + changed-path on-demand 执行；launcher/shared runtime 命中时会额外补跑 launcher Web `trunk build`。
-- 当前窗口摘要: `TASK-TESTING-065/064/063/062` 已依次收口 launcher `build-web-dist` wasm 兼容性、`release-gate-soak` S10 样本修复、Web UI 闭环 canonical manual，以及 Token 创世分配 QA 审计清单。
-- 近期完成项不再在本页按时间顺序手工追加；详细收口请回到对应 topic `*.project.md`、`doc/testing/evidence/*.md` 与 `.pm/tasks/task_<32hex>.yaml` / execution log 追溯。
 - 阶段收口优先级: `P0`
-- 阶段 owner: `qa_engineer`（联审：`producer_system_designer`）
-- 阻断条件: 在 `TASK-TESTING-002/003` 完成前，跨模块发布评审不得声称“测试范围明确且证据齐备”。
-- 承接约束: `TASK-TESTING-002` 完成后进入 `TASK-TESTING-003`；`TASK-TESTING-004` 作为趋势化建设保留在其后。
-- 专题映射状态: 2026-03-02 批次 3/3 已纳入模块项目管理文档。
-- 专题映射状态补充: 2026-03-06 批次 1/1 已纳入模块项目管理文档。
-- 专题映射状态补充: 2026-03-08 批次 1/1 已完成（启动器全功能可用性审查）。
-- 专题映射状态补充: 2026-03-10 批次 1/1 已完成（启动器人工测试清单建档）。
+- 阶段 owner: `qa_engineer`（联审: `producer_system_designer`）
+- 当前阻断条件: 在 `test-coverage-gate-fill` 完成前，跨模块发布评审不得声称 workspace support crates 与 required-gate changed-path planner 覆盖已经完整。
+- 承接约束: `test-coverage-gate-fill` 是当前唯一 active 测试治理任务；历史 `TASK-TESTING-*` 完成项回到上方追溯索引、专题 project 与 `.pm` execution log 查询。
 - headless-runtime 长稳门禁联动: 已通过 `doc/headless-runtime/templates/headless-runtime-release-gate-linkage.md` 约定证据包字段映射。
 - PRD 质量门状态: strict schema 已对齐（含第 6 章验证与决策记录）。
 - 模块进展补充（2026-03-11）: 已新增 `doc/testing/evidence/testing-quality-trend-baseline-2026-03-11.md`，以 launcher / game / runtime 三个近期样本建立首次通过率、阶段内逃逸率与修复时长 baseline。
-- 说明: 本文档仅维护 testing 模块当前执行窗口；更细的历史完成项、旧阶段交接与专题收口请回到对应 topic `*.project.md`、`doc/testing/evidence/*.md` 与 `.pm/tasks/task_<32hex>.execution.md` 追溯。
+- 说明: 本文档仅维护 testing 模块当前执行窗口和高价值追溯入口；更细的历史完成项、旧阶段交接与专题收口请回到对应 topic `*.project.md`、`doc/testing/evidence/*.md` 与 `.pm/tasks/task_<32hex>.execution.md` 追溯。

--- a/doc/testing/project.md
+++ b/doc/testing/project.md
@@ -30,6 +30,7 @@
 | Performance coverage and baselines | `doc/testing/performance/performance-coverage-gap-matrix-2026-06-09.md`、`testing-manual.md` 的 required-gate / Viewer performance probe 段落 |
 
 ## 最近高价值完成摘要
+- `testing-doc-default-surface-slimming` (Trace: .pm/tasks/task_0af93d9ebb8c45df8cf013e11840cc9b.yaml): 默认 testing 文档阅读面已压缩为当前执行窗口、历史追溯索引与 canonical redirect；Viewer perf smoke 当前态同步为 required-gate report-only scoped 行为。
 - `engineering-code-quality-performance-baselines` (Trace: `.pm/tasks/task_35657c5f0a5543dda5d57f51fc4b8841.execution.md`): Viewer changed-path perf smoke 已接入 required-gate report-only scope；runtime module routing perf harness 已有首个 dev/release baseline。
 - `required-gate-ondemand-launcher-web-build` (Trace: `.pm/tasks/task_3778b0e747b249bc85b92b942a32b3fd.yaml`): launcher Web `trunk build` 已按 changed-path 注入 required gate，避免 release `build-web-dist` 才暴露编译错误。
 - `release-web-*` hardening 系列 (Trace examples: `.pm/tasks/task_b7097f476e674a429469a98d6ae36794.execution.md`、`.pm/tasks/task_bca86dc8b045420baf35b7e28414818c.execution.md`、`.pm/tasks/task_f59a3d14ebcd47dcacbee3a7aa725675.execution.md`): release Web gate 已收口 preflight shadow、独立端口、software-safe live-control 语义与 headed/headless evidence 边界。


### PR DESCRIPTION
## Summary
- Slim default testing documentation surfaces while preserving traceability through current-window and historical pointers.
- Remove drift-prone static counts from testing README/index surfaces.
- Refresh Viewer performance matrix wording and compact completed systematic testing manual planning triplet into historical redirects.

## Validation
- `./scripts/doc-governance-check.sh` -> OK
- `./scripts/pm/workflow-lint.sh --task-uid task_0af93d9ebb8c45df8cf013e11840cc9b --phase pr-ready` -> OK
- `git diff --check` -> OK
- Pre-PR local role review: `repository_health_engineer` and `qa_engineer` no_findings; narrow repository-health re-review no_findings for PR-readiness Trace/evidence update.

Residual risk: repo-wide PM lint still has unrelated historical task-log failures; current-task workflow lint and filtered current-task checks are clean.