### PR TITLE
Backfill SIG-PM-0068 regression tests

### DIFF
--- a/.pm/roles/qa_engineer/backlog/done.yaml
+++ b/.pm/roles/qa_engineer/backlog/done.yaml
@@ -461,3 +461,17 @@ tasks:
     handoff_to: []
     status: done
     task_path: .pm/tasks/task_46ea1c81166043e3a1e3d5899b618ae6.yaml
+  - task_uid: task_22364604bc04498ebe7f10a5247757cd
+    title: "Backfill SIG-PM-0068 regression tests"
+    priority: P2
+    source_signal: null
+    related_prd: []
+    acceptance:
+      - "Permanent automated regression coverage exists for unified-world terminology scan path/content negative cases."
+      - "Permanent automated regression coverage exists for Bash 4+ preflight behavior on SIG-PM-0068 release-gate entrypoints under Bash 3.2-compatible local shells."
+      - "Focused verification commands pass and are recorded in the task execution log."
+    handoff_to:
+      - repository_health_engineer
+      - qa_engineer
+    status: done
+    task_path: .pm/tasks/task_22364604bc04498ebe7f10a5247757cd.yaml

--- a/.pm/tasks/task_22364604bc04498ebe7f10a5247757cd.execution.md
+++ b/.pm/tasks/task_22364604bc04498ebe7f10a5247757cd.execution.md
@@ -146,3 +146,12 @@ Example:
 - Review Findings Disposition: addressed
 - Finding Disposition Evidence: Refreshed packet records `Source Head: 891eb2edf0ae1cdb99da760a6ae71e789ba49d9c` and `Comparison Ref: refs/remotes/origin/main`; no code/test changes required after review findings.
 - Residual Risk: Bash 4+/5 positive `--help` branch is expected to run in Linux CI; local macOS exercised Bash 3.2 preflight branch and no-`rg` scan behavior.
+
+## 2026-06-17 14:08:12 CST / tpm
+- 完成内容: Addressed PR #501 GitHub automated review feedback about Bash 3 preflight coverage in required gate.
+- 遗留事项: Local dynamic early-exit execution still uses Bash 3.2 on this machine; Linux CI will additionally run the new environment-independent static guard-order assertions under Bash 5.
+- Action: Updated `scripts/release-gate-bash-preflight.test.sh` to assert, independent of interpreter version, that each SIG-PM-0068 release-gate entrypoint contains the Bash 4+ guard, reason, hint, and `exit 2` before the first body marker (`source`, `declare -A`, `mapfile`, or `usage`). Kept the existing dynamic Bash 3.2 early-exit assertions and Bash 4+ `--help` branch.
+- Validation Command: `./scripts/release-gate-bash-preflight.test.sh && ./scripts/unified-world-code-terminology-scan.test.sh && ./scripts/unified-world-code-terminology-scan.sh`; `bash -n scripts/release-gate-bash-preflight.test.sh scripts/unified-world-code-terminology-scan.sh scripts/unified-world-code-terminology-scan.test.sh scripts/ci-tests.sh`; `git diff --check`; `./scripts/doc-governance-check.sh`.
+- Expected Result: Bash preflight test passes locally and now catches guard removal/reordering even on Bash 5 CI.
+- Actual Result: `release-gate-bash-preflight.test: OK`; terminology test and standalone scan exited `0`; Bash syntax exited `0`; `git diff --check` exited `0`; `doc-governance-check: OK`.
+- Blocker / Next Action: Commit/push review fix, reply to and resolve GitHub review thread, refresh current-head local role review evidence, and watch PR #501 checks.

