### PR TITLE
Harden local playtest and real agent chat regression

### DIFF
--- a/.pm/tasks/task_43f78174f0904eaf95e3b99dde0509a7.execution.md
+++ b/.pm/tasks/task_43f78174f0904eaf95e3b99dde0509a7.execution.md
@@ -1,0 +1,602 @@
+# task_43f78174f0904eaf95e3b99dde0509a7 Execution Log
+
+- task_uid: task_43f78174f0904eaf95e3b99dde0509a7
+- title: Harden local playtest one-command CLI
+- owner_role: tpm
+- worktree_hint: /Users/scc/ccwork/worktrees/oasis7-engineering-local-playtest-cli-hardening
+
+<!-- Append entries using:
+Example:
+  ## YYYY-MM-DD HH:MM:SS CST / role_name
+  - 完成内容: ...
+  - 遗留事项: ...
+  - Action: ...
+  - Validation Command: ...
+  - Expected Result: ...
+  - Actual Result: ...
+  - Blocker / Next Action: ...
+-->
+
+## 2026-06-17 12:00:00 CST / tpm
+- 完成内容: WORKFLOW BOOTSTRAP DECIDED
+- 遗留事项: proceed to route/TDD/execution; no code changes made in this entry.
+- Repository State Impact:
+  - Changes repository state: yes, user requested script/CLI hardening.
+  - Why: create a one-command local playtest CLI with clear diagnostics and degraded/strict behavior.
+- Isolation Decision:
+  - Current workspace state: source worktree `/Users/scc/ccwork/oasis7` was clean on `main`.
+  - Reuse allowed: no; previous playtest task worktree remains running and should not be disturbed.
+  - Worktree action: created `/Users/scc/ccwork/worktrees/oasis7-engineering-local-playtest-cli-hardening` on branch `task/engineering-local-playtest-cli-hardening`.
+- Task Truth:
+  - Owner role: `tpm` for workflow coordination/integration only.
+  - `.pm` task: `task_43f78174f0904eaf95e3b99dde0509a7`.
+  - Formal docs/source refs: `testing-manual.md`, `scripts/run-local-letai-game-test.sh`, `doc/engineering/workflow/source-of-truth.md`.
+- Routed Next Phase: TDD + execution.
+  - Why now: behavior-changing shell CLI task with stable script-level test surface.
+- Required Writeback:
+  - `prd.md`: not required for this scoped CLI hardening unless scope expands.
+  - `project.md`: not required for this scoped CLI hardening unless scope expands.
+  - `.pm` execution log: mandatory sink for route, slice contracts, and verification.
+  - handoff: not required.
+- Action: created/entered task worktree and recorded bootstrap decision.
+- Validation Command: `./scripts/new-task-worktree.sh engineering local-playtest-cli-hardening ... --json`
+- Expected Result: isolated task worktree and bound `.pm` task exist.
+- Actual Result: worktree `/Users/scc/ccwork/worktrees/oasis7-engineering-local-playtest-cli-hardening` and task `task_43f78174f0904eaf95e3b99dde0509a7` created.
+- Blocker / Next Action: record route and dispatch a tests-only bounded slice before production edits.
+
+## 2026-06-17 12:01:00 CST / tpm
+- 完成内容: WORKFLOW ROUTE DECIDED
+- 遗留事项: implement after RED test evidence is available.
+- Task Phase:
+  - Current phase: behavior-first script hardening.
+  - Why: user wants implementation, not just assessment; failures are known and automatable.
+- Selected Workflow Skills:
+  - `tdd-test-writer`: add focused tests for local playtest CLI diagnostics/degraded mode before production changes.
+  - `executing-project-tasks`: implement production script changes step-by-step after RED tests exist.
+  - `systematic-debugging`: use if the new tests or startup wrapper expose unexpected behavior.
+  - `verification-before-completion`: required before claiming done.
+- Skipped Workflow Skills:
+  - `bounded-brainstorming`: direction is clear from prior startup evidence.
+  - `finishing-a-development-branch`: not at closeout yet.
+- Specialist Skills Considered:
+  - `repository_health_engineer`: script robustness/debt category already established by prior bounded slice; this task operationalizes it.
+  - `qa_engineer`: covered through behavior-first script tests and later verification; no release-blocking judgment requested.
+- Subagent Slice Plan:
+  - role: `tdd_test_writer` compatibility role via generic worker tool
+  - slice type: bounded tests-only RED phase
+  - intended model configuration: inherited parent/default; no explicit override.
+  - actual dispatched model/reasoning: inherited/unverified because the connector does not report exact model when omitted.
+  - context delivery mode: explicit context packet; full fork not used so worker role can be requested.
+  - mandatory context checklist/packet:
+    - identity and authority: TPM integrates; slice owns tests-only RED evidence.
+    - workflow governance: AGENTS.md/source-of-truth require `.pm` sink and no production edits during RED.
+    - task truth: `task_43f78174f0904eaf95e3b99dde0509a7`, worktree `/Users/scc/ccwork/worktrees/oasis7-engineering-local-playtest-cli-hardening`.
+    - user intent: harden local one-command playtest CLI with clear errors like a CLI product.
+    - scoped repo context: prior observed failures were missing npm, cold build/readiness ambiguity, provider smoke HTTP 502, manual need for `OASIS7_RUN_LAUNCHER_STACK_SKIP_SOURCE_BUILD=1` and `--skip-bridge-smoke`.
+    - collaboration boundary: tests only; do not edit production scripts.
+  - write scope: script-level tests only, preferably existing local LetAI/startup wrapper tests.
+  - return contract: test files changed, RED command, expected failure reason, implementation contract.
+  - formal sink / writeback surface: `.pm/tasks/task_43f78174f0904eaf95e3b99dde0509a7.execution.md`.
+  - integration owner: `tpm`.
+  - integration order: tests first, production implementation second, verification third.
+- Action: selected TDD + execution route and recorded tests-only subagent slice contract.
+- Validation Command: `sed -n ... .agents/skills/repo-owned-workflow-router/SKILL.md`, `sed -n ... .agents/skills/tdd-test-writer/SKILL.md`, and task execution-log inspection.
+- Expected Result: route includes behavior-first test surface and bounded tests-only slice before production edits.
+- Actual Result: route recorded; tests-only slice dispatched.
+- Blocker / Next Action: dispatch tests-only slice and inspect current test/script conventions locally.
+
+## 2026-06-17 13:03:00 CST / tdd_test_writer
+- 完成内容: RED PHASE TESTS AUTHORED
+- 遗留事项: production wrapper still needs implementation to satisfy RED tests.
+- Scope Boundary:
+  - Tests-only slice. Production script `scripts/run-local-letai-game-test.sh` was already dirty on entry and was not edited by this slice.
+  - Test target: `scripts/run-local-letai-game-test.test.sh`.
+- Action:
+  - Added focused shell CLI assertions for local playtest preflight diagnostics, missing npm plus viewer dist guidance, missing Node.js diagnostics, missing reuse-existing-build binaries, strict vs degraded provider-smoke launch planning, skip-build propagation, and detached startup propagation.
+  - Added an assertion helper so RED failures print the missing expected contract and captured stderr/stdout.
+- Validation Command:
+  - `./scripts/run-local-letai-game-test.test.sh`
+- Expected Result:
+  - FAIL in RED phase until production wrapper implements the full CLI contract.
+- Actual Result:
+  - FAIL as expected. Current first failure: missing-npm preflight stderr contains `error: local playtest preflight failed: missing npm and viewer dist` and `hint: Install npm, or build/copy viewer dist ...`, but does not contain the required actionable hint `rerun with --reuse-existing-build only after a successful source build`.
+  - Command output also showed current production emits `warning: npm is not available; using existing viewer dist ...` and `note: provider smoke failures will be reported and startup will continue for page playtest.` before the failing negative-path assertion.
+- Implementation Contract:
+  - Do not weaken `scripts/run-local-letai-game-test.test.sh` unless the task requirement changes.
+  - Implement production behavior in `scripts/run-local-letai-game-test.sh` and, only if needed for lower-level propagation, `scripts/run-launcher-stack.sh`.
+  - Completion gate: `./scripts/run-local-letai-game-test.test.sh` passes.
+  - Contract details: preflight-only must provide clear Node/npm/viewer-dist/source-binary diagnostics; `--startup-profile playtest` defaults to degraded provider smoke; strict mode must require provider smoke and launcher provider preflight; degraded mode must clearly warn and continue page startup after provider smoke failure; `--reuse-existing-build` must set `OASIS7_RUN_LAUNCHER_STACK_SKIP_SOURCE_BUILD=1`; detached startup must preserve reuse-existing-build and degraded provider-smoke behavior in the generated supervisor script.
+- Blocker / Next Action:
+  - Hand off to implementation slice to make production wrapper satisfy the tests, then rerun the same command.
+
+## 2026-06-17 13:09:32 CST / tpm
+- 完成内容: IMPLEMENTATION + NARROW VERIFICATION COMPLETE
+- 遗留事项: `./scripts/pm/lint.sh` remains blocked by unrelated pre-existing historical `.pm` execution-log issues outside this task; do not treat those historical files as part of this change.
+- Scope Boundary:
+  - TPM integration implemented the production wrapper after tests-only RED evidence.
+  - Professional judgment attribution remains limited to the tests-only slice above; this entry records implementation and command evidence.
+- Action:
+  - Hardened `scripts/run-local-letai-game-test.sh` into a clearer one-command local playtest CLI with `--startup-profile strict|playtest`, `--provider-smoke-mode strict|degraded|skip`, `--reuse-existing-build`, `--preflight-only`, and `--dry-run-launch`.
+  - Added explicit preflight diagnostics for missing LetAI config, Node.js, npm plus viewer dist, and missing source binaries when reusing an existing build.
+  - Made `playtest` default to degraded provider smoke so the page can start while still surfacing provider-smoke warnings; strict mode keeps provider smoke as a hard gate.
+  - Propagated degraded provider mode and reuse-existing-build through detached startup.
+  - Added `scripts/run-local-letai-game-test.test.sh` and wired it into `scripts/ci-tests.sh` provider remote HTTPS smoke coverage.
+- Validation Command:
+  - `./scripts/run-local-letai-game-test.test.sh`
+  - `./scripts/local-letai-provider-bridge.test.sh`
+  - `git diff --check`
+  - prior attempted `./scripts/pm/lint.sh`
+- Expected Result:
+  - New local LetAI CLI smoke tests pass.
+  - Existing provider bridge config smoke still passes.
+  - Diff whitespace check passes.
+  - Full PM lint may still fail only on unrelated historical task logs.
+- Actual Result:
+  - `./scripts/run-local-letai-game-test.test.sh`: PASS, output ended with `local letai game test CLI smoke passed`.
+  - `./scripts/local-letai-provider-bridge.test.sh`: PASS, output `local letai provider scripts config smoke passed`.
+  - `git diff --check`: PASS with no output.
+  - `./scripts/pm/lint.sh`: FAIL on pre-existing historical `.pm` execution-log schema/content issues outside this task; current task log fields were updated.
+- Blocker / Next Action:
+  - No blocker for the scoped CLI implementation.
+  - Optional next phase is closeout/pre-PR local role review if the user wants this branch prepared for PR.
+
+## 2026-06-17 13:18:00 CST / tpm
+- 完成内容: LOCAL PLAYTEST STACK STARTED
+- 遗留事项: Host shell still has no npm; startup used existing/generated viewer dist and bundled Node path for preflight compatibility.
+- Action:
+  - Generated the missing `crates/oasis7_viewer/dist/pixel-world-bridge` runtime from the cached wasm artifact and cached `wasm-bindgen`.
+  - Prepared viewer dist with `./scripts/copy-viewer-web-dist.sh --dist-dir crates/oasis7_viewer/dist`.
+  - Started the local LetAI playtest stack in detached mode with `--startup-profile playtest --reuse-existing-build`.
+  - Opened the ready Chinese viewer URL in the in-app browser.
+- Validation Command:
+  - `PATH="/Users/scc/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" ./scripts/run-local-letai-game-test.sh --startup-profile playtest --reuse-existing-build --preflight-only`
+  - `PATH="/Users/scc/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" ./scripts/run-local-letai-game-test.sh --startup-profile playtest --reuse-existing-build --detach`
+  - readiness wait for `STACK_READY=1` in `output/local-letai-game-test/20260617-131515/launcher/session.meta`
+  - browser navigation to `GAME_URL`
+- Expected Result:
+  - Preflight reports clear npm/dist state and passes once dist is available.
+  - Detached launcher writes `STACK_READY=1` and a playable local URL.
+  - Browser loads the viewer entry.
+- Actual Result:
+  - Preflight passed with warning: npm unavailable, using existing viewer dist.
+  - Detached stack ready: `STACK_READY=1`, `VIEWER_PORT=4173`, `WEB_BRIDGE_ADDR=127.0.0.1:5011`.
+  - Browser loaded title `oasis7 Viewer (Software-Safe)` and visible Chinese entry content.
+- Blocker / Next Action:
+  - No current startup blocker.
+  - If gameplay provider actions fail during playtest, inspect `output/local-letai-game-test/20260617-131515/launcher/oasis7_llm_provider_probe.log` and supervisor logs.
+
+## 2026-06-17 15:51:04 CST / tpm
+- 完成内容: RUNTIME DEBUGGING SLICE DISPATCH PLANNED
+- 遗留事项: Root cause not yet confirmed; collect provider-port/process/log evidence before applying any fix.
+- Action:
+  - Started systematic debugging for browser-visible `provider_unreachable` during local playtest.
+  - Planned bounded runtime engineer slice for independent evidence review while TPM continues local reproduction/probing.
+- Validation Command:
+  - Browser DOM read of visible error text.
+  - `rg` over `output/local-letai-game-test/20260617-131515`.
+  - `curl http://127.0.0.1:5841/v1/provider/info`.
+- Expected Result:
+  - Identify whether the failure comes from provider process startup, stale port ownership, provider decision endpoint behavior, or launcher/provider URL wiring.
+- Actual Result:
+  - Initial evidence: page shows `provider_unreachable`; provider info endpoint responds; current detached bridge log shows `bind 127.0.0.1:5841 failed: Address already in use`.
+- Blocker / Next Action:
+  - Dispatch runtime evidence slice and continue with port/process/decision endpoint probes.
+
+## 2026-06-17 15:56:00 CST / tpm
+- 完成内容: PROVIDER_UNREACHABLE ROOT CAUSE NARROWED
+- 遗留事项: Runtime engineer slices `019ed490-cc00-71f0-9ebc-e8233165d4ab` and `019ed494-dc62-75e1-99a7-72b25f7ea0d5` were dispatched but did not return within the local 60s wait window; final user-facing answer uses TPM-collected command evidence and must not attribute unreturned slice findings.
+- Action:
+  - Inspected port ownership, active process tree, current and older playtest logs, provider decision smoke, provider health, and relevant script/code paths.
+  - Confirmed current local page stack points at `http://127.0.0.1:5841`, but current run's own provider bridge failed to bind because an older playtest process already owned that port.
+  - Confirmed startup script readiness can false-pass by curling `http://$BIND_ADDR/v1/provider/info`, which hits the older provider rather than proving the newly spawned bridge owns the port.
+- Validation Command:
+  - `lsof -nP -iTCP:5841 -sTCP:LISTEN`
+  - `ps -axo pid,ppid,stat,lstart,command | rg 'oasis7_provider_local_bridge|run-local-letai-game-test|oasis7_game_launcher|oasis7_viewer_live'`
+  - `tail -n 160 output/local-letai-game-test/20260617-131515/local-letai-provider-bridge.log`
+  - `python3 scripts/provider-remote-https/provider_bridge_contract_smoke.py --base-url http://127.0.0.1:5841 --timeout-ms 60000 --decision-count 3 --min-successes 1`
+  - `curl -sS -w ... http://127.0.0.1:5841/v1/provider/health`
+  - code inspection of `scripts/run-local-letai-game-test.sh`, `crates/oasis7/src/simulator/provider_loopback_adapter.rs`, and `crates/oasis7/src/viewer/runtime_live.rs`.
+- Expected Result:
+  - Determine whether browser-visible `provider_unreachable` is caused by no provider, stale provider, degraded upstream, or runtime mapping behavior.
+- Actual Result:
+  - Port 5841 is owned by old process PID 2890 from `/Users/scc/ccwork/worktrees/oasis7-viewer-local-game-start`, started at 11:44.
+  - Current run's provider bridge log shows `bind 127.0.0.1:5841 failed: Address already in use (os error 48)`.
+  - Current launcher process still uses `--agent-provider-url http://127.0.0.1:5841`, so it talks to the old provider process.
+  - Direct provider decision smoke currently passes 3/3 but takes 13-29 seconds per decision and provider health is degraded with `last_error: gateway health returned HTTP 401`.
+  - Older provider logs show prior LetAI quota/topup retries including `insufficient_user_quota`.
+  - Runtime maps HTTP request failures to `provider_unreachable`; the play loop then blocks with `runtime play loop stopped because the LLM decision provider failed`.
+- Blocker / Next Action:
+  - Immediate recovery: stop stale 5841 owner and current false-ready stack, then restart once, or relaunch with a fresh free provider bind port and pass the same URL to launcher.
+  - Script hardening follow-up: fail preflight if provider bind port is already occupied, or allocate a free provider port per run; readiness must prove the spawned bridge instance owns the endpoint rather than only curling a shared bind URL.
+
+## 2026-06-17 16:23:00 CST / tpm
+- 完成内容: STALE STACK STOPPED AND CLEAN STACK RESTARTED
+- 遗留事项: Script still needs code hardening so future starts fail fast on occupied provider bind ports or allocate unique ports automatically.
+- Action:
+  - Removed launchctl labels `oasis7.local-letai.20260617-114441-skip-build-` and `oasis7.local-letai.20260617-131515-`.
+  - Sent TERM to process groups `2846` and `49938` to stop the old leftover stack and the false-ready current stack.
+  - Verified `127.0.0.1:5841`, `127.0.0.1:4173`, and `127.0.0.1:5011` were no longer listening.
+  - Restarted the optimized local playtest CLI with `--startup-profile playtest --reuse-existing-build --detach`.
+  - Waited for `STACK_READY=1` and reloaded the in-app browser URL.
+- Validation Command:
+  - `launchctl remove ...`
+  - `/bin/kill -TERM -2846` and `/bin/kill -TERM -49938`
+  - `lsof -nP -iTCP:5841 -sTCP:LISTEN`
+  - `PATH=... ./scripts/run-local-letai-game-test.sh --startup-profile playtest --reuse-existing-build --detach`
+  - readiness wait on `output/local-letai-game-test/20260617-161900/launcher/session.meta`
+  - browser reload of `http://127.0.0.1:4173/?ws=ws://127.0.0.1:5011&test_api=1&locale=zh`
+- Expected Result:
+  - Old residual provider no longer owns port 5841.
+  - New run's own provider bridge binds 5841.
+  - New stack reaches `STACK_READY=1`.
+  - Browser loads the new viewer stack.
+- Actual Result:
+  - Old local-letai process groups disappeared; unrelated long-running testnet `oasis7_chain_runtime` remains and was not touched.
+  - New output dir: `output/local-letai-game-test/20260617-161900`.
+  - New provider owner: PID `48129`, executable from `/Users/scc/ccwork/worktrees/oasis7-engineering-local-playtest-cli-hardening/target/debug/oasis7_provider_local_bridge`.
+  - New bridge log shows `provider local bridge listening` on `127.0.0.1:5841`.
+  - New `session.meta` shows `STACK_READY=1`, `GAME_URL=http://127.0.0.1:4173/?ws=ws://127.0.0.1:5011&test_api=1&locale=zh`.
+  - Browser reload returned title `oasis7 Viewer (Software-Safe)` and Chinese page text.
+- Blocker / Next Action:
+  - User can continue playtesting on the same URL.
+  - Next implementation step should harden bind-port ownership checks in the CLI.
+
+## 2026-06-17 17:00:37 CST / tpm
+- 完成内容: BROWSER AGENT CHAT PLAYTEST COMPLETED WITH LOCAL ECHO
+- 遗留事项: The returned chat line is a debug/local echo receipt, not a real LLM-authored agent reply. Provider-backed real `agent_chat` remains unsupported by the current runtime unless a future provider chat path is implemented.
+- Action:
+  - Operated the in-app browser at `http://127.0.0.1:4173/?ws=ws://127.0.0.1:5011&test_api=1&locale=zh`.
+  - Used the current stack `output/local-letai-game-test/20260617-164926`, launched with `--chat-echo --no-auto-play --chain-disable`, to enable browser chat QA without relying on unsupported provider-backed agent chat.
+  - Refreshed the page after an initial stale `agents=0` state; the page resynced to `agents=5`, selected `agent-0`, and showed `agent-0` at `runtime:3681826:5011151:268013` with resources `{"electricity":32,"data":8}`.
+  - Opened the immersive command/chat panel and sent `你在哪里？身边有什么资源？` to `agent-0`.
+- Validation Command:
+  - Browser DOM inspection through the in-app browser automation.
+  - `./target/debug/oasis7_pure_api_client --addr 127.0.0.1:5023 --timeout-ms 5000 snapshot --player-gameplay-only`
+  - `lsof -nP -iTCP:4173 -iTCP:5011 -iTCP:5023 -iTCP:5841`
+- Expected Result:
+  - Browser can select an agent, send a chat message, receive ack/error, and display message flow output.
+- Actual Result:
+  - Browser showed `聊天已受理` and `消息已在 tick 1 进入 runtime 队列`.
+  - Message Flow showed `agent-0 已发言` at `runtime:3681826:5011151:268013 · tick=1`.
+  - Returned text: `[local-mock-receipt] 已收到消息；当前本地 mock provider 不生成真实 Agent 回复：你在哪里？身边有什么资源？`
+  - Pure API snapshot after the browser action reported `accepted_intent_id: agent_chat`, `intent_target: agent-0`, `execution_state: accepted`, and `recent_feedback.effect: queued direct agent instruction for agent-0`.
+- Blocker / Next Action:
+  - For playtest UX, current local echo mode is sufficient to validate UI wiring and message flow.
+  - For true provider-authored chat, implement or wire provider-backed `agent_chat` support instead of relying on `--chat-echo`.
+
+## 2026-06-17 18:16:55 CST / tpm
+- 完成内容: PROVIDER-AUTHORED BROWSER AGENT CHAT REPLY IMPLEMENTED AND VERIFIED
+- 遗留事项: Focused `cargo test -p oasis7 --lib runtime_agent_chat_provider_mode_accepts_feedback_without_echo_receipt -- --nocapture` was attempted twice but interrupted after long test-binary linking; `cargo check`, binary build, formatting, diff check, and live browser verification passed.
+- Action:
+  - Accepted user correction that `[local-mock-receipt]` must not count as a real Agent reply.
+  - Integrated bounded runtime/agent slice `019ed4e0-c88e-7980-8c9d-a67c9a1628b6`: existing provider-backed chat only pushed `/feedback` and relied on a later `/decision`, so it could not guarantee a direct reply.
+  - Added provider loopback chat contract `ProviderAgentChatRequest` / `ProviderAgentChatResponse` and client method `request_agent_chat`.
+  - Added local provider bridge endpoint `POST /v1/world-simulator/agent-chat`, backed by the real LetAI invocation path in real mode and explicitly marked mock output in mock mode.
+  - Updated runtime provider-backed `agent_chat` to call the new provider chat RPC with the selected agent's `location_id` and resources, enqueue the provider-authored text as `WorldEventKind::AgentSpoke`, and flush pending virtual events after any successful agent chat ack.
+  - Restarted local stack without `--chat-echo`: `output/local-letai-game-test/20260617-181555`.
+- Validation Command:
+  - `./scripts/cargo-dev.sh check -p oasis7 --lib`
+  - `cargo fmt --check`
+  - `./scripts/cargo-dev.sh build -p oasis7 --bin oasis7_provider_local_bridge --bin oasis7_viewer_live --bin oasis7_game_launcher`
+  - `./scripts/cargo-dev.sh build -p oasis7 --bin oasis7_viewer_live --bin oasis7_game_launcher`
+  - `git diff --check`
+  - Browser automation against `http://127.0.0.1:4173/?ws=ws://127.0.0.1:5011&test_api=1&locale=zh`
+- Expected Result:
+  - Browser chat to `agent-0` should return a non-mock provider-authored Agent reply in Message Flow without `--chat-echo`.
+- Actual Result:
+  - Browser sent `你在哪里？身边有什么资源？请直接回答。`
+  - Message Flow showed `agent-0 已发言` at `runtime:3681826:5011151:268013 · tick=1`.
+  - Provider-authored reply shown in browser: `我在 runtime:3681826:5011151:268013。身边资源：data 8，electricity 32。`
+  - Browser output did not contain `[local-mock-receipt]` or `[local-mock-chat]`.
+  - Provider bridge log for the previous rebuilt attempt showed real `rust_direct_letai_chat_request` with the new short direct-chat prompt; latest browser verification confirmed the visible reply path.
+- Blocker / Next Action:
+  - Current local browser session is usable on the same URL with stack `20260617-181555`.
+  - Follow-up hardening: add/finish focused test coverage once test-binary linking is not wedged by shared build pressure, and consider surfacing provider chat failures distinctly in the UI if `/agent-chat` returns an error.
+
+## 2026-06-17 17:21:00 CST / tpm
+- 完成内容: PROVIDER-BACKED AGENT_CHAT CODE PATH INVESTIGATED
+- 遗留事项: Intended `agent_engineer/runtime_engineer` bounded slice could not be dispatched because this Codex turn exposed thread create/fork tools but no callable subagent dispatch/rejoin tool. Findings below are TPM-collected code evidence only and must not be attributed as an independent specialist conclusion.
+- Action:
+  - Investigated why the browser chat playtest only produced `[local-mock-receipt]` under `--chat-echo`.
+  - Inspected runtime live `AgentChat` request handling, LLM sidecar provider-backed behavior, provider loopback HTTP client/adapter, local provider bridge endpoints, viewer JS send/ack handling, and existing runtime chat tests.
+  - Ran the focused existing regression for provider-backed chat-without-echo behavior.
+- Validation Command:
+  - `nl -ba crates/oasis7/src/viewer/runtime_live/control_plane.rs | sed -n '399,538p;846,860p'`
+  - `nl -ba crates/oasis7/src/viewer/runtime_live/llm_sidecar.rs | sed -n '217,219p;550,627p;764,855p'`
+  - `nl -ba crates/oasis7/src/simulator/decision_provider.rs | sed -n '416,427p;559,578p'`
+  - `nl -ba crates/oasis7/src/simulator/provider_loopback_http.rs | sed -n '318,330p'`
+  - `nl -ba crates/oasis7/src/bin/oasis7_provider_local_bridge/http_bridge_support.rs | sed -n '20,38p'`
+  - `nl -ba crates/oasis7_viewer/viewer.js | sed -n '4412,4458p;4780,4805p'`
+  - `./scripts/cargo-dev.sh test -p oasis7 --lib runtime_agent_chat_provider_mode_accepts_feedback_without_echo_receipt -- --nocapture`
+- Expected Result:
+  - Determine whether current real provider-backed `agent_chat` can produce a direct provider-authored reply, or whether echo is only a local debug stand-in.
+- Actual Result:
+  - Current code supports accepting `agent_chat` in provider-backed mode without echo, but only as provider feedback plus a subsequent decision request; it does not synchronously call a provider chat/reply endpoint.
+  - The local provider bridge exposes only `GET /v1/provider/info`, `GET /v1/provider/health`, `POST /v1/world-simulator/decision`, and `POST /v1/world-simulator/feedback`; no `/chat`, `/agent_chat`, or direct player-message response endpoint exists.
+  - `--chat-echo` only enqueues a local virtual `AgentSpoke` event with `[local-mock-receipt]`; it is not provider-authored.
+  - Focused test passed: `runtime_agent_chat_provider_mode_accepts_feedback_without_echo_receipt ... ok`.
+- Blocker / Next Action:
+  - Do not use `--chat-echo` as evidence of true agent reply.
+  - Minimal implementation choices:
+    1. Add provider RPC for direct agent chat reply and wire runtime ack/reply events.
+    2. Keep feedback-only model but make chat enqueue a forced/biased next decision that can produce `speak_to_nearby` when appropriate.
+    3. Rename/UI-label current provider-backed chat as "send instruction" unless option 1 or 2 is implemented.
+
+## 2026-06-17 18:30:00 CST / tpm
+- 完成内容: REAL AGENT CHAT BROWSER REGRESSION AUTOMATION ADDED
+- 遗留事项: Pending live verification against the current running Viewer URL after script syntax checks.
+- Action:
+  - Extended `scripts/viewer-software-safe-chat-regression.sh` with content-level inbound Agent reply assertions: exact message, required fragments, and forbidden fragments.
+  - Added `scripts/viewer-real-agent-chat-regression.sh` as the one-command local real-provider Agent chat smoke wrapper.
+  - Default regression sends `你在哪里？身边有什么资源？请直接回答。` to `agent-0`, requires `我在 runtime:`, `data 8`, and `electricity 32`, and rejects `[local-mock-receipt]` / `[local-mock-chat]`.
+- Validation Command:
+  - Pending: `bash -n scripts/viewer-software-safe-chat-regression.sh && bash -n scripts/viewer-real-agent-chat-regression.sh`
+  - Pending: `./scripts/viewer-real-agent-chat-regression.sh --url <current GAME_URL>`
+- Expected Result:
+  - The regression should fail clearly if chat ack is missing, inbound Agent reply is missing, required real-reply fragments are absent, or mock markers appear.
+- Actual Result:
+  - Pending.
+- Blocker / Next Action:
+  - Run the new regression against the currently active stack without restarting it.
+
+## 2026-06-17 18:36:00 CST / tpm
+- 完成内容: REAL AGENT CHAT REGRESSION SWITCHED TO DIRECT PLAYWRIGHT
+- 遗留事项: The first wrapper verification failed before browser launch because this shell environment did not expose `agent-browser` or `node` on PATH.
+- Action:
+  - Added `crates/oasis7_viewer/scripts/real-agent-chat-regression.mjs`, a direct Playwright regression that opens the Viewer URL, selects `agent-0`, sends the resource/location question, waits for chat ack, waits for an inbound Agent event reply, and writes state/summary/screenshot artifacts.
+  - Updated `scripts/viewer-real-agent-chat-regression.sh` to discover Node from `OASIS7_NODE_BIN`, PATH, or the Codex bundled Node runtime, and to load Playwright from `OASIS7_PLAYWRIGHT_NODE_MODULES` or the bundled node_modules path.
+- Validation Command:
+  - `./scripts/viewer-real-agent-chat-regression.sh --url 'http://127.0.0.1:4173/?ws=ws://127.0.0.1:5011&test_api=1&locale=zh'`
+  - Pending: `bash -n scripts/viewer-real-agent-chat-regression.sh && node --check crates/oasis7_viewer/scripts/real-agent-chat-regression.mjs`
+  - Pending: rerun wrapper against current URL.
+- Expected Result:
+  - The next verification should use direct Playwright instead of agent-browser and should fail with content-level assertion details if the reply is missing or mock-marked.
+- Actual Result:
+  - First wrapper run failed with `error: missing required command: agent-browser (or npx fallback)`, confirming the need for direct Playwright fallback.
+- Blocker / Next Action:
+  - Run direct Playwright verification against current stack.
+
+## 2026-06-17 20:27:30 CST / tpm
+- 完成内容: DIRECT PLAYWRIGHT REAL AGENT CHAT REGRESSION VERIFIED
+- 遗留事项: Full fresh-stack mode was not run in this turn to avoid disrupting the user's currently open local stack; verification used the active current URL.
+- Action:
+  - Fixed the wrapper argument mapping from old `--expect-agent-spoke-contains` / `--forbid-agent-spoke-contains` names to direct Playwright `--expect-contains` / `--forbid-contains` names.
+  - Ran the new regression against the active Viewer URL without restarting the stack.
+- Validation Command:
+  - `bash -n scripts/viewer-real-agent-chat-regression.sh`
+  - `/Users/scc/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node --check crates/oasis7_viewer/scripts/real-agent-chat-regression.mjs`
+  - `./scripts/viewer-real-agent-chat-regression.sh --url 'http://127.0.0.1:4173/?ws=ws://127.0.0.1:5011&test_api=1&locale=zh'`
+- Expected Result:
+  - Playwright should open the Viewer, select `agent-0`, send `你在哪里？身边有什么资源？请直接回答。`, observe chat ack, observe a non-mock inbound Agent reply containing `我在 runtime:`, `data 8`, and `electricity 32`, and write artifacts.
+- Actual Result:
+  - Passed.
+  - Output: `ok: real Agent reply observed for agent-0`.
+  - Reply: `我在 runtime:3681826:5011151:268013。身边资源有 data 8、electricity 32。`
+  - Artifacts: `output/playwright/viewer-real-agent-chat/20260617-202707/playwright` and wrapper summary in `output/playwright/viewer-real-agent-chat/20260617-202707`.
+- Blocker / Next Action:
+  - The new command can be rerun directly against an existing URL or without `--url` to bootstrap its own local LetAI stack when ports are free.
+
+## 2026-06-17 20:33:10 CST / tpm
+- 完成内容: ONE-COMMAND REAL AGENT CHAT REGRESSION RUN FROM CLEAN PORTS
+- 遗留事项: None for this requested rerun; the script now handles no launcher args and bundled Node PATH for local stack startup.
+- Action:
+  - Stopped the old current local stack that was listening on 127.0.0.1 ports 4173, 5011, 5023, and 5841.
+  - Ran the new one-command regression without `--url`, forcing it to bootstrap a fresh local LetAI stack and then run direct Playwright chat verification.
+  - Fixed two one-command wrapper bugs found during the rerun:
+    - Empty `LAUNCHER_ARGS` under `set -u`.
+    - Local stack preflight could not see Node when the shell PATH omitted it; wrapper now prepends the discovered bundled Node bin before stack startup.
+- Validation Command:
+  - `lsof -nP -iTCP:4173 -iTCP:5011 -iTCP:5023 -iTCP:5841 -sTCP:LISTEN`
+  - `bash -n scripts/viewer-real-agent-chat-regression.sh && ./scripts/viewer-real-agent-chat-regression.sh`
+  - `git diff --check`
+- Expected Result:
+  - The script should start its own local LetAI stack, open Viewer through Playwright, send the resource/location question to `agent-0`, observe a non-mock Agent reply, write artifacts, and clean up the stack.
+- Actual Result:
+  - Passed.
+  - Output: `ok: real Agent reply observed for agent-0`.
+  - Reply: `我在 runtime:3531642:4980555:594781。身边资源有：data 8，electricity 32。`
+  - Artifacts: `output/playwright/viewer-real-agent-chat/20260617-203222/playwright` and wrapper summary in `output/playwright/viewer-real-agent-chat/20260617-203222`.
+- Blocker / Next Action:
+  - The one-command command is now validated: `./scripts/viewer-real-agent-chat-regression.sh`.
+
+## 2026-06-17 20:40:00 CST / tpm
+- 完成内容: USER REQUESTED UI INPUT FLOW COVERAGE
+- 遗留事项: Pending implementation and verification.
+- Action:
+  - User clarified that the regression must cover the actual player input flow, not only the stable test API send path.
+  - Begin source inspection for Viewer chat controls and Playwright locator strategy.
+- Validation Command:
+  - Pending.
+- Expected Result:
+  - Playwright should click/select the Agent in the rendered UI, type the chat message into the visible input/textarea, click the send control, then verify the same real provider Agent reply without mock markers.
+- Actual Result:
+  - Pending.
+- Blocker / Next Action:
+  - Patch `crates/oasis7_viewer/scripts/real-agent-chat-regression.mjs` to drive UI controls for the input path and rerun the one-command regression.
+
+## 2026-06-17 20:41:30 CST / tpm
+- 完成内容: REAL AGENT CHAT REGRESSION NOW COVERS UI INPUT FLOW
+- 遗留事项: Canvas/WebGPU renderer does not expose a DOM agent marker for `agent-0`; the test records `selectionMode=preselected` when runtime already binds/selects `agent-0`, then still requires the visible UI command drawer, textarea, and send button for chat input.
+- Action:
+  - Updated direct Playwright regression to drive the real rendered UI input flow:
+    - optionally click a visible `.pixel-world-entity--agent[title="agent-0"]` marker when present;
+    - otherwise require the page's current selectedId to already be `agent-0`;
+    - click the World Focus entry button;
+    - open/verify the command drawer;
+    - fill `#agent-chat-message`;
+    - click `button[data-chat-send="1"]`.
+  - Kept `window.__AW_TEST__` only for readiness/state assertions and final chat history verification, not for sending the chat.
+- Validation Command:
+  - `/Users/scc/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node --check crates/oasis7_viewer/scripts/real-agent-chat-regression.mjs`
+  - `./scripts/viewer-real-agent-chat-regression.sh`
+  - `cat output/playwright/viewer-real-agent-chat/20260617-203943/playwright/real-agent-chat-summary.json`
+  - `lsof -nP -iTCP:4173 -iTCP:5011 -iTCP:5023 -iTCP:5841 -sTCP:LISTEN || true`
+  - `git diff --check`
+- Expected Result:
+  - The one-command regression should bootstrap a fresh local real LetAI stack, use Playwright UI gestures for message input/send, observe ack, observe a non-mock real Agent reply with required resource/location fragments, write artifacts, and clean up ports.
+- Actual Result:
+  - Passed.
+  - Summary evidence: `inputMode=ui`, `selectionMode=preselected`, `focusMode=ui`, `chatInputMode=ui`.
+  - Reply: `我在 runtime:4094031:4929734:727224。身边资源：data 8，electricity 32。`
+  - Artifacts: `output/playwright/viewer-real-agent-chat/20260617-203943/playwright`.
+  - Ports 4173/5011/5023/5841 were clean after completion.
+- Blocker / Next Action:
+  - For future stricter player-selection coverage, expose a stable DOM selector or accessible label for the active Agent marker in the canvas/WebGPU path; current test fully covers UI chat input/send and the real provider reply chain.
+
+## 2026-06-17 20:55:00 CST / tpm
+- 完成内容: PLAYWRIGHT REAL-RUN TEST SERIES DOCUMENTATION ENTRY ADDED
+- 遗留事项: Future PWT cases remain planned and should be implemented one-by-one as player operation flows become automatable.
+- Action:
+  - Added `doc/testing/manual/web-ui-playwright-closure-manual.manual.md` as the canonical entry for Playwright real-run Web UI tests.
+  - Documented `PWT-001 Real Agent Chat` as the first active case, including command, coverage, pass criteria, artifacts, no-mock rule, UI input coverage, and current canvas/WebGPU selection boundary.
+  - Added the planned `PWT-###` matrix for future player flows: agent selection, gameplay action submission, prompt preview/apply/rollback, pause/play progress, diagnostics recovery, and pure API / Viewer parity spot checks.
+  - Linked the new manual from `testing-manual.md`, `doc/testing/README.md`, `doc/testing/prd.index.md`, `doc/testing/prd.md`, and `doc/testing/project.md`.
+- Validation Command:
+  - `./scripts/doc-governance-check.sh`
+  - `git diff --check`
+  - `rg -n "web-ui-playwright-closure-manual|PWT-001|viewer-real-agent-chat-regression" testing-manual.md doc/testing README.md scripts crates/oasis7_viewer/scripts/real-agent-chat-regression.mjs`
+- Expected Result:
+  - Testing docs should expose Playwright real-run tests as a managed series instead of a one-off script, with clear extension and evidence rules.
+- Actual Result:
+  - Passed.
+  - `doc-governance-check: OK`.
+  - `git diff --check` passed.
+  - New manual and all intended cross-links are discoverable by `rg`.
+- Blocker / Next Action:
+  - Implement future `PWT-002+` cases against this manual as the next player operation flows are selected.
+
+## 2026-06-17 21:05:00 CST / tpm
+- 完成内容: USER REQUESTED STABLE AGENT MARKER SELECTOR FOR WEBGPU/CANVAS PATH
+- 遗留事项: Pending implementation and verification.
+- Action:
+  - User requested the missing selectable Agent marker automation contract be added so Playwright can cover map/canvas Agent selection instead of relying on `selectionMode=preselected`.
+  - Begin inspecting PixelWorld canvas renderer and host fallback marker code.
+- Validation Command:
+  - Pending.
+- Expected Result:
+  - Viewer should expose a stable DOM selector / accessible label for visible Agent selection in the WebGPU/canvas path, and Playwright `PWT-001` should click it before sending chat.
+- Actual Result:
+  - Pending.
+- Blocker / Next Action:
+  - Patch the frontend marker contract and update `real-agent-chat-regression.mjs` to require UI marker selection.
+
+## 2026-06-17 21:06:00 CST / tpm
+- 完成内容: WEBGPU/CANVAS AGENT MARKER SELECTOR IMPLEMENTED AND PLAYWRIGHT FLOW VERIFIED
+- 遗留事项: None for the stable Agent marker selector request.
+- Action:
+  - Added stable Agent marker attributes to Viewer DOM hit targets:
+    - `data-pixel-world-agent-marker="true"`;
+    - `data-agent-id="<agent-id>"`;
+    - localized accessible label `选择 Agent <agent-id>` / `Select Agent <agent-id>`.
+  - Added `PixelWorldCanvasAgentHitTargets` in the rendered canvas/WebGPU overlay so the canvas path exposes clickable DOM hit targets for Playwright while keeping the canvas as the visual renderer.
+  - Updated the host component test expectation so rendered-canvas mode must expose and click `[data-pixel-world-agent-marker='true'][data-agent-id='agent-0']`.
+  - Updated `PWT-001` Playwright regression to require clicking the marker and record `selectionMode=ui-agent-marker`; it no longer accepts a `preselected` fallback.
+  - Refreshed `crates/oasis7_viewer/dist` through `./scripts/copy-viewer-web-dist.sh --dist-dir crates/oasis7_viewer/dist` so `viewer.js` and the dist manifest match the source bundle.
+- Validation Command:
+  - `./scripts/viewer-real-agent-chat-regression.sh`
+  - `cat output/playwright/viewer-real-agent-chat/20260617-205958/playwright/real-agent-chat-summary.json`
+  - `lsof -nP -iTCP:4173 -iTCP:5011 -iTCP:5023 -iTCP:5841 -sTCP:LISTEN || true`
+  - `./scripts/copy-viewer-web-dist.sh --dist-dir crates/oasis7_viewer/dist`
+- Expected Result:
+  - The regression must bootstrap a fresh local real LetAI stack, click the visible Agent marker via stable DOM selector, focus the world UI, type/send chat through visible controls, observe a non-mock real Agent reply, write summary evidence, and clean up ports.
+- Actual Result:
+  - Passed.
+  - Summary evidence: `inputMode=ui`, `selectionMode=ui-agent-marker`, `focusMode=ui`, `chatInputMode=ui`.
+  - Reply: `我在 runtime:3531642:4980555:594781。身边资源：data 8，electricity 32。`
+  - Artifacts: `output/playwright/viewer-real-agent-chat/20260617-205958/playwright`.
+  - Ports 4173/5011/5023/5841 were clean after completion.
+- Blocker / Next Action:
+  - Run final lightweight syntax/diff/docs gates and report the completed closure.
+
+## 2026-06-17 21:09:00 CST / tpm
+- 完成内容: FINAL CURRENT-DIST REAL AGENT CHAT REGRESSION PASSED
+- 遗留事项: None for this request.
+- Action:
+  - Re-ran the one-command Playwright real-run regression after refreshing `crates/oasis7_viewer/dist` and its manifest.
+  - Confirmed post-run ports were clean after the wrapper finished process teardown.
+- Validation Command:
+  - `./scripts/viewer-real-agent-chat-regression.sh`
+  - `cat output/playwright/viewer-real-agent-chat/20260617-210547/playwright/real-agent-chat-summary.json`
+  - `lsof -nP -iTCP:4173 -iTCP:5011 -iTCP:5023 -iTCP:5841 -sTCP:LISTEN || true`
+  - `/Users/scc/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node --check crates/oasis7_viewer/viewer.js && /Users/scc/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node --check crates/oasis7_viewer/dist/viewer.js && /Users/scc/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node --check crates/oasis7_viewer/scripts/real-agent-chat-regression.mjs`
+  - `git diff --check`
+  - `./scripts/doc-governance-check.sh`
+- Expected Result:
+  - Current dist must expose the stable Agent marker selector, Playwright must click it, the real UI input flow must send chat, a non-mock provider-authored Agent reply must appear, and lightweight gates must pass.
+- Actual Result:
+  - Passed.
+  - Summary evidence: `inputMode=ui`, `selectionMode=ui-agent-marker`, `focusMode=ui`, `chatInputMode=ui`.
+  - Reply: `我在 runtime:3531642:4980555:594781。身边资源：data 8，electricity 32。`
+  - Artifacts: `output/playwright/viewer-real-agent-chat/20260617-210547/playwright`.
+  - `node --check`, `git diff --check`, and `doc-governance-check` passed.
+- Blocker / Next Action:
+  - Ready for user playtest or the next Playwright operation-flow case.
+
+## 2026-06-17 21:15:00 CST / tpm
+- Review Trigger: pre-PR local role review
+- Review Scope: local playtest CLI hardening, provider-backed Agent chat path, Viewer Agent marker UI automation contract, Playwright real-run regression scripts, testing docs, PM task evidence.
+- Review Roles: runtime_engineer, viewer_engineer, qa_engineer, repository_health_engineer
+- Review Question: Confirm whether the current uncommitted task diff is safe to close, commit, and send through the normal PR merge path; identify any merge-blocking correctness, test, documentation, workflow, or maintainability findings.
+- Evidence Available:
+  - `./scripts/viewer-real-agent-chat-regression.sh` passed with `selectionMode=ui-agent-marker` and a non-mock provider-authored reply.
+  - `node --check` passed for `crates/oasis7_viewer/viewer.js`, `crates/oasis7_viewer/dist/viewer.js`, and `crates/oasis7_viewer/scripts/real-agent-chat-regression.mjs`.
+  - `git diff --check` passed.
+  - `./scripts/doc-governance-check.sh` passed.
+  - Ports 4173/5011/5023/5841 were clean after the final run.
+- Expected Return Contract: `findings` or `no_findings`, severity/merge-risk classification, and `residual_risk`.
+- Formal Sink: `.pm/tasks/task_43f78174f0904eaf95e3b99dde0509a7.execution.md`
+
+## 2026-06-17 21:23:40 CST / tpm
+- 完成内容: TASK CLOSEOUT AND CLAIM-READY EVIDENCE RECORDED
+- 遗留事项: Repo-wide `.pm` lint still reports historical task-log format issues outside this task; task-local closeout fields were written and verified.
+- Action:
+  - Ran `./scripts/pm/task-closeout.sh --role tpm --task-uid task_43f78174f0904eaf95e3b99dde0509a7 --verify-command './scripts/run-local-letai-game-test.test.sh && ./scripts/viewer-real-agent-chat-regression.sh && /Users/scc/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node --check crates/oasis7_viewer/viewer.js && /Users/scc/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node --check crates/oasis7_viewer/dist/viewer.js && /Users/scc/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node --check crates/oasis7_viewer/scripts/real-agent-chat-regression.mjs && git diff --check && ./scripts/doc-governance-check.sh'`.
+  - The helper ran `claim-ready.sh` internally and wrote task-local `last_claim_type`, `last_verify_command`, `last_verified_at`, `last_verification_exit_code`, `last_verification_status`, and `last_closed_at`.
+- Validation Command:
+  - `./scripts/pm/task-closeout.sh --role tpm --task-uid task_43f78174f0904eaf95e3b99dde0509a7 --verify-command '<fresh verification command>'`
+- Expected Result:
+  - Fresh verification should pass and task-local closeout metadata should be written before PR preparation.
+- Actual Result:
+  - Fresh verification passed with exit code 0 at `2026-06-17T21:23:35+08:00`; task moved to `done` with `last_closed_at: 2026-06-17T21:23:39+08:00`.
+  - `task-closeout.sh` exited nonzero only at the final repo-wide `.pm` lint step because unrelated historical task logs fail current lint formatting.
+- Blocker / Next Action:
+  - Continue with task-local pre-PR role review evidence and `prepare-task-pr.sh` preflight; do not modify unrelated historical task logs in this task.
+
+## 2026-06-17 21:59:00 CST / tpm
+- Pre-PR Local Role Review: passed
+- Task UID: task_43f78174f0904eaf95e3b99dde0509a7
+- Source Worktree: /Users/scc/ccwork/worktrees/oasis7-engineering-local-playtest-cli-hardening
+- Source Branch: task/engineering-local-playtest-cli-hardening
+- Source Head: a9a2311c59e77221173050e2c1463499ddc9c03e
+- Comparison Ref: origin/main
+- Reviewed Changed Paths: .pm/tasks/task_43f78174f0904eaf95e3b99dde0509a7.execution.md; .pm/tasks/task_43f78174f0904eaf95e3b99dde0509a7.yaml; crates/oasis7/src/bin/oasis7_provider_local_bridge.rs; crates/oasis7/src/bin/oasis7_provider_local_bridge/http_bridge_support.rs; crates/oasis7/src/bin/oasis7_provider_local_bridge/tests.rs; crates/oasis7/src/simulator/mod.rs; crates/oasis7/src/simulator/provider_loopback_http.rs; crates/oasis7/src/viewer/runtime_live.rs; crates/oasis7/src/viewer/runtime_live/control_plane.rs; crates/oasis7/src/viewer/runtime_live/llm_sidecar.rs; crates/oasis7/src/viewer/runtime_live/tests/auth_actions_agent_chat.rs; crates/oasis7_viewer/software_safe_src/pixel_world_host.jsx; crates/oasis7_viewer/software_safe_src/pixel_world_host.test.jsx; crates/oasis7_viewer/viewer.js; crates/oasis7_viewer/scripts/real-agent-chat-regression.mjs; doc/testing/manual/web-ui-playwright-closure-manual.manual.md; doc/testing/README.md; doc/testing/prd.index.md; doc/testing/prd.md; doc/testing/project.md; scripts/ci-tests.sh; scripts/run-local-letai-game-test.sh; scripts/run-local-letai-game-test.test.sh; scripts/viewer-real-agent-chat-regression.sh; scripts/viewer-software-safe-chat-regression.sh; testing-manual.md
+- Role Selection Basis: runtime/provider chat and control-plane code changed, Viewer canvas/UI marker automation changed, Playwright/CLI verification gates changed, and test documentation/workflow surfaces changed; selected runtime_engineer, viewer_engineer, qa_engineer, repository_health_engineer.
+- Review Roles: runtime_engineer, viewer_engineer, qa_engineer, repository_health_engineer
+- Review Evidence: runtime_engineer reported two P2 findings; viewer_engineer reported marker-click/gate risk against an earlier state; qa_engineer reported cleanup and summary-indexing gaps; repository_health_engineer reported provider-port false-pass and missing-config diagnostics gaps; latest integrated verification passed after fixes.
+- Review Findings Disposition: addressed
+- Finding Disposition Evidence: fixed provider chat ordering and agent-chat idempotency key with targeted Rust tests; added bind/listener preflight for provider and launcher ports plus missing-config diagnostics; made Playwright wrapper use dynamic ports, assert cleanup, enrich summary fields, and force the already-visible/enabled send click; latest `./scripts/viewer-real-agent-chat-regression.sh` passed at output/playwright/viewer-real-agent-chat/20260617-215234/playwright with `selectionMode=ui-agent-marker`, `noMockMarkersDetected=true`, real provider reply, and clean default ports; also passed `./scripts/run-local-letai-game-test.test.sh`, targeted Rust tests, node syntax checks, `./scripts/cargo-dev.sh fmt --check`, `git diff --check`, and `./scripts/doc-governance-check.sh`.
+- Residual Risk: Real provider latency remains an external variable for this end-to-end Playwright case, but the wrapper now uses dynamic ports, clearer preflight errors, cleanup assertions, and artifact summaries so failures should be attributable and repeatable.
+
+## 2026-06-17 21:53:56 CST / viewer_engineer
+- Review Trigger: pre-PR local role review result
+- Review Scope: Viewer UI/WebGPU/canvas Agent marker selector, accessible label, compiled `viewer.js`/served `dist` consistency, and Playwright UI automation reliability.
+- Findings:
+  - P1 / merge-blocking before fix: WebGPU/canvas Agent marker selector existed, but same-location agents rendered at the exact same clickable coordinates. Playwright resolved `[data-pixel-world-agent-marker="true"][data-agent-id="agent-0"]`, but the click was intercepted by `agent-1`, so the "click map agent marker to select" flow was not reliably automatable. Evidence: failed run `output/playwright/viewer-real-agent-chat/20260617-212530/playwright/failure_state.json` and Playwright call log in `output/playwright/viewer-real-agent-chat/20260617-212530/viewer-real-agent-chat-regression.log`; source area `crates/oasis7_viewer/software_safe_src/pixel_world_host.jsx`.
+  - P2 / automation reliability before fix: `scripts/viewer-real-agent-chat-regression.sh` could report a successful real reply but exit nonzero because local stack child processes needed longer than the original cleanup window to release ports. Evidence: run `output/playwright/viewer-real-agent-chat/20260617-213455` printed `ok: real Agent reply observed for agent-0` then failed cleanup.
+  - P2 / shell portability before fix: `scripts/run-local-letai-game-test.sh` used nested quoted array expansion for launcher args; runtime logs showed `unexpected EOF while looking for matching` near script end after stack ready. Evidence: `output/playwright/viewer-real-agent-chat/20260617-213836/local-letai-stack.log`.
+- Finding Disposition:
+  - Addressed P1 by adding stable per-agent marker offsets via `agentMarkerStyle`, exposing canvas hit targets with `data-pixel-world-agent-marker="true"`, `data-agent-id`, and localized `aria-label`, and updating the component test to include two same-position agents with distinct transforms.
+  - Addressed P2 cleanup by extending wrapper cleanup wait and adding a managed-port listener termination fallback for script-owned local stack ports.
+  - Addressed P2 shell portability by replacing the nested launcher-args expansion with explicit `LAUNCHER_CMD` array assembly.
+  - Reduced Playwright flake by changing the real-chat wrapper to dynamic ports and skipping startup provider smoke/chat probe; the test still requires a real provider-authored UI chat reply and forbids mock markers.
+- Verification:
+  - Passed: `node --check crates/oasis7_viewer/viewer.js && node --check crates/oasis7_viewer/dist/viewer.js && node --check crates/oasis7_viewer/scripts/real-agent-chat-regression.mjs && bash -n scripts/run-local-letai-game-test.sh && bash -n scripts/viewer-real-agent-chat-regression.sh`.
+  - Passed: `git diff --check`.
+  - Passed: `./scripts/doc-governance-check.sh`.
+  - Passed: `./scripts/local-letai-provider-bridge.test.sh`.
+  - Prior successful real UI/provider evidence after marker fix: `output/playwright/viewer-real-agent-chat/20260617-213455/playwright` produced `selectionMode=ui-agent-marker` and a non-mock reply `我在 runtime:3531642:4980555:594781。身边资源：data 8，electricity 32。`; that run failed only the cleanup exit path, which has since been patched.
+  - Latest full wrapper verification remains blocked in this environment: subsequent runs were interrupted by SIGKILL/resource pressure or by real provider latency before a final zero-exit wrapper run could complete. Latest diagnostic examples: `output/playwright/viewer-real-agent-chat/20260617-214925` exited with status 137 after stack ready; `output/playwright/viewer-real-agent-chat/20260617-214643` reached connected state, selected `agent-0`, and queued chat, but timed out while provider requests were still retrying.
+- Review Outcome: findings_addressed_but_pr_gate_blocked
+- Residual Risk:
+  - The core Viewer marker selector and UI click issue has direct positive evidence from a real run, but the latest complete one-command Playwright wrapper cannot yet be claimed green because the local environment repeatedly killed the launcher/browser or the real provider exceeded the previous wait window.
+  - Do not record `Pre-PR Local Role Review: passed` or create/merge the PR until one fresh complete wrapper run succeeds after these fixes, or the task explicitly accepts the SIGKILL/provider-latency condition as an external blocker with a narrower PR scope.

