### PR TITLE
Recover active transport request fallback

### DIFF
--- a/.pm/tasks/task_c612861fd1fe4187b789ceff61a6d0f7.execution.md
+++ b/.pm/tasks/task_c612861fd1fe4187b789ceff61a6d0f7.execution.md
@@ -203,3 +203,51 @@ Example:
 - Expected Result: peer selection tests pass.
 - Actual Result: passed, 10 tests.
 - Blocker / Next Action: amend commit, force-push branch, recheck PR #508 checks and review comments.
+
+## 2026-06-18 01:28:00 CST / tpm
+- 完成内容: PR #508 merged to `main` as `072c773a7091d5a6daca6a0ae787089a435458b6`; Testnet Packages run `27704122480` produced Linux x64 package `0.0.0+testnet.97.072c773a7091`; all-existing Testnet Packages run `27705230788` produced Windows x64 package `0.0.0+testnet.98.072c773a7091`. Upgraded sequencer/storage/Linux observer with `scripts/p2p-public-testnet-package-node-upgrade.sh`, upgraded local macOS arm64 node from local release build, and upgraded Windows observer with the run 98 NSIS installer plus runtime hash rewrite.
+- 遗留事项: Five-node health after the first code fix remained not ready; this live validation found a second code-level root cause.
+- Action: Post-upgrade samples showed Windows changed from `no connected providers` to `no connected peers` while its process had an active TCP/libp2p transport to ECS peers; `connected_peers=[]`, `registered_protocols=[]`, height stuck at 17536, lag 167. Sequencer/storage/fourth/Linux observer were on the new commit but still showed nonzero recent replication errors / transport instability, with sequencer storage challenge degraded.
+- Validation Command: `.tmp/five_node_expect_health.sh`
+- Expected Result: five nodes running, no persistent runtime last_error, observers catch up, no storage challenge degraded, no persistent transport warning.
+- Actual Result: failed. Sample 4: sequencer height 17737 lag 0 but `storage_challenge=true`, transport false, recent_errors 71; storage height 17734 lag 2, transport false, recent_errors 23; Linux observer height 17737 lag 0, transport false, recent_errors 8; fourth local height 17737 lag 0, transport false, recent_errors 18; Windows height 17536 lag 167, last_error `no connected peers for protocol /aw/node/replication/fetch-commit/1.0.0`.
+- Blocker / Next Action: code-level follow-up required before another package/upgrade pass; runtime loop request selection must honor active transport fallback, not only the connected peer snapshot.
+
+## 2026-06-18 01:36:00 CST / tpm
+- 完成内容: Started second code-level fix on branch `codex/replication-active-transport-request-fallback`.
+- 遗留事项: Needs PR, package build, and live node replacement before acceptance can pass.
+- Action: Updated `crates/oasis7_net/src/libp2p_net/runtime_loop.rs` so `Command::Request` falls back to active transport peers from peer-health state when the connected peer snapshot is empty, and `Command::RequestToPeer` accepts peers that are connected by active transport fallback. Added regression coverage in `crates/oasis7_net/src/libp2p_net/tests/request_peer_filter_tests.rs`.
+- Validation Command: `env -u RUSTC_WRAPPER cargo fmt --check`
+- Expected Result: formatting passes.
+- Actual Result: passed.
+- Validation Command: `env -u RUSTC_WRAPPER cargo test -p oasis7_net request_peer -- --nocapture`
+- Expected Result: request peer filtering tests pass.
+- Actual Result: passed, 14 tests.
+- Validation Command: `env -u RUSTC_WRAPPER cargo test -p oasis7_net admissible_request -- --nocapture`
+- Expected Result: admissible request peer tests pass.
+- Actual Result: passed, 4 tests.
+- Blocker / Next Action: pre-PR local role review found one P2 test coverage gap; add direct `handle_command` runtime-path regression tests.
+
+## 2026-06-18 01:47:00 CST / tpm
+- 完成内容: Addressed qa_engineer P2 pre-PR finding for the active transport fallback patch.
+- 遗留事项: Needs QA recheck, PR, package build, and live node replacement before acceptance can pass.
+- Action: Added direct `handle_command` regression coverage proving `Command::Request` and `Command::RequestToPeer` create pending requests when `peers` and `swarm.connected_peers()` are empty but peer-health state contains an admissible active transport path.
+- Validation Command: `env -u RUSTC_WRAPPER cargo fmt --check`
+- Expected Result: formatting passes.
+- Actual Result: passed.
+- Validation Command: `env -u RUSTC_WRAPPER cargo test -p oasis7_net active_transport -- --nocapture`
+- Expected Result: active transport fallback and handle-command tests pass.
+- Actual Result: passed, 12 tests.
+- Validation Command: `env -u RUSTC_WRAPPER cargo test -p oasis7_net request_peer -- --nocapture`
+- Expected Result: request peer filtering tests pass with new runtime coverage present.
+- Actual Result: passed, 14 tests.
+- Blocker / Next Action: request QA recheck, then commit amend/push/create PR.
+
+## 2026-06-18 01:50:00 CST / tpm
+- 完成内容: Pre-PR Local Role Review: passed for `codex/replication-active-transport-request-fallback`.
+- 遗留事项: GitHub PR checks and live redeploy validation remain.
+- Action: runtime_engineer review slice returned no findings. qa_engineer first found a P2 missing runtime-level test; after adding direct `handle_command` coverage, qa_engineer recheck returned no findings and confirmed coverage is adequate.
+- Validation Command: runtime_engineer + qa_engineer bounded review slices.
+- Expected Result: no unresolved P0/P1/P2 findings before PR.
+- Actual Result: passed; no unresolved findings.
+- Blocker / Next Action: push branch, create PR, monitor checks, merge/package/redeploy.