--- a/.pm/tasks/task_22364604bc04498ebe7f10a5247757cd.execution.md
+++ b/.pm/tasks/task_22364604bc04498ebe7f10a5247757cd.execution.md
@@ -1,0 +1,63 @@
+# task_22364604bc04498ebe7f10a5247757cd Execution Log
+
+- task_uid: task_22364604bc04498ebe7f10a5247757cd
+- title: Backfill SIG-PM-0068 regression tests
+- owner_role: qa_engineer
+- worktree_hint: /Users/scc/ccwork/worktrees/oasis7-runtime-sig-pm-0068-test-coverage
+
+<!-- Append entries using:
+Example:
+  ## YYYY-MM-DD HH:MM:SS CST / role_name
+  - 完成内容: ...
+  - 遗留事项: ...
+  - Action: ...
+  - Validation Command: ...
+  - Expected Result: ...
+  - Actual Result: ...
+  - Blocker / Next Action: ...
+-->
+
+## 2026-06-17 13:19:19 CST / tpm
+- 完成内容: WORKFLOW BOOTSTRAP DECIDED. Created canonical task worktree `/Users/scc/ccwork/worktrees/oasis7-runtime-sig-pm-0068-test-coverage` on branch `task/runtime-sig-pm-0068-test-coverage`, bound new task `task_22364604bc04498ebe7f10a5247757cd`, and moved it to `committed`.
+- 遗留事项: None for bootstrap.
+- Action: Ran `./scripts/new-task-worktree.sh runtime sig-pm-0068-test-coverage --base main --pm-owner-role qa_engineer --pm-title "Backfill SIG-PM-0068 regression tests" --pm-source-ref doc/core/unified-persistent-world-terminology-upgrade-plan-2026-06-16.md --pm-doc-ref doc/core/project.md --pm-acceptance ... --pm-handoff-to repository_health_engineer --pm-handoff-to qa_engineer --json`.
+- Validation Command: `git -C /Users/scc/ccwork/worktrees/oasis7-runtime-sig-pm-0068-test-coverage status --short --branch`
+- Expected Result: Worktree is isolated on the task branch with task truth created under `.pm/tasks/`.
+- Actual Result: Worktree created with task UID `task_22364604bc04498ebe7f10a5247757cd`, owner `qa_engineer`, source ref `doc/core/unified-persistent-world-terminology-upgrade-plan-2026-06-16.md`, and acceptance criteria for permanent SIG-PM-0068 regression tests.
+- Blocker / Next Action: Route to TDD-style test authoring and QA/repository-health review slices before closeout.
+
+## 2026-06-17 13:19:19 CST / tpm
+- 完成内容: WORKFLOW ROUTE DECIDED. Current phase is test backfill implementation for a newly bootstrapped task. Selected skills: `tdd-test-writer` for behavior-first permanent regression tests, `executing-project-tasks` for implementation, `verification-before-completion` before completion claims, `requesting-repo-owned-review` before PR, and `finishing-a-development-branch` after local verification/review passes.
+- 遗留事项: TDD strict RED may be partial because the requested task is to add tests for already-merged behavior; RED evidence can be shown by temporary mutation/probe or by adding tests that would have failed before SIG-PM-0068 fixes.
+- Action: TODO decomposition: 1) inspect existing shell test conventions; 2) add committed regression test for unified-world terminology scan content and path negative cases; 3) add committed regression test for Bash 4+ preflight behavior on `p2p-longrun-soak.sh`, `s10-five-node-game-soak.sh`, and `module-release-node-acceptance.sh`; 4) wire the tests into the required shell-test surface if appropriate; 5) run focused verification plus governance checks; 6) dispatch/collect QA and repository-health slices for coverage review.
+- Validation Command: `sed -n '1,220p' scripts/plan-rust-required-scope.test.sh`; `sed -n '90,180p' scripts/ci-tests.sh`; `sed -n '1,220p' scripts/unified-world-code-terminology-scan.sh`
+- Expected Result: Existing repo-owned shell tests are executable `scripts/*.test.sh` files and required-gate wiring can be updated without a new framework.
+- Actual Result: Existing conventions confirmed: focused shell tests use `scripts/*.test.sh`; `scripts/ci-tests.sh` runs required shell governance checks through `run_required_gate_checks`.
+- Blocker / Next Action: Author permanent shell regression tests.
+
+## 2026-06-17 13:19:19 CST / tpm
+- 完成内容: Subagent Slice Contracts recorded before professional validation. Slice A role `qa_engineer`; slice type: coverage design and verification review; intended model configuration: workflow source-of-truth default subagent runtime; actual dispatched model/reasoning: inherited/unverified if current tool cannot report exact model; context delivery mode: full-thread/full-history fork preferred, explicit context packet fallback; mandatory context checklist: AGENTS.md workflow, `.agents/roles/qa_engineer.md`, `doc/engineering/workflow/source-of-truth.md`, this task yaml/execution log, SIG-PM-0068 source plan Phase 3B, PR #500 residual test gaps, branch/worktree, and shell test conventions; write scope: no production code unless explicitly returning patch suggestions, may edit only test/docs if delegated; return contract: findings/no_findings, missing regression risks, commands to run, residual risk; formal sink: this execution log; integration owner/order: TPM integrates after local test authoring.
+- 遗留事项: None for slice contract.
+- Action: Slice B role `repository_health_engineer`; slice type: test-surface integration and required-gate impact review; intended model configuration: workflow source-of-truth default subagent runtime; actual dispatched model/reasoning: inherited/unverified if current tool cannot report exact model; context delivery mode: full-thread/full-history fork preferred, explicit context packet fallback; mandatory context checklist: AGENTS.md workflow, `.agents/roles/repository_health_engineer.md`, `doc/engineering/workflow/source-of-truth.md`, this task truth, `scripts/ci-tests.sh`, new shell tests, and SIG-PM-0068 scan/preflight scripts; write scope: review only unless delegated to patch CI test wiring; return contract: findings/no_findings, gate integration concerns, residual risk; formal sink: this execution log; integration owner/order: TPM integrates after QA slice.
+- Validation Command: `tool_search multi-agent spawn_agent availability`
+- Expected Result: Subagent dispatch is available under existing repo policy authorization.
+- Actual Result: `multi_agent_v1.spawn_agent` is available; actual model selection is not guaranteed to be reportable, so contracts record inherited/unverified.
+- Blocker / Next Action: Dispatch bounded review slices after initial tests are in place.
+
+## 2026-06-17 13:27:53 CST / tpm
+- 完成内容: Permanent SIG-PM-0068 regression tests added. `scripts/unified-world-code-terminology-scan.test.sh` now creates and cleans temporary negative probes for both legacy content and legacy path names. `scripts/release-gate-bash-preflight.test.sh` now verifies the three Bash-4-dependent release-gate entrypoints fail early under Bash 3.2-compatible local shells with clear reason/hint text and without raw `mapfile` / `declare -A` errors. `scripts/ci-tests.sh` wires both tests into `run_required_gate_checks`.
+- 遗留事项: Bash 4+ positive `--help` behavior is conditional in the new test and will be exercised only in environments whose `bash` is Bash 4+; this local macOS shell verified the task's explicit Bash 3.2-compatible preflight branch.
+- Action: Added `scripts/unified-world-code-terminology-scan.test.sh`; added `scripts/release-gate-bash-preflight.test.sh`; updated `scripts/ci-tests.sh`; chmodded both new shell tests executable. Dispatched QA slice `019ed408-5333-7343-9718-65338fc90b24` and repository-health slice `019ed408-61f8-7621-8055-950eae718512`.
+- Validation Command: `./scripts/unified-world-code-terminology-scan.test.sh && ./scripts/release-gate-bash-preflight.test.sh`; `bash -n scripts/unified-world-code-terminology-scan.test.sh scripts/release-gate-bash-preflight.test.sh scripts/ci-tests.sh`; `./scripts/unified-world-code-terminology-scan.sh`; `./scripts/check-script-executable-bits.sh`; `./scripts/pm/workflow-lint.sh --task-uid task_22364604bc04498ebe7f10a5247757cd --phase current`; `git diff --check`; QA/repository-health slice review.
+- Expected Result: New tests pass, remain non-self-triggering for the terminology scan, are executable, are wired into required gate, and professional slices find no blocking coverage or repository-health issue.
+- Actual Result: Focused tests exited `0`; `bash -n` exited `0`; terminology scan exited `0` with `allowed compatibility content hits: 17` and `allowed compatibility path hits: 17`; executable-bit check exited `0`; workflow lint exited `0`; `git diff --check` exited `0`. QA slice returned `no_findings` and judged permanent content/path negative coverage plus Bash 3.2 preflight coverage sufficient. Repository-health slice returned `no_findings`, judged required-gate wiring lightweight, and noted TPM should ensure new files are staged as executable mode `100755`.
+- Blocker / Next Action: Wait for `./scripts/doc-governance-check.sh`, verify staged modes, then close out the task.
+
+## 2026-06-17 13:33:26 CST / tpm
+- 完成内容: Task closeout verification completed and task truth was marked `done`. The helper's verify-command passed and wrote `last_verification_status=verified`, `last_verification_exit_code=0`, and `last_closed_at` into `.pm/tasks/task_22364604bc04498ebe7f10a5247757cd.yaml`.
+- 遗留事项: Full `pm-lint` remains blocked by pre-existing unrelated historical task-log shape failures outside this task; task-scoped workflow lint for this task passes.
+- Action: Ran `./scripts/pm/task-closeout.sh --role qa_engineer --task-uid task_22364604bc04498ebe7f10a5247757cd --verify-command '<focused SIG-PM-0068 test-backfill verification command>'`. Then attempted the same command with `--no-lint`, which correctly reported the task was already closed with `status=done`.
+- Validation Command: Closeout verify-command: `./scripts/unified-world-code-terminology-scan.test.sh && ./scripts/release-gate-bash-preflight.test.sh && bash -n scripts/unified-world-code-terminology-scan.test.sh scripts/release-gate-bash-preflight.test.sh scripts/ci-tests.sh && ./scripts/unified-world-code-terminology-scan.sh && ./scripts/check-script-executable-bits.sh && ./scripts/pm/workflow-lint.sh --task-uid task_22364604bc04498ebe7f10a5247757cd --phase current && ./scripts/doc-governance-check.sh && git diff --check`; task yaml inspection.
+- Expected Result: Focused verification exits `0`, task yaml records verified closeout, and any remaining lint failure is unrelated to this task.
+- Actual Result: Focused verification exited `0`; `doc-governance-check: OK`; task yaml records `status: done`, `last_claim_type: task_complete`, `last_verification_exit_code: 0`, `last_verification_status: verified`, and `last_closed_at: 2026-06-17T13:32:20+08:00`. Full `pm-lint` failed only after closeout on unrelated existing `.pm/tasks/*` logs such as `task_0deb46f616874e40b147407f6b1e510b`; this task's `./scripts/pm/workflow-lint.sh --task-uid task_22364604bc04498ebe7f10a5247757cd --phase current` passed.
+- Blocker / Next Action: Stage, verify executable modes, commit, then record pre-PR local role review evidence before PR creation.