--- a/.pm/tasks/task_43f78174f0904eaf95e3b99dde0509a7.execution.md
+++ b/.pm/tasks/task_43f78174f0904eaf95e3b99dde0509a7.execution.md
@@ -567,8 +567,8 @@ Example:
 - Task UID: task_43f78174f0904eaf95e3b99dde0509a7
 - Source Worktree: /Users/scc/ccwork/worktrees/oasis7-engineering-local-playtest-cli-hardening
 - Source Branch: task/engineering-local-playtest-cli-hardening
-- Source Head: a9a2311c59e77221173050e2c1463499ddc9c03e
-- Comparison Ref: origin/main
+- Source Head: 5e9e0551ca5c02f107afe9d92e80495b02f77b89
+- Comparison Ref: refs/remotes/origin/main
 - Reviewed Changed Paths: .pm/tasks/task_43f78174f0904eaf95e3b99dde0509a7.execution.md; .pm/tasks/task_43f78174f0904eaf95e3b99dde0509a7.yaml; crates/oasis7/src/bin/oasis7_provider_local_bridge.rs; crates/oasis7/src/bin/oasis7_provider_local_bridge/http_bridge_support.rs; crates/oasis7/src/bin/oasis7_provider_local_bridge/tests.rs; crates/oasis7/src/simulator/mod.rs; crates/oasis7/src/simulator/provider_loopback_http.rs; crates/oasis7/src/viewer/runtime_live.rs; crates/oasis7/src/viewer/runtime_live/control_plane.rs; crates/oasis7/src/viewer/runtime_live/llm_sidecar.rs; crates/oasis7/src/viewer/runtime_live/tests/auth_actions_agent_chat.rs; crates/oasis7_viewer/software_safe_src/pixel_world_host.jsx; crates/oasis7_viewer/software_safe_src/pixel_world_host.test.jsx; crates/oasis7_viewer/viewer.js; crates/oasis7_viewer/scripts/real-agent-chat-regression.mjs; doc/testing/manual/web-ui-playwright-closure-manual.manual.md; doc/testing/README.md; doc/testing/prd.index.md; doc/testing/prd.md; doc/testing/project.md; scripts/ci-tests.sh; scripts/run-local-letai-game-test.sh; scripts/run-local-letai-game-test.test.sh; scripts/viewer-real-agent-chat-regression.sh; scripts/viewer-software-safe-chat-regression.sh; testing-manual.md
 - Role Selection Basis: runtime/provider chat and control-plane code changed, Viewer canvas/UI marker automation changed, Playwright/CLI verification gates changed, and test documentation/workflow surfaces changed; selected runtime_engineer, viewer_engineer, qa_engineer, repository_health_engineer.
 - Review Roles: runtime_engineer, viewer_engineer, qa_engineer, repository_health_engineer