--- a/crates/oasis7_net/src/libp2p_net/runtime_loop.rs
+++ b/crates/oasis7_net/src/libp2p_net/runtime_loop.rs
@@ -182,10 +182,40 @@ pub(super) fn dial_target_is_already_connected(peers: &[PeerId], addr: &Multiadd
         .unwrap_or(false)
 }
 
-fn current_request_peers(peers: &[PeerId], swarm: &Swarm<Behaviour>) -> Vec<PeerId> {
+fn current_request_peers(
+    peers: &[PeerId],
+    swarm: &Swarm<Behaviour>,
+    peer_healths: &HashMap<PeerId, PeerManagerPeerHealth>,
+) -> Vec<PeerId> {
     let mut current = peers.to_vec();
     current.extend(swarm.connected_peers().copied());
-    super::api::dedup_sorted_peers(current)
+    let current = super::api::dedup_sorted_peers(current);
+    if !current.is_empty() {
+        return current;
+    }
+    active_transport_request_peers(peer_healths)
+}
+
+pub(super) fn active_transport_request_peers(
+    peer_healths: &HashMap<PeerId, PeerManagerPeerHealth>,
+) -> Vec<PeerId> {
+    let peers = peer_healths
+        .iter()
+        .filter(|(_, health)| health.active_path_kind.is_some())
+        .map(|(peer_id, _)| *peer_id)
+        .collect::<Vec<_>>();
+    filter_request_peers_by_health(super::api::dedup_sorted_peers(peers), peer_healths)
+}
+
+fn request_peer_is_connected_or_active(
+    peer: PeerId,
+    peers: &[PeerId],
+    swarm: &Swarm<Behaviour>,
+    peer_healths: &HashMap<PeerId, PeerManagerPeerHealth>,
+) -> bool {
+    peers.contains(&peer)
+        || swarm.is_connected(&peer)
+        || active_transport_request_peers(peer_healths).contains(&peer)
 }
 
 pub(super) fn filter_request_peers_by_lane(
@@ -650,7 +680,8 @@ pub(super) fn handle_command(
             providers,
             response,
         }) => {
-            let connected_request_peers = current_request_peers(peers.as_slice(), swarm);
+            let connected_request_peers =
+                current_request_peers(peers.as_slice(), swarm, peer_healths_by_id);
             if connected_request_peers.is_empty() {
                 if providers.is_empty() {
                     if let Some(handler) = handlers.get(&protocol) {
@@ -725,7 +756,12 @@ pub(super) fn handle_command(
             peer,
             response,
         }) => {
-            if !peers.contains(&peer) && !swarm.is_connected(&peer) {
+            if !request_peer_is_connected_or_active(
+                peer,
+                peers.as_slice(),
+                swarm,
+                peer_healths_by_id,
+            ) {
                 let _ = response.send(Err(WorldError::NetworkProtocolUnavailable {
                     protocol: format!("peer {peer} is not connected for protocol {protocol}"),
                 }));

--- a/crates/oasis7_net/src/libp2p_net/tests/request_peer_filter_tests.rs
+++ b/crates/oasis7_net/src/libp2p_net/tests/request_peer_filter_tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::libp2p_net::runtime_loop::active_transport_request_peers;
 
 #[test]
 fn filter_request_peers_by_health_prefers_non_suspect_peers() {
@@ -142,6 +143,78 @@ fn filter_request_peers_by_health_keeps_record_exchange_pending_blocked_peer_as_
 
     let filtered = filter_request_peers_by_health(peers, &healths);
     assert_eq!(filtered, vec![active_peer, soft_blocked_peer]);
+}
+
+#[test]
+fn active_transport_request_peers_keeps_record_exchange_pending_bootstrap_peer() {
+    let bootstrap_peer = PeerId::random();
+    let hard_blocked_peer = PeerId::random();
+    let healths = HashMap::from([
+        (
+            bootstrap_peer,
+            PeerManagerPeerHealth {
+                peer_id: bootstrap_peer.to_string(),
+                status: PeerManagerHealthStatus::Blocked,
+                issues: vec![
+                    PeerManagerHealthIssue::MissingPeerRecord,
+                    PeerManagerHealthIssue::InsufficientActiveDiscoverySources {
+                        observed_sources: 1,
+                        required_sources: 2,
+                    },
+                ],
+                discovery_sources: Vec::new(),
+                active_path_kind: Some("direct".to_string()),
+                source_operator: None,
+                source_asn: None,
+            },
+        ),
+        (
+            hard_blocked_peer,
+            PeerManagerPeerHealth {
+                peer_id: hard_blocked_peer.to_string(),
+                status: PeerManagerHealthStatus::Blocked,
+                issues: vec![PeerManagerHealthIssue::RelayBudgetExceeded {
+                    relayed_active_peers: 2,
+                    active_peer_count: 2,
+                    limit_per_mille: 500,
+                }],
+                discovery_sources: Vec::new(),
+                active_path_kind: Some("relay_reserved".to_string()),
+                source_operator: None,
+                source_asn: None,
+            },
+        ),
+    ]);
+
+    assert_eq!(
+        active_transport_request_peers(&healths),
+        vec![bootstrap_peer]
+    );
+}
+
+#[test]
+fn active_transport_request_peers_returns_empty_without_active_path() {
+    let bootstrap_peer = PeerId::random();
+    let healths = HashMap::from([(
+        bootstrap_peer,
+        PeerManagerPeerHealth {
+            peer_id: bootstrap_peer.to_string(),
+            status: PeerManagerHealthStatus::Blocked,
+            issues: vec![
+                PeerManagerHealthIssue::MissingPeerRecord,
+                PeerManagerHealthIssue::InsufficientActiveDiscoverySources {
+                    observed_sources: 1,
+                    required_sources: 2,
+                },
+            ],
+            discovery_sources: Vec::new(),
+            active_path_kind: None,
+            source_operator: None,
+            source_asn: None,
+        },
+    )]);
+
+    assert!(active_transport_request_peers(&healths).is_empty());
 }
 
 #[test]

--- a/crates/oasis7_net/src/libp2p_net/tests/subscribe_ack_tests.rs
+++ b/crates/oasis7_net/src/libp2p_net/tests/subscribe_ack_tests.rs
@@ -9,7 +9,10 @@ use libp2p::{identity::Keypair, Multiaddr, PeerId};
 use super::super::runtime_loop::{
     handle_command, Command, CommandContext, CommandOutcome, CommandStateRefs,
 };
-use super::super::{Libp2pReachabilitySnapshot, DEFAULT_SUBSCRIPTION_INBOX_MAX_MESSAGES};
+use super::super::{
+    Libp2pReachabilitySnapshot, PeerManagerHealthIssue, PeerManagerHealthStatus,
+    PeerManagerPeerHealth, DEFAULT_SUBSCRIPTION_INBOX_MAX_MESSAGES,
+};
 
 #[test]
 fn handle_command_subscribe_acknowledges_success() {
@@ -243,6 +246,240 @@ fn handle_command_request_uses_swarm_connections_when_runtime_peers_are_empty() 
         pending.len(),
         1,
         "request should be sent through swarm connection"
+    );
+    assert!(matches!(
+        receiver.try_recv(),
+        Err(std::sync::mpsc::TryRecvError::Empty)
+    ));
+}
+
+#[test]
+fn handle_command_request_uses_active_transport_peer_when_snapshots_are_empty() {
+    let keypair = Keypair::generate_ed25519();
+    let mut swarm = super::super::swarm_behaviour::build_swarm(
+        &keypair,
+        false,
+        true,
+        std::time::Duration::from_secs(30),
+        super::super::wire_bytes::init_shared_wire_byte_counters(),
+    );
+    let active_peer = PeerId::random();
+    let event_published = Arc::new(Mutex::new(Vec::new()));
+    let event_errors = Arc::new(Mutex::new(Vec::new()));
+    let event_listening_addrs = Arc::new(Mutex::new(Vec::new()));
+    let event_reachability = Arc::new(Mutex::new(Libp2pReachabilitySnapshot::default()));
+    let event_traffic_metrics = super::super::traffic_metrics::init_shared_traffic_metrics();
+    let mut subscriptions = HashSet::new();
+    let mut topic_map = HashMap::new();
+    let mut topic_inbox_limits = HashMap::new();
+    let mut handlers = HashMap::new();
+    let mut pending = HashMap::new();
+    let mut pending_peer_record_requests = HashMap::new();
+    let mut pending_dht = HashMap::new();
+    let mut peers = Vec::new();
+    let mut provider_keys = HashMap::new();
+    let discovered_peer_records = HashMap::new();
+    let peer_healths_by_id = HashMap::from([(
+        active_peer,
+        PeerManagerPeerHealth {
+            peer_id: active_peer.to_string(),
+            status: PeerManagerHealthStatus::Blocked,
+            issues: vec![
+                PeerManagerHealthIssue::MissingPeerRecord,
+                PeerManagerHealthIssue::InsufficientActiveDiscoverySources {
+                    observed_sources: 1,
+                    required_sources: 2,
+                },
+            ],
+            discovery_sources: Vec::new(),
+            active_path_kind: Some("direct".to_string()),
+            source_operator: None,
+            source_asn: None,
+        },
+    )]);
+    let mut pending_cached_discovery_peers = HashSet::new();
+    let mut cached_discovery_peer_cooldowns = HashMap::new();
+    let mut pending_rendezvous_registers = HashSet::new();
+    let mut pending_rendezvous_discovers = HashSet::new();
+    let registered_rendezvous_nodes = HashSet::new();
+    let rendezvous_cookies = HashMap::new();
+    let mut peer_record_last_published_at_ms = None;
+    let mut peer_discovery_query_last_started_at_ms = None;
+    let (sender, receiver) = std::sync::mpsc::channel();
+
+    let outcome = handle_command(
+        &mut swarm,
+        Some(Command::Request {
+            protocol: "/aw/test/active-transport-request/1.0.0".to_string(),
+            payload: b"ping".to_vec(),
+            providers: vec![active_peer.to_string()],
+            response: sender,
+        }),
+        CommandStateRefs {
+            subscriptions: &mut subscriptions,
+            topic_map: &mut topic_map,
+            topic_inbox_limits: &mut topic_inbox_limits,
+            handlers: &mut handlers,
+            pending: &mut pending,
+            pending_peer_record_requests: &mut pending_peer_record_requests,
+            pending_dht: &mut pending_dht,
+            peers: &mut peers,
+            provider_keys: &mut provider_keys,
+            discovered_peer_records: &discovered_peer_records,
+            peer_healths_by_id: &peer_healths_by_id,
+            pending_cached_discovery_peers: &mut pending_cached_discovery_peers,
+            cached_discovery_peer_cooldowns: &mut cached_discovery_peer_cooldowns,
+            pending_rendezvous_registers: &mut pending_rendezvous_registers,
+            pending_rendezvous_discovers: &mut pending_rendezvous_discovers,
+            registered_rendezvous_nodes: &registered_rendezvous_nodes,
+            rendezvous_cookies: &rendezvous_cookies,
+            peer_record_last_published_at_ms: &mut peer_record_last_published_at_ms,
+            peer_discovery_query_last_started_at_ms: &mut peer_discovery_query_last_started_at_ms,
+        },
+        &CommandContext {
+            event_published: &event_published,
+            event_errors: &event_errors,
+            event_listening_addrs: &event_listening_addrs,
+            event_reachability: &event_reachability,
+            event_traffic_metrics: &event_traffic_metrics,
+            keypair: &keypair,
+            peer_record_template: None,
+            local_peer_id: PeerId::from(keypair.public()),
+            max_published_messages: 8,
+            max_error_messages: 8,
+            republish_interval_ms: 1_000,
+            discovery_query_cooldown_ms: 1_000,
+            allow_loopback_external_addrs_for_testing: true,
+        },
+    );
+
+    assert!(matches!(outcome, CommandOutcome::Continue));
+    assert!(peers.is_empty(), "test must keep runtime peers empty");
+    assert!(
+        !swarm.is_connected(&active_peer),
+        "test must rely on active transport health fallback"
+    );
+    assert_eq!(
+        pending.len(),
+        1,
+        "provider request should be sent through active transport fallback"
+    );
+    assert!(matches!(
+        receiver.try_recv(),
+        Err(std::sync::mpsc::TryRecvError::Empty)
+    ));
+}
+
+#[test]
+fn handle_command_request_to_peer_accepts_active_transport_peer() {
+    let keypair = Keypair::generate_ed25519();
+    let mut swarm = super::super::swarm_behaviour::build_swarm(
+        &keypair,
+        false,
+        true,
+        std::time::Duration::from_secs(30),
+        super::super::wire_bytes::init_shared_wire_byte_counters(),
+    );
+    let active_peer = PeerId::random();
+    let event_published = Arc::new(Mutex::new(Vec::new()));
+    let event_errors = Arc::new(Mutex::new(Vec::new()));
+    let event_listening_addrs = Arc::new(Mutex::new(Vec::new()));
+    let event_reachability = Arc::new(Mutex::new(Libp2pReachabilitySnapshot::default()));
+    let event_traffic_metrics = super::super::traffic_metrics::init_shared_traffic_metrics();
+    let mut subscriptions = HashSet::new();
+    let mut topic_map = HashMap::new();
+    let mut topic_inbox_limits = HashMap::new();
+    let mut handlers = HashMap::new();
+    let mut pending = HashMap::new();
+    let mut pending_peer_record_requests = HashMap::new();
+    let mut pending_dht = HashMap::new();
+    let mut peers = Vec::new();
+    let mut provider_keys = HashMap::new();
+    let discovered_peer_records = HashMap::new();
+    let peer_healths_by_id = HashMap::from([(
+        active_peer,
+        PeerManagerPeerHealth {
+            peer_id: active_peer.to_string(),
+            status: PeerManagerHealthStatus::Blocked,
+            issues: vec![
+                PeerManagerHealthIssue::MissingPeerRecord,
+                PeerManagerHealthIssue::InsufficientActiveDiscoverySources {
+                    observed_sources: 1,
+                    required_sources: 2,
+                },
+            ],
+            discovery_sources: Vec::new(),
+            active_path_kind: Some("direct".to_string()),
+            source_operator: None,
+            source_asn: None,
+        },
+    )]);
+    let mut pending_cached_discovery_peers = HashSet::new();
+    let mut cached_discovery_peer_cooldowns = HashMap::new();
+    let mut pending_rendezvous_registers = HashSet::new();
+    let mut pending_rendezvous_discovers = HashSet::new();
+    let registered_rendezvous_nodes = HashSet::new();
+    let rendezvous_cookies = HashMap::new();
+    let mut peer_record_last_published_at_ms = None;
+    let mut peer_discovery_query_last_started_at_ms = None;
+    let (sender, receiver) = std::sync::mpsc::channel();
+
+    let outcome = handle_command(
+        &mut swarm,
+        Some(Command::RequestToPeer {
+            protocol: "/aw/test/active-transport-request-to-peer/1.0.0".to_string(),
+            payload: b"ping".to_vec(),
+            peer: active_peer,
+            response: sender,
+        }),
+        CommandStateRefs {
+            subscriptions: &mut subscriptions,
+            topic_map: &mut topic_map,
+            topic_inbox_limits: &mut topic_inbox_limits,
+            handlers: &mut handlers,
+            pending: &mut pending,
+            pending_peer_record_requests: &mut pending_peer_record_requests,
+            pending_dht: &mut pending_dht,
+            peers: &mut peers,
+            provider_keys: &mut provider_keys,
+            discovered_peer_records: &discovered_peer_records,
+            peer_healths_by_id: &peer_healths_by_id,
+            pending_cached_discovery_peers: &mut pending_cached_discovery_peers,
+            cached_discovery_peer_cooldowns: &mut cached_discovery_peer_cooldowns,
+            pending_rendezvous_registers: &mut pending_rendezvous_registers,
+            pending_rendezvous_discovers: &mut pending_rendezvous_discovers,
+            registered_rendezvous_nodes: &registered_rendezvous_nodes,
+            rendezvous_cookies: &rendezvous_cookies,
+            peer_record_last_published_at_ms: &mut peer_record_last_published_at_ms,
+            peer_discovery_query_last_started_at_ms: &mut peer_discovery_query_last_started_at_ms,
+        },
+        &CommandContext {
+            event_published: &event_published,
+            event_errors: &event_errors,
+            event_listening_addrs: &event_listening_addrs,
+            event_reachability: &event_reachability,
+            event_traffic_metrics: &event_traffic_metrics,
+            keypair: &keypair,
+            peer_record_template: None,
+            local_peer_id: PeerId::from(keypair.public()),
+            max_published_messages: 8,
+            max_error_messages: 8,
+            republish_interval_ms: 1_000,
+            discovery_query_cooldown_ms: 1_000,
+            allow_loopback_external_addrs_for_testing: true,
+        },
+    );
+
+    assert!(matches!(outcome, CommandOutcome::Continue));
+    assert!(peers.is_empty(), "test must keep runtime peers empty");
+    assert!(
+        !swarm.is_connected(&active_peer),
+        "test must rely on active transport health fallback"
+    );
+    assert_eq!(
+        pending.len(),
+        1,
+        "direct request should be sent through active transport fallback"
     );
     assert!(matches!(
         receiver.try_recv(),


### PR DESCRIPTION
## Summary
- route libp2p runtime requests through active transport peers when connected peer snapshots are empty
- allow RequestToPeer admission through the same active transport fallback
- add runtime-level handle_command regressions for Request and RequestToPeer fallback paths

## Validation
- env -u RUSTC_WRAPPER cargo fmt --check
- env -u RUSTC_WRAPPER cargo test -p oasis7_net active_transport -- --nocapture
- env -u RUSTC_WRAPPER cargo test -p oasis7_net request_peer -- --nocapture
- env -u RUSTC_WRAPPER cargo test -p oasis7_net admissible_request -- --nocapture

## Live Context
- follow-up from five-node testnet upgrade: Windows observer had active transport evidence but gap-sync failed with `no connected peers for protocol /aw/node/replication/fetch-commit/1.0.0` because runtime request selection only trusted connected peer snapshots.