--- a/.pm/tasks/task_22364604bc04498ebe7f10a5247757cd.execution.md
+++ b/.pm/tasks/task_22364604bc04498ebe7f10a5247757cd.execution.md
@@ -115,3 +115,12 @@ Example:
 - Expected Result: PR is opened against `main` after pre-PR local role review passes.
 - Actual Result: `prepare-task-pr --json` exited `0` with `pre_pr_local_role_review.status=passed`; `prepare-task-pr --create` failed only on missing local `gh`; branch pushed successfully; PR created at `https://github.com/eng-cc/oasis7/pull/501`, head `eba6b0dd795f4c4e7e766931648f1c0492d3c8bc`, base `1a2c5527c49072e9397b23b90a498d7c23a1247d`.
 - Blocker / Next Action: Commit/push this PR-purpose evidence, then watch PR #501 required checks and review/comment state.
+
+## 2026-06-17 13:48:25 CST / tpm
+- 完成内容: Addressed PR #501 Rust required-gate failure. CI failed in `scripts/unified-world-code-terminology-scan.test.sh` because the Linux runner did not have `rg` in `PATH`; the underlying scan script depended on spawning `rg` from Python. Removed that runtime dependency by using Python path traversal and UTF-8 line scanning directly inside `scripts/unified-world-code-terminology-scan.sh`.
+- 遗留事项: None for this failure; the scan still reports the same allowed compatibility content/path hit counts locally.
+- Action: Replaced subprocess `rg` content/path scans with Python `pathlib` traversal, `read_text`, regex matching, and path-name matching.
+- Validation Command: `./scripts/unified-world-code-terminology-scan.test.sh && ./scripts/unified-world-code-terminology-scan.sh`; `bash -n scripts/unified-world-code-terminology-scan.sh scripts/unified-world-code-terminology-scan.test.sh scripts/release-gate-bash-preflight.test.sh scripts/ci-tests.sh`; `./scripts/release-gate-bash-preflight.test.sh`; `./scripts/check-script-executable-bits.sh`; `./scripts/pm/workflow-lint.sh --task-uid task_22364604bc04498ebe7f10a5247757cd --phase pr-ready`; `./scripts/doc-governance-check.sh`; `git diff --check`.
+- Expected Result: Terminology scan tests pass without relying on `rg`; Bash syntax and task/governance checks pass.
+- Actual Result: Terminology regression test exited `0`; standalone scan exited `0` with `allowed compatibility content hits: 17` and `allowed compatibility path hits: 17`; Bash syntax exited `0`; release-gate Bash preflight test exited `0`; executable-bit check exited `0`; workflow lint exited `0`; `doc-governance-check: OK`; `git diff --check` exited `0`.
+- Blocker / Next Action: Commit/push the CI fix, refresh current-head local role review evidence, and watch new required checks.

--- a/.pm/tasks/task_22364604bc04498ebe7f10a5247757cd.execution.md
+++ b/.pm/tasks/task_22364604bc04498ebe7f10a5247757cd.execution.md
@@ -60,4 +60,27 @@ Example:
 - Validation Command: Closeout verify-command: `./scripts/unified-world-code-terminology-scan.test.sh && ./scripts/release-gate-bash-preflight.test.sh && bash -n scripts/unified-world-code-terminology-scan.test.sh scripts/release-gate-bash-preflight.test.sh scripts/ci-tests.sh && ./scripts/unified-world-code-terminology-scan.sh && ./scripts/check-script-executable-bits.sh && ./scripts/pm/workflow-lint.sh --task-uid task_22364604bc04498ebe7f10a5247757cd --phase current && ./scripts/doc-governance-check.sh && git diff --check`; task yaml inspection.
 - Expected Result: Focused verification exits `0`, task yaml records verified closeout, and any remaining lint failure is unrelated to this task.
 - Actual Result: Focused verification exited `0`; `doc-governance-check: OK`; task yaml records `status: done`, `last_claim_type: task_complete`, `last_verification_exit_code: 0`, `last_verification_status: verified`, and `last_closed_at: 2026-06-17T13:32:20+08:00`. Full `pm-lint` failed only after closeout on unrelated existing `.pm/tasks/*` logs such as `task_0deb46f616874e40b147407f6b1e510b`; this task's `./scripts/pm/workflow-lint.sh --task-uid task_22364604bc04498ebe7f10a5247757cd --phase current` passed.
+- claim-ready evidence: `./scripts/pm/task-closeout.sh --role qa_engineer --task-uid task_22364604bc04498ebe7f10a5247757cd --verify-command '<focused SIG-PM-0068 test-backfill verification command>'` wrote `last_claim_type: task_complete`, `last_verification_status: verified`, and `last_verification_exit_code: 0`.
 - Blocker / Next Action: Stage, verify executable modes, commit, then record pre-PR local role review evidence before PR creation.