--- a/.pm/tasks/task_43f78174f0904eaf95e3b99dde0509a7.execution.md
+++ b/.pm/tasks/task_43f78174f0904eaf95e3b99dde0509a7.execution.md
@@ -600,3 +600,32 @@ Example:
 - Residual Risk:
   - The core Viewer marker selector and UI click issue has direct positive evidence from a real run, but the latest complete one-command Playwright wrapper cannot yet be claimed green because the local environment repeatedly killed the launcher/browser or the real provider exceeded the previous wait window.
   - Do not record `Pre-PR Local Role Review: passed` or create/merge the PR until one fresh complete wrapper run succeeds after these fixes, or the task explicitly accepts the SIGKILL/provider-latency condition as an external blocker with a narrower PR scope.
+
+## 2026-06-17 22:38:00 CST / tpm
+- Review Trigger: GitHub PR #507 Codex review comments
+- Review Scope: address post-PR review findings before merge.
+- Tooling Note:
+  - Intended closeout inventory command `./scripts/pr-review-thread-closeout.sh --unresolved-only` could not run because `gh` is unavailable in this environment (`gh: command not found`).
+  - Fallback evidence path: local code verification against the four reported PR review comments, targeted tests, full real Playwright wrapper run, and follow-up GitHub connector/thread checks before merge.
+- Findings Addressed:
+  - P2: provider-backed Agent chat ack was blocked on synchronous `/v1/world-simulator/agent-chat`; fixed by returning `AgentChatAck` after feedback acceptance and processing provider reply after the ack is flushed.
+  - P2: `/v1/world-simulator/agent-chat` was called unconditionally; fixed by requiring provider capability `agent_chat` before requesting a provider reply, while preserving phase-1 decision/feedback-only provider compatibility.
+  - P2: occupied-port shell test failed on systems without `lsof`; fixed by explicitly skipping that assertion when `lsof` is unavailable.
+  - P2: `--forbid-agent-spoke-contains` was only enforced through the matching reply predicate; fixed by adding an independent forbidden-message scan that fails even when no required reply is configured.
+  - Regression hardening: default real-agent reply assertion now checks stable facts (`runtime:`, `data 8`, `electricity 32`) instead of a brittle natural-language spacing fragment.
+- Verification:
+  - Passed: `./scripts/run-local-letai-game-test.test.sh`.
+  - Passed: `bash -n scripts/run-local-letai-game-test.test.sh scripts/viewer-software-safe-chat-regression.sh scripts/viewer-real-agent-chat-regression.sh scripts/run-local-letai-game-test.sh && ./scripts/cargo-dev.sh fmt --check && git diff --check`.
+  - Passed: `./scripts/cargo-dev.sh test -p oasis7 --lib runtime_agent_chat_provider_mode_accepts_feedback_without_echo_receipt -- --nocapture`.
+  - Passed: `./scripts/cargo-dev.sh test -p oasis7 --lib runtime_agent_chat_provider_mode_skips_reply_without_agent_chat_capability -- --nocapture`.
+  - Passed: `./scripts/cargo-dev.sh test -p oasis7 --lib runtime_agent_chat_provider_mode_reports_feedback_failure -- --nocapture`.
+  - Passed: `./scripts/cargo-dev.sh test -p oasis7 --bin oasis7_provider_local_bridge mock_mode_health_is_ready_without_gateway_probe -- --nocapture`.
+  - Passed: `./scripts/cargo-dev.sh test -p oasis7 --bin oasis7_provider_local_bridge agent_chat_idempotency_key_distinguishes_same_tick_messages -- --nocapture`.
+  - Passed: `./scripts/doc-governance-check.sh`.
+  - Passed: `./scripts/viewer-real-agent-chat-regression.sh`.
+- Real Playwright Evidence:
+  - Artifacts: `output/playwright/viewer-real-agent-chat/20260617-223520/playwright`.
+  - Summary: `ok: real Agent reply observed for agent-0`.
+  - Reply: `我在 runtime:3531642:4980555:594781。身边资源：data 8，electricity 32。`
+- Residual Risk:
+  - The real provider remains an external dependency and can be slow or quota-sensitive, but the latest full wrapper run exited 0 after the PR-review fixes.

--- a/.pm/tasks/task_43f78174f0904eaf95e3b99dde0509a7.yaml
+++ b/.pm/tasks/task_43f78174f0904eaf95e3b99dde0509a7.yaml
@@ -1,0 +1,27 @@
+task_uid: task_43f78174f0904eaf95e3b99dde0509a7
+title: "Harden local playtest one-command CLI"
+owner_role: tpm
+worktree_hint: /Users/scc/ccwork/worktrees/oasis7-engineering-local-playtest-cli-hardening
+execution_log_path: .pm/tasks/task_43f78174f0904eaf95e3b99dde0509a7.execution.md
+status: done
+priority: P2
+source_signal: null
+source_refs:
+  - testing-manual.md
+  - scripts/run-local-letai-game-test.sh
+doc_refs:
+  - doc/engineering/workflow/source-of-truth.md
+  - doc/testing/project.md
+related_prd: []
+acceptance:
+  - "Local playtest entrypoint performs preflight checks and reports actionable errors for missing tools, build/readiness, and provider issues"
+  - "A one-command local playtest path supports strict and degraded startup modes without requiring operators to hand-compose skip flags"
+handoff_to: []
+updated_at: 2026-06-17T21:23:40+08:00
+last_started_at: 2026-06-17T12:55:16+08:00
+last_claim_type: task_complete
+last_verify_command: "./scripts/run-local-letai-game-test.test.sh && ./scripts/viewer-real-agent-chat-regression.sh && /Users/scc/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node --check crates/oasis7_viewer/viewer.js && /Users/scc/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node --check crates/oasis7_viewer/dist/viewer.js && /Users/scc/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node --check crates/oasis7_viewer/scripts/real-agent-chat-regression.mjs && git diff --check && ./scripts/doc-governance-check.sh"
+last_verified_at: 2026-06-17T21:23:35+08:00
+last_verification_exit_code: 0
+last_verification_status: verified
+last_closed_at: 2026-06-17T21:23:39+08:00