+
+## 2026-06-17 13:34:00 CST / tpm
+- 完成内容: Pre-PR local role review integrated and passed for the committed test-backfill diff.
+- 遗留事项: Bash 4+ positive `--help` branch remains CI/environment-dependent; local Bash 3.2 branch is covered and is the explicit acceptance target.
+- Action: Recorded fresh involved-role reviews from QA slice `019ed408-5333-7343-9718-65338fc90b24` and repository-health slice `019ed408-61f8-7621-8055-950eae718512`; committed the implementation slice first as `6ecb2b27fac97a2761f4ee8539cd5c6da9c98fdf`; only this review-evidence entry is appended after the reviewed source head.
+- Validation Command: QA slice commands: `bash --version | head -1`; `bash -n scripts/unified-world-code-terminology-scan.test.sh scripts/release-gate-bash-preflight.test.sh scripts/ci-tests.sh scripts/unified-world-code-terminology-scan.sh`; `./scripts/unified-world-code-terminology-scan.test.sh`; `./scripts/release-gate-bash-preflight.test.sh`; `./scripts/unified-world-code-terminology-scan.sh`; `git diff --check`; `bash ./scripts/check-script-executable-bits.sh`. Repository-health slice commands: `./scripts/unified-world-code-terminology-scan.test.sh`; `./scripts/release-gate-bash-preflight.test.sh`; `bash ./scripts/check-script-executable-bits.sh`; `bash -n scripts/unified-world-code-terminology-scan.test.sh scripts/release-gate-bash-preflight.test.sh scripts/ci-tests.sh scripts/check-script-executable-bits.sh scripts/unified-world-code-terminology-scan.sh`.
+- Expected Result: Involved professional roles return no blocking findings or all findings are addressed before PR creation.
+- Actual Result: QA slice returned `no_findings`, confirming permanent content/path negative terminology coverage, Bash 3.2-compatible Bash 4+ preflight coverage for the three SIG-PM-0068 release-gate entrypoints, and required-gate integration. Repository-health slice returned `no_findings`, confirming the tests avoid self-triggering the scan, are executable, are lightweight, and are wired into required gate; TPM verified staged commit mode `100755` for both new test files before commit.
+- Blocker / Next Action: Run PR preflight/create.
+- Pre-PR Local Role Review: passed
+- Task UID: task_22364604bc04498ebe7f10a5247757cd
+- Source Worktree: /Users/scc/ccwork/worktrees/oasis7-runtime-sig-pm-0068-test-coverage
+- Source Branch: task/runtime-sig-pm-0068-test-coverage
+- Source Head: 6ecb2b27fac97a2761f4ee8539cd5c6da9c98fdf
+- Comparison Ref: main
+- Reviewed Changed Paths: .pm/roles/qa_engineer/backlog/done.yaml; .pm/tasks/task_22364604bc04498ebe7f10a5247757cd.execution.md; .pm/tasks/task_22364604bc04498ebe7f10a5247757cd.yaml; scripts/ci-tests.sh; scripts/release-gate-bash-preflight.test.sh; scripts/unified-world-code-terminology-scan.test.sh
+- Role Selection Basis: Changed paths add permanent test coverage and required-gate wiring; `qa_engineer` selected for coverage/readiness claims; `repository_health_engineer` selected for shared required-gate/test-surface integration and terminology-scan self-pollution risk.
+- Review Roles: qa_engineer, repository_health_engineer
+- Review Evidence: `qa_engineer`: no_findings, verified terminology content/path negative cases and Bash 3.2 preflight coverage; `repository_health_engineer`: no_findings, verified lightweight required-gate wiring, executable test files, and no scan self-trigger.
+- Review Findings Disposition: no_findings
+- Finding Disposition Evidence: No fixes required after slice review; TPM verified staged modes `100755` before commit.
+- Residual Risk: Bash 4+ positive branch is conditional and should run naturally in Linux/CI environments where `bash` is Bash 4+; local macOS covered the explicit Bash 3.2 preflight acceptance.

--- a/.pm/tasks/task_22364604bc04498ebe7f10a5247757cd.execution.md
+++ b/.pm/tasks/task_22364604bc04498ebe7f10a5247757cd.execution.md
@@ -106,3 +106,12 @@ Example:
 - Review Findings Disposition: addressed
 - Finding Disposition Evidence: Refreshed packet records `Source Head: f2ae5c39f712024042410b2b14b2ca3003e7d14b` and `Comparison Ref: refs/remotes/origin/main`; no code/test changes required.
 - Residual Risk: Local machine only exercised Bash 3.2 preflight branch; Bash 4+/5 positive `--help` branch is encoded in test logic and expected to run in Linux CI.
+
+## 2026-06-17 13:44:03 CST / tpm
+- 完成内容: PR #501 created for normal CI/watch flow.
+- 遗留事项: Continue watching GitHub required checks, mergeability, PR comments, and review threads through merge; `REVIEW_REQUIRED` alone is informational under repo policy.
+- Action: Ran `./scripts/prepare-task-pr.sh --json` successfully; `./scripts/prepare-task-pr.sh --create` passed preflight but failed because `gh` is not installed in this environment. Pushed branch `task/runtime-sig-pm-0068-test-coverage` and used GitHub connector fallback to create PR #501.
+- Validation Command: `./scripts/prepare-task-pr.sh --json`; `./scripts/prepare-task-pr.sh --create`; `git push -u origin task/runtime-sig-pm-0068-test-coverage`; GitHub connector `_create_pull_request`.
+- Expected Result: PR is opened against `main` after pre-PR local role review passes.
+- Actual Result: `prepare-task-pr --json` exited `0` with `pre_pr_local_role_review.status=passed`; `prepare-task-pr --create` failed only on missing local `gh`; branch pushed successfully; PR created at `https://github.com/eng-cc/oasis7/pull/501`, head `eba6b0dd795f4c4e7e766931648f1c0492d3c8bc`, base `1a2c5527c49072e9397b23b90a498d7c23a1247d`.
+- Blocker / Next Action: Commit/push this PR-purpose evidence, then watch PR #501 required checks and review/comment state.

--- a/.pm/tasks/task_22364604bc04498ebe7f10a5247757cd.execution.md
+++ b/.pm/tasks/task_22364604bc04498ebe7f10a5247757cd.execution.md
@@ -155,3 +155,25 @@ Example:
 - Expected Result: Bash preflight test passes locally and now catches guard removal/reordering even on Bash 5 CI.
 - Actual Result: `release-gate-bash-preflight.test: OK`; terminology test and standalone scan exited `0`; Bash syntax exited `0`; `git diff --check` exited `0`; `doc-governance-check: OK`.
 - Blocker / Next Action: Commit/push review fix, reply to and resolve GitHub review thread, refresh current-head local role review evidence, and watch PR #501 checks.
+
+## 2026-06-17 14:15:15 CST / tpm
+- 完成内容: Refreshed pre-PR local role review packet for the GitHub review fix head.
+- 遗留事项: Full `./scripts/ci-tests.sh required` was not run locally; GitHub required gate is the full required-scope authority for this PR.
+- Action: Integrated current-head QA slice `019ed432-b36f-75f2-854a-985355d3c898` and repository-health slice `019ed432-b491-7d01-9010-f27055d0943c`. Both returned `no_findings` and confirmed the updated Bash preflight test addresses PR #501 review feedback by adding environment-independent static guard-order assertions while retaining dynamic Bash 3.2 coverage.
+- Validation Command: QA commands included diff/status checks, `bash -n scripts/unified-world-code-terminology-scan.sh scripts/unified-world-code-terminology-scan.test.sh scripts/release-gate-bash-preflight.test.sh scripts/ci-tests.sh scripts/p2p-longrun-soak.sh scripts/s10-five-node-game-soak.sh scripts/module-release-node-acceptance.sh`, `./scripts/unified-world-code-terminology-scan.test.sh`, `./scripts/release-gate-bash-preflight.test.sh`, `./scripts/unified-world-code-terminology-scan.sh`, `bash ./scripts/check-script-executable-bits.sh`, `git ls-files --stage ...`, `./scripts/pm/workflow-lint.sh --task-uid task_22364604bc04498ebe7f10a5247757cd --phase pr-ready`, `./scripts/doc-governance-check.sh`, and no-`rg` scan simulation. Repository-health ran equivalent required-gate/test-wiring checks and `prepare-task-pr --json`.
+- Expected Result: Current-head professional review finds no blocking issues, and the refreshed packet matches current source head and `refs/remotes/origin/main`.
+- Actual Result: QA `no_findings`: current diff ready from coverage standpoint, static guard-order assertions cover the Bash 3 preflight concern under Linux Bash 5, dynamic Bash 3.2 branch still passes locally. Repository-health `no_findings`: required-gate wiring is correct, no-`rg` scan simulation passes, and the GitHub review concern is addressed.
+- Blocker / Next Action: Commit/push refreshed review evidence, reply to GitHub review thread, resolve it, and watch PR #501 required checks again.
+- Pre-PR Local Role Review: passed
+- Task UID: task_22364604bc04498ebe7f10a5247757cd
+- Source Worktree: /Users/scc/ccwork/worktrees/oasis7-runtime-sig-pm-0068-test-coverage
+- Source Branch: task/runtime-sig-pm-0068-test-coverage
+- Source Head: 80a03358120e45a2597a08328acf401517d42382
+- Comparison Ref: refs/remotes/origin/main
+- Reviewed Changed Paths: .pm/roles/qa_engineer/backlog/done.yaml; .pm/tasks/task_22364604bc04498ebe7f10a5247757cd.execution.md; .pm/tasks/task_22364604bc04498ebe7f10a5247757cd.yaml; doc/core/project.md; scripts/ci-tests.sh; scripts/release-gate-bash-preflight.test.sh; scripts/unified-world-code-terminology-scan.sh; scripts/unified-world-code-terminology-scan.test.sh
+- Role Selection Basis: Changed paths add permanent QA regression tests, required-gate wiring, PM task truth, core project trace, CI fix to the shared terminology scan, and GitHub review fix for Bash preflight coverage; `qa_engineer` selected for test coverage/readiness claims; `repository_health_engineer` selected for required-gate/test-surface integration, executable mode, prepare-task-pr marker health, no-`rg` dependency removal, and GitHub review feedback.
+- Review Roles: qa_engineer, repository_health_engineer
+- Review Evidence: `qa_engineer`: no_findings, confirmed static guard-order assertions plus dynamic Bash 3.2 checks cover PR #501 feedback; focused tests/governance passed. `repository_health_engineer`: no_findings, confirmed required-gate wiring, no-`rg` scan simulation, executable modes, and environment-independent Bash preflight assertions.
+- Review Findings Disposition: no_findings
+- Finding Disposition Evidence: No code/test fixes required after current-head role reviews.
+- Residual Risk: Linux CI should exercise Bash 4+/5 positive `--help` behavior and full required scope; local macOS exercised Bash 3.2 branch and no-`rg` scan behavior.

--- a/.pm/tasks/task_22364604bc04498ebe7f10a5247757cd.execution.md
+++ b/.pm/tasks/task_22364604bc04498ebe7f10a5247757cd.execution.md
@@ -124,3 +124,25 @@ Example:
 - Expected Result: Terminology scan tests pass without relying on `rg`; Bash syntax and task/governance checks pass.
 - Actual Result: Terminology regression test exited `0`; standalone scan exited `0` with `allowed compatibility content hits: 17` and `allowed compatibility path hits: 17`; Bash syntax exited `0`; release-gate Bash preflight test exited `0`; executable-bit check exited `0`; workflow lint exited `0`; `doc-governance-check: OK`; `git diff --check` exited `0`.
 - Blocker / Next Action: Commit/push the CI fix, refresh current-head local role review evidence, and watch new required checks.
+
+## 2026-06-17 13:54:15 CST / tpm
+- 完成内容: Refreshed pre-PR local role review packet for the CI fix head after both current-head review slices found only stale evidence markers.
+- 遗留事项: Bash 4+/5 positive `--help` branch remains environment-dependent; local Bash 3.2 branch and no-`rg` scan behavior are covered.
+- Action: Integrated current-head QA slice `019ed420-7045-7092-bc93-eb154a9f08bb` and repository-health slice `019ed420-7152-7403-97cd-535a96c5ff79`. Both slices found the same valid P1 evidence issue: previous packet was stale because `scripts/unified-world-code-terminology-scan.sh` changed after review. Both judged the code/test surface itself ready after the Python traversal fix.
+- Validation Command: QA commands included `git diff --check refs/remotes/origin/main...HEAD`, `bash -n scripts/unified-world-code-terminology-scan.sh scripts/unified-world-code-terminology-scan.test.sh scripts/release-gate-bash-preflight.test.sh scripts/ci-tests.sh`, `./scripts/unified-world-code-terminology-scan.test.sh`, `./scripts/release-gate-bash-preflight.test.sh`, `./scripts/unified-world-code-terminology-scan.sh`, `git ls-files --stage ...`, `./scripts/pm/workflow-lint.sh --task-uid task_22364604bc04498ebe7f10a5247757cd --phase pr-ready`, `./scripts/doc-governance-check.sh`, and `./scripts/prepare-task-pr.sh --json`. Repository-health additionally ran no-`rg` simulation: `env PATH="/usr/bin:/bin" bash -lc 'command -v rg || true; command -v python3; ./scripts/unified-world-code-terminology-scan.test.sh && ./scripts/unified-world-code-terminology-scan.sh'`.
+- Expected Result: Current-head professional review has no blocking code/test findings, and the refreshed packet matches current source head and `refs/remotes/origin/main`.
+- Actual Result: QA finding: stale review evidence only; coverage/readiness itself QA-ready. Repository-health finding: stale review evidence only; Python traversal scan is an appropriate required-gate fix and passes without `rg` in `PATH`. Focused checks passed.
+- Blocker / Next Action: Commit/push refreshed review evidence, rerun `prepare-task-pr --json`, then watch PR #501 checks.
+- Pre-PR Local Role Review: passed
+- Task UID: task_22364604bc04498ebe7f10a5247757cd
+- Source Worktree: /Users/scc/ccwork/worktrees/oasis7-runtime-sig-pm-0068-test-coverage
+- Source Branch: task/runtime-sig-pm-0068-test-coverage
+- Source Head: 891eb2edf0ae1cdb99da760a6ae71e789ba49d9c
+- Comparison Ref: refs/remotes/origin/main
+- Reviewed Changed Paths: .pm/roles/qa_engineer/backlog/done.yaml; .pm/tasks/task_22364604bc04498ebe7f10a5247757cd.execution.md; .pm/tasks/task_22364604bc04498ebe7f10a5247757cd.yaml; doc/core/project.md; scripts/ci-tests.sh; scripts/release-gate-bash-preflight.test.sh; scripts/unified-world-code-terminology-scan.sh; scripts/unified-world-code-terminology-scan.test.sh
+- Role Selection Basis: Changed paths add permanent QA regression tests, required-gate wiring, PM task truth, core project trace, and CI fix to the shared terminology scan; `qa_engineer` selected for test coverage/readiness claims; `repository_health_engineer` selected for required-gate/test-surface integration, executable mode, prepare-task-pr marker health, and removal of external `rg` runtime dependency.
+- Review Roles: qa_engineer, repository_health_engineer
+- Review Evidence: `qa_engineer`: current-head finding only on stale evidence markers; test/code surface QA-ready with terminology content/path tests, Bash 3.2 preflight tests, syntax, workflow lint, doc governance, and executable mode passing. `repository_health_engineer`: current-head finding only on stale evidence markers; Python traversal scan is appropriate, no-`rg` simulation passed, focused gate checks passed.
+- Review Findings Disposition: addressed
+- Finding Disposition Evidence: Refreshed packet records `Source Head: 891eb2edf0ae1cdb99da760a6ae71e789ba49d9c` and `Comparison Ref: refs/remotes/origin/main`; no code/test changes required after review findings.
+- Residual Risk: Bash 4+/5 positive `--help` branch is expected to run in Linux CI; local macOS exercised Bash 3.2 preflight branch and no-`rg` scan behavior.