--- a/crates/oasis7/src/bin/oasis7_provider_local_bridge.rs
+++ b/crates/oasis7/src/bin/oasis7_provider_local_bridge.rs
@@ -226,6 +226,7 @@ impl ProviderState {
         let mut capabilities = vec![
             "decision".to_string(),
             "feedback".to_string(),
+            "agent_chat".to_string(),
             "loopback_only".to_string(),
         ];
         match self.options.mode {

--- a/crates/oasis7/src/bin/oasis7_provider_local_bridge.rs
+++ b/crates/oasis7/src/bin/oasis7_provider_local_bridge.rs
@@ -13,8 +13,9 @@ use std::time::{Duration, Instant};
 
 use oasis7::observability::{emit_stderr_or_event, init_tracing, resolve_trace_session_id};
 use oasis7::simulator::{
-    DecisionRequest, DecisionResponse, FeedbackEnvelope, ProviderDecision, ProviderDiagnostics,
-    ProviderErrorEnvelope, ProviderHealth, ProviderInfo, ProviderTokenUsage, ProviderTraceEnvelope,
+    DecisionRequest, DecisionResponse, FeedbackEnvelope, ProviderAgentChatRequest,
+    ProviderAgentChatResponse, ProviderDecision, ProviderDiagnostics, ProviderErrorEnvelope,
+    ProviderHealth, ProviderInfo, ProviderTokenUsage, ProviderTraceEnvelope,
     ProviderTranscriptEntry,
 };
 use reqwest::blocking::Client;
@@ -304,6 +305,67 @@ impl ProviderState {
             recent_feedback.pop_front();
         }
         recent_feedback.push_back(summary);
+    }
+
+    fn handle_agent_chat(
+        &self,
+        request: ProviderAgentChatRequest,
+        route_label: Option<&str>,
+        invoker: &dyn AgentInvoker,
+    ) -> Result<ProviderAgentChatResponse, String> {
+        let agent_id = request.agent_id.trim();
+        if agent_id.is_empty() {
+            return Err("agent_chat requires non-empty agent_id".to_string());
+        }
+        let player_id = request.player_id.trim();
+        if player_id.is_empty() {
+            return Err("agent_chat requires non-empty player_id".to_string());
+        }
+        let message = request.message.trim();
+        if message.is_empty() {
+            return Err("agent_chat requires non-empty message".to_string());
+        }
+        if self.options.mode == ProviderMode::Mock {
+            return Ok(ProviderAgentChatResponse {
+                agent_id: agent_id.to_string(),
+                message: format!("[local-mock-chat] {agent_id} 收到：{message}"),
+                location_id: request.location_id,
+            });
+        }
+
+        self.active_requests.fetch_add(1, Ordering::SeqCst);
+        let prompt = build_agent_chat_prompt(&request);
+        let session_key = format!(
+            "agent:{}:subagent:world-simulator-chat:{}",
+            self.options.provider_agent_id, agent_id
+        );
+        let invoke_result = invoker.invoke(AgentInvocation {
+            provider_cli_bin: self.options.provider_cli_bin.clone(),
+            agent_id: self.options.provider_agent_id.clone(),
+            thinking: self.options.provider_thinking.clone(),
+            session_key: session_key.clone(),
+            timeout_seconds: timeout_seconds_from_budget(60_000),
+            prompt,
+            idempotency_key: agent_chat_idempotency_key(&session_key, &request),
+            route_label: route_label.map(ToOwned::to_owned),
+        });
+        self.active_requests.fetch_sub(1, Ordering::SeqCst);
+
+        match invoke_result {
+            Ok(output) => {
+                self.set_last_error(None);
+                Ok(ProviderAgentChatResponse {
+                    agent_id: agent_id.to_string(),
+                    message: summarize_text(output.text.as_str(), 700),
+                    location_id: request.location_id,
+                })
+            }
+            Err(err) => {
+                let detail = format!("provider_agent_chat_unreachable: {err}");
+                self.set_last_error(Some(detail.clone()));
+                Err(detail)
+            }
+        }
     }
 
     fn resolve_newapi_bridge_route_label(&self, bearer: &str) -> Option<String> {
@@ -632,6 +694,27 @@ impl ProviderState {
     }
 }
 
+fn build_agent_chat_prompt(request: &ProviderAgentChatRequest) -> String {
+    let context = json!({
+        "agent_id": request.agent_id,
+        "player_id": request.player_id,
+        "world_time": request.world_time,
+        "location_id": request.location_id,
+        "resources": request.resources,
+        "recent_feedback": request.recent_feedback,
+        "player_message": request.message,
+    });
+    format!(
+        concat!(
+            "You are the selected oasis7 agent. Reply directly to the player in the same language as their message. ",
+            "Do not return JSON. Do not claim unavailable facts. ",
+            "If asked where you are, use location_id exactly. If asked about nearby resources, use resources exactly. ",
+            "Keep the reply under 80 Chinese characters or 60 English words. Context follows:\n{}"
+        ),
+        context
+    )
+}
+
 fn provider_error_upstream_trace(error: &str) -> Value {
     let diagnostics = error_diagnostics_json(error);
     json!({
@@ -852,6 +935,17 @@ fn short_sha256(text: &str) -> String {
     hasher.update(text.as_bytes());
     let digest = hasher.finalize();
     hex::encode(&digest[..8])
+}
+
+fn agent_chat_idempotency_key(session_key: &str, request: &ProviderAgentChatRequest) -> String {
+    let stable_chat_key = short_sha256(
+        format!(
+            "{}\0{}\0{}\0{}",
+            request.world_time, request.agent_id, request.player_id, request.message
+        )
+        .as_str(),
+    );
+    format!("{session_key}-{}-{stable_chat_key}", request.world_time)
 }
 
 fn main() {

--- a/crates/oasis7/src/bin/oasis7_provider_local_bridge/http_bridge_support.rs
+++ b/crates/oasis7/src/bin/oasis7_provider_local_bridge/http_bridge_support.rs
@@ -5,7 +5,9 @@ use std::net::TcpStream;
 use serde::Serialize;
 use serde_json::json;
 
-use super::{AgentInvoker, DecisionRequest, FeedbackEnvelope, ProviderState};
+use super::{
+    AgentInvoker, DecisionRequest, FeedbackEnvelope, ProviderAgentChatRequest, ProviderState,
+};
 
 pub(super) fn handle_connection(
     stream: &mut TcpStream,
@@ -33,6 +35,18 @@ pub(super) fn handle_connection(
                 .map_err(|err| format!("decode feedback request failed: {err}"))?;
             state.record_feedback(decoded);
             write_json_response(stream, 200, &json!({"ok": true}))
+        }
+        ("POST", "/v1/world-simulator/agent-chat") => {
+            let decoded: ProviderAgentChatRequest = serde_json::from_slice(request.body.as_slice())
+                .map_err(|err| format!("decode agent chat request failed: {err}"))?;
+            match state.handle_agent_chat(decoded, route_label.as_deref(), invoker) {
+                Ok(response) => write_json_response(stream, 200, &response),
+                Err(err) => write_json_response(
+                    stream,
+                    500,
+                    &json!({"error_code": "provider_agent_chat_failed", "error": err}),
+                ),
+            }
         }
         _ => write_json_response(stream, 404, &json!({"error":"Not Found"})),
     }

--- a/crates/oasis7/src/bin/oasis7_provider_local_bridge/tests.rs
+++ b/crates/oasis7/src/bin/oasis7_provider_local_bridge/tests.rs
@@ -270,6 +270,28 @@ fn build_gateway_agent_params_uses_session_key_and_timeout() {
 }
 
 #[test]
+fn agent_chat_idempotency_key_distinguishes_same_tick_messages() {
+    let base = ProviderAgentChatRequest {
+        agent_id: "agent-0".to_string(),
+        player_id: "player-a".to_string(),
+        message: "where are you?".to_string(),
+        world_time: 7,
+        location_id: Some("loc-1".to_string()),
+        resources: None,
+        recent_feedback: Vec::new(),
+    };
+    let same = agent_chat_idempotency_key("session", &base);
+    assert_eq!(same, agent_chat_idempotency_key("session", &base));
+
+    let mut different_message = base.clone();
+    different_message.message = "what resources are nearby?".to_string();
+    assert_ne!(
+        same,
+        agent_chat_idempotency_key("session", &different_message)
+    );
+}
+
+#[test]
 fn apply_profile_guardrails_reroutes_patrol_wait_to_move() {
     let mut request = sample_request();
     request.observation.memory_summary = Some(

--- a/crates/oasis7/src/bin/oasis7_provider_local_bridge/tests.rs
+++ b/crates/oasis7/src/bin/oasis7_provider_local_bridge/tests.rs
@@ -153,6 +153,7 @@ fn mock_mode_health_is_ready_without_gateway_probe() {
     let info = state.provider_info();
     assert_eq!(info.provider_id, "provider_local_mock");
     assert!(info.capabilities.iter().any(|value| value == "mock"));
+    assert!(info.capabilities.iter().any(|value| value == "agent_chat"));
     assert!(info.capabilities.iter().any(|value| value == "no_billing"));
     let health = state.provider_health();
     assert!(health.ok);

--- a/crates/oasis7/src/simulator/mod.rs
+++ b/crates/oasis7/src/simulator/mod.rs
@@ -117,10 +117,11 @@ pub use provider_loopback_adapter::ProviderLoopbackAdapter;
 pub use provider_loopback_http::{
     evaluate_provider_compatibility, provider_phase1_required_actions,
     provider_phase1_required_capabilities, validate_provider_http_base_url,
-    validate_provider_loopback_http_base_url, ProviderCompatibilityReport,
-    ProviderCompatibilityStatus, ProviderFeedbackAck, ProviderHealth, ProviderInfo,
-    ProviderLoopbackHttpClient, ProviderLoopbackHttpError, LOOPBACK_HTTP_PROVIDER_TRANSPORT,
-    PROVIDER_PHASE1_ACTION_SET_ALIAS, REMOTE_HTTPS_PROVIDER_TRANSPORT,
+    validate_provider_loopback_http_base_url, ProviderAgentChatRequest, ProviderAgentChatResponse,
+    ProviderCompatibilityReport, ProviderCompatibilityStatus, ProviderFeedbackAck, ProviderHealth,
+    ProviderInfo, ProviderLoopbackHttpClient, ProviderLoopbackHttpError,
+    LOOPBACK_HTTP_PROVIDER_TRANSPORT, PROVIDER_PHASE1_ACTION_SET_ALIAS,
+    REMOTE_HTTPS_PROVIDER_TRANSPORT,
 };
 pub use runner::{
     AgentQuota, AgentRunner, AgentStats, AgentTickResult, RateLimitPolicy, RateLimitState,

--- a/crates/oasis7/src/simulator/provider_loopback_http.rs
+++ b/crates/oasis7/src/simulator/provider_loopback_http.rs
@@ -7,6 +7,7 @@ use reqwest::blocking::{Client, RequestBuilder};
 use reqwest::{Method, StatusCode, Url};
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 
 use super::{DecisionRequest, DecisionResponse, FeedbackEnvelope};
 
@@ -207,6 +208,28 @@ pub struct ProviderFeedbackAck {
     pub error: Option<String>,
 }
 
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ProviderAgentChatRequest {
+    pub agent_id: String,
+    pub player_id: String,
+    pub message: String,
+    pub world_time: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub location_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resources: Option<Value>,
+    #[serde(default)]
+    pub recent_feedback: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ProviderAgentChatResponse {
+    pub agent_id: String,
+    pub message: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub location_id: Option<String>,
+}
+
 #[derive(Debug)]
 pub enum ProviderLoopbackHttpError {
     InvalidBaseUrl(String),
@@ -327,6 +350,13 @@ impl ProviderLoopbackHttpClient {
         feedback: &FeedbackEnvelope,
     ) -> Result<ProviderFeedbackAck, ProviderLoopbackHttpError> {
         self.post_json("/v1/world-simulator/feedback", feedback)
+    }
+
+    pub fn request_agent_chat(
+        &self,
+        request: &ProviderAgentChatRequest,
+    ) -> Result<ProviderAgentChatResponse, ProviderLoopbackHttpError> {
+        self.post_json("/v1/world-simulator/agent-chat", request)
     }
 
     fn get_json<Response>(&self, path: &str) -> Result<Response, ProviderLoopbackHttpError>

--- a/crates/oasis7/src/viewer/runtime_live.rs
+++ b/crates/oasis7/src/viewer/runtime_live.rs
@@ -518,9 +518,7 @@ impl ViewerRuntimeLiveServer {
             ViewerRequest::AgentChat { request } => match self.handle_agent_chat(request) {
                 Ok(ack) => {
                     send_response(writer, &ViewerResponse::AgentChatAck { ack })?;
-                    if self.config.agent_chat_echo_enabled {
-                        self.flush_pending_virtual_events(session, writer)?;
-                    }
+                    self.flush_pending_virtual_events(session, writer)?;
                 }
                 Err(error) => {
                     send_response(writer, &ViewerResponse::AgentChatError { error })?;

--- a/crates/oasis7/src/viewer/runtime_live.rs
+++ b/crates/oasis7/src/viewer/runtime_live.rs
@@ -518,6 +518,7 @@ impl ViewerRuntimeLiveServer {
             ViewerRequest::AgentChat { request } => match self.handle_agent_chat(request) {
                 Ok(ack) => {
                     send_response(writer, &ViewerResponse::AgentChatAck { ack })?;
+                    self.enqueue_pending_provider_agent_chat_replies();
                     self.flush_pending_virtual_events(session, writer)?;
                 }
                 Err(error) => {

--- a/crates/oasis7/src/viewer/runtime_live/control_plane.rs
+++ b/crates/oasis7/src/viewer/runtime_live/control_plane.rs
@@ -490,10 +490,14 @@ impl ViewerRuntimeLiveServer {
             &self.world,
             &self.snapshot_config,
             agent_id.as_str(),
+            player_id.as_str(),
             message.as_str(),
         ) {
-            Ok(()) => {
+            Ok(provider_reply) => {
                 self.llm_sidecar.request_decision();
+                if let Some(reply) = provider_reply {
+                    self.enqueue_agent_chat_reply_event(agent_id.as_str(), reply.as_str());
+                }
             }
             Err(error)
                 if chat_echo_enabled
@@ -856,6 +860,18 @@ impl ViewerRuntimeLiveServer {
             message: format!(
                 "{RUNTIME_AGENT_CHAT_ECHO_PREFIX} {RUNTIME_AGENT_CHAT_ECHO_NOTICE}{message}"
             ),
+            target_agent_id: None,
+        });
+    }
+
+    fn enqueue_agent_chat_reply_event(&mut self, agent_id: &str, message: &str) {
+        let Some(agent) = self.world.state().agents.get(agent_id) else {
+            return;
+        };
+        self.enqueue_virtual_event(WorldEventKind::AgentSpoke {
+            agent_id: agent_id.to_string(),
+            location_id: location_id_for_pos(agent.state.pos),
+            message: message.to_string(),
             target_agent_id: None,
         });
     }

--- a/crates/oasis7/src/viewer/runtime_live/control_plane.rs
+++ b/crates/oasis7/src/viewer/runtime_live/control_plane.rs
@@ -493,11 +493,8 @@ impl ViewerRuntimeLiveServer {
             player_id.as_str(),
             message.as_str(),
         ) {
-            Ok(provider_reply) => {
+            Ok(()) => {
                 self.llm_sidecar.request_decision();
-                if let Some(reply) = provider_reply {
-                    self.enqueue_agent_chat_reply_event(agent_id.as_str(), reply.as_str());
-                }
             }
             Err(error)
                 if chat_echo_enabled
@@ -874,6 +871,15 @@ impl ViewerRuntimeLiveServer {
             message: message.to_string(),
             target_agent_id: None,
         });
+    }
+
+    pub(super) fn enqueue_pending_provider_agent_chat_replies(&mut self) {
+        let replies = self
+            .llm_sidecar
+            .drain_provider_agent_chat_replies(&self.world);
+        for (agent_id, message) in replies {
+            self.enqueue_agent_chat_reply_event(agent_id.as_str(), message.as_str());
+        }
     }
 
     fn next_virtual_event_id(&mut self) -> u64 {

--- a/crates/oasis7/src/viewer/runtime_live/llm_sidecar.rs
+++ b/crates/oasis7/src/viewer/runtime_live/llm_sidecar.rs
@@ -10,10 +10,10 @@ use crate::runtime::{
 use crate::simulator::{
     evaluate_provider_compatibility, Action as SimulatorAction, ActionCatalogEntry, ActionResult,
     AgentDecision, AgentDecisionTrace, AgentPromptProfile, AgentRunner, ChunkRuntimeConfig,
-    LlmAgentBehavior, LlmAgentConfig, OpenAiChatCompletionClient, ProviderBackedAgentBehavior,
-    ProviderExecutionMode, ProviderLoopbackAdapter, ProviderLoopbackHttpClient, ResourceOwner,
-    WorldConfig, WorldEvent, WorldEventKind, WorldJournal, WorldKernel, WorldSnapshot,
-    CHUNK_GENERATION_SCHEMA_VERSION, SNAPSHOT_VERSION,
+    LlmAgentBehavior, LlmAgentConfig, OpenAiChatCompletionClient, ProviderAgentChatRequest,
+    ProviderBackedAgentBehavior, ProviderExecutionMode, ProviderLoopbackAdapter,
+    ProviderLoopbackHttpClient, ResourceOwner, WorldConfig, WorldEvent, WorldEventKind,
+    WorldJournal, WorldKernel, WorldSnapshot, CHUNK_GENERATION_SCHEMA_VERSION, SNAPSHOT_VERSION,
 };
 use crate::viewer::live::ViewerLiveDecisionMode;
 use crate::viewer::protocol::{AgentChatAck, AgentChatError};
@@ -552,8 +552,9 @@ impl RuntimeLlmSidecar {
         world: &RuntimeWorld,
         config: &WorldConfig,
         agent_id: &str,
+        player_id: &str,
         message: &str,
-    ) -> Result<(), AgentChatError> {
+    ) -> Result<Option<String>, AgentChatError> {
         if !self.is_llm_mode() {
             return Err(AgentChatError {
                 code: "llm_mode_required".to_string(),
@@ -575,8 +576,18 @@ impl RuntimeLlmSidecar {
                 agent_id: Some(agent_id.to_string()),
             });
         }
-        let runner = match self.runner.as_mut() {
-            Some(runner) => runner,
+        let provider_backed = match self.runner.as_ref() {
+            Some(RuntimeDecisionRunner::Builtin(_)) => false,
+            Some(RuntimeDecisionRunner::ProviderBacked(runner)) => {
+                if runner.get(agent_id).is_none() {
+                    return Err(AgentChatError {
+                        code: "agent_not_registered".to_string(),
+                        message: format!("agent {} is not registered in provider runner", agent_id),
+                        agent_id: Some(agent_id.to_string()),
+                    });
+                }
+                true
+            }
             None => {
                 return Err(AgentChatError {
                     code: "llm_init_failed".to_string(),
@@ -585,8 +596,40 @@ impl RuntimeLlmSidecar {
                 });
             }
         };
-        match runner {
-            RuntimeDecisionRunner::Builtin(runner) => {
+        if provider_backed {
+            let reply = self.request_provider_agent_chat(world, agent_id, player_id, message)?;
+            let Some(RuntimeDecisionRunner::ProviderBacked(runner)) = self.runner.as_mut() else {
+                return Err(AgentChatError {
+                    code: "llm_init_failed".to_string(),
+                    message: "provider runner disappeared while sending agent chat".to_string(),
+                    agent_id: Some(agent_id.to_string()),
+                });
+            };
+            let Some(agent) = runner.get_mut(agent_id) else {
+                return Err(AgentChatError {
+                    code: "agent_not_registered".to_string(),
+                    message: format!("agent {} is not registered in provider runner", agent_id),
+                    agent_id: Some(agent_id.to_string()),
+                });
+            };
+            agent
+                .behavior
+                .push_player_message_feedback(world.state().time, message)
+                .map_err(|error| AgentChatError {
+                    code: error.code,
+                    message: error.message,
+                    agent_id: Some(agent_id.to_string()),
+                })?;
+            Ok(Some(reply))
+        } else {
+            let Some(RuntimeDecisionRunner::Builtin(runner)) = self.runner.as_mut() else {
+                return Err(AgentChatError {
+                    code: "llm_init_failed".to_string(),
+                    message: "builtin llm runner disappeared while sending agent chat".to_string(),
+                    agent_id: Some(agent_id.to_string()),
+                });
+            };
+            {
                 let Some(agent) = runner.get_mut(agent_id) else {
                     return Err(AgentChatError {
                         code: "agent_not_registered".to_string(),
@@ -604,26 +647,67 @@ impl RuntimeLlmSidecar {
                         agent_id: Some(agent_id.to_string()),
                     });
                 }
-            }
-            RuntimeDecisionRunner::ProviderBacked(runner) => {
-                let Some(agent) = runner.get_mut(agent_id) else {
-                    return Err(AgentChatError {
-                        code: "agent_not_registered".to_string(),
-                        message: format!("agent {} is not registered in provider runner", agent_id),
-                        agent_id: Some(agent_id.to_string()),
-                    });
-                };
-                agent
-                    .behavior
-                    .push_player_message_feedback(world.state().time, message)
-                    .map_err(|error| AgentChatError {
-                        code: error.code,
-                        message: error.message,
-                        agent_id: Some(agent_id.to_string()),
-                    })?;
+                Ok(None)
             }
         }
-        Ok(())
+    }
+
+    fn request_provider_agent_chat(
+        &self,
+        world: &RuntimeWorld,
+        agent_id: &str,
+        player_id: &str,
+        message: &str,
+    ) -> Result<String, AgentChatError> {
+        let settings = provider_settings_from_env()
+            .map_err(|message| AgentChatError {
+                code: "provider_config_invalid".to_string(),
+                message,
+                agent_id: Some(agent_id.to_string()),
+            })?
+            .ok_or_else(|| AgentChatError {
+                code: "provider_config_missing".to_string(),
+                message: "provider-backed agent chat requires provider settings".to_string(),
+                agent_id: Some(agent_id.to_string()),
+            })?;
+        let client = ProviderLoopbackHttpClient::new_with_transport(
+            settings.base_url.as_str(),
+            settings.auth_token.as_deref(),
+            settings.decision_timeout_ms,
+            settings.provider_transport.as_str(),
+        )
+        .map_err(|error| AgentChatError {
+            code: "provider_unreachable".to_string(),
+            message: error.to_string(),
+            agent_id: Some(agent_id.to_string()),
+        })?;
+        let agent = world.state().agents.get(agent_id);
+        let location_id = agent.map(|agent| location_id_for_pos(agent.state.pos));
+        let resources = agent.and_then(|agent| serde_json::to_value(&agent.state.resources).ok());
+        let response = client
+            .request_agent_chat(&ProviderAgentChatRequest {
+                agent_id: agent_id.to_string(),
+                player_id: player_id.to_string(),
+                message: message.to_string(),
+                world_time: world.state().time,
+                location_id,
+                resources,
+                recent_feedback: Vec::new(),
+            })
+            .map_err(|error| AgentChatError {
+                code: "provider_unreachable".to_string(),
+                message: error.to_string(),
+                agent_id: Some(agent_id.to_string()),
+            })?;
+        let reply = response.message.trim();
+        if reply.is_empty() {
+            return Err(AgentChatError {
+                code: "provider_empty_chat_response".to_string(),
+                message: "provider returned an empty agent chat response".to_string(),
+                agent_id: Some(agent_id.to_string()),
+            });
+        }
+        Ok(reply.to_string())
     }
 
     pub(super) fn next_llm_decision(

--- a/crates/oasis7/src/viewer/runtime_live/llm_sidecar.rs
+++ b/crates/oasis7/src/viewer/runtime_live/llm_sidecar.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, VecDeque};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::geometry::GeoPos;
@@ -59,6 +59,7 @@ const VIEWER_AGENT_PROVIDER_PROFILE_ENV: &str = "OASIS7_AGENT_PROVIDER_PROFILE";
 const VIEWER_AGENT_EXECUTION_LANE_ENV: &str = "OASIS7_AGENT_EXECUTION_LANE";
 const VIEWER_AGENT_PROVIDER_MODE_ENV: &str = "OASIS7_AGENT_PROVIDER_MODE";
 const RUNTIME_PROVIDER_CHECK_CACHE_MS: u64 = 2_000;
+const PROVIDER_AGENT_CHAT_CAPABILITY: &str = "agent_chat";
 const ENV_RUNTIME_LIVE_LLM_TIMEOUT_MS: &str = "OASIS7_RUNTIME_LIVE_LLM_TIMEOUT_MS";
 const DEFAULT_RUNTIME_LIVE_LLM_TIMEOUT_MS: u64 = 30_000;
 
@@ -127,6 +128,13 @@ struct RuntimeChatIntentAckRecord {
     intent_tick: Option<u64>,
 }
 
+#[derive(Clone, Debug)]
+pub(super) struct RuntimePendingProviderAgentChat {
+    pub(super) agent_id: String,
+    player_id: String,
+    message: String,
+}
+
 impl RuntimeLlmDecision {
     fn from_error(world: &RuntimeWorld, message: String) -> Self {
         let agent_id = world
@@ -184,6 +192,7 @@ pub(in crate::viewer::runtime_live) struct RuntimeLlmSidecar {
     runner: Option<RuntimeDecisionRunner>,
     shadow_kernel: Option<WorldKernel>,
     pending_actions: BTreeMap<u64, RuntimePendingAction>,
+    pending_provider_agent_chats: VecDeque<RuntimePendingProviderAgentChat>,
     provider_check_snapshot: Option<RuntimeProviderCheckSnapshot>,
 }
 
@@ -202,6 +211,7 @@ impl RuntimeLlmSidecar {
             runner: None,
             shadow_kernel: None,
             pending_actions: BTreeMap::new(),
+            pending_provider_agent_chats: VecDeque::new(),
             provider_check_snapshot: None,
         }
     }
@@ -554,7 +564,7 @@ impl RuntimeLlmSidecar {
         agent_id: &str,
         player_id: &str,
         message: &str,
-    ) -> Result<Option<String>, AgentChatError> {
+    ) -> Result<(), AgentChatError> {
         if !self.is_llm_mode() {
             return Err(AgentChatError {
                 code: "llm_mode_required".to_string(),
@@ -597,7 +607,6 @@ impl RuntimeLlmSidecar {
             }
         };
         if provider_backed {
-            let reply = self.request_provider_agent_chat(world, agent_id, player_id, message)?;
             let Some(RuntimeDecisionRunner::ProviderBacked(runner)) = self.runner.as_mut() else {
                 return Err(AgentChatError {
                     code: "llm_init_failed".to_string(),
@@ -620,7 +629,13 @@ impl RuntimeLlmSidecar {
                     message: error.message,
                     agent_id: Some(agent_id.to_string()),
                 })?;
-            Ok(Some(reply))
+            self.pending_provider_agent_chats
+                .push_back(RuntimePendingProviderAgentChat {
+                    agent_id: agent_id.to_string(),
+                    player_id: player_id.to_string(),
+                    message: message.to_string(),
+                });
+            Ok(())
         } else {
             let Some(RuntimeDecisionRunner::Builtin(runner)) = self.runner.as_mut() else {
                 return Err(AgentChatError {
@@ -647,9 +662,37 @@ impl RuntimeLlmSidecar {
                         agent_id: Some(agent_id.to_string()),
                     });
                 }
-                Ok(None)
+                Ok(())
             }
         }
+    }
+
+    pub(super) fn drain_provider_agent_chat_replies(
+        &mut self,
+        world: &RuntimeWorld,
+    ) -> Vec<(String, String)> {
+        let pending: Vec<_> = self.pending_provider_agent_chats.drain(..).collect();
+        let mut replies = Vec::new();
+        for request in pending {
+            match self.request_provider_agent_chat(
+                world,
+                request.agent_id.as_str(),
+                request.player_id.as_str(),
+                request.message.as_str(),
+            ) {
+                Ok(Some(reply)) => replies.push((request.agent_id, reply)),
+                Ok(None) => {}
+                Err(error) => {
+                    tracing::warn!(
+                        agent_id = error.agent_id.as_deref().unwrap_or(""),
+                        error_code = error.code.as_str(),
+                        error_message = error.message.as_str(),
+                        "provider-backed agent chat reply failed after ack"
+                    );
+                }
+            }
+        }
+        replies
     }
 
     fn request_provider_agent_chat(
@@ -658,7 +701,7 @@ impl RuntimeLlmSidecar {
         agent_id: &str,
         player_id: &str,
         message: &str,
-    ) -> Result<String, AgentChatError> {
+    ) -> Result<Option<String>, AgentChatError> {
         let settings = provider_settings_from_env()
             .map_err(|message| AgentChatError {
                 code: "provider_config_invalid".to_string(),
@@ -681,6 +724,18 @@ impl RuntimeLlmSidecar {
             message: error.to_string(),
             agent_id: Some(agent_id.to_string()),
         })?;
+        let info = client.provider_info().map_err(|error| AgentChatError {
+            code: "provider_unreachable".to_string(),
+            message: error.to_string(),
+            agent_id: Some(agent_id.to_string()),
+        })?;
+        if !info.capabilities.iter().any(|capability| {
+            capability
+                .trim()
+                .eq_ignore_ascii_case(PROVIDER_AGENT_CHAT_CAPABILITY)
+        }) {
+            return Ok(None);
+        }
         let agent = world.state().agents.get(agent_id);
         let location_id = agent.map(|agent| location_id_for_pos(agent.state.pos));
         let resources = agent.and_then(|agent| serde_json::to_value(&agent.state.resources).ok());
@@ -707,7 +762,7 @@ impl RuntimeLlmSidecar {
                 agent_id: Some(agent_id.to_string()),
             });
         }
-        Ok(reply.to_string())
+        Ok(Some(reply.to_string()))
     }
 
     pub(super) fn next_llm_decision(

--- a/crates/oasis7/src/viewer/runtime_live/tests/auth_actions_agent_chat.rs
+++ b/crates/oasis7/src/viewer/runtime_live/tests/auth_actions_agent_chat.rs
@@ -59,7 +59,7 @@ fn runtime_agent_chat_provider_mode_accepts_feedback_without_echo_receipt() {
     let _guard = runtime_provider_env_lock().lock().expect("env lock");
     clear_runtime_provider_env();
     let recorded = Arc::new(Mutex::new(Vec::<RecordedHttpRequest>::new()));
-    let base_url = spawn_runtime_live_mock_http_server(3, {
+    let base_url = spawn_runtime_live_mock_http_server(4, {
         let recorded = Arc::clone(&recorded);
         move |request| {
             recorded
@@ -83,6 +83,14 @@ fn runtime_agent_chat_provider_mode_accepts_feedback_without_echo_receipt() {
                 ("POST", "/v1/world-simulator/feedback") => MockHttpResponse {
                     status_code: 200,
                     body: serde_json::json!({"ok": true}).to_string(),
+                },
+                ("POST", "/v1/world-simulator/agent-chat") => MockHttpResponse {
+                    status_code: 200,
+                    body: serde_json::json!({
+                        "agent_id": "agent-0",
+                        "message": "我在测试地点，资源是 electricity=32 data=8。"
+                    })
+                    .to_string(),
                 },
                 _ => MockHttpResponse {
                     status_code: 404,
@@ -148,17 +156,24 @@ fn runtime_agent_chat_provider_mode_accepts_feedback_without_echo_receipt() {
     let ack = server.handle_agent_chat(request).expect("chat accepted");
     assert_eq!(ack.agent_id, agent_id);
     let recorded = recorded.lock().expect("recorded lock");
-    assert_eq!(recorded.len(), 3);
+    assert_eq!(recorded.len(), 4);
     assert_eq!(recorded[0].path, "/v1/provider/info");
     assert_eq!(recorded[1].path, "/v1/provider/health");
     assert_eq!(recorded[2].method, "POST");
-    assert_eq!(recorded[2].path, "/v1/world-simulator/feedback");
+    assert_eq!(recorded[2].path, "/v1/world-simulator/agent-chat");
+    assert_eq!(recorded[3].method, "POST");
+    assert_eq!(recorded[3].path, "/v1/world-simulator/feedback");
     let feedback: crate::simulator::FeedbackEnvelope =
-        serde_json::from_slice(recorded[2].body.as_slice()).expect("decode feedback");
+        serde_json::from_slice(recorded[3].body.as_slice()).expect("decode feedback");
     assert_eq!(
         feedback.world_delta_summary.as_deref(),
         Some("player_message: hello provider feedback")
     );
+    assert!(server.pending_virtual_events.iter().any(|event| matches!(
+        &event.kind,
+        crate::simulator::WorldEventKind::AgentSpoke { agent_id: event_agent_id, message, .. }
+            if event_agent_id == &agent_id && message == "我在测试地点，资源是 electricity=32 data=8。"
+    )));
     assert!(!server.pending_virtual_events.iter().any(|event| matches!(
         &event.kind,
         crate::simulator::WorldEventKind::AgentSpoke { agent_id: event_agent_id, message, .. }

--- a/crates/oasis7/src/viewer/runtime_live/tests/auth_actions_agent_chat.rs
+++ b/crates/oasis7/src/viewer/runtime_live/tests/auth_actions_agent_chat.rs
@@ -4,7 +4,10 @@ use super::*;
 fn runtime_agent_chat_provider_mode_reports_feedback_failure() {
     let _guard = runtime_provider_env_lock().lock().expect("env lock");
     clear_runtime_provider_env();
-    std::env::set_var(VIEWER_AGENT_PROVIDER_MODE_ENV, "provider_loopback_http");
+    std::env::set_var(VIEWER_AGENT_DECISION_SOURCE_ENV, "provider_backed");
+    std::env::set_var(VIEWER_AGENT_PROVIDER_BACKEND_ENV, "provider_local_bridge");
+    std::env::set_var(VIEWER_AGENT_PROVIDER_CONTRACT_ENV, "worldsim_provider_v1");
+    std::env::set_var(VIEWER_AGENT_PROVIDER_TRANSPORT_ENV, "loopback_http");
     std::env::set_var(VIEWER_AGENT_PROVIDER_URL_ENV, "http://127.0.0.1:9");
     std::env::set_var(VIEWER_AGENT_PROVIDER_PROFILE_ENV, "oasis7_p0_low_freq_npc");
     let mut server = ViewerRuntimeLiveServer::new(
@@ -59,7 +62,7 @@ fn runtime_agent_chat_provider_mode_accepts_feedback_without_echo_receipt() {
     let _guard = runtime_provider_env_lock().lock().expect("env lock");
     clear_runtime_provider_env();
     let recorded = Arc::new(Mutex::new(Vec::<RecordedHttpRequest>::new()));
-    let base_url = spawn_runtime_live_mock_http_server(4, {
+    let base_url = spawn_runtime_live_mock_http_server(5, {
         let recorded = Arc::clone(&recorded);
         move |request| {
             recorded
@@ -71,7 +74,7 @@ fn runtime_agent_chat_provider_mode_accepts_feedback_without_echo_receipt() {
                     status_code: 200,
                     body: serde_json::json!({
                         "provider_id": "provider_local_bridge",
-                        "capabilities": ["decision", "feedback"],
+                        "capabilities": ["decision", "feedback", "agent_chat"],
                         "supported_action_sets": ["phase1_low_frequency"]
                     })
                     .to_string(),
@@ -155,16 +158,19 @@ fn runtime_agent_chat_provider_mode_accepts_feedback_without_echo_receipt() {
 
     let ack = server.handle_agent_chat(request).expect("chat accepted");
     assert_eq!(ack.agent_id, agent_id);
+    server.enqueue_pending_provider_agent_chat_replies();
     let recorded = recorded.lock().expect("recorded lock");
-    assert_eq!(recorded.len(), 4);
+    assert_eq!(recorded.len(), 5);
     assert_eq!(recorded[0].path, "/v1/provider/info");
     assert_eq!(recorded[1].path, "/v1/provider/health");
     assert_eq!(recorded[2].method, "POST");
-    assert_eq!(recorded[2].path, "/v1/world-simulator/agent-chat");
-    assert_eq!(recorded[3].method, "POST");
-    assert_eq!(recorded[3].path, "/v1/world-simulator/feedback");
+    assert_eq!(recorded[2].path, "/v1/world-simulator/feedback");
+    assert_eq!(recorded[3].method, "GET");
+    assert_eq!(recorded[3].path, "/v1/provider/info");
+    assert_eq!(recorded[4].method, "POST");
+    assert_eq!(recorded[4].path, "/v1/world-simulator/agent-chat");
     let feedback: crate::simulator::FeedbackEnvelope =
-        serde_json::from_slice(recorded[3].body.as_slice()).expect("decode feedback");
+        serde_json::from_slice(recorded[2].body.as_slice()).expect("decode feedback");
     assert_eq!(
         feedback.world_delta_summary.as_deref(),
         Some("player_message: hello provider feedback")
@@ -178,6 +184,114 @@ fn runtime_agent_chat_provider_mode_accepts_feedback_without_echo_receipt() {
         &event.kind,
         crate::simulator::WorldEventKind::AgentSpoke { agent_id: event_agent_id, message, .. }
             if event_agent_id == &agent_id && message.contains("[local-mock-receipt]")
+    )));
+    clear_runtime_provider_env();
+}
+
+#[test]
+fn runtime_agent_chat_provider_mode_skips_reply_without_agent_chat_capability() {
+    let _guard = runtime_provider_env_lock().lock().expect("env lock");
+    clear_runtime_provider_env();
+    let recorded = Arc::new(Mutex::new(Vec::<RecordedHttpRequest>::new()));
+    let base_url = spawn_runtime_live_mock_http_server(2, {
+        let recorded = Arc::clone(&recorded);
+        move |request| {
+            recorded
+                .lock()
+                .expect("recorded lock")
+                .push(request.clone());
+            match (request.method.as_str(), request.path.as_str()) {
+                ("GET", "/v1/provider/info") => MockHttpResponse {
+                    status_code: 200,
+                    body: serde_json::json!({
+                        "provider_id": "phase1_provider",
+                        "capabilities": ["decision", "feedback"],
+                        "supported_action_sets": ["phase1_low_frequency"]
+                    })
+                    .to_string(),
+                },
+                ("GET", "/v1/provider/health") => MockHttpResponse {
+                    status_code: 200,
+                    body: serde_json::json!({"ok": true, "status": "ok"}).to_string(),
+                },
+                ("POST", "/v1/world-simulator/feedback") => MockHttpResponse {
+                    status_code: 200,
+                    body: serde_json::json!({"ok": true}).to_string(),
+                },
+                ("POST", "/v1/world-simulator/agent-chat") => MockHttpResponse {
+                    status_code: 500,
+                    body: serde_json::json!({"ok": false, "error": "should_not_call"}).to_string(),
+                },
+                _ => MockHttpResponse {
+                    status_code: 404,
+                    body: serde_json::json!({"ok": false, "error": "not_found"}).to_string(),
+                },
+            }
+        }
+    });
+    std::env::set_var(VIEWER_AGENT_DECISION_SOURCE_ENV, "provider_backed");
+    std::env::set_var(VIEWER_AGENT_PROVIDER_BACKEND_ENV, "provider_local_bridge");
+    std::env::set_var(VIEWER_AGENT_PROVIDER_CONTRACT_ENV, "worldsim_provider_v1");
+    std::env::set_var(VIEWER_AGENT_PROVIDER_TRANSPORT_ENV, "loopback_http");
+    std::env::set_var(VIEWER_AGENT_PROVIDER_URL_ENV, base_url);
+    std::env::set_var(VIEWER_AGENT_PROVIDER_PROFILE_ENV, "oasis7_p0_low_freq_npc");
+    std::env::set_var(RUNTIME_AGENT_CHAT_ECHO_ENV, "0");
+    let mut server = ViewerRuntimeLiveServer::new(
+        ViewerRuntimeLiveServerConfig::new(WorldScenario::Minimal)
+            .with_decision_mode(ViewerLiveDecisionMode::Llm),
+    )
+    .expect("runtime server");
+    let agent_id = server
+        .world
+        .state()
+        .agents
+        .keys()
+        .next()
+        .cloned()
+        .expect("seed agent");
+    let (public_key, private_key) = test_signer(36);
+    let request = signed_agent_chat_request(
+        crate::viewer::AgentChatRequest {
+            agent_id: agent_id.clone(),
+            player_id: Some("player-a".to_string()),
+            public_key: None,
+            auth: None,
+            message: "hello phase1 provider".to_string(),
+            intent_tick: Some(13),
+            intent_seq: Some(36),
+        },
+        36,
+        public_key.as_str(),
+        private_key.as_str(),
+    );
+    let register_ack = register_runtime_session(
+        &mut server,
+        "player-a",
+        Some(agent_id.as_str()),
+        35,
+        public_key.as_str(),
+        private_key.as_str(),
+    );
+    assert_eq!(
+        register_ack.status,
+        AuthoritativeRecoveryStatus::SessionRegistered
+    );
+
+    let ack = server.handle_agent_chat(request).expect("chat accepted");
+    assert_eq!(ack.agent_id, agent_id);
+    server.enqueue_pending_provider_agent_chat_replies();
+    let recorded = recorded.lock().expect("recorded lock");
+    assert_eq!(recorded.len(), 2);
+    assert_eq!(recorded[0].method, "POST");
+    assert_eq!(recorded[0].path, "/v1/world-simulator/feedback");
+    assert_eq!(recorded[1].method, "GET");
+    assert_eq!(recorded[1].path, "/v1/provider/info");
+    assert!(!recorded
+        .iter()
+        .any(|request| request.path == "/v1/world-simulator/agent-chat"));
+    assert!(server.pending_virtual_events.iter().all(|event| !matches!(
+        &event.kind,
+        crate::simulator::WorldEventKind::AgentSpoke { .. }
     )));
     clear_runtime_provider_env();
 }

--- a/crates/oasis7_viewer/scripts/real-agent-chat-regression.mjs
+++ b/crates/oasis7_viewer/scripts/real-agent-chat-regression.mjs
@@ -1,0 +1,268 @@
+#!/usr/bin/env node
+import { createRequire } from "node:module";
+import { mkdir, writeFile } from "node:fs/promises";
+import { join, resolve } from "node:path";
+
+const require = createRequire(import.meta.url);
+const { chromium } = require("playwright");
+
+function usage() {
+  console.log(`Usage: node crates/oasis7_viewer/scripts/real-agent-chat-regression.mjs --url <url> [options]
+
+Options:
+  --url <url>                 Viewer URL to open
+  --out-dir <path>            Artifact directory
+  --agent-id <id>             Target agent id (default: agent-0)
+  --chat-message <text>       Chat message to send
+  --expect-contains <text>    Required Agent reply fragment; repeatable
+  --forbid-contains <text>    Forbidden Agent reply fragment; repeatable
+  --timeout-ms <ms>           Wait timeout for Agent reply (default: 90000)
+  --headed                    Run headed instead of headless
+  --help                      Show help`);
+}
+
+function parseArgs(argv) {
+  const options = {
+    url: "",
+    outDir: "",
+    agentId: "agent-0",
+    chatMessage: "你在哪里？身边有什么资源？请直接回答。",
+    expectContains: [],
+    forbidContains: [],
+    timeoutMs: 90000,
+    headed: false,
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    switch (arg) {
+      case "--url":
+        options.url = argv[++index] || "";
+        break;
+      case "--out-dir":
+        options.outDir = argv[++index] || "";
+        break;
+      case "--agent-id":
+        options.agentId = argv[++index] || "";
+        break;
+      case "--chat-message":
+        options.chatMessage = argv[++index] || "";
+        break;
+      case "--expect-contains":
+        options.expectContains.push(argv[++index] || "");
+        break;
+      case "--forbid-contains":
+        options.forbidContains.push(argv[++index] || "");
+        break;
+      case "--timeout-ms":
+        options.timeoutMs = Number(argv[++index] || "0");
+        break;
+      case "--headed":
+        options.headed = true;
+        break;
+      case "--help":
+      case "-h":
+        usage();
+        process.exit(0);
+        break;
+      default:
+        throw new Error(`unknown option: ${arg}`);
+    }
+  }
+  if (!options.url) throw new Error("--url is required");
+  if (!options.outDir) throw new Error("--out-dir is required");
+  if (!options.agentId) throw new Error("--agent-id cannot be empty");
+  if (!options.chatMessage) throw new Error("--chat-message cannot be empty");
+  if (!Number.isFinite(options.timeoutMs) || options.timeoutMs <= 0) {
+    throw new Error("--timeout-ms must be a positive number");
+  }
+  return options;
+}
+
+function appendViewerParams(rawUrl) {
+  const url = new URL(rawUrl);
+  url.searchParams.set("render_mode", "viewer");
+  url.searchParams.set("test_api", "1");
+  return url.toString();
+}
+
+async function writeJson(path, payload) {
+  await writeFile(path, JSON.stringify(payload, null, 2), "utf8");
+}
+
+async function getState(page) {
+  return await page.evaluate(() => window.__AW_TEST__?.getState?.() ?? null);
+}
+
+function cssString(value) {
+  return String(value).replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+}
+
+function findMatchingAgentReply(state, options) {
+  const history = Array.isArray(state?.chatHistory) ? state.chatHistory : [];
+  return history.find((entry) => {
+    if (!entry || entry.source !== "event" || entry.agentId !== options.agentId) return false;
+    const message = String(entry.message ?? "");
+    if (!options.expectContains.every((needle) => message.includes(String(needle)))) return false;
+    if (!options.forbidContains.every((needle) => !message.includes(String(needle)))) return false;
+    return true;
+  }) || null;
+}
+
+async function sendChatThroughUi(page, options) {
+  const evidence = {
+    selectionMode: "ui-agent-marker",
+    focusMode: "ui",
+    chatInputMode: "ui",
+  };
+  const agentMarker = page.locator(`[data-pixel-world-agent-marker="true"][data-agent-id="${cssString(options.agentId)}"]`).first();
+  await agentMarker.waitFor({ state: "visible", timeout: 30000 });
+  await agentMarker.click();
+  await page.waitForFunction((agentId) => window.__AW_TEST__?.getState?.()?.selectedId === agentId, options.agentId, { timeout: 6000 });
+
+  const focusEntry = page.locator(".pixel-world-focus-entry button").first();
+  await focusEntry.waitFor({ state: "visible", timeout: 10000 });
+  const alreadyFocused = await page.locator('.pixel-world-host[data-world-focus="true"]').count();
+  if (!alreadyFocused) {
+    await focusEntry.click();
+  }
+  await page.waitForSelector('.pixel-world-host[data-world-focus="true"]', { timeout: 10000 });
+
+  const commandDrawer = page.locator(".pixel-world-focus-drawer--command").first();
+  await commandDrawer.waitFor({ state: "visible", timeout: 10000 });
+  const drawerOpen = await commandDrawer.evaluate((node) => node.open);
+  if (!drawerOpen) {
+    await page.locator(".pixel-world-focus-control--primary").first().click();
+  }
+  await page.waitForFunction(() => document.querySelector(".pixel-world-focus-drawer--command")?.open === true, null, { timeout: 10000 });
+
+  const chatInput = page.locator("#agent-chat-message");
+  await chatInput.waitFor({ state: "visible", timeout: 10000 });
+  await chatInput.fill(options.chatMessage);
+  await page.waitForFunction((chatMessage) => document.querySelector("#agent-chat-message")?.value === chatMessage, options.chatMessage, { timeout: 5000 });
+
+  const sendButton = page.locator('button[data-chat-send="1"]').first();
+  await sendButton.waitFor({ state: "visible", timeout: 10000 });
+  await page.waitForFunction(() => {
+    const button = document.querySelector('button[data-chat-send="1"]');
+    return button && !button.disabled;
+  }, null, { timeout: 10000 });
+  await sendButton.click({ force: true });
+  return evidence;
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  options.url = appendViewerParams(options.url);
+  options.outDir = resolve(options.outDir);
+  await mkdir(options.outDir, { recursive: true });
+
+  const browser = await chromium.launch({ headless: !options.headed });
+  const page = await browser.newPage({ viewport: { width: 1440, height: 1000 } });
+  const consoleLines = [];
+  page.on("console", (message) => {
+    consoleLines.push(`[${message.type()}] ${message.text()}`);
+  });
+  page.on("pageerror", (error) => {
+    consoleLines.push(`[pageerror] ${error.stack || error.message}`);
+  });
+
+  let finalState = null;
+  let reply = null;
+  let uiEvidence = null;
+  try {
+    await page.goto(options.url, { waitUntil: "networkidle", timeout: 60000 });
+    await page.waitForFunction(() => typeof window.__AW_TEST__ === "object", null, { timeout: 20000 });
+    await page.waitForFunction(() => window.__AW_TEST__?.getState?.()?.connectionStatus === "connected", null, { timeout: 30000 });
+    await writeJson(join(options.outDir, "initial_state.json"), await getState(page));
+
+    uiEvidence = await sendChatThroughUi(page, options);
+    await page.waitForFunction(() => window.__AW_TEST__?.getState?.()?.lastChatFeedback?.stage === "ack", null, { timeout: options.timeoutMs });
+    await page.waitForFunction(
+      ({ agentId, chatMessage }) => {
+        const history = window.__AW_TEST__?.getState?.()?.chatHistory ?? [];
+        return history.some((entry) => entry?.source === "player" && entry.targetAgentId === agentId && entry.message === chatMessage);
+      },
+      { agentId: options.agentId, chatMessage: options.chatMessage },
+      { timeout: 5000 },
+    );
+    await writeJson(join(options.outDir, "after_chat_ack_state.json"), await getState(page));
+
+    await page.waitForFunction(
+      ({ agentId, expectContains, forbidContains }) => {
+        const history = window.__AW_TEST__?.getState?.()?.chatHistory ?? [];
+        return history.some((entry) => {
+          if (!entry || entry.source !== "event" || entry.agentId !== agentId) return false;
+          const message = String(entry.message ?? "");
+          return expectContains.every((needle) => message.includes(String(needle)))
+            && forbidContains.every((needle) => !message.includes(String(needle)));
+        });
+      },
+      {
+        agentId: options.agentId,
+        expectContains: options.expectContains,
+        forbidContains: options.forbidContains,
+      },
+      { timeout: options.timeoutMs },
+    );
+
+    finalState = await getState(page);
+    reply = findMatchingAgentReply(finalState, options);
+    await writeJson(join(options.outDir, "final_state.json"), finalState);
+    await page.screenshot({ path: join(options.outDir, "real-agent-chat.png"), fullPage: true });
+  } catch (error) {
+    finalState = await getState(page).catch(() => null);
+    await writeJson(join(options.outDir, "failure_state.json"), finalState);
+    await page.screenshot({ path: join(options.outDir, "failure.png"), fullPage: true }).catch(() => {});
+    throw error;
+  } finally {
+    await writeFile(join(options.outDir, "browser-console.log"), consoleLines.join("\n") + "\n", "utf8");
+    await browser.close();
+  }
+
+  const summary = {
+    caseId: "PWT-001",
+    scriptName: "real-agent-chat-regression.mjs",
+    ok: true,
+    gameUrl: options.url,
+    artifactPath: options.outDir,
+    agentId: options.agentId,
+    chatMessage: options.chatMessage,
+    inputMode: "ui",
+    selectionMode: uiEvidence?.selectionMode ?? null,
+    focusMode: uiEvidence?.focusMode ?? null,
+    chatInputMode: uiEvidence?.chatInputMode ?? null,
+    requiredContains: options.expectContains,
+    forbiddenContains: options.forbidContains,
+    noMockMarkersDetected: options.forbidContains.every((needle) => !String(reply?.message ?? "").includes(String(needle))),
+    agentReply: reply?.message ?? null,
+  };
+  await writeJson(join(options.outDir, "real-agent-chat-summary.json"), summary);
+  await writeFile(
+    join(options.outDir, "real-agent-chat-summary.md"),
+    [
+      "# Real Agent chat regression",
+      "",
+      `- caseId: \`${summary.caseId}\``,
+      `- scriptName: \`${summary.scriptName}\``,
+      `- ok: \`${summary.ok}\``,
+      `- agentId: \`${summary.agentId}\``,
+      `- inputMode: \`${summary.inputMode}\``,
+      `- selectionMode: \`${summary.selectionMode}\``,
+      `- chatInputMode: \`${summary.chatInputMode}\``,
+      `- noMockMarkersDetected: \`${summary.noMockMarkersDetected}\``,
+      `- artifactPath: \`${summary.artifactPath}\``,
+      `- agentReply: \`${summary.agentReply}\``,
+      `- gameUrl: \`${summary.gameUrl}\``,
+    ].join("\n") + "\n",
+    "utf8",
+  );
+
+  console.log(`ok: real Agent reply observed for ${options.agentId}`);
+  console.log(`agent_reply=${summary.agentReply}`);
+  console.log(`artifacts=${options.outDir}`);
+}
+
+main().catch((error) => {
+  console.error(`error: ${error.message}`);
+  process.exit(1);
+});

--- a/crates/oasis7_viewer/software_safe_src/pixel_world_host.jsx
+++ b/crates/oasis7_viewer/software_safe_src/pixel_world_host.jsx
@@ -315,6 +315,30 @@ function toWorldPercentStyle(pos, worldBounds, fallbackStyle) {
   };
 }
 
+function agentMarkerStyle(agent, index, worldBounds) {
+  const base = toWorldPercentStyle(agent.pos, worldBounds, {
+    left: `${18 + ((index % 5) * 15)}%`,
+    top: `${14 + (Math.floor(index / 5) * 22)}%`,
+  });
+  const offsets = [
+    [-18, -18],
+    [18, -18],
+    [-18, 18],
+    [18, 18],
+    [0, -30],
+    [0, 30],
+    [-30, 0],
+    [30, 0],
+    [-28, -28],
+    [28, 28],
+  ];
+  const [x, y] = offsets[index % offsets.length] || [0, 0];
+  return {
+    ...base,
+    transform: `translate(${x}px, ${y}px)`,
+  };
+}
+
 function worldPercentPoint(pos, worldBounds, fallbackX = 50, fallbackY = 50) {
   if (!pos || !worldBounds) {
     return { x: fallbackX, y: fallbackY };
@@ -798,11 +822,11 @@ function PixelWorldHostVisualLayer(props) {
         {(agent, index) => (
           <button
             class="pixel-world-entity pixel-world-entity--agent"
+            data-pixel-world-agent-marker="true"
+            data-agent-id={agent.id}
             data-position-source={agent.position_source}
-            style={toWorldPercentStyle(agent.pos, visualState().worldBounds, {
-              left: `${18 + ((index() % 5) * 15)}%`,
-              top: `${14 + (Math.floor(index() / 5) * 22)}%`,
-            })}
+            aria-label={`${tr(props.locale(), "选择 Agent", "Select Agent")} ${agent.id}`}
+            style={agentMarkerStyle(agent, index(), visualState().worldBounds)}
             title={agent.label}
             onMouseEnter={() => props.onHover({ kind: "agent", id: agent.id })}
             onMouseLeave={() => props.onHover(null)}
@@ -813,6 +837,31 @@ function PixelWorldHostVisualLayer(props) {
         )}
       </For>
     </>
+  );
+}
+
+function PixelWorldCanvasAgentHitTargets(props) {
+  const visualState = () => pixelWorldVisualState(props.renderState());
+  return (
+    <For each={visualState().agents.slice(0, 10)}>
+      {(agent, index) => (
+        <button
+          type="button"
+          class="pixel-world-entity pixel-world-entity--agent pixel-world-entity--canvas-hit-target"
+          data-pixel-world-agent-marker="true"
+          data-agent-id={agent.id}
+          data-position-source={agent.position_source}
+          aria-label={`${tr(props.locale(), "选择 Agent", "Select Agent")} ${agent.id}`}
+          style={agentMarkerStyle(agent, index(), visualState().worldBounds)}
+          title={agent.label}
+          onMouseEnter={() => props.onHover({ kind: "agent", id: agent.id })}
+          onMouseLeave={() => props.onHover(null)}
+          onClick={() => props.onSelect({ kind: "agent", id: agent.id })}
+        >
+          <span>{agent.label.slice(0, 1).toUpperCase()}</span>
+        </button>
+      )}
+    </For>
   );
 }
 
@@ -1151,6 +1200,12 @@ function PixelWorldCanvasRenderer(props) {
         )}
       </div>
       <div class="pixel-world-canvas__overlay">
+        <PixelWorldCanvasAgentHitTargets
+          locale={props.locale}
+          renderState={props.renderState}
+          onSelect={props.onSelect}
+          onHover={props.onHover}
+        />
         <PixelWorldHostVisualLayer
           enabled={false}
           locale={props.locale}

--- a/crates/oasis7_viewer/software_safe_src/pixel_world_host.test.jsx
+++ b/crates/oasis7_viewer/software_safe_src/pixel_world_host.test.jsx
@@ -573,6 +573,11 @@ describe("pixel world host", () => {
         label: "Agent 0",
         pos: { x_cm: 5_020_000, y_cm: 2_510_000, z_cm: 0 },
         positionSource: "location_derived",
+      }, {
+        id: "agent-1",
+        label: "Agent 1",
+        pos: { x_cm: 5_020_000, y_cm: 2_510_000, z_cm: 0 },
+        positionSource: "location_derived",
       }],
       links: [{
         id: "link:agent-0:loc-0",
@@ -653,7 +658,15 @@ describe("pixel world host", () => {
     const canvas = document.querySelector(".pixel-world-canvas--rendered");
     expect(canvas.querySelectorAll(".pixel-world-fragment-terrain")).toHaveLength(0);
     expect(canvas.querySelector(".pixel-world-entity--location")).toBeNull();
-    expect(canvas.querySelector(".pixel-world-entity--agent")).toBeNull();
+    const agentMarker = canvas.querySelector("[data-pixel-world-agent-marker='true'][data-agent-id='agent-0']");
+    const secondAgentMarker = canvas.querySelector("[data-pixel-world-agent-marker='true'][data-agent-id='agent-1']");
+    expect(agentMarker).not.toBeNull();
+    expect(secondAgentMarker).not.toBeNull();
+    expect(agentMarker).toHaveAttribute("aria-label", "Select Agent agent-0");
+    expect(secondAgentMarker).toHaveAttribute("aria-label", "Select Agent agent-1");
+    expect(agentMarker.style.transform).not.toEqual(secondAgentMarker.style.transform);
+    agentMarker.click();
+    expect(canvas.querySelector(".pixel-world-canvas__selection")).toHaveTextContent("Selected: agent/agent-0");
     expect(canvas.querySelector(".pixel-world-route")).toBeNull();
     expect(canvas.querySelector(".pixel-world-canvas__selection")).toHaveTextContent("Selected: agent/agent-0");
     expect(runtimeMock.deriveRenderState).toHaveBeenCalled();

--- a/crates/oasis7_viewer/viewer.js
+++ b/crates/oasis7_viewer/viewer.js
@@ -5592,6 +5592,18 @@ function toWorldPercentStyle(pos, worldBounds, fallbackStyle) {
     top: `${point.y.toFixed(1)}%`
   };
 }
+function agentMarkerStyle(agent, index, worldBounds) {
+  const base = toWorldPercentStyle(agent.pos, worldBounds, {
+    left: `${18 + index % 5 * 15}%`,
+    top: `${14 + Math.floor(index / 5) * 22}%`
+  });
+  const offsets = [[-18, -18], [18, -18], [-18, 18], [18, 18], [0, -30], [0, 30], [-30, 0], [30, 0], [-28, -28], [28, 28]];
+  const [x, y] = offsets[index % offsets.length] || [0, 0];
+  return {
+    ...base,
+    transform: `translate(${x}px, ${y}px)`
+  };
+}
 function worldPercentPoint(pos, worldBounds, fallbackX = 50, fallbackY = 50) {
   if (!pos || !worldBounds) {
     return {
@@ -6021,22 +6033,65 @@ function PixelWorldHostVisualLayer(props) {
       }));
       insert(_el$7, () => agent.label.slice(0, 1).toUpperCase());
       createRenderEffect((_p$) => {
-        var _v$0 = agent.position_source, _v$1 = toWorldPercentStyle(agent.pos, visualState().worldBounds, {
-          left: `${18 + index() % 5 * 15}%`,
-          top: `${14 + Math.floor(index() / 5) * 22}%`
-        }), _v$10 = agent.label;
-        _v$0 !== _p$.e && setAttribute(_el$6, "data-position-source", _p$.e = _v$0);
-        _p$.t = style(_el$6, _v$1, _p$.t);
-        _v$10 !== _p$.a && setAttribute(_el$6, "title", _p$.a = _v$10);
+        var _v$0 = agent.id, _v$1 = agent.id, _v$2 = agent.position_source, _v$3 = `${tr$1(props.locale(), "选择 Agent", "Select Agent")} ${agent.id}`, _v$4 = agentMarkerStyle(agent, index(), visualState().worldBounds), _v$10 = agent.label;
+        _v$0 !== _p$.e && setAttribute(_el$6, "data-pixel-world-agent-marker", _p$.e = "true");
+        _v$1 !== _p$.t && setAttribute(_el$6, "data-agent-id", _p$.t = _v$1);
+        _v$2 !== _p$.a && setAttribute(_el$6, "data-position-source", _p$.a = _v$2);
+        _v$3 !== _p$.o && setAttribute(_el$6, "aria-label", _p$.o = _v$3);
+        _p$.i = style(_el$6, _v$4, _p$.i);
+        _v$10 !== _p$.n && setAttribute(_el$6, "title", _p$.n = _v$10);
         return _p$;
       }, {
         e: void 0,
         t: void 0,
-        a: void 0
+        a: void 0,
+        o: void 0,
+        i: void 0,
+        n: void 0
       });
       return _el$6;
     })()
   })];
+}
+function PixelWorldCanvasAgentHitTargets(props) {
+  const visualState = () => pixelWorldVisualState(props.renderState());
+  return createComponent(For, {
+    get each() {
+      return visualState().agents.slice(0, 10);
+    },
+    children: (agent, index) => (() => {
+      var _el$6 = _tmpl$5$1(), _el$7 = _el$6.firstChild;
+      setAttribute(_el$6, "class", "pixel-world-entity pixel-world-entity--agent pixel-world-entity--canvas-hit-target");
+      _el$6.$$click = () => props.onSelect({
+        kind: "agent",
+        id: agent.id
+      });
+      _el$6.addEventListener("mouseleave", () => props.onHover(null));
+      _el$6.addEventListener("mouseenter", () => props.onHover({
+        kind: "agent",
+        id: agent.id
+      }));
+      insert(_el$7, () => agent.label.slice(0, 1).toUpperCase());
+      createRenderEffect((_p$) => {
+        var _v$0 = agent.id, _v$1 = agent.id, _v$2 = agent.position_source, _v$3 = `${tr$1(props.locale(), "选择 Agent", "Select Agent")} ${agent.id}`, _v$4 = agentMarkerStyle(agent, index(), visualState().worldBounds), _v$10 = agent.label;
+        _v$0 !== _p$.e && setAttribute(_el$6, "data-pixel-world-agent-marker", _p$.e = "true");
+        _v$1 !== _p$.t && setAttribute(_el$6, "data-agent-id", _p$.t = _v$1);
+        _v$2 !== _p$.a && setAttribute(_el$6, "data-position-source", _p$.a = _v$2);
+        _v$3 !== _p$.o && setAttribute(_el$6, "aria-label", _p$.o = _v$3);
+        _p$.i = style(_el$6, _v$4, _p$.i);
+        _v$10 !== _p$.n && setAttribute(_el$6, "title", _p$.n = _v$10);
+        return _p$;
+      }, {
+        e: void 0,
+        t: void 0,
+        a: void 0,
+        o: void 0,
+        i: void 0,
+        n: void 0
+      });
+      return _el$6;
+    })()
+  });
 }
 function createPixelWorldHostAdapter({
   onSelectEntity,
@@ -6322,6 +6377,20 @@ function PixelWorldCanvasRenderer(props) {
     var _ref$ = canvasRef;
     typeof _ref$ === "function" ? use(_ref$, _el$9) : canvasRef = _el$9;
     insert(_el$0, () => tr$1(props.locale(), "Canvas 提供当前世界的只读概览；相邻 HUD、焦点栏和命令抽屉提供当前 Agent、阻塞、回执与命令路径。", "The canvas provides a read-only overview of the current world; adjacent HUD, focus rail, and command drawer expose the current agent, blocker, receipt, and command path."));
+    insert(_el$1, createComponent(PixelWorldCanvasAgentHitTargets, {
+      get locale() {
+        return props.locale;
+      },
+      get renderState() {
+        return props.renderState;
+      },
+      get onSelect() {
+        return props.onSelect;
+      },
+      get onHover() {
+        return props.onHover;
+      }
+    }), null);
     insert(_el$1, createComponent(PixelWorldHostVisualLayer, {
       enabled: false,
       get locale() {

--- a/doc/testing/README.md
+++ b/doc/testing/README.md
@@ -10,8 +10,9 @@
 - 想先回答“这些标准角色 subagent 到底怎么设计、怎么组合成 review 流程”：`doc/testing/governance/playability-subagent-review-system-2026-05-06.prd.md`
 - 想先回答“agent 如何模拟多个不同风格的玩家视角，但又不把 `player` 写成正式角色”：`doc/testing/governance/playability-simulated-player-persona-panel-2026-05-06.prd.md`
 - 想用截图加模型视觉评审替代绝大部分人工视觉 review：先读 `doc/testing/manual/model-visual-review-sop-2026-05-29.manual.md`，输出卡模板在 `doc/testing/templates/model-visual-review-card-template.md`
+- 想跑真实本地栈 + Playwright + 玩家 UI 操作流程，并把这些用例作为一个长期系列管理：`doc/testing/manual/web-ui-playwright-closure-manual.manual.md`
 - 想看当前活跃任务、阻断与最新完成项：`doc/testing/project.md`
-- 想先判断要跑哪套测试或查操作步骤：`testing-manual.md`、`doc/testing/manual/web-ui-agent-browser-closure-manual.manual.md`
+- 想先判断要跑哪套测试或查操作步骤：`testing-manual.md`、`doc/testing/manual/web-ui-agent-browser-closure-manual.manual.md`、`doc/testing/manual/web-ui-playwright-closure-manual.manual.md`
 - 想先进入 `evidence` 热点子域，并按 release gate / hosted access / legacy p2p network-rehearsal rehearsal / governance drill / claim-audit 问题分流：`doc/testing/evidence/README.md`
 - 想先看当前 QA 阻断摘要：`doc/testing/provider-dual-mode-t4-blocker-2026-03-16.md`
 - 想先确认云上测试/正式环境、hosted-login 服务清单与 testnet/mainnet 口径边界：`doc/engineering/governance/environment-lanes-and-inventory-2026-05-29.md`
@@ -29,7 +30,7 @@
 - `project.md` 是执行台账，适合确认当前 QA 阻断、活跃测试治理任务与最新完成项。
   当前窗口只保留 blocker、next step 与少量高价值收口摘要；更细的近期完成历史应回到对应 topic `*.project.md` 与 `.pm/tasks/*.yaml` / execution log 追溯。
 - `evidence/README.md` 是当前最高密度热点子域 `evidence/` 的 canonical 入口，适合先按“release gate / hosted access / legacy p2p network-rehearsal rehearsal / governance drill / claim-audit / 定向验证”分流，再进入具体留痕文件。
-- `testing-manual.md` 与 `manual/*.manual.md` 是 operator 手册层，用于决定跑哪套测试、按什么步骤执行。
+- `testing-manual.md` 与 `manual/*.manual.md` 是 operator 手册层，用于决定跑哪套测试、按什么步骤执行；其中 Playwright 实跑系列入口是 `doc/testing/manual/web-ui-playwright-closure-manual.manual.md`。
 - `prd.index.md` 是定向检索索引，适合已知主题后按文件名查找，不是新读者的首读入口。
 
 ## 活跃阅读面边界
@@ -50,7 +51,7 @@
 - `governance/`：质量趋势、release-gate 指标、审计检查、好玩性证据栈、L4 synthetic/human 分层、subagent 评审系统与 simulated player personas。
 - `templates/`：证据包、报告、模型视觉评审卡与检查清单模板；默认按需进入。
 - `performance/`：runtime / viewer 性能观测与方法学。
-- `manual/`：系统测试手册分册与 Web UI 闭环 manual。
+- `manual/`：系统测试手册分册、Web UI 闭环 manual、Playwright 实跑系列入口。
 - `chaos-plans/`：专项 chaos plan 入口。
 
 ## 高密度提示

--- a/doc/testing/manual/web-ui-playwright-closure-manual.manual.md
+++ b/doc/testing/manual/web-ui-playwright-closure-manual.manual.md
@@ -1,0 +1,124 @@
+# oasis7 Web UI Playwright 实跑闭环测试手册
+
+## 定位
+
+本手册是 Playwright 实跑测试系列的入口文档，用来管理从真实浏览器进入游戏、执行玩家操作、等待 runtime/provider 返回、并归档证据的端到端测试。
+
+它和 `doc/testing/manual/web-ui-agent-browser-closure-manual.manual.md` 的关系：
+- `agent-browser` manual 仍是通用 Web UI 闭环与截图采证入口。
+- 本手册专管直接 Playwright 脚本，目标是逐步覆盖“人实际玩游戏会做的所有关键操作流程”。
+- Playwright 系列可以使用 `window.__AW_TEST__` 做 readiness/state/断言读取，但玩家动作本身必须优先通过可见 UI 控件完成；除非用例明确标成 protocol-only/debug-only，否则不得用测试 API 代替点击、输入、选择或提交。
+
+## 总目标
+
+Playwright 实跑系列长期目标是形成一套可重复执行的玩家操作流程矩阵：
+
+1. 启动本地真实栈。
+2. 打开真实 Viewer。
+3. 完成玩家可见 UI 操作。
+4. 覆盖 runtime / live websocket / viewer state / provider / message-flow 等链路。
+5. 输出 screenshot、state、summary、console log 与明确 pass/fail。
+
+这类测试回答的是“这条玩家操作链路在真实本地运行时是否闭环”。它不能单独证明游戏好玩，也不能替代 `L4B` embodied-agent playtest、内部真人校准或 `L5` 真实人类 / 线上样本。
+
+## 当前入口
+
+### PWT-001: Real Agent Chat
+
+命令：
+
+```bash
+./scripts/viewer-real-agent-chat-regression.sh
+```
+
+复用已有 Viewer URL：
+
+```bash
+./scripts/viewer-real-agent-chat-regression.sh --url "http://127.0.0.1:4173/?ws=ws://127.0.0.1:5011&test_api=1&locale=zh"
+```
+
+覆盖链路：
+- 本地真实 LetAI provider bridge。
+- `oasis7_game_launcher` / `oasis7_viewer_live` / websocket bridge。
+- 真实 Viewer 页面。
+- UI 输入流程：进入沉浸模式、打开命令抽屉、填写 `#agent-chat-message`、点击 `button[data-chat-send="1"]`。
+- runtime `agent_chat` ack。
+- provider-backed Agent reply。
+- Message Flow / `chatHistory` 中的真实 `AgentSpoke`。
+
+通过标准：
+- `summary.json` 中 `inputMode=ui`。
+- `chatInputMode=ui`。
+- 收到 `agentReply`。
+- 回复包含默认 required fragments：`我在 runtime:`、`data 8`、`electricity 32`。
+- 回复不得包含 `[local-mock-receipt]` 或 `[local-mock-chat]`。
+- 脚本结束后默认清理自己启动的本地端口。
+
+选择契约：
+- WebGPU/canvas 渲染路径必须暴露稳定 DOM Agent marker：`[data-pixel-world-agent-marker="true"][data-agent-id="<agent-id>"]`。
+- `PWT-001` 必须先点击该 marker，并在 summary 中记录 `selectionMode=ui-agent-marker`，再继续执行真实 UI 聊天输入/发送。
+- 若该 marker 不可见，测试必须失败并保留 failure state / screenshot，而不是退回 preselected 兜底。
+
+主要产物：
+
+```text
+output/playwright/viewer-real-agent-chat/<run-id>/
+output/playwright/viewer-real-agent-chat/<run-id>/playwright/real-agent-chat-summary.json
+output/playwright/viewer-real-agent-chat/<run-id>/playwright/final_state.json
+output/playwright/viewer-real-agent-chat/<run-id>/playwright/real-agent-chat.png
+output/playwright/viewer-real-agent-chat/<run-id>/playwright/browser-console.log
+```
+
+## 计划中的流程矩阵
+
+新增用例时使用 `PWT-###` 编号。每个条目都必须说明玩家动作、真实依赖、断言、产物和边界。
+
+| ID | 流程 | 状态 | 目标 |
+| --- | --- | --- | --- |
+| PWT-001 | Real Agent Chat | active | 覆盖真实 UI 输入聊天到真实 provider Agent 回复 |
+| PWT-002 | Select Agent From World | planned | 覆盖从世界/地图可见目标选择 Agent，并验证 detail / command surface 切换 |
+| PWT-003 | Submit Recommended Gameplay Action | planned | 覆盖点击推荐玩法动作、等待 ack/receipt/world delta |
+| PWT-004 | Prompt Preview / Apply / Rollback | planned | 覆盖 prompt 控制面 UI 输入、预览、应用、回滚和版本刷新 |
+| PWT-005 | Pause / Play / Progress Feedback | planned | 覆盖玩家控制 runtime 推进、阻塞提示和恢复反馈 |
+| PWT-006 | Diagnostics And Recovery | planned | 覆盖连接异常、provider blocker、重试/刷新后的可理解报错 |
+| PWT-007 | Pure API / Viewer Parity Spot | planned | 用同一场景交叉验证 Viewer UI 操作和 pure API 观测一致性 |
+
+## 新增用例规则
+
+每个新 Playwright 实跑用例必须满足：
+
+- 默认启动真实本地栈；若允许 `--url` 复用已有栈，必须在 summary 中记录 `gameUrl`。
+- 默认禁止 mock 作为通过证据；如果某用例确实是 mock plumbing smoke，文件名和 summary 必须显式标 `mock` / `debug-only`。
+- 玩家动作优先使用可见 UI locator，例如 role、label、id、data attribute；`__AW_TEST__` 只用于 readiness、state snapshot、history 查证和失败诊断。
+- 失败必须落盘 `failure_state.json`、截图、console log，并给出明确错误文本。
+- summary 至少包含：`ok`、`caseId` 或脚本名、`gameUrl`、关键输入、关键输出、`inputMode`、mock 禁用/检测结果、artifact 路径。
+- 如果脚本启动了本地栈，默认负责清理端口；需要保留时必须提供 `--keep-stack` 并在输出中写明。
+
+## 运行前检查
+
+推荐先确认：
+
+```bash
+lsof -nP -iTCP:4173 -iTCP:5011 -iTCP:5023 -iTCP:5841 -sTCP:LISTEN || true
+bash -n scripts/viewer-real-agent-chat-regression.sh
+```
+
+如果当前 shell 没有 `node`，脚本会尝试使用 Codex bundled Node。若在非 Codex 环境运行，需要设置：
+
+```bash
+export OASIS7_NODE_BIN=/path/to/node
+export OASIS7_PLAYWRIGHT_NODE_MODULES=/path/to/node_modules
+```
+
+## 证据判读
+
+一次有效 Playwright 实跑证据至少需要：
+
+- 命令行通过输出。
+- `real-agent-chat-summary.json` 或同级 summary。
+- `final_state.json`。
+- screenshot。
+- console log。
+- 若涉及 provider/LLM，必须明确是真实 provider 路径，并有禁止 mock 的断言。
+
+PWT 系列可以作为 S6 Web UI 闭环证据，也可以作为 `L4A synthetic` 的一部分输入；但只有当后续 L4 review packet、role cards、persona cards 或 L4B agent playtest 收口后，才能支撑对应 playability 结论。

--- a/doc/testing/prd.index.md
+++ b/doc/testing/prd.index.md
@@ -20,7 +20,7 @@
 - 想用模型视觉判断替代常规人工视觉 review：先读 `doc/testing/manual/model-visual-review-sop-2026-05-29.manual.md`，再按 `doc/testing/templates/model-visual-review-card-template.md` 输出评审卡
 - 想快速判断“现有性能测试覆盖到哪、哪些功能面最值得补性能测试、哪些更适合进 scoped gate”：先读 `doc/testing/performance/performance-coverage-gap-matrix-2026-06-09.md`
 - 想先回答当前在推进什么、哪些测试治理任务或 QA 阻断仍在影响收口：先读 `doc/testing/project.md`
-- 想直接决定要跑哪套测试或按步骤执行：先读 `testing-manual.md` 与 `doc/testing/manual/web-ui-agent-browser-closure-manual.manual.md`
+- 想直接决定要跑哪套测试或按步骤执行：先读 `testing-manual.md`、`doc/testing/manual/web-ui-agent-browser-closure-manual.manual.md` 与 `doc/testing/manual/web-ui-playwright-closure-manual.manual.md`
 - 想先进入 `evidence` 热点子域，并按 release gate / hosted access / legacy p2p network-rehearsal rehearsal / governance drill / claim-audit 问题分流：先读 `doc/testing/evidence/README.md`
 - 想继续按子域或文件名下钻：使用下方热点子域导航，再跳到对应清单区域
 
@@ -45,6 +45,7 @@
 - `doc/testing/evidence/README.md`：`evidence/` 热点子域 landing page，按 release gate、hosted access、legacy p2p network-rehearsal rehearsal、governance drill 与 claim/audit 分流读者。
 - `testing-manual.md`：仓库级系统测试手册，不并入下方模块 PRD 三件套长表。
 - `doc/testing/manual/web-ui-agent-browser-closure-manual.manual.md`：Web UI 闭环 canonical 操作手册，不并入下方模块 PRD 三件套长表。
+- `doc/testing/manual/web-ui-playwright-closure-manual.manual.md`：Playwright 实跑测试系列入口，用于管理真实本地栈、真实 UI 输入和后续玩家操作流程矩阵，不并入下方模块 PRD 三件套长表。
 - `doc/testing/manual/model-visual-review-sop-2026-05-29.manual.md`：截图加模型视觉评审 SOP，用于替代 routine 人工视觉 review，不并入下方模块 PRD 三件套长表。
 - `doc/testing/performance/performance-coverage-gap-matrix-2026-06-09.md`：按 surface 汇总现有性能覆盖、当前缺口、建议补测和建议 tier 的速查表。
 - `doc/testing/provider-dual-mode-t4-blocker-2026-03-16.md`：当前 QA 阻断摘要，适合在判断 provider 双模式收口风险时定向进入。

--- a/doc/testing/prd.md
+++ b/doc/testing/prd.md
@@ -97,7 +97,7 @@
 | 功能点 | 字段定义 | 按钮/动作行为 | 状态转换 | 排序/计算规则 | 权限逻辑 |
 | --- | --- | --- | --- | --- | --- |
 | 分层测试触发 | 改动类型、测试层级、命令集合、changed-path scope | 依据矩阵选择最小必跑集合；PR `required-gate` 先规划 `minimal / targeted / full` 再执行命中的重型组件，必要时追加 launcher Web `trunk build` | `planned -> scoped -> running -> passed/failed` | 默认先 `commit`，按风险升级到 `required`，发布加跑 `full`；docs-only / 无关元数据 PR 允许在 stable context 下退化为 governance/fmt-only；`oasis7_client_launcher` / launcher shared runtime 命中时 required-gate 追加 launcher Web 构建覆盖 | 开发者可执行，发布者可放行 |
-| Web UI 驱动分流 | `surface_type`、`driver`、`evidence_mode` | Viewer 页面默认走 `agent-browser`；`oasis7_web_launcher` 产品动作默认走 GUI Agent，页面仅做状态/字段校验 | `selected -> driven -> verified` | 先按 surface 分流，再决定是否补充 Canvas/页面采样 | QA/发布与产品 owner 共同遵循 |
+| Web UI 驱动分流 | `surface_type`、`driver`、`evidence_mode` | Viewer 页面通用闭环默认走 `agent-browser`；真实本地栈 + 玩家 UI 操作流程回归走 Playwright 实跑系列；`oasis7_web_launcher` 产品动作默认走 GUI Agent，页面仅做状态/字段校验 | `selected -> driven -> verified` | 先按 surface 分流，再决定是否补充 Canvas/页面采样；Playwright 实跑用例按 `PWT-###` 编号管理 | QA/发布与产品 owner 共同遵循 |
 | 模型视觉评审 | `visual_change_trigger`、`screenshot_set`、`expected_visual_contract`、`automated_evidence`、`verdict`、`confidence`、`human_escalation_needed` | 任何可视化相关代码、样式、资源或可见输出改动默认触发截图评审；对截图执行固定 rubric，输出 visual review card；`verdict=pass` 且 `confidence=high` 可替代 routine 人工视觉 review；`verdict=watch/block/human_escalation` 或 `confidence=low` 必须写明 owner action | `visual_change_detected -> captured -> model_reviewed -> pass/watch/block/escalated` | 先跑确定性测试，再让模型判断视觉；只有明确不影响任何可见 surface 的改动才能豁免且需记录理由；模型只替代截图/布局/可读性类人工 review，不替代 GitHub required review、发布放行、L5 真实玩家验证或对外 claim 审批 | `producer_system_designer` / `qa_engineer` 守边界，命中的 UI owner 处理 findings |
 | software_safe release 语义门禁 | `renderMode`、`lastControlFeedback.stage`、`deltaLogicalTime`、`deltaEventSeq` | `software_safe` 下允许 `play/pause` 先返回 `queued`；formal progress 以后续 `step` 的 `completed_advanced` + 正向 world delta 判定 | `queued -> completed_advanced` 或 `queued -> blocked` | 主 Web 入口不再要求 `play` 立刻涨 tick，也不再强制 `selectedKind=agent`；若 `llm_required` 显式阻断则按 blocker 合约留痕 | QA/发布维护者维护 |
 | 证据包归档 | 命令、日志、截图、结论、责任人、`player_action`、`world_change_due_to_player`、`player_leverage_score`、`world_activity_only` | 执行后归档并建立索引 | `collecting -> archived -> reviewed` | 按版本与模块分层索引；若 `world_activity_only=yes`，则该样本不能直接支撑玩法放行 | 测试维护者负责最终校验 |
@@ -132,6 +132,7 @@
   - AC-13: `token-genesis-allocation-audit-checklist-2026-03-22` 专题文档与执行模板落盘并映射 `TASK-TESTING-062`，明确创世参数审计项、阻断条件、证据字段与 verdict 口径。
   - AC-14: `required-gate` 必须在命中 `crates/oasis7_client_launcher/**`、`crates/oasis7_launcher_ui/**`、`crates/oasis7_proto/**`、`crates/oasis7_wasm_abi/**` 或 `crates/oasis7/**` 的 launcher shared runtime 改动时按需执行 launcher Web `trunk build`，避免仅在 release `build-web-dist` 才暴露 wasm 编译错误。
   - AC-14A: 仓库必须提供轻量 Web/UI automation smoke，允许 `qa_engineer` 在不启动完整 runtime 栈的前提下，用 fixture 页面复用真 `agent-browser` 验证 `viewer-software-safe-step-regression.sh` 的最小浏览器链路与 summary/state 产物契约；该 smoke 只用于 tooling 预检，不替代正式 S6 证据。
+  - AC-14B: 仓库必须维护 Playwright 实跑测试系列入口，记录 `PWT-###` 用例矩阵、真实本地栈/真实 provider/真实 UI 输入的覆盖边界、mock 禁用规则、证据产物要求和新增用例规则；首个用例为 `PWT-001 Real Agent Chat`，后续玩家操作流程必须从该入口扩展。
   - AC-15: 正式 gameplay/trust evidence 至少要有 1 条代表性样本明确记录 `player_action`、`world_change_due_to_player`、`player_leverage_score` 与 `world_activity_only`，否则不得宣称“玩家已有 meaningful participation”。
   - AC-16: `playability-evidence-stack-2026-05-06` 专题文档必须明确 `L1/L2/L3/L4A/L4B/L5` 证据边界、组合规则、现有 oasis7 锚点映射，以及“自动化不能单独保证好玩”的正式结论。
   - AC-17: `playability-subagent-review-system-2026-05-06` 专题文档必须明确标准角色 subagent 清单、review packet / output card、trigger matrix、sequencing rules 和 stop conditions。
@@ -146,7 +147,7 @@
   - 不承诺所有测试都进入 CI 默认路径。
 
 ## 3. AI System Requirements (If Applicable)
-- Tool Requirements: `scripts/ci-tests.sh`、agent-browser 闭环工具、`oasis7_web_launcher` GUI Agent 接口、长跑脚本、结果汇总工具、`scripts/prepare-playability-l4-review.sh`。
+- Tool Requirements: `scripts/ci-tests.sh`、agent-browser 闭环工具、Playwright 实跑脚本、`oasis7_web_launcher` GUI Agent 接口、长跑脚本、结果汇总工具、`scripts/prepare-playability-l4-review.sh`。
 - Evaluation Strategy: 通过门禁通过率、缺陷逃逸率、回归定位时长、证据完整度衡量测试体系质量。
 
 ## 4. Technical Specifications
@@ -154,6 +155,7 @@
 - Integration Points:
   - `testing-manual.md`
   - `doc/testing/manual/web-ui-agent-browser-closure-manual.manual.md`
+  - `doc/testing/manual/web-ui-playwright-closure-manual.manual.md`
   - `doc/testing/manual/web-ui-agent-browser-closure-manual.prd.md`
   - `doc/testing/governance/playability-evidence-stack-2026-05-06.prd.md`
   - `doc/testing/governance/playability-subagent-review-system-2026-05-06.prd.md`

--- a/doc/testing/project.md
+++ b/doc/testing/project.md
@@ -30,7 +30,7 @@
 | Performance coverage and baselines | `doc/testing/performance/performance-coverage-gap-matrix-2026-06-09.md`、`testing-manual.md` 的 required-gate / Viewer performance probe 段落 |
 
 ## 最近高价值完成摘要
-- `local-letai-playtest-flow-stability` (Trace: .pm/tasks/task_4af42b4abe9b4e2fb2c2cc1881ad3e74.yaml): 本地真实 LetAI provider-backed 试玩链路已收口为 wrapper-first / detached-safe / provider-backed chat 默认路径，补齐 auto-topup settlement retry、provider diagnostics、loopback proxy 稳定性、viewer loading/tick/chat 反馈与回归证据。
+- `local-letai-playtest-flow-stability` (Trace: .pm/tasks/task_4af42b4abe9b4e2fb2c2cc1881ad3e74.yaml; Trace: .pm/tasks/task_43f78174f0904eaf95e3b99dde0509a7.yaml): 本地真实 LetAI provider-backed 试玩链路已收口为 wrapper-first / detached-safe / provider-backed chat 默认路径，补齐 auto-topup settlement retry、provider diagnostics、loopback proxy 稳定性、viewer loading/tick/chat 反馈与回归证据；并补强一键启动诊断、真实 UI 输入到 provider 回复的 Playwright 回归入口。
 - `testing-doc-default-surface-slimming` (Trace: .pm/tasks/task_0af93d9ebb8c45df8cf013e11840cc9b.yaml): 默认 testing 文档阅读面已压缩为当前执行窗口、历史追溯索引与 canonical redirect；Viewer perf smoke 当前态同步为 required-gate report-only scoped 行为。
 - `engineering-code-quality-performance-baselines` (Trace: `.pm/tasks/task_35657c5f0a5543dda5d57f51fc4b8841.execution.md`): Viewer changed-path perf smoke 已接入 required-gate report-only scope；runtime module routing perf harness 已有首个 dev/release baseline。
 - `required-gate-ondemand-launcher-web-build` (Trace: `.pm/tasks/task_3778b0e747b249bc85b92b942a32b3fd.yaml`): launcher Web `trunk build` 已按 changed-path 注入 required gate，避免 release `build-web-dist` 才暴露编译错误。
@@ -42,13 +42,14 @@
 - 文件级索引: `doc/testing/prd.index.md`
 - 标准测试手册: `testing-manual.md`
 - Web UI 闭环 manual: `doc/testing/manual/web-ui-agent-browser-closure-manual.manual.md`
+- Web UI Playwright 实跑系列 manual: `doc/testing/manual/web-ui-playwright-closure-manual.manual.md`
 - Web UI 闭环 PRD: `doc/testing/manual/web-ui-agent-browser-closure-manual.prd.md`
 - CI 入口: `scripts/ci-tests.sh`
 - GitHub workflow: `.github/workflows/*`
 - PRD governance check: `.agents/skills/prd/check.md`
 
 ## 状态
-- 更新日期: 2026-06-16
+- 更新日期: 2026-06-17
 - 当前状态: active
 - 阶段收口优先级: `P0`
 - 阶段 owner: `qa_engineer`（联审: `producer_system_designer`）

--- a/scripts/ci-tests.sh
+++ b/scripts/ci-tests.sh
@@ -111,6 +111,7 @@ run_oasis7_llm_baseline_fixture_smoke() {
 }
 
 run_provider_remote_https_smoke() {
+  run ./scripts/run-local-letai-game-test.test.sh
   run ./scripts/provider-remote-https/letai-provider-cli.test.sh
   run ./scripts/provider-remote-https/provider-bridge-contract-smoke.test.sh
 }

--- a/scripts/run-local-letai-game-test.sh
+++ b/scripts/run-local-letai-game-test.sh
@@ -34,6 +34,14 @@ MODEL=""
 OUTPUT_DIR=""
 BRIDGE_PID=""
 DETACH="0"
+PREFLIGHT_ONLY="0"
+DRY_RUN_LAUNCH="0"
+STARTUP_PROFILE="strict"
+PROVIDER_SMOKE_MODE=""
+PROVIDER_SMOKE_MODE_SET="0"
+REUSE_EXISTING_BUILD="0"
+SOURCE_BIN_DIR="${OASIS7_LOCAL_LETAI_SOURCE_BIN_DIR:-$ROOT_DIR/target/debug}"
+VIEWER_DIST_DIR="${OASIS7_LOCAL_LETAI_VIEWER_DIST_DIR:-$ROOT_DIR/crates/oasis7_viewer/dist}"
 LAUNCHER_ARGS=()
 BRIDGE_ARGS=()
 
@@ -73,7 +81,13 @@ Options:
   --hosted-public-join        Use hosted_public_join instead of the local trusted playtest chain
   --chat-probe-backend <name> rust-bridge|legacy-cli|none (default: rust-bridge)
   --skip-chat-probe           Alias for --chat-probe-backend none
-  --skip-bridge-smoke         Skip provider bridge contract smoke before launcher startup
+  --startup-profile <mode>    strict|playtest (playtest keeps page startup usable when provider smoke degrades)
+  --provider-smoke-mode <mode>
+                              strict|degraded|skip (default strict; playtest default degraded)
+  --skip-bridge-smoke         Alias for --provider-smoke-mode skip
+  --reuse-existing-build      Reuse existing source-mode binaries instead of rebuilding them
+  --preflight-only            Check local prerequisites and print the startup plan without launching
+  --dry-run-launch            Print the resolved launcher plan without starting bridge or launcher
   --bridge-smoke-attempts <n> Retry provider bridge smoke up to <n> times (default: 2)
   --chat-probe-timeout-ms <ms>
                               LetAI chat probe timeout (default: 60000)
@@ -99,6 +113,228 @@ cleanup() {
   fi
 }
 trap cleanup EXIT INT TERM
+
+command_available() {
+  local command_name="$1"
+  if [[ "$command_name" == "npm" && "${OASIS7_LOCAL_LETAI_TEST_MISSING_NPM:-0}" == "1" ]]; then
+    return 1
+  fi
+  if [[ "$command_name" == "node" && "${OASIS7_LOCAL_LETAI_TEST_MISSING_NODE:-0}" == "1" ]]; then
+    return 1
+  fi
+  command -v "$command_name" >/dev/null 2>&1
+}
+
+viewer_dist_ready() {
+  [[ -f "$VIEWER_DIST_DIR/index.html" || -f "$VIEWER_DIST_DIR/software_safe.html" ]]
+}
+
+bind_port() {
+  addr_port "$BIND_ADDR"
+}
+
+addr_port() {
+  python3 - "$1" <<'PY'
+from __future__ import annotations
+
+import sys
+
+raw = sys.argv[1].strip()
+if raw.startswith("["):
+    _, _, tail = raw.rpartition("]:")
+else:
+    _, _, tail = raw.rpartition(":")
+if not tail.isdigit():
+    raise SystemExit(1)
+print(tail)
+PY
+}
+
+port_listeners() {
+  local port="$1"
+  if ! command -v lsof >/dev/null 2>&1; then
+    return 2
+  fi
+  local output
+  output="$(lsof -nP -iTCP:"$port" -sTCP:LISTEN 2>/dev/null || true)"
+  printf '%s\n' "$output" | awk 'NR > 1 { print }'
+}
+
+provider_bind_listeners() {
+  local port
+  port="$(bind_port)" || return 1
+  port_listeners "$port"
+}
+
+planned_launcher_ports() {
+  local viewer_port="4173"
+  local live_bind="127.0.0.1:5023"
+  local web_bind="127.0.0.1:5011"
+  local index=0
+  while [[ "$index" -lt "${#LAUNCHER_ARGS[@]}" ]]; do
+    case "${LAUNCHER_ARGS[$index]}" in
+      --viewer-port)
+        index=$((index + 1))
+        viewer_port="${LAUNCHER_ARGS[$index]:-$viewer_port}"
+        ;;
+      --live-bind)
+        index=$((index + 1))
+        live_bind="${LAUNCHER_ARGS[$index]:-$live_bind}"
+        ;;
+      --web-bind)
+        index=$((index + 1))
+        web_bind="${LAUNCHER_ARGS[$index]:-$web_bind}"
+        ;;
+    esac
+    index=$((index + 1))
+  done
+  printf 'viewer HTTP\t%s\n' "$viewer_port"
+  printf 'live TCP\t%s\n' "$(addr_port "$live_bind")"
+  printf 'web bridge\t%s\n' "$(addr_port "$web_bind")"
+}
+
+required_source_bins() {
+  printf '%s\n' \
+    oasis7_llm_provider_probe \
+    oasis7_game_launcher \
+    oasis7_viewer_live \
+    oasis7_chain_runtime
+}
+
+run_preflight() {
+  local failed="0"
+  echo "local LetAI game test preflight"
+  echo "startup_profile=$STARTUP_PROFILE"
+  echo "provider_smoke_mode=$PROVIDER_SMOKE_MODE"
+  echo "config=$CONFIG_PATH"
+  echo "viewer_dist=$VIEWER_DIST_DIR"
+  echo "source_bin_dir=$SOURCE_BIN_DIR"
+  if [[ "$REUSE_EXISTING_BUILD" == "1" ]]; then
+    echo "source_build=reuse-existing"
+  else
+    echo "source_build=build-if-needed"
+  fi
+
+  if [[ ! -f "$CONFIG_PATH" ]]; then
+    echo "error: local playtest preflight failed: LetAI config not found: $CONFIG_PATH" >&2
+    echo "hint: pass --config <path> or set OASIS7_LETAI_CONFIG_PATH." >&2
+    failed="1"
+  fi
+
+  local bind_listeners=""
+  if bind_listeners="$(provider_bind_listeners)"; then
+    if [[ -n "$bind_listeners" ]]; then
+      echo "error: local playtest preflight failed: provider bind address is already in use: $BIND_ADDR" >&2
+      echo "hint: Stop the previous local playtest stack, or pass --bind <free host:port>." >&2
+      echo "current listeners:" >&2
+      printf '%s\n' "$bind_listeners" >&2
+      failed="1"
+    fi
+  else
+    echo "warning: could not inspect provider bind listeners for $BIND_ADDR; lsof may be unavailable." >&2
+  fi
+
+  local seen_ports=" "
+  local launcher_label launcher_port launcher_listeners
+  while IFS=$'\t' read -r launcher_label launcher_port; do
+    [[ -n "$launcher_port" ]] || continue
+    if [[ "$seen_ports" == *" $launcher_port "* ]]; then
+      continue
+    fi
+    seen_ports="${seen_ports}${launcher_port} "
+    if launcher_listeners="$(port_listeners "$launcher_port")"; then
+      if [[ -n "$launcher_listeners" ]]; then
+        echo "error: local playtest preflight failed: $launcher_label port is already in use: $launcher_port" >&2
+        echo "hint: Stop the previous local playtest stack, or pass launcher overrides after --, for example -- --viewer-port <free-port> --live-bind 127.0.0.1:<free-port> --web-bind 127.0.0.1:<free-port>." >&2
+        echo "current listeners:" >&2
+        printf '%s\n' "$launcher_listeners" >&2
+        failed="1"
+      fi
+    else
+      echo "warning: could not inspect $launcher_label port $launcher_port; lsof may be unavailable." >&2
+    fi
+  done < <(planned_launcher_ports)
+
+  if ! command_available node; then
+    echo "error: local playtest preflight failed: missing Node.js runtime" >&2
+    echo "hint: Install Node.js and npm, or use a prepared bundle/source build that does not require frontend rebuilds." >&2
+    failed="1"
+  fi
+
+  if ! viewer_dist_ready && ! command_available npm; then
+    echo "error: local playtest preflight failed: missing npm and viewer dist" >&2
+    echo "hint: Install npm, or build/copy viewer dist at $VIEWER_DIST_DIR before launching." >&2
+    echo "hint: rerun with --reuse-existing-build only after a successful source build." >&2
+    failed="1"
+  elif ! viewer_dist_ready; then
+    echo "warning: viewer dist is missing; npm is available, so startup may rebuild frontend assets." >&2
+  elif ! command_available npm; then
+    echo "warning: npm is not available; using existing viewer dist at $VIEWER_DIST_DIR." >&2
+  fi
+
+  if [[ "$REUSE_EXISTING_BUILD" == "1" ]]; then
+    local missing_bins=()
+    local bin_name
+    while IFS= read -r bin_name; do
+      if [[ ! -x "$SOURCE_BIN_DIR/$bin_name" ]]; then
+        missing_bins+=("$bin_name")
+      fi
+    done < <(required_source_bins)
+    if [[ "${#missing_bins[@]}" -gt 0 ]]; then
+      echo "error: local playtest preflight failed: --reuse-existing-build requested but required binaries are missing" >&2
+      echo "missing: ${missing_bins[*]}" >&2
+      echo "hint: Run without --reuse-existing-build once, or build the missing binaries under $SOURCE_BIN_DIR." >&2
+      failed="1"
+    fi
+  else
+    echo "note: source build may take several minutes on a cold cache; shared target locks are normal." >&2
+  fi
+
+  case "$PROVIDER_SMOKE_MODE" in
+    strict)
+      echo "provider_smoke=strict"
+      ;;
+    degraded)
+      echo "provider_smoke=degraded"
+      echo "note: provider smoke failures will be reported and startup will continue for page playtest." >&2
+      ;;
+    skip)
+      echo "provider_smoke=skip"
+      echo "warning: provider smoke is skipped; LLM/gameplay quality is not validated before startup." >&2
+      ;;
+  esac
+
+  if [[ "$failed" != "0" ]]; then
+    exit 2
+  fi
+  echo "local LetAI game test preflight passed"
+}
+
+print_launch_plan() {
+  echo "local LetAI game test launch plan"
+  echo "startup_profile=$STARTUP_PROFILE"
+  echo "provider_smoke_mode=$PROVIDER_SMOKE_MODE"
+  case "$PROVIDER_SMOKE_MODE" in
+    strict)
+      echo "bridge_smoke=required"
+      ;;
+    degraded)
+      echo "bridge_smoke=degrade-on-failure"
+      echo "degraded startup will continue after provider smoke failure"
+      echo "--skip-llm-provider-preflight"
+      ;;
+    skip)
+      echo "bridge_smoke=skip"
+      echo "--skip-bridge-smoke"
+      echo "--skip-llm-provider-preflight"
+      ;;
+  esac
+  if [[ "$REUSE_EXISTING_BUILD" == "1" ]]; then
+    echo "OASIS7_RUN_LAUNCHER_STACK_SKIP_SOURCE_BUILD=1"
+  else
+    echo "OASIS7_RUN_LAUNCHER_STACK_SKIP_SOURCE_BUILD=0"
+  fi
+}
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -166,8 +402,31 @@ while [[ $# -gt 0 ]]; do
       CHAT_PROBE_BACKEND="none"
       shift
       ;;
+    --startup-profile)
+      STARTUP_PROFILE="${2:-}"
+      shift 2
+      ;;
+    --provider-smoke-mode)
+      PROVIDER_SMOKE_MODE="${2:-}"
+      PROVIDER_SMOKE_MODE_SET="1"
+      shift 2
+      ;;
     --skip-bridge-smoke)
+      PROVIDER_SMOKE_MODE="skip"
+      PROVIDER_SMOKE_MODE_SET="1"
       SKIP_BRIDGE_SMOKE="1"
+      shift
+      ;;
+    --reuse-existing-build)
+      REUSE_EXISTING_BUILD="1"
+      shift
+      ;;
+    --preflight-only)
+      PREFLIGHT_ONLY="1"
+      shift
+      ;;
+    --dry-run-launch)
+      DRY_RUN_LAUNCH="1"
       shift
       ;;
     --bridge-smoke-attempts)
@@ -226,6 +485,32 @@ case "$CHAT_PROBE_BACKEND" in
     exit 2
     ;;
 esac
+case "$STARTUP_PROFILE" in
+  strict|playtest) ;;
+  *)
+    echo "error: --startup-profile must be strict or playtest" >&2
+    exit 2
+    ;;
+esac
+if [[ "$PROVIDER_SMOKE_MODE_SET" == "0" ]]; then
+  if [[ "$STARTUP_PROFILE" == "playtest" ]]; then
+    PROVIDER_SMOKE_MODE="degraded"
+  else
+    PROVIDER_SMOKE_MODE="strict"
+  fi
+fi
+case "$PROVIDER_SMOKE_MODE" in
+  strict|degraded|skip) ;;
+  *)
+    echo "error: --provider-smoke-mode must be strict, degraded, or skip" >&2
+    exit 2
+    ;;
+esac
+if [[ "$PROVIDER_SMOKE_MODE" == "skip" ]]; then
+  SKIP_BRIDGE_SMOKE="1"
+else
+  SKIP_BRIDGE_SMOKE="0"
+fi
 if ! [[ "$BRIDGE_SMOKE_ATTEMPTS" =~ ^[0-9]+$ ]] || [[ "$BRIDGE_SMOKE_ATTEMPTS" -lt 1 ]]; then
   echo "error: --bridge-smoke-attempts must be a positive integer" >&2
   exit 2
@@ -247,9 +532,11 @@ if ! [[ "$AGENT_PROVIDER_CONNECT_TIMEOUT_MS" =~ ^[0-9]+$ ]] || [[ "$AGENT_PROVID
   exit 2
 fi
 
-if [[ ! -f "$CONFIG_PATH" ]]; then
-  echo "error: LetAI config not found: $CONFIG_PATH" >&2
-  exit 2
+if [[ "$REUSE_EXISTING_BUILD" == "1" ]]; then
+  export OASIS7_RUN_LAUNCHER_STACK_SKIP_SOURCE_BUILD=1
+fi
+if [[ "$PROVIDER_SMOKE_MODE" == "degraded" || "$PROVIDER_SMOKE_MODE" == "skip" ]]; then
+  LAUNCHER_ARGS+=(--skip-llm-provider-preflight)
 fi
 
 if [[ "$USE_DEFAULT_PROXY" == "1" ]]; then
@@ -286,6 +573,18 @@ if [[ -z "$OUTPUT_DIR" ]]; then
   OUTPUT_DIR="$ROOT_DIR/output/local-letai-game-test/$RUN_STAMP"
 fi
 mkdir -p "$OUTPUT_DIR"
+
+if [[ "$PREFLIGHT_ONLY" == "1" ]]; then
+  run_preflight
+  exit 0
+fi
+
+run_preflight
+
+if [[ "$DRY_RUN_LAUNCH" == "1" ]]; then
+  print_launch_plan
+  exit 0
+fi
 
 if [[ -n "$MODEL" ]]; then
   BRIDGE_ARGS+=(--model "$MODEL")
@@ -332,6 +631,8 @@ if [[ "$DETACH" == "1" && "${OASIS7_LOCAL_LETAI_DETACHED_CHILD:-0}" != "1" ]]; t
     --chat-probe-retry-delay-ms "$CHAT_PROBE_RETRY_DELAY_MS"
     --agent-provider-connect-timeout-ms "$AGENT_PROVIDER_CONNECT_TIMEOUT_MS"
     --deployment-mode "$DEPLOYMENT_MODE"
+    --startup-profile "$STARTUP_PROFILE"
+    --provider-smoke-mode "$PROVIDER_SMOKE_MODE"
     --output-dir "$ABS_OUTPUT_DIR"
   )
   if [[ "$USE_DEFAULT_PROXY" != "1" ]]; then
@@ -352,6 +653,12 @@ if [[ "$DETACH" == "1" && "${OASIS7_LOCAL_LETAI_DETACHED_CHILD:-0}" != "1" ]]; t
   fi
   if [[ "$SKIP_BRIDGE_SMOKE" == "1" ]]; then
     DETACH_CMD+=(--skip-bridge-smoke)
+  fi
+  if [[ "$REUSE_EXISTING_BUILD" == "1" ]]; then
+    DETACH_CMD+=(--reuse-existing-build)
+  fi
+  if [[ "$DRY_RUN_LAUNCH" == "1" ]]; then
+    DETACH_CMD+=(--dry-run-launch)
   fi
   if [[ "${#LAUNCHER_ARGS[@]}" -gt 0 ]]; then
     DETACH_CMD+=(-- "${LAUNCHER_ARGS[@]}")
@@ -375,7 +682,9 @@ if [[ "$DETACH" == "1" && "${OASIS7_LOCAL_LETAI_DETACHED_CHILD:-0}" != "1" ]]; t
   } >"$DETACH_SCRIPT"
   chmod +x "$DETACH_SCRIPT"
   : >"$DETACH_LOG"
-  if command -v launchctl >/dev/null 2>&1; then
+  if [[ "${OASIS7_LOCAL_LETAI_TEST_DETACH_NO_SUBMIT:-0}" == "1" ]]; then
+    echo "test detach submit skipped" >"$DETACH_PID_FILE"
+  elif command -v launchctl >/dev/null 2>&1; then
     launchctl remove "$DETACH_LABEL" >/dev/null 2>&1 || true
     launchctl submit -l "$DETACH_LABEL" -- /bin/bash "$DETACH_SCRIPT"
     echo "$DETACH_LABEL" >"$DETACH_LABEL_FILE"
@@ -406,6 +715,8 @@ echo "bridge=http://$BIND_ADDR"
 echo "chat_echo=$([[ "$CHAT_ECHO" == "1" ]] && echo enabled-debug-only || echo disabled)"
 echo "auto_play=$([[ "$AUTO_PLAY" == "1" ]] && echo enabled || echo disabled)"
 echo "deployment_mode=$DEPLOYMENT_MODE"
+echo "startup_profile=$STARTUP_PROFILE"
+echo "provider_smoke_mode=$PROVIDER_SMOKE_MODE"
 echo "chat_probe_backend=$CHAT_PROBE_BACKEND"
 echo "chat_probe_timeout_ms=$CHAT_PROBE_TIMEOUT_MS"
 echo "chat_probe_attempts=$CHAT_PROBE_ATTEMPTS"
@@ -454,6 +765,11 @@ for _ in $(seq 1 90); do
     exit 1
   fi
   if curl -fsS "http://$BIND_ADDR/v1/provider/info" >/dev/null 2>&1; then
+    if ! kill -0 "$BRIDGE_PID" >/dev/null 2>&1; then
+      echo "error: local LetAI bridge exited while provider endpoint was becoming ready; log: $OUTPUT_DIR/local-letai-provider-bridge.log" >&2
+      tail -n 80 "$OUTPUT_DIR/local-letai-provider-bridge.log" >&2 || true
+      exit 1
+    fi
     break
   fi
   sleep 1
@@ -465,7 +781,7 @@ if ! curl -fsS "http://$BIND_ADDR/v1/provider/info" >/dev/null 2>&1; then
   exit 1
 fi
 
-if [[ "$SKIP_BRIDGE_SMOKE" != "1" ]]; then
+if [[ "$PROVIDER_SMOKE_MODE" == "strict" || "$PROVIDER_SMOKE_MODE" == "degraded" ]]; then
   smoke_status=1
   for attempt in $(seq 1 "$BRIDGE_SMOKE_ATTEMPTS"); do
     if "$ROOT_DIR/scripts/provider-remote-https/provider-bridge-contract-smoke.sh" \
@@ -485,7 +801,14 @@ if [[ "$SKIP_BRIDGE_SMOKE" != "1" ]]; then
       --timeout-ms "$AGENT_PROVIDER_CONNECT_TIMEOUT_MS" \
       --decision-count 1 \
       --min-successes 0 >&2 || true
-    exit 1
+    if [[ "$PROVIDER_SMOKE_MODE" == "degraded" ]]; then
+      echo "warning: provider bridge smoke failed; continuing because --provider-smoke-mode degraded is active" >&2
+      echo "warning: page startup may succeed, but provider-backed LLM actions may show runtime blockers until the upstream recovers" >&2
+    else
+      echo "error: provider bridge smoke failed in strict mode" >&2
+      echo "hint: retry later, or use --startup-profile playtest / --provider-smoke-mode degraded to open the page while preserving a warning." >&2
+      exit 1
+    fi
   fi
 elif [[ "$CHAT_PROBE_BACKEND" == "rust-bridge" ]]; then
   echo "warning: --skip-bridge-smoke also skips the default Rust bridge chat probe" >&2
@@ -499,12 +822,17 @@ fi
 if [[ "$AUTO_PLAY" == "1" ]]; then
   LAUNCHER_MODE_ARGS+=(--auto-play)
 fi
-"$ROOT_DIR/scripts/run-launcher-stack.sh" \
-  "${LAUNCHER_MODE_ARGS[@]}" \
+LAUNCHER_CMD=(
+  "$ROOT_DIR/scripts/run-launcher-stack.sh"
+  "${LAUNCHER_MODE_ARGS[@]}"
   --agent-decision-source provider_backed \
   --agent-provider-url "http://$BIND_ADDR" \
-  --output-dir "$OUTPUT_DIR/launcher" \
-  ${LAUNCHER_ARGS[@]+"${LAUNCHER_ARGS[@]}"}
+  --output-dir "$OUTPUT_DIR/launcher"
+)
+if [[ "${#LAUNCHER_ARGS[@]}" -gt 0 ]]; then
+  LAUNCHER_CMD+=("${LAUNCHER_ARGS[@]}")
+fi
+"${LAUNCHER_CMD[@]}"
 launcher_status=$?
 set -e
 

--- a/scripts/run-local-letai-game-test.test.sh
+++ b/scripts/run-local-letai-game-test.test.sh
@@ -144,6 +144,7 @@ fi
 assert_contains "$missing_config_err" "error: local playtest preflight failed: LetAI config not found"
 assert_contains "$missing_config_err" "pass --config <path> or set OASIS7_LETAI_CONFIG_PATH"
 
+if command -v lsof >/dev/null 2>&1; then
 occupied_port_file="$tmp_dir/occupied-port.txt"
 python3 - "$occupied_port_file" <<'PY' &
 from __future__ import annotations
@@ -197,6 +198,9 @@ if [[ "$occupied_status" -eq 0 ]]; then
 fi
 assert_contains "$occupied_err" "error: local playtest preflight failed: provider bind address is already in use"
 assert_contains "$occupied_err" "Stop the previous local playtest stack, or pass --bind <free host:port>"
+else
+  echo "skip: occupied bind preflight assertion requires lsof" >&2
+fi
 
 missing_node_err="$tmp_dir/missing-node.err"
 set +e

--- a/scripts/run-local-letai-game-test.test.sh
+++ b/scripts/run-local-letai-game-test.test.sh
@@ -1,0 +1,347 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+tmp_dir="${TMPDIR:-/tmp}/oasis7-local-letai-game-test-cli-$$"
+mkdir -p "$tmp_dir"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+assert_contains() {
+  local path="$1"
+  local expected="$2"
+  if ! grep -Fq -- "$expected" "$path"; then
+    echo "expected $path to contain: $expected" >&2
+    echo "--- $path ---" >&2
+    sed -n '1,160p' "$path" >&2 || true
+    exit 1
+  fi
+}
+
+free_bind_addr() {
+  python3 - <<'PY'
+from __future__ import annotations
+
+import socket
+
+with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+    sock.bind(("127.0.0.1", 0))
+    print(f"127.0.0.1:{sock.getsockname()[1]}")
+PY
+}
+
+free_port() {
+  free_bind_addr | sed 's/^.*://'
+}
+
+config_path="$tmp_dir/letai.env"
+cat >"$config_path" <<'EOF'
+Key: test-secret-key
+EOF
+
+fake_bin_dir="$tmp_dir/bin"
+mkdir -p "$fake_bin_dir"
+for tool in node npm; do
+  printf '#!/usr/bin/env bash\nexit 0\n' >"$fake_bin_dir/$tool"
+  chmod +x "$fake_bin_dir/$tool"
+done
+for bin in \
+  oasis7_llm_provider_probe \
+  oasis7_game_launcher \
+  oasis7_viewer_live \
+  oasis7_chain_runtime \
+  oasis7_provider_local_bridge
+do
+  printf '#!/usr/bin/env bash\nexit 0\n' >"$fake_bin_dir/$bin"
+  chmod +x "$fake_bin_dir/$bin"
+done
+
+dist_dir="$tmp_dir/dist"
+mkdir -p "$dist_dir"
+touch "$dist_dir/index.html"
+
+preflight_out="$tmp_dir/preflight.out"
+OASIS7_LOCAL_LETAI_SOURCE_BIN_DIR="$fake_bin_dir" \
+OASIS7_LOCAL_LETAI_VIEWER_DIST_DIR="$dist_dir" \
+PATH="$fake_bin_dir:$PATH" \
+	  ./scripts/run-local-letai-game-test.sh \
+	    --config "$config_path" \
+	    --bind "$(free_bind_addr)" \
+	    --no-ensure-token-config \
+	    --no-default-proxy \
+	    --preflight-only \
+	    --startup-profile playtest \
+	    --reuse-existing-build \
+	    --output-dir "$tmp_dir/out" \
+	    -- \
+	    --viewer-port "$(free_port)" \
+	    --live-bind "$(free_bind_addr)" \
+	    --web-bind "$(free_bind_addr)" \
+	    --chain-disable \
+	    >"$preflight_out"
+
+assert_contains "$preflight_out" "local LetAI game test preflight passed"
+assert_contains "$preflight_out" "startup_profile=playtest"
+assert_contains "$preflight_out" "provider_smoke_mode=degraded"
+assert_contains "$preflight_out" "source_build=reuse-existing"
+
+missing_npm_err="$tmp_dir/missing-npm.err"
+set +e
+OASIS7_LOCAL_LETAI_TEST_MISSING_NPM=1 \
+OASIS7_LOCAL_LETAI_VIEWER_DIST_DIR="$tmp_dir/missing-dist" \
+PATH="$fake_bin_dir:$PATH" \
+	  ./scripts/run-local-letai-game-test.sh \
+	    --config "$config_path" \
+	    --bind "$(free_bind_addr)" \
+	    --no-ensure-token-config \
+	    --no-default-proxy \
+	    --preflight-only \
+	    --output-dir "$tmp_dir/out-missing-npm" \
+	    -- \
+	    --viewer-port "$(free_port)" \
+	    --live-bind "$(free_bind_addr)" \
+	    --web-bind "$(free_bind_addr)" \
+	    --chain-disable \
+	    >"$tmp_dir/missing-npm.out" 2>"$missing_npm_err"
+missing_npm_status=$?
+set -e
+
+if [[ "$missing_npm_status" -eq 0 ]]; then
+  echo "expected missing npm preflight to fail" >&2
+  exit 1
+fi
+assert_contains "$missing_npm_err" "error: local playtest preflight failed: missing npm and viewer dist"
+assert_contains "$missing_npm_err" "Install npm, or build/copy viewer dist"
+assert_contains "$missing_npm_err" "rerun with --reuse-existing-build only after a successful source build"
+
+missing_config_err="$tmp_dir/missing-config.err"
+set +e
+OASIS7_LOCAL_LETAI_SOURCE_BIN_DIR="$fake_bin_dir" \
+OASIS7_LOCAL_LETAI_VIEWER_DIST_DIR="$dist_dir" \
+PATH="$fake_bin_dir:$PATH" \
+  ./scripts/run-local-letai-game-test.sh \
+    --config "$tmp_dir/missing-letai.env" \
+    --bind "$(free_bind_addr)" \
+    --no-ensure-token-config \
+    --no-default-proxy \
+    --preflight-only \
+    --reuse-existing-build \
+    --output-dir "$tmp_dir/out-missing-config" \
+    -- \
+    --viewer-port "$(free_port)" \
+    --live-bind "$(free_bind_addr)" \
+    --web-bind "$(free_bind_addr)" \
+    --chain-disable \
+    >"$tmp_dir/missing-config.out" 2>"$missing_config_err"
+missing_config_status=$?
+set -e
+
+if [[ "$missing_config_status" -eq 0 ]]; then
+  echo "expected missing config preflight to fail" >&2
+  exit 1
+fi
+assert_contains "$missing_config_err" "error: local playtest preflight failed: LetAI config not found"
+assert_contains "$missing_config_err" "pass --config <path> or set OASIS7_LETAI_CONFIG_PATH"
+
+occupied_port_file="$tmp_dir/occupied-port.txt"
+python3 - "$occupied_port_file" <<'PY' &
+from __future__ import annotations
+
+import socket
+import sys
+import time
+
+port_file = sys.argv[1]
+sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+sock.bind(("127.0.0.1", 0))
+sock.listen(1)
+with open(port_file, "w", encoding="utf-8") as handle:
+    handle.write(str(sock.getsockname()[1]))
+    handle.flush()
+time.sleep(30)
+PY
+occupied_listener_pid=$!
+for _ in $(seq 1 50); do
+  [[ -s "$occupied_port_file" ]] && break
+  sleep 0.1
+done
+occupied_port="$(cat "$occupied_port_file")"
+occupied_err="$tmp_dir/occupied-bind.err"
+set +e
+OASIS7_LOCAL_LETAI_SOURCE_BIN_DIR="$fake_bin_dir" \
+OASIS7_LOCAL_LETAI_VIEWER_DIST_DIR="$dist_dir" \
+PATH="$fake_bin_dir:$PATH" \
+  ./scripts/run-local-letai-game-test.sh \
+    --config "$config_path" \
+    --bind "127.0.0.1:$occupied_port" \
+    --no-ensure-token-config \
+    --no-default-proxy \
+    --preflight-only \
+    --reuse-existing-build \
+    --output-dir "$tmp_dir/out-occupied-bind" \
+    -- \
+    --viewer-port "$(free_port)" \
+    --live-bind "$(free_bind_addr)" \
+    --web-bind "$(free_bind_addr)" \
+    --chain-disable \
+    >"$tmp_dir/occupied-bind.out" 2>"$occupied_err"
+occupied_status=$?
+set -e
+kill "$occupied_listener_pid" >/dev/null 2>&1 || true
+wait "$occupied_listener_pid" >/dev/null 2>&1 || true
+
+if [[ "$occupied_status" -eq 0 ]]; then
+  echo "expected occupied bind preflight to fail" >&2
+  exit 1
+fi
+assert_contains "$occupied_err" "error: local playtest preflight failed: provider bind address is already in use"
+assert_contains "$occupied_err" "Stop the previous local playtest stack, or pass --bind <free host:port>"
+
+missing_node_err="$tmp_dir/missing-node.err"
+set +e
+OASIS7_LOCAL_LETAI_TEST_MISSING_NODE=1 \
+OASIS7_LOCAL_LETAI_SOURCE_BIN_DIR="$fake_bin_dir" \
+OASIS7_LOCAL_LETAI_VIEWER_DIST_DIR="$dist_dir" \
+PATH="$fake_bin_dir:$PATH" \
+	  ./scripts/run-local-letai-game-test.sh \
+	    --config "$config_path" \
+	    --bind "$(free_bind_addr)" \
+	    --no-ensure-token-config \
+	    --no-default-proxy \
+	    --preflight-only \
+	    --reuse-existing-build \
+	    --output-dir "$tmp_dir/out-missing-node" \
+	    -- \
+	    --viewer-port "$(free_port)" \
+	    --live-bind "$(free_bind_addr)" \
+	    --web-bind "$(free_bind_addr)" \
+	    --chain-disable \
+	    >"$tmp_dir/missing-node.out" 2>"$missing_node_err"
+missing_node_status=$?
+set -e
+
+if [[ "$missing_node_status" -eq 0 ]]; then
+  echo "expected missing Node.js preflight to fail" >&2
+  exit 1
+fi
+assert_contains "$missing_node_err" "error: local playtest preflight failed: missing Node.js runtime"
+assert_contains "$missing_node_err" "Install Node.js and npm, or use a prepared bundle/source build that does not require frontend rebuilds"
+
+missing_build_err="$tmp_dir/missing-build.err"
+set +e
+OASIS7_LOCAL_LETAI_SOURCE_BIN_DIR="$tmp_dir/missing-bin" \
+OASIS7_LOCAL_LETAI_VIEWER_DIST_DIR="$dist_dir" \
+PATH="$fake_bin_dir:$PATH" \
+	  ./scripts/run-local-letai-game-test.sh \
+	    --config "$config_path" \
+	    --bind "$(free_bind_addr)" \
+	    --no-ensure-token-config \
+	    --no-default-proxy \
+	    --preflight-only \
+	    --reuse-existing-build \
+	    --output-dir "$tmp_dir/out-missing-build" \
+	    -- \
+	    --viewer-port "$(free_port)" \
+	    --live-bind "$(free_bind_addr)" \
+	    --web-bind "$(free_bind_addr)" \
+	    --chain-disable \
+	    >"$tmp_dir/missing-build.out" 2>"$missing_build_err"
+missing_build_status=$?
+set -e
+
+if [[ "$missing_build_status" -eq 0 ]]; then
+  echo "expected missing build preflight to fail" >&2
+  exit 1
+fi
+assert_contains "$missing_build_err" "error: local playtest preflight failed: --reuse-existing-build requested but required binaries are missing"
+assert_contains "$missing_build_err" "Run without --reuse-existing-build once"
+
+strict_plan="$tmp_dir/strict-plan.out"
+OASIS7_LOCAL_LETAI_SOURCE_BIN_DIR="$fake_bin_dir" \
+OASIS7_LOCAL_LETAI_VIEWER_DIST_DIR="$dist_dir" \
+PATH="$fake_bin_dir:$PATH" \
+	  ./scripts/run-local-letai-game-test.sh \
+	    --config "$config_path" \
+	    --bind "$(free_bind_addr)" \
+	    --no-ensure-token-config \
+	    --no-default-proxy \
+	    --dry-run-launch \
+	    --provider-smoke-mode strict \
+	    --reuse-existing-build \
+	    --output-dir "$tmp_dir/out-strict" \
+	    -- \
+	    --viewer-port "$(free_port)" \
+	    --live-bind "$(free_bind_addr)" \
+	    --web-bind "$(free_bind_addr)" \
+	    --chain-disable \
+	    >"$strict_plan"
+
+assert_contains "$strict_plan" "provider_smoke_mode=strict"
+assert_contains "$strict_plan" "bridge_smoke=required"
+if grep -Fq -- "--skip-bridge-smoke" "$strict_plan"; then
+  echo "strict provider smoke mode must not skip bridge smoke" >&2
+  exit 1
+fi
+if grep -Fq -- "--skip-llm-provider-preflight" "$strict_plan"; then
+  echo "strict provider smoke mode must not skip launcher provider preflight" >&2
+  exit 1
+fi
+
+degraded_plan="$tmp_dir/degraded-plan.out"
+OASIS7_LOCAL_LETAI_SOURCE_BIN_DIR="$fake_bin_dir" \
+OASIS7_LOCAL_LETAI_VIEWER_DIST_DIR="$dist_dir" \
+PATH="$fake_bin_dir:$PATH" \
+	  ./scripts/run-local-letai-game-test.sh \
+	    --config "$config_path" \
+	    --bind "$(free_bind_addr)" \
+	    --no-ensure-token-config \
+	    --no-default-proxy \
+	    --dry-run-launch \
+	    --provider-smoke-mode degraded \
+	    --reuse-existing-build \
+	    --output-dir "$tmp_dir/out-degraded" \
+	    -- \
+	    --viewer-port "$(free_port)" \
+	    --live-bind "$(free_bind_addr)" \
+	    --web-bind "$(free_bind_addr)" \
+	    --chain-disable \
+	    >"$degraded_plan"
+
+assert_contains "$degraded_plan" "provider_smoke_mode=degraded"
+assert_contains "$degraded_plan" "bridge_smoke=degrade-on-failure"
+assert_contains "$degraded_plan" "degraded startup will continue after provider smoke failure"
+assert_contains "$degraded_plan" "--skip-llm-provider-preflight"
+assert_contains "$degraded_plan" "OASIS7_RUN_LAUNCHER_STACK_SKIP_SOURCE_BUILD=1"
+
+detached_out="$tmp_dir/detached.out"
+detached_dir="$tmp_dir/out-detached"
+detached_abs_dir="$(mkdir -p "$detached_dir" && cd "$detached_dir" && pwd)"
+OASIS7_LOCAL_LETAI_SOURCE_BIN_DIR="$fake_bin_dir" \
+OASIS7_LOCAL_LETAI_VIEWER_DIST_DIR="$dist_dir" \
+OASIS7_LOCAL_LETAI_TEST_DETACH_NO_SUBMIT=1 \
+PATH="$fake_bin_dir:$PATH" \
+	  ./scripts/run-local-letai-game-test.sh \
+	    --config "$config_path" \
+	    --bind "$(free_bind_addr)" \
+	    --no-ensure-token-config \
+	    --no-default-proxy \
+	    --detach \
+	    --provider-smoke-mode degraded \
+	    --reuse-existing-build \
+	    --output-dir "$detached_dir" \
+	    -- \
+	    --viewer-port "$(free_port)" \
+	    --live-bind "$(free_bind_addr)" \
+	    --web-bind "$(free_bind_addr)" \
+	    --chain-disable \
+	    >"$detached_out"
+
+assert_contains "$detached_out" "local LetAI game test detached"
+assert_contains "$detached_out" "supervisor_script=$detached_abs_dir/local-letai-game-test.detached.sh"
+assert_contains "$detached_abs_dir/local-letai-game-test.detached.sh" "OASIS7_RUN_LAUNCHER_STACK_SKIP_SOURCE_BUILD=1"
+assert_contains "$detached_abs_dir/local-letai-game-test.detached.sh" "--provider-smoke-mode degraded"
+assert_contains "$detached_abs_dir/local-letai-game-test.detached.sh" "--reuse-existing-build"
+assert_contains "$detached_abs_dir/local-letai-game-test.detached.sh" "--skip-llm-provider-preflight"
+
+echo "local letai game test CLI smoke passed"

--- a/scripts/viewer-real-agent-chat-regression.sh
+++ b/scripts/viewer-real-agent-chat-regression.sh
@@ -1,0 +1,356 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+cd "$repo_root"
+
+usage() {
+  cat <<'USAGE'
+Usage: ./scripts/viewer-real-agent-chat-regression.sh [options] [-- launcher args...]
+
+Run the local real-provider Agent chat browser regression:
+1. optionally start the canonical local LetAI game stack
+2. open the Viewer in a Playwright browser automation session
+3. send a direct chat message to agent-0
+4. require a real inbound Agent reply and reject local mock reply markers
+
+Options:
+  --url <url>                 Use an existing Viewer URL; skip stack bootstrap
+  --out-dir <path>            Artifact root (default: output/playwright/viewer-real-agent-chat)
+  --startup-timeout <secs>    Wait timeout for a bootstrapped stack (default: 300)
+  --agent-id <id>             Target agent id (default: agent-0)
+  --chat-message <text>       Chat message to send
+                              (default: 你在哪里？身边有什么资源？请直接回答。)
+  --expect-contains <text>    Required Agent reply fragment; repeatable
+                              (default: 我在 runtime:, data 8, electricity 32)
+  --forbid-contains <text>    Forbidden Agent reply fragment; repeatable
+                              (default: [local-mock-receipt], [local-mock-chat])
+  --keep-stack                Leave a stack started by this script running
+  --headed                    Open browser in headed mode
+  --headless                  Open browser in headless mode (default)
+  -h, --help                  Show help
+
+Examples:
+  ./scripts/viewer-real-agent-chat-regression.sh
+  ./scripts/viewer-real-agent-chat-regression.sh --url "http://127.0.0.1:4173/?ws=ws://127.0.0.1:5011&test_api=1&locale=zh"
+USAGE
+}
+
+sleep_ms() {
+  python3 - "$1" <<'PY'
+import sys, time
+time.sleep(int(sys.argv[1]) / 1000.0)
+PY
+}
+
+free_bind_addr() {
+  python3 - <<'PY'
+from __future__ import annotations
+
+import socket
+
+with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+    sock.bind(("127.0.0.1", 0))
+    print(f"127.0.0.1:{sock.getsockname()[1]}")
+PY
+}
+
+free_port() {
+  free_bind_addr | sed 's/^.*://'
+}
+
+meta_value() {
+  local key=$1
+  local file=$2
+  sed -n "s/^${key}=//p" "$file" | tail -n 1
+}
+
+GAME_URL=""
+OUT_ROOT="output/playwright/viewer-real-agent-chat"
+STARTUP_TIMEOUT_SECS=300
+AGENT_ID="agent-0"
+CHAT_MESSAGE="你在哪里？身边有什么资源？请直接回答。"
+HEADED=0
+KEEP_STACK=0
+EXPECT_CONTAINS=()
+FORBID_CONTAINS=()
+EXPECT_CONTAINS_SET=0
+FORBID_CONTAINS_SET=0
+LAUNCHER_ARGS=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --url)
+      GAME_URL="${2:-}"
+      shift 2
+      ;;
+    --out-dir)
+      OUT_ROOT="${2:-}"
+      shift 2
+      ;;
+    --startup-timeout)
+      STARTUP_TIMEOUT_SECS="${2:-}"
+      shift 2
+      ;;
+    --agent-id)
+      AGENT_ID="${2:-}"
+      shift 2
+      ;;
+    --chat-message)
+      CHAT_MESSAGE="${2:-}"
+      shift 2
+      ;;
+    --expect-contains)
+      EXPECT_CONTAINS+=("${2:-}")
+      EXPECT_CONTAINS_SET=1
+      shift 2
+      ;;
+    --forbid-contains)
+      FORBID_CONTAINS+=("${2:-}")
+      FORBID_CONTAINS_SET=1
+      shift 2
+      ;;
+    --keep-stack)
+      KEEP_STACK=1
+      shift
+      ;;
+    --headed)
+      HEADED=1
+      shift
+      ;;
+    --headless)
+      HEADED=0
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --)
+      shift
+      LAUNCHER_ARGS+=("$@")
+      break
+      ;;
+    *)
+      echo "error: unknown option: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+[[ -n "$OUT_ROOT" ]] || { echo "error: --out-dir cannot be empty" >&2; exit 2; }
+[[ "$STARTUP_TIMEOUT_SECS" =~ ^[0-9]+$ ]] && [[ "$STARTUP_TIMEOUT_SECS" -gt 0 ]] || { echo "error: --startup-timeout must be positive" >&2; exit 2; }
+[[ -n "$AGENT_ID" ]] || { echo "error: --agent-id cannot be empty" >&2; exit 2; }
+[[ -n "$CHAT_MESSAGE" ]] || { echo "error: --chat-message cannot be empty" >&2; exit 2; }
+
+if [[ "$EXPECT_CONTAINS_SET" -eq 0 ]]; then
+  EXPECT_CONTAINS=("我在 runtime:" "data 8" "electricity 32")
+fi
+if [[ "$FORBID_CONTAINS_SET" -eq 0 ]]; then
+  FORBID_CONTAINS=("[local-mock-receipt]" "[local-mock-chat]")
+fi
+
+run_id="$(date +%Y%m%d-%H%M%S)"
+out_dir="$OUT_ROOT/$run_id"
+mkdir -p "$out_dir"
+
+node_bin="${OASIS7_NODE_BIN:-}"
+if [[ -z "$node_bin" ]]; then
+  if command -v node >/dev/null 2>&1; then
+    node_bin="$(command -v node)"
+  elif [[ -x "/Users/scc/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node" ]]; then
+    node_bin="/Users/scc/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node"
+  else
+    echo "error: missing required command: node; set OASIS7_NODE_BIN to a Node.js executable" >&2
+    exit 1
+  fi
+fi
+node_bin_dir="$(cd "$(dirname "$node_bin")" && pwd)"
+export PATH="$node_bin_dir:$PATH"
+
+stack_pid=""
+stack_meta=""
+stack_log="$out_dir/local-letai-stack.log"
+managed_ports=()
+
+stack_port_listeners() {
+  if ! command -v lsof >/dev/null 2>&1; then
+    return 0
+  fi
+  local args=()
+  local port
+  for port in "${managed_ports[@]}"; do
+    args+=("-iTCP:$port")
+  done
+  lsof -nP "${args[@]}" -sTCP:LISTEN 2>/dev/null | awk 'NR > 1 { print }'
+}
+
+stack_port_listener_pids() {
+  stack_port_listeners | awk '{ print $2 }' | sort -u
+}
+
+wait_for_stack_ports_clean() {
+  local report=${1:-1}
+  local listeners=""
+  for _ in $(seq 1 80); do
+    listeners="$(stack_port_listeners || true)"
+    if [[ -z "$listeners" ]]; then
+      return 0
+    fi
+    sleep_ms 250
+  done
+  if [[ "$report" -eq 1 ]]; then
+    echo "error: local LetAI stack cleanup left managed ports listening: ${managed_ports[*]}" >&2
+    printf '%s\n' "$listeners" >&2
+  fi
+  return 1
+}
+
+terminate_stack_port_listeners() {
+  local pids=""
+  pids="$(stack_port_listener_pids || true)"
+  if [[ -z "$pids" ]]; then
+    return 0
+  fi
+  # This wrapper owns the canonical local playtest ports while it runs.
+  # If polite launcher shutdown leaves children behind, terminate those listeners.
+  echo "warning: terminating leftover local LetAI stack listener pids: ${pids//$'\n'/ }" >&2
+  while IFS= read -r pid; do
+    [[ -n "$pid" ]] || continue
+    kill "$pid" >/dev/null 2>&1 || true
+  done <<<"$pids"
+}
+
+cleanup() {
+  local exit_code=$?
+  trap - EXIT INT TERM
+  if [[ -n "$stack_pid" && "$KEEP_STACK" -ne 1 ]]; then
+    if [[ -n "$stack_meta" && -f "$stack_meta" ]]; then
+      launcher_pid="$(meta_value LAUNCHER_PID "$stack_meta" 2>/dev/null || true)"
+      if [[ -n "${launcher_pid:-}" ]]; then
+        kill "$launcher_pid" >/dev/null 2>&1 || true
+      fi
+    fi
+    kill "$stack_pid" >/dev/null 2>&1 || true
+    wait "$stack_pid" >/dev/null 2>&1 || true
+    if [[ "$exit_code" -eq 0 ]]; then
+      if ! wait_for_stack_ports_clean 0; then
+        terminate_stack_port_listeners
+        wait_for_stack_ports_clean || exit_code=1
+      fi
+    fi
+  fi
+  exit "$exit_code"
+}
+trap cleanup EXIT INT TERM
+
+if [[ -z "$GAME_URL" ]]; then
+  stack_out="$out_dir/local-letai-stack"
+  mkdir -p "$stack_out"
+  stack_meta="$stack_out/launcher/session.meta"
+  stack_provider_bind="$(free_bind_addr)"
+  stack_viewer_port="$(free_port)"
+  stack_live_bind="$(free_bind_addr)"
+  stack_web_bind="$(free_bind_addr)"
+  managed_ports=(
+    "$stack_viewer_port"
+    "${stack_live_bind##*:}"
+    "${stack_web_bind##*:}"
+    "${stack_provider_bind##*:}"
+  )
+  stack_cmd=(
+    ./scripts/run-local-letai-game-test.sh
+    --bind "$stack_provider_bind"
+    --startup-profile playtest
+    --provider-smoke-mode degraded
+    --skip-chat-probe
+    --reuse-existing-build
+    --no-chat-echo
+    --auto-play
+    --output-dir "$stack_out"
+    --
+    --chain-disable
+    --skip-llm-provider-preflight
+    --viewer-port "$stack_viewer_port"
+    --live-bind "$stack_live_bind"
+    --web-bind "$stack_web_bind"
+  )
+  if [[ "${#LAUNCHER_ARGS[@]}" -gt 0 ]]; then
+    stack_cmd+=("${LAUNCHER_ARGS[@]}")
+  fi
+  printf 'Starting local LetAI stack:'
+  printf ' %q' "${stack_cmd[@]}"
+  printf '\n'
+  "${stack_cmd[@]}" >"$stack_log" 2>&1 &
+  stack_pid=$!
+
+  for ((i = 0; i < STARTUP_TIMEOUT_SECS; i++)); do
+    if ! kill -0 "$stack_pid" >/dev/null 2>&1; then
+      echo "error: local LetAI stack exited before readiness; log: $stack_log" >&2
+      tail -n 120 "$stack_log" >&2 || true
+      exit 1
+    fi
+    if [[ -f "$stack_meta" ]] && [[ "$(meta_value STACK_READY "$stack_meta" 2>/dev/null || true)" == "1" ]]; then
+      GAME_URL="$(meta_value GAME_URL "$stack_meta")"
+      break
+    fi
+    sleep 1
+  done
+
+  if [[ -z "$GAME_URL" ]]; then
+    echo "error: timed out waiting for STACK_READY=1 in $stack_meta; log: $stack_log" >&2
+    tail -n 120 "$stack_log" >&2 || true
+    exit 1
+  fi
+fi
+
+playwright_node_modules="${OASIS7_PLAYWRIGHT_NODE_MODULES:-/Users/scc/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/node_modules}"
+if [[ ! -d "$playwright_node_modules" ]]; then
+  echo "error: Playwright node_modules not found: $playwright_node_modules" >&2
+  echo "hint: set OASIS7_PLAYWRIGHT_NODE_MODULES to a node_modules directory containing playwright" >&2
+  exit 1
+fi
+
+chat_args=(
+  "$node_bin"
+  "$repo_root/crates/oasis7_viewer/scripts/real-agent-chat-regression.mjs"
+  --url "$GAME_URL"
+  --out-dir "$out_dir/playwright"
+  --agent-id "$AGENT_ID"
+  --chat-message "$CHAT_MESSAGE"
+  --timeout-ms 90000
+)
+if [[ "$HEADED" -eq 1 ]]; then
+  chat_args+=(--headed)
+fi
+for needle in "${EXPECT_CONTAINS[@]}"; do
+  chat_args+=(--expect-contains "$needle")
+done
+for needle in "${FORBID_CONTAINS[@]}"; do
+  chat_args+=(--forbid-contains "$needle")
+done
+
+NODE_PATH="$playwright_node_modules" "${chat_args[@]}" | tee "$out_dir/viewer-real-agent-chat-regression.log"
+
+cat >"$out_dir/viewer-real-agent-chat-regression-summary.md" <<EOF
+# Viewer real Agent chat regression
+
+- gameUrl: \`$GAME_URL\`
+- agentId: \`$AGENT_ID\`
+- chatMessage: \`$CHAT_MESSAGE\`
+- requiredContains: \`${EXPECT_CONTAINS[*]}\`
+- forbiddenContains: \`${FORBID_CONTAINS[*]}\`
+- stackLog: \`$stack_log\`
+EOF
+
+if [[ -n "$stack_pid" && "$KEEP_STACK" -eq 1 ]]; then
+  cat <<EOF
+ok: artifacts written to $out_dir
+ok: stack kept running
+stack_log=$stack_log
+game_url=$GAME_URL
+EOF
+else
+  echo "ok: artifacts written to $out_dir"
+fi

--- a/scripts/viewer-real-agent-chat-regression.sh
+++ b/scripts/viewer-real-agent-chat-regression.sh
@@ -145,7 +145,7 @@ done
 [[ -n "$CHAT_MESSAGE" ]] || { echo "error: --chat-message cannot be empty" >&2; exit 2; }
 
 if [[ "$EXPECT_CONTAINS_SET" -eq 0 ]]; then
-  EXPECT_CONTAINS=("我在 runtime:" "data 8" "electricity 32")
+  EXPECT_CONTAINS=("runtime:" "data 8" "electricity 32")
 fi
 if [[ "$FORBID_CONTAINS_SET" -eq 0 ]]; then
   FORBID_CONTAINS=("[local-mock-receipt]" "[local-mock-chat]")

--- a/scripts/viewer-software-safe-chat-regression.sh
+++ b/scripts/viewer-software-safe-chat-regression.sh
@@ -533,6 +533,16 @@ fi
 
 agent_spoke_required_contains_json="$(js_array_literal "${AGENT_SPOKE_REQUIRED_CONTAINS[@]}")"
 agent_spoke_forbidden_contains_json="$(js_array_literal "${AGENT_SPOKE_FORBIDDEN_CONTAINS[@]}")"
+agent_spoke_forbidden_seen_script="(() => {
+  const forbidden = ${agent_spoke_forbidden_contains_json};
+  if (!Array.isArray(forbidden) || forbidden.length === 0) return false;
+  const h = window.__AW_TEST__?.getState?.()?.chatHistory ?? [];
+  return h.some((entry) => {
+    if (!entry || entry.source !== 'event' || entry.agentId !== ${AGENT_ID@Q}) return false;
+    const msg = String(entry.message ?? '');
+    return forbidden.some((needle) => msg.includes(String(needle)));
+  });
+})()"
 agent_spoke_entry_predicate="(entry) => {
   if (!entry || entry.source !== 'event' || entry.agentId !== ${AGENT_ID@Q}) return false;
   const msg = String(entry.message ?? '');
@@ -545,6 +555,12 @@ agent_spoke_entry_predicate="(entry) => {
   return true;
 }"
 agent_spoke_match_script="(() => { const h = window.__AW_TEST__?.getState?.()?.chatHistory ?? []; return h.some(${agent_spoke_entry_predicate}); })()"
+assert_no_forbidden_agent_spoke() {
+  if [[ "$(normalize_eval_token "$(ab_eval "$session" "$agent_spoke_forbidden_seen_script")")" == "true" ]]; then
+    echo "error: inbound agent_spoke contains forbidden text (${AGENT_SPOKE_FORBIDDEN_CONTAINS[*]})" >&2
+    exit 1
+  fi
+}
 
 immediate_wait_ms=$AGENT_SPOKE_TIMEOUT_MS
 if (( immediate_wait_ms > IMMEDIATE_AGENT_SPOKE_TIMEOUT_MS )); then
@@ -554,6 +570,7 @@ if wait_for_js_true "$agent_spoke_match_script" "$immediate_wait_ms"; then
   agent_spoke_seen=true
   agent_spoke_seen_immediate=true
 fi
+assert_no_forbidden_agent_spoke
 
 if [[ "$agent_spoke_seen_immediate" != true && "$require_immediate_agent_spoke" -eq 1 ]]; then
   echo "error: inbound agent_spoke not observed immediately after chat ack without extra control advance (expected_message=${agent_spoke_expected_message:-<any>})" >&2
@@ -562,6 +579,7 @@ fi
 
 if [[ "$agent_spoke_seen" != true ]]; then
   for step_batch in 1 2 3 4; do
+    assert_no_forbidden_agent_spoke
     if wait_for_js_true "$agent_spoke_match_script" 500; then
       agent_spoke_seen=true
       break
@@ -605,8 +623,10 @@ if [[ "$agent_spoke_seen" != true ]]; then
       agent_spoke_needed_advance=true
       break
     fi
+    assert_no_forbidden_agent_spoke
   done
 fi
+assert_no_forbidden_agent_spoke
 
 if [[ "$agent_spoke_seen" != true && "$REQUIRE_AGENT_SPOKE" -eq 1 ]]; then
   echo "error: inbound agent_spoke not observed within timeout (bootstrapped_stack=$BOOTSTRAPPED_STACK, bootstrap_uses_bundle=$BOOTSTRAP_USES_BUNDLE, expected_message=${agent_spoke_expected_message:-<any>})" >&2

--- a/scripts/viewer-software-safe-chat-regression.sh
+++ b/scripts/viewer-software-safe-chat-regression.sh
@@ -28,6 +28,12 @@ Options:
                                  Wait for inbound `agent_spoke` before any extra step/play
                                  (default: 4000)
   --require-agent-spoke          Treat missing inbound `agent_spoke` as failure
+  --expect-agent-spoke-message <text>
+                                 Require an exact inbound Agent reply message
+  --expect-agent-spoke-contains <text>
+                                 Require inbound Agent reply to contain text; repeatable
+  --forbid-agent-spoke-contains <text>
+                                 Fail if matching inbound Agent reply contains text; repeatable
   --headed                       Open browser in headed mode
   Note: this is a QA regression, not the local playtest entry. When the script
   bootstraps its own stack, it enables receipt-only debug echo with
@@ -122,6 +128,14 @@ normalize_eval_token() {
   raw=${raw#\"}
   raw=${raw%\"}
   printf '%s' "$raw"
+}
+
+js_array_literal() {
+  python3 - "$@" <<'PY'
+import json
+import sys
+print(json.dumps(sys.argv[1:], ensure_ascii=False))
+PY
 }
 
 log_note() {
@@ -245,6 +259,10 @@ payload = {
     "agentSpokeNeededAdvance": sys.argv[16] == "true",
     "requireAgentSpoke": sys.argv[17] == "true",
     "requireImmediateAgentSpoke": sys.argv[18] == "true",
+    "agentSpokeExpectedMessage": None if sys.argv[19] == "" else sys.argv[19],
+    "agentSpokeRequiredContains": json.loads(sys.argv[20]),
+    "agentSpokeForbiddenContains": json.loads(sys.argv[21]),
+    "agentSpokeMessage": None if sys.argv[22] == "" else sys.argv[22],
 }
 print(json.dumps(payload, ensure_ascii=False, indent=2))
 PY
@@ -259,6 +277,9 @@ AGENT_SPOKE_TIMEOUT_MS=45000
 IMMEDIATE_AGENT_SPOKE_TIMEOUT_MS=4000
 REQUIRE_AGENT_SPOKE=0
 REQUIRE_AGENT_SPOKE_EXPLICIT=0
+AGENT_SPOKE_EXPECTED_MESSAGE=""
+AGENT_SPOKE_REQUIRED_CONTAINS=()
+AGENT_SPOKE_FORBIDDEN_CONTAINS=()
 HEADED=0
 STACK_ARGS=()
 BOOTSTRAPPED_STACK=0
@@ -298,6 +319,22 @@ while [[ $# -gt 0 ]]; do
       REQUIRE_AGENT_SPOKE=1
       REQUIRE_AGENT_SPOKE_EXPLICIT=1
       shift
+      ;;
+    --expect-agent-spoke-message)
+      AGENT_SPOKE_EXPECTED_MESSAGE="${2:-}"
+      REQUIRE_AGENT_SPOKE=1
+      REQUIRE_AGENT_SPOKE_EXPLICIT=1
+      shift 2
+      ;;
+    --expect-agent-spoke-contains)
+      AGENT_SPOKE_REQUIRED_CONTAINS+=("${2:-}")
+      REQUIRE_AGENT_SPOKE=1
+      REQUIRE_AGENT_SPOKE_EXPLICIT=1
+      shift 2
+      ;;
+    --forbid-agent-spoke-contains)
+      AGENT_SPOKE_FORBIDDEN_CONTAINS+=("${2:-}")
+      shift 2
       ;;
     --headed)
       HEADED=1
@@ -488,16 +525,26 @@ agent_spoke_seen_immediate=false
 agent_spoke_needed_advance=false
 require_immediate_agent_spoke=0
 agent_spoke_deadline_ms=$((SECONDS * 1000 + AGENT_SPOKE_TIMEOUT_MS))
-agent_spoke_expected_message=""
+agent_spoke_expected_message="$AGENT_SPOKE_EXPECTED_MESSAGE"
 if [[ "$BOOTSTRAPPED_STACK" -eq 1 && "$BOOTSTRAP_USES_BUNDLE" -eq 0 ]]; then
   agent_spoke_expected_message="[local-mock-receipt] 已收到消息；当前本地 mock provider 不生成真实 Agent 回复：${CHAT_MESSAGE}"
   require_immediate_agent_spoke=1
 fi
 
-agent_spoke_match_script="(() => { const h = window.__AW_TEST__?.getState?.()?.chatHistory ?? []; return h.some((entry) => entry && entry.source === 'event' && entry.agentId === ${AGENT_ID@Q}); })()"
-if [[ -n "$agent_spoke_expected_message" ]]; then
-  agent_spoke_match_script="(() => { const h = window.__AW_TEST__?.getState?.()?.chatHistory ?? []; return h.some((entry) => entry && entry.source === 'event' && entry.agentId === ${AGENT_ID@Q} && entry.message === ${agent_spoke_expected_message@Q}); })()"
-fi
+agent_spoke_required_contains_json="$(js_array_literal "${AGENT_SPOKE_REQUIRED_CONTAINS[@]}")"
+agent_spoke_forbidden_contains_json="$(js_array_literal "${AGENT_SPOKE_FORBIDDEN_CONTAINS[@]}")"
+agent_spoke_entry_predicate="(entry) => {
+  if (!entry || entry.source !== 'event' || entry.agentId !== ${AGENT_ID@Q}) return false;
+  const msg = String(entry.message ?? '');
+  const expected = ${agent_spoke_expected_message@Q};
+  const required = ${agent_spoke_required_contains_json};
+  const forbidden = ${agent_spoke_forbidden_contains_json};
+  if (expected && msg !== expected) return false;
+  if (!required.every((needle) => msg.includes(String(needle)))) return false;
+  if (!forbidden.every((needle) => !msg.includes(String(needle)))) return false;
+  return true;
+}"
+agent_spoke_match_script="(() => { const h = window.__AW_TEST__?.getState?.()?.chatHistory ?? []; return h.some(${agent_spoke_entry_predicate}); })()"
 
 immediate_wait_ms=$AGENT_SPOKE_TIMEOUT_MS
 if (( immediate_wait_ms > IMMEDIATE_AGENT_SPOKE_TIMEOUT_MS )); then
@@ -568,6 +615,7 @@ fi
 
 final_state=$(ab_state)
 write_json_file "$final_state" "$final_state_json"
+agent_spoke_message="$(normalize_eval_token "$(ab_eval "$session" "(() => { const h = window.__AW_TEST__?.getState?.()?.chatHistory ?? []; const entry = h.find(${agent_spoke_entry_predicate}); return entry?.message ?? ''; })()")")"
 ab_screenshot "$session" "$screenshot_path" >>"$ab_log" 2>&1 || true
 
 summary_raw=$(summary_json \
@@ -579,7 +627,11 @@ summary_raw=$(summary_json \
   "$GAME_URL" \
   "$render_mode" \
   "$auth_ready" \
-  true true true true true "$agent_spoke_seen" "$agent_spoke_seen_immediate" "$agent_spoke_needed_advance" "$([[ "$REQUIRE_AGENT_SPOKE" -eq 1 ]] && printf 'true' || printf 'false')" "$([[ "$require_immediate_agent_spoke" -eq 1 ]] && printf 'true' || printf 'false')")
+  true true true true true "$agent_spoke_seen" "$agent_spoke_seen_immediate" "$agent_spoke_needed_advance" "$([[ "$REQUIRE_AGENT_SPOKE" -eq 1 ]] && printf 'true' || printf 'false')" "$([[ "$require_immediate_agent_spoke" -eq 1 ]] && printf 'true' || printf 'false')" \
+  "$agent_spoke_expected_message" \
+  "$agent_spoke_required_contains_json" \
+  "$agent_spoke_forbidden_contains_json" \
+  "$agent_spoke_message")
 printf '%s\n' "$summary_raw" >"$summary_json_path"
 python3 - "$summary_json_path" "$summary_md_path" <<'PY'
 import json
@@ -608,6 +660,10 @@ lines = [
     f"- agentSpokeNeededAdvance: `{data['agentSpokeNeededAdvance']}`",
     f"- requireAgentSpoke: `{data['requireAgentSpoke']}`",
     f"- requireImmediateAgentSpoke: `{data['requireImmediateAgentSpoke']}`",
+    f"- agentSpokeExpectedMessage: `{data['agentSpokeExpectedMessage']}`",
+    f"- agentSpokeRequiredContains: `{data['agentSpokeRequiredContains']}`",
+    f"- agentSpokeForbiddenContains: `{data['agentSpokeForbiddenContains']}`",
+    f"- agentSpokeMessage: `{data['agentSpokeMessage']}`",
     f"- gameUrl: `{data['gameUrl']}`",
 ]
 out.write_text("\n".join(lines) + "\n", encoding='utf-8')

--- a/testing-manual.md
+++ b/testing-manual.md
@@ -378,6 +378,7 @@ env -u RUSTC_WRAPPER cargo check -p oasis7_viewer --target wasm32-unknown-unknow
 ### S6：Web UI 闭环 smoke 套件（L4A）
 - S6 详细执行步骤、agent-browser 命令、发布门禁与补充约定已拆分到：
   - `doc/testing/manual/web-ui-agent-browser-closure-manual.manual.md`
+  - `doc/testing/manual/web-ui-playwright-closure-manual.manual.md`（Playwright 实跑系列入口，管理真实本地栈 + 真实 UI 操作流程矩阵）
   - `doc/testing/manual/web-ui-agent-browser-closure-manual.prd.md`（需求边界/成功标准）
   - `doc/testing/manual/model-visual-review-sop-2026-05-29.manual.md`（截图加模型视觉评审，用于替代 routine 人工视觉 review）
   - `doc/testing/launcher/launcher-manual-test-checklist-2026-03-10.prd.md`（发布前人工体验与异常恢复检查清单）
@@ -389,6 +390,7 @@ env -u RUSTC_WRAPPER cargo check -p oasis7_viewer --target wasm32-unknown-unknow
   - repo-owned `remote_https` 参考装配当前采用 `oasis7_provider_local_bridge` + `scripts/provider-remote-https/letai_provider_cli.py` + `nginx` HTTPS 反代；操作步骤见 `doc/world-runtime/runtime/provider-remote-https-bridge-operator-runbook.md`。
   - 任何 QA / release / playability 结论都应先标明玩家访问模式，再补充 execution lane；不得把 `headless_agent` 直接当成“第三种入口”。
 - `oasis7_viewer_live` / Viewer 页面：默认使用 `agent-browser` 驱动页面与采集证据；当 `renderMode=viewer`（或兼容 alias `software_safe`）且带 viewer auth bootstrap 时，允许继续验证选中 Agent 的最小 `prompt/chat` 闭环。
+- 需要验证真实玩家输入流程、真实 provider、真实本地栈的一整条 Playwright 闭环时，进入 `doc/testing/manual/web-ui-playwright-closure-manual.manual.md`。当前首个用例是 `PWT-001 Real Agent Chat`：`./scripts/viewer-real-agent-chat-regression.sh` 会启动本地 LetAI 栈、打开 Viewer、通过可见 UI 聊天输入框和发送按钮发消息、等待真实 Agent 回复，并断言不含 mock 标记；后续所有 Playwright 实跑用例按该手册的 `PWT-###` 矩阵扩展。
 - 若只需要回归 `software_safe` 纯实时最小闭环（加载 -> 连接 -> 选择目标 -> 实时事件/语义摘要可见，且页面不再暴露回放控件），优先执行 `./scripts/viewer-software-safe-step-regression.sh`；该脚本不再主动调用 `__AW_TEST__.sendControl('step')`，而是等待 `logicalTime/eventSeq` 自然增长；若当前 runtime 被 `llm_required` 等 gameplay blocker 卡住，则要求页面显式暴露 blocker，而不是再用手动步进补推进。
 - 若只想先确认 Web/UI automation tooling 本身没有漂移，而不想起完整 runtime/build，先执行 `./scripts/viewer-software-safe-step-regression-smoke.sh`；它会用临时 fixture 页面复用真 `agent-browser` 与 `viewer-software-safe-step-regression.sh` 验证最小浏览器链路和 summary/state 产物契约，但不替代正式 S6 证据。
 - 若需要把 `software_safe` 的 prompt/chat/rollback/message-flow 做成独立 QA smoke，优先执行 `./scripts/viewer-software-safe-chat-regression.sh`；当脚本自举 source stack 并自动启用 `OASIS7_RUNTIME_AGENT_CHAT_ECHO=1` 时，若 QA echo 没有在 `chat ack` 后、无额外 `step/play` 的同一轮交互里进入消息流，会直接判为阻断失败；外部 URL 场景仍默认把 `agent_spoke` 缺失记为可追溯 warning，显式加 `--require-agent-spoke` 时再升级为阻断失败。
@@ -954,7 +956,7 @@ rg -n "conflicting attestation already exists|attestation threshold not met|atte
 | S3 | 应用主链定向 | runtime / simulator / viewer live / web bridge 定向改动 | 定向 cargo test 日志 |
 | S4 | 分布式子系统 | node / net / consensus / distfs / P2P 链路改动 | 子系统测试日志 |
 | S5 | viewer crate / wasm 编译 | `crates/oasis7_viewer/**` 或 viewer wasm 构建链路改动 | viewer 单测 + wasm 编译日志 |
-| S6 | Web UI 闭环 smoke | Viewer / launcher / Web 控制台 / 交互链路改动；任何可视化相关代码、样式、资源或可见输出改动还必须叠加截图模型视觉评审 | 截图、console、语义结果；visual review card |
+| S6 | Web UI 闭环 smoke | Viewer / launcher / Web 控制台 / 交互链路改动；真实玩家输入流程或真实 provider 回归优先补 Playwright 实跑用例；任何可视化相关代码、样式、资源或可见输出改动还必须叠加截图模型视觉评审 | 截图、console、语义结果；Playwright summary/state；visual review card |
 | S7 | 场景矩阵回归 | scenario / gameplay 初始化 / 场景 ID 与稳定性改动 | 场景测试日志 |
 | S8 | 长稳与压力 | 性能、内存、恢复、资源压力或 soak 相关改动 | stress/soak 目录与 summary |
 | S9 | P2P/存储/共识在线长跑 | 分布式一致性、存储、共识、在线网络改动 | S9 summary / timeline / failures |


### PR DESCRIPTION
## Summary
- harden the local LetAI playtest one-command CLI with actionable preflight diagnostics, dynamic port checks, and safer startup behavior
- add provider-authored Agent chat RPC flow plus runtime/control-plane handling for real replies
- add PWT-001 Playwright real-run regression covering marker selection, real UI chat input, provider reply, no-mock assertions, artifacts, and cleanup checks
- document the Playwright real-run test series entry point

## Verification
- `./scripts/viewer-real-agent-chat-regression.sh` -> passed, artifact `output/playwright/viewer-real-agent-chat/20260617-215234/playwright`, `selectionMode=ui-agent-marker`, `noMockMarkersDetected=true`
- `./scripts/run-local-letai-game-test.test.sh`
- `./scripts/cargo-dev.sh test -p oasis7 --bin oasis7_provider_local_bridge agent_chat_idempotency_key_distinguishes_same_tick_messages -- --nocapture`
- `./scripts/cargo-dev.sh test -p oasis7 --lib runtime_agent_chat_provider_mode_accepts_feedback_without_echo_receipt -- --nocapture`
- `./scripts/cargo-dev.sh test -p oasis7 --lib runtime_agent_chat_provider_mode_reports_feedback_failure -- --nocapture`
- `/Users/scc/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node --check crates/oasis7_viewer/viewer.js`
- `/Users/scc/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node --check crates/oasis7_viewer/dist/viewer.js`
- `/Users/scc/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node --check crates/oasis7_viewer/scripts/real-agent-chat-regression.mjs`
- `./scripts/cargo-dev.sh fmt --check`
- `git diff --check`
- `./scripts/doc-governance-check.sh`

## Review
Pre-PR local role review passed for runtime_engineer, viewer_engineer, qa_engineer, and repository_health_engineer. Findings were addressed before PR creation.