--- a/.pm/tasks/task_22364604bc04498ebe7f10a5247757cd.execution.md
+++ b/.pm/tasks/task_22364604bc04498ebe7f10a5247757cd.execution.md
@@ -84,3 +84,25 @@ Example:
 - Review Findings Disposition: no_findings
 - Finding Disposition Evidence: No fixes required after slice review; TPM verified staged modes `100755` before commit.
 - Residual Risk: Bash 4+ positive branch is conditional and should run naturally in Linux/CI environments where `bash` is Bash 4+; local macOS covered the explicit Bash 3.2 preflight acceptance.
+
+## 2026-06-17 13:42:11 CST / tpm
+- 完成内容: Refreshed pre-PR local role review packet for current full PR diff head after repository-health found the previous packet stale.
+- 遗留事项: Bash 4+ positive `--help` branch remains CI/environment-dependent; local Bash 3.2 branch is covered.
+- Action: Integrated current-head QA review `019ed415-73dd-7f13-b803-7b3a5f3f0ccf` and repository-health review `019ed415-7515-7061-87ea-0d73a587e465`. Repository-health P1 finding was valid: prior packet used `Source Head: 6ecb2b27...` and `Comparison Ref: main` after `doc/core/project.md` was added in `f2ae5c39...`; this entry refreshes the packet to current full diff head and exact comparison ref expected by `prepare-task-pr`.
+- Validation Command: Current-head QA review commands included `git diff --check refs/remotes/origin/main...HEAD`, `bash -n ...`, `./scripts/unified-world-code-terminology-scan.test.sh`, `./scripts/release-gate-bash-preflight.test.sh`, `./scripts/unified-world-code-terminology-scan.sh`, `bash ./scripts/check-script-executable-bits.sh`, `git ls-files --stage ...`, `./scripts/pm/workflow-lint.sh --task-uid task_22364604bc04498ebe7f10a5247757cd --phase pr-ready`, and `./scripts/doc-governance-check.sh`; repository-health ran the same focused test/gate checks plus `./scripts/prepare-task-pr.sh --json` to identify the stale packet.
+- Expected Result: Current-head professional review has no blocking code/test findings, and pre-PR packet markers now describe the full PR diff against `refs/remotes/origin/main`.
+- Actual Result: QA review returned `no_findings` for current head `f2ae5c39f712024042410b2b14b2ca3003e7d14b`. Repository-health review found only stale pre-PR markers, no test-surface issue; finding addressed by this refreshed packet with `Comparison Ref: refs/remotes/origin/main` and current `Source Head`.
+- Blocker / Next Action: Commit refreshed review evidence and rerun `./scripts/prepare-task-pr.sh --json`.
+- Pre-PR Local Role Review: passed
+- Task UID: task_22364604bc04498ebe7f10a5247757cd
+- Source Worktree: /Users/scc/ccwork/worktrees/oasis7-runtime-sig-pm-0068-test-coverage
+- Source Branch: task/runtime-sig-pm-0068-test-coverage
+- Source Head: f2ae5c39f712024042410b2b14b2ca3003e7d14b
+- Comparison Ref: refs/remotes/origin/main
+- Reviewed Changed Paths: .pm/roles/qa_engineer/backlog/done.yaml; .pm/tasks/task_22364604bc04498ebe7f10a5247757cd.execution.md; .pm/tasks/task_22364604bc04498ebe7f10a5247757cd.yaml; doc/core/project.md; scripts/ci-tests.sh; scripts/release-gate-bash-preflight.test.sh; scripts/unified-world-code-terminology-scan.test.sh
+- Role Selection Basis: Changed paths add permanent QA regression tests, required-gate wiring, PM task truth, and core project trace; `qa_engineer` selected for test coverage/readiness claims; `repository_health_engineer` selected for required-gate/test-surface integration, project trace, executable mode, and prepare-task-pr marker health.
+- Review Roles: qa_engineer, repository_health_engineer
+- Review Evidence: `qa_engineer`: current-head `no_findings`, ready for PR, verified task truth, project trace, CI wiring, content/path negative terminology coverage, Bash 3.2 preflight coverage for all three SIG-PM-0068 release-gate entrypoints, executable mode `100755`, workflow lint and doc governance. `repository_health_engineer`: current-head finding only on stale packet markers; test surface passed focused checks; stale marker finding addressed in this entry.
+- Review Findings Disposition: addressed
+- Finding Disposition Evidence: Refreshed packet records `Source Head: f2ae5c39f712024042410b2b14b2ca3003e7d14b` and `Comparison Ref: refs/remotes/origin/main`; no code/test changes required.
+- Residual Risk: Local machine only exercised Bash 3.2 preflight branch; Bash 4+/5 positive `--help` branch is encoded in test logic and expected to run in Linux CI.

--- a/.pm/tasks/task_22364604bc04498ebe7f10a5247757cd.yaml
+++ b/.pm/tasks/task_22364604bc04498ebe7f10a5247757cd.yaml
@@ -1,0 +1,28 @@
+task_uid: task_22364604bc04498ebe7f10a5247757cd
+title: "Backfill SIG-PM-0068 regression tests"
+owner_role: qa_engineer
+worktree_hint: /Users/scc/ccwork/worktrees/oasis7-runtime-sig-pm-0068-test-coverage
+execution_log_path: .pm/tasks/task_22364604bc04498ebe7f10a5247757cd.execution.md
+status: done
+priority: P2
+source_signal: null
+source_refs:
+  - doc/core/unified-persistent-world-terminology-upgrade-plan-2026-06-16.md
+doc_refs:
+  - doc/core/project.md
+related_prd: []
+acceptance:
+  - "Permanent automated regression coverage exists for unified-world terminology scan path/content negative cases."
+  - "Permanent automated regression coverage exists for Bash 4+ preflight behavior on SIG-PM-0068 release-gate entrypoints under Bash 3.2-compatible local shells."
+  - "Focused verification commands pass and are recorded in the task execution log."
+handoff_to:
+  - repository_health_engineer
+  - qa_engineer
+updated_at: 2026-06-17T13:32:21+08:00
+last_started_at: 2026-06-17T13:17:47+08:00
+last_claim_type: task_complete
+last_verify_command: "./scripts/unified-world-code-terminology-scan.test.sh && ./scripts/release-gate-bash-preflight.test.sh && bash -n scripts/unified-world-code-terminology-scan.test.sh scripts/release-gate-bash-preflight.test.sh scripts/ci-tests.sh && ./scripts/unified-world-code-terminology-scan.sh && ./scripts/check-script-executable-bits.sh && ./scripts/pm/workflow-lint.sh --task-uid task_22364604bc04498ebe7f10a5247757cd --phase current && ./scripts/doc-governance-check.sh && git diff --check"
+last_verified_at: 2026-06-17T13:32:16+08:00
+last_verification_exit_code: 0
+last_verification_status: verified
+last_closed_at: 2026-06-17T13:32:20+08:00

--- a/doc/core/project.md
+++ b/doc/core/project.md
@@ -337,6 +337,19 @@
     - `bash -n scripts/unified-world-code-terminology-scan.sh scripts/module-release-node-acceptance.sh scripts/p2p-longrun-soak.sh scripts/s10-five-node-game-soak.sh scripts/shared-devnet-blocker-packet.sh scripts/shared-devnet-rehearsal.sh scripts/shared-network-track-gate.sh`
     - `./scripts/pm/workflow-lint.sh --task-uid task_acb7e3599b4242628a7ac99a62628d55 --phase pr-ready`
     - `git diff --check`
+- [x] sig-pm-0068-test-coverage (PRD-CORE-003/009) [test_tier_required]: 补齐 SIG-PM-0068 代码层迁移的永久自动化回归测试，覆盖 active terminology scan 的内容/路径负向案例，以及 Bash 3.2-compatible local shell 下 release-gate Bash 4+ preflight 的前置失败行为。 Trace: .pm/tasks/task_22364604bc04498ebe7f10a5247757cd.yaml
+  - 产物文件:
+    - `scripts/unified-world-code-terminology-scan.test.sh`
+    - `scripts/release-gate-bash-preflight.test.sh`
+    - `scripts/ci-tests.sh`
+  - 验收命令 (`test_tier_required`):
+    - `./scripts/unified-world-code-terminology-scan.test.sh`
+    - `./scripts/release-gate-bash-preflight.test.sh`
+    - `bash -n scripts/unified-world-code-terminology-scan.test.sh scripts/release-gate-bash-preflight.test.sh scripts/ci-tests.sh`
+    - `./scripts/unified-world-code-terminology-scan.sh`
+    - `./scripts/check-script-executable-bits.sh`
+    - `./scripts/pm/workflow-lint.sh --task-uid task_22364604bc04498ebe7f10a5247757cd --phase pr-ready`
+    - `git diff --check`
 
 ## 依赖
 - doc/core/prd.index.md

--- a/scripts/ci-tests.sh
+++ b/scripts/ci-tests.sh
@@ -162,6 +162,8 @@ run_required_gate_checks() {
   run bash ./scripts/check-script-executable-bits.sh
   run ./scripts/cargo-dev-lib.test.sh
   run ./scripts/plan-rust-required-scope.test.sh
+  run ./scripts/unified-world-code-terminology-scan.test.sh
+  run ./scripts/release-gate-bash-preflight.test.sh
   run_provider_remote_https_smoke
   run_required_component "provider bridge live gate" "${OASIS7_CI_RUN_PROVIDER_LIVE_GATE:-false}" run_provider_bridge_live_gate
   run_newapi_bridge_service_accounting_tests

--- a/scripts/release-gate-bash-preflight.test.sh
+++ b/scripts/release-gate-bash-preflight.test.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+assert_preflight_for_bash3() {
+  local script="$1"
+  local expected_reason="$2"
+  local expected_hint="$3"
+  local status=0
+  local output
+
+  output="$(bash "$script" --help 2>&1)" || status=$?
+  if (( BASH_VERSINFO[0] < 4 )); then
+    if [[ "$status" -ne 2 ]]; then
+      echo "expected $script to exit 2 under Bash ${BASH_VERSION}, got $status" >&2
+      printf '%s\n' "$output" >&2
+      exit 1
+    fi
+    if [[ "$output" != *"$script requires Bash 4+"* ]]; then
+      echo "expected $script to report Bash 4+ requirement" >&2
+      printf '%s\n' "$output" >&2
+      exit 1
+    fi
+    if [[ "$output" != *"$expected_reason"* ]]; then
+      echo "expected $script to report reason: $expected_reason" >&2
+      printf '%s\n' "$output" >&2
+      exit 1
+    fi
+    if [[ "$output" != *"$expected_hint"* ]]; then
+      echo "expected $script to report hint: $expected_hint" >&2
+      printf '%s\n' "$output" >&2
+      exit 1
+    fi
+    if [[ "$output" == *"mapfile: command not found"* || "$output" == *"declare: -A"* ]]; then
+      echo "expected $script to fail before raw Bash 4-only syntax errors" >&2
+      printf '%s\n' "$output" >&2
+      exit 1
+    fi
+  else
+    if [[ "$status" -ne 0 ]]; then
+      echo "expected $script --help to pass under Bash ${BASH_VERSION}, got $status" >&2
+      printf '%s\n' "$output" >&2
+      exit 1
+    fi
+    if [[ "$output" != *"Usage:"* ]]; then
+      echo "expected $script --help to print usage under Bash ${BASH_VERSION}" >&2
+      printf '%s\n' "$output" >&2
+      exit 1
+    fi
+  fi
+}
+
+assert_preflight_for_bash3 \
+  "scripts/p2p-longrun-soak.sh" \
+  "uses mapfile and associative arrays" \
+  "before release-gate longrun execution"
+
+assert_preflight_for_bash3 \
+  "scripts/s10-five-node-game-soak.sh" \
+  "uses associative arrays" \
+  "before release-gate longrun execution"
+
+assert_preflight_for_bash3 \
+  "scripts/module-release-node-acceptance.sh" \
+  "uses associative arrays" \
+  "before module release acceptance execution"
+
+echo "release-gate-bash-preflight.test: OK"

--- a/scripts/release-gate-bash-preflight.test.sh
+++ b/scripts/release-gate-bash-preflight.test.sh
@@ -4,6 +4,61 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 
+assert_guard_precedes_body() {
+  local script="$1"
+  local expected_reason="$2"
+  local expected_hint="$3"
+  python3 - "$script" "$expected_reason" "$expected_hint" <<'PY'
+from __future__ import annotations
+
+import pathlib
+import sys
+
+script = pathlib.Path(sys.argv[1])
+expected_reason = sys.argv[2]
+expected_hint = sys.argv[3]
+lines = script.read_text(encoding="utf-8").splitlines()
+
+def find(fragment: str) -> int:
+    for index, line in enumerate(lines):
+        if fragment in line:
+            return index
+    raise SystemExit(f"{script}: missing {fragment!r}")
+
+guard_index = find("BASH_VERSINFO[0] < 4")
+requirement_index = find("requires Bash 4+")
+reason_index = find(expected_reason)
+hint_index = find(expected_hint)
+exit_index = find("exit 2")
+body_candidates = [
+    index
+    for index, line in enumerate(lines)
+    for stripped in [line.lstrip()]
+    if (
+        stripped.startswith("source ")
+        or stripped.startswith("declare -A")
+        or stripped.startswith("mapfile ")
+        or stripped.startswith("usage()")
+    )
+]
+if not body_candidates:
+    raise SystemExit(f"{script}: missing body marker")
+first_body_index = min(body_candidates)
+for label, index in {
+    "guard": guard_index,
+    "requirement": requirement_index,
+    "reason": reason_index,
+    "hint": hint_index,
+    "exit": exit_index,
+}.items():
+    if index >= first_body_index:
+        raise SystemExit(
+            f"{script}: {label} line must appear before first body marker "
+            f"(line {index + 1} >= {first_body_index + 1})"
+        )
+PY
+}
+
 assert_preflight_for_bash3() {
   local script="$1"
   local expected_reason="$2"
@@ -52,16 +107,28 @@ assert_preflight_for_bash3() {
   fi
 }
 
+assert_guard_precedes_body \
+  "scripts/p2p-longrun-soak.sh" \
+  "uses mapfile and associative arrays" \
+  "before release-gate longrun execution"
 assert_preflight_for_bash3 \
   "scripts/p2p-longrun-soak.sh" \
   "uses mapfile and associative arrays" \
   "before release-gate longrun execution"
 
+assert_guard_precedes_body \
+  "scripts/s10-five-node-game-soak.sh" \
+  "uses associative arrays" \
+  "before release-gate longrun execution"
 assert_preflight_for_bash3 \
   "scripts/s10-five-node-game-soak.sh" \
   "uses associative arrays" \
   "before release-gate longrun execution"
 
+assert_guard_precedes_body \
+  "scripts/module-release-node-acceptance.sh" \
+  "uses associative arrays" \
+  "before module release acceptance execution"
 assert_preflight_for_bash3 \
   "scripts/module-release-node-acceptance.sh" \
   "uses associative arrays" \

--- a/scripts/unified-world-code-terminology-scan.sh
+++ b/scripts/unified-world-code-terminology-scan.sh
@@ -9,7 +9,6 @@ from __future__ import annotations
 
 import pathlib
 import re
-import subprocess
 import sys
 
 repo_root = pathlib.Path(sys.argv[1]).resolve()
@@ -80,43 +79,44 @@ allowed_path_names = {
     "scripts/shared-network-track-gate.sh",
 }
 
-cmd = [
-    "rg",
-    "-n",
-    "--no-heading",
-    "-g",
-    "!scripts/unified-world-code-terminology-scan.sh",
-    pattern,
-    *scan_paths,
-]
-proc = subprocess.run(cmd, cwd=repo_root, text=True, capture_output=True)
-if proc.returncode not in {0, 1}:
-    sys.stderr.write(proc.stderr)
-    raise SystemExit(proc.returncode)
+def iter_scan_files() -> list[pathlib.Path]:
+    files: list[pathlib.Path] = []
+    for rel in scan_paths:
+        path = repo_root / rel
+        if path.is_file():
+            files.append(path)
+            continue
+        if path.is_dir():
+            files.extend(p for p in path.rglob("*") if p.is_file())
+    return sorted(files)
+
 
 unexpected: list[str] = []
 allowed_hits: list[str] = []
-for line in proc.stdout.splitlines():
-    rel, _, rest = line.partition(":")
-    if not rest:
-        unexpected.append(line)
+scan_re = re.compile(pattern)
+scan_files = iter_scan_files()
+for path in scan_files:
+    rel = path.relative_to(repo_root).as_posix()
+    if rel == "scripts/unified-world-code-terminology-scan.sh":
         continue
-    _, _, text = rest.partition(":")
+    try:
+        text = path.read_text(encoding="utf-8")
+    except UnicodeDecodeError:
+        continue
     snippets = allowed_snippets.get(rel, ())
-    if any(snippet in text for snippet in snippets):
-        allowed_hits.append(line)
-    else:
-        unexpected.append(line)
-
-files_cmd = ["rg", "--files", *scan_paths]
-files_proc = subprocess.run(files_cmd, cwd=repo_root, text=True, capture_output=True)
-if files_proc.returncode != 0:
-    sys.stderr.write(files_proc.stderr)
-    raise SystemExit(files_proc.returncode)
+    for line_no, text_line in enumerate(text.splitlines(), start=1):
+        if not scan_re.search(text_line):
+            continue
+        rendered = f"{rel}:{line_no}:{text_line}"
+        if any(snippet in text_line for snippet in snippets):
+            allowed_hits.append(rendered)
+        else:
+            unexpected.append(rendered)
 
 path_pattern = re.compile(pattern)
 allowed_path_hits: list[str] = []
-for rel in files_proc.stdout.splitlines():
+for path in scan_files:
+    rel = path.relative_to(repo_root).as_posix()
     if rel == "scripts/unified-world-code-terminology-scan.sh":
         continue
     if not path_pattern.search(rel):

--- a/scripts/unified-world-code-terminology-scan.test.sh
+++ b/scripts/unified-world-code-terminology-scan.test.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+content_probe="doc/testing/templates/unified-world-code-scan-content-probe.template.tsv"
+path_probe="doc/testing/templates/shared""-network-regression-probe.template.tsv"
+
+cleanup() {
+  rm -f "$content_probe" "$path_probe"
+}
+trap cleanup EXIT
+
+assert_fails_with() {
+  local expected="$1"
+  shift
+  local status=0
+  local output
+  output="$("$@" 2>&1)" || status=$?
+  if [[ "$status" -eq 0 ]]; then
+    echo "expected command to fail: $*" >&2
+    printf '%s\n' "$output" >&2
+    exit 1
+  fi
+  if [[ "$output" != *"$expected"* ]]; then
+    echo "expected failure output to contain: $expected" >&2
+    printf '%s\n' "$output" >&2
+    exit 1
+  fi
+}
+
+cleanup
+
+./scripts/unified-world-code-terminology-scan.sh >/dev/null
+
+legacy_content="shared""_network should not re-enter active templates"
+printf 'mode\tclaim\nprobe\t%s\n' "$legacy_content" > "$content_probe"
+assert_fails_with "$content_probe" ./scripts/unified-world-code-terminology-scan.sh
+assert_fails_with "$legacy_content" ./scripts/unified-world-code-terminology-scan.sh
+rm -f "$content_probe"
+
+printf 'mode\tclaim\nprobe\tclean contents\n' > "$path_probe"
+assert_fails_with "$path_probe: legacy terminology in path name" ./scripts/unified-world-code-terminology-scan.sh
+rm -f "$path_probe"
+
+./scripts/unified-world-code-terminology-scan.sh >/dev/null
+
+echo "unified-world-code-terminology-scan.test: OK"


### PR DESCRIPTION
## Summary
- Add permanent regression coverage for the unified-world code terminology scan, including both legacy content and legacy path-name negative probes.
- Add Bash 4+ preflight regression coverage for the SIG-PM-0068 release-gate entrypoints under Bash 3.2-compatible local shells.
- Wire both shell tests into `run_required_gate_checks` and record the task/review evidence.

## Verification
- `./scripts/unified-world-code-terminology-scan.test.sh`
- `./scripts/release-gate-bash-preflight.test.sh`
- `bash -n scripts/unified-world-code-terminology-scan.test.sh scripts/release-gate-bash-preflight.test.sh scripts/ci-tests.sh`
- `./scripts/unified-world-code-terminology-scan.sh`
- `./scripts/check-script-executable-bits.sh`
- `./scripts/pm/workflow-lint.sh --task-uid task_22364604bc04498ebe7f10a5247757cd --phase pr-ready`
- `./scripts/doc-governance-check.sh`
- `git diff --check`

Residual risk: local macOS exercised the Bash 3.2 preflight branch; the Bash 4+/5 positive `--help` branch is encoded in the test and should run in Linux CI environments where `bash` is Bash 4+.