### PR TITLE
Avoid blocking replication provider publication

### DIFF
--- a/.pm/tasks/task_c612861fd1fe4187b789ceff61a6d0f7.execution.md
+++ b/.pm/tasks/task_c612861fd1fe4187b789ceff61a6d0f7.execution.md
@@ -251,3 +251,72 @@ Example:
 - Expected Result: no unresolved P0/P1/P2 findings before PR.
 - Actual Result: passed; no unresolved findings.
 - Blocker / Next Action: push branch, create PR, monitor checks, merge/package/redeploy.
+
+## 2026-06-18 02:32:00 CST / tpm
+- 完成内容: PR #509 merged and Testnet Packages run `27708440428` produced `0.0.0+testnet.99.e4432716c608`; upgraded sequencer/storage/Linux observer/local fourth/Windows observer to run 99 or matching local macOS arm64 build.
+- 遗留事项: Five-node health still failed after upgrade; this produced a third code-level root cause.
+- Action: Post-upgrade health showed sequencer `last_error=node replication error: replication network route unavailable: libp2p command publish timed out after 30000ms` and `storage_challenge_network_degraded_height=17801` with reason `blob fetch provider routes exhausted without response ... before retryable provider failure`. This points to provider publication/discovery starvation rather than an ops restart problem. Root-cause patch started on branch `codex/nonblocking-provider-publish`: add a `DistributedDht::publish_provider_best_effort` path and make the libp2p implementation enqueue `PublishProvider` without a response channel, so the node tick path no longer synchronously waits on Kademlia provider publication.
+- Validation Command: `env -u RUSTC_WRAPPER cargo fmt --check`
+- Expected Result: formatting passes.
+- Actual Result: passed.
+- Validation Command: `env -u RUSTC_WRAPPER cargo test -p oasis7_node best_effort_provider_publish_does_not_block_on_slow_dht -- --nocapture`
+- Expected Result: regression proves best-effort provider publish returns while a slow DHT publish is still in progress.
+- Actual Result: passed, 1 test.
+- Validation Command: `env -u RUSTC_WRAPPER cargo test -p oasis7_node fetch_blob_provider_route -- --nocapture`
+- Expected Result: existing provider-route strict fallback boundaries still pass.
+- Actual Result: passed, 2 tests.
+- Validation Command: `env -u RUSTC_WRAPPER cargo test -p oasis7_node storage_challenge_gate_provider -- --nocapture`
+- Expected Result: provider lookup fallback storage challenge tests still pass.
+- Actual Result: passed, 3 tests.
+- Blocker / Next Action: run wider validation, dispatch pre-PR role review, create/merge PR, package and redeploy this third fix.
+
+## 2026-06-18 02:45:00 CST / tpm
+- 完成内容: Addressed qa_engineer P1 pre-PR finding: fetch-commit handler still used blocking `publish_local_content_provider` before checkpoint descriptor provider publication.
+- 遗留事项: Needs QA recheck, commit, PR, package, redeploy and live health validation.
+- Action: Added `NodeReplicationNetworkHandle::publish_local_content_provider_best_effort` and `publish_checkpoint_descriptor_providers_from_root_best_effort`; changed fetch-commit provider publication to use these best-effort APIs for both commit payload provider and checkpoint descriptor blob providers. Added/updated DHT best-effort trait coverage so production libp2p enqueues provider publication without waiting for Kademlia completion, while strict APIs remain available for explicit synchronous callers.
+- Validation Command: `env -u RUSTC_WRAPPER cargo test -p oasis7_node fetch_commit_handler_does_not_block_on_checkpoint_provider_publish -- --nocapture`
+- Expected Result: fetch-commit response returns before provider publication can block, and provider publication is still scheduled.
+- Actual Result: passed, 1 test.
+- Validation Command: `env -u RUSTC_WRAPPER cargo test -p oasis7_node fetch_commit_handler_publishes_commit_payload_provider_to_dht -- --nocapture`
+- Expected Result: fetch-commit handler still publishes the commit payload provider route.
+- Actual Result: passed, 1 test.
+- Validation Command: `env -u RUSTC_WRAPPER cargo fmt --check`
+- Expected Result: formatting passes.
+- Actual Result: passed.
+- Validation Command: `env -u RUSTC_WRAPPER cargo test -p oasis7_node best_effort_provider_publish_does_not_block_on_slow_dht -- --nocapture`
+- Expected Result: endpoint best-effort DHT provider publication does not block on a slow strict DHT publish.
+- Actual Result: passed, 1 test.
+- Validation Command: `env -u RUSTC_WRAPPER cargo test -p oasis7_node fetch_blob_provider_route -- --nocapture`
+- Expected Result: existing provider-route strict fallback boundaries still pass.
+- Actual Result: passed, 2 tests.
+- Validation Command: `env -u RUSTC_WRAPPER cargo test -p oasis7_node storage_challenge_gate_provider -- --nocapture`
+- Expected Result: storage challenge provider lookup fallback tests still pass.
+- Actual Result: passed, 3 tests.
+- Validation Command: `env -u RUSTC_WRAPPER cargo test -p oasis7_net publish_provider -- --nocapture`
+- Expected Result: libp2p provider-publish code compiles with new optional response command path.
+- Actual Result: passed compile with 0 matching tests.
+- Validation Command: runtime_engineer + qa_engineer bounded pre-PR review slices.
+- Expected Result: no unresolved P0/P1/P2 findings before PR.
+- Actual Result: passed. runtime_engineer: no findings. qa_engineer initially found P1 blocking fetch-commit provider publication path; after changing fetch-commit provider publication to best-effort APIs, qa_engineer recheck returned no findings.
+- Blocker / Next Action: commit, push, create PR, monitor checks, merge/package/redeploy.
+
+## 2026-06-18 02:58:00 CST / tpm
+- 完成内容: Fixed PR #510 required-gate failure from `./scripts/check-rust-file-size.sh`.
+- 遗留事项: PR checks must rerun after force-push; then merge/package/redeploy.
+- Action: Moved inline `network_bridge` tests into `crates/oasis7_node/src/tests_network_bridge.rs` as a `network_bridge` child test module so private helper access is preserved while `network_bridge.rs` drops below the 1200-line code limit. Removed now-unused strict checkpoint descriptor provider helper; best-effort provider publication remains the active fetch-commit path.
+- Validation Command: `./scripts/check-rust-file-size.sh`
+- Expected Result: no oversized Rust files.
+- Actual Result: passed; oversized code files=0, test files=0, structural slice files=0, include targets=0, limit=1200.
+- Validation Command: `env -u RUSTC_WRAPPER cargo fmt --check`
+- Expected Result: formatting passes.
+- Actual Result: passed.
+- Validation Command: `env -u RUSTC_WRAPPER cargo test -p oasis7_node best_effort_provider_publish_does_not_block_on_slow_dht -- --nocapture`
+- Expected Result: moved network_bridge regression still passes.
+- Actual Result: passed, 1 test.
+- Validation Command: `env -u RUSTC_WRAPPER cargo test -p oasis7_node fetch_commit_handler_does_not_block_on_checkpoint_provider_publish -- --nocapture`
+- Expected Result: fetch-commit handler nonblocking provider publication regression still passes.
+- Actual Result: passed, 1 test.
+- Validation Command: `env -u RUSTC_WRAPPER cargo test -p oasis7_node fetch_commit_handler_publishes_commit_payload_provider_to_dht -- --nocapture`
+- Expected Result: fetch-commit handler still publishes commit payload provider route.
+- Actual Result: passed, 1 test.
+- Blocker / Next Action: amend/force-push and recheck PR #510.

--- a/crates/oasis7_net/src/libp2p_net/api.rs
+++ b/crates/oasis7_net/src/libp2p_net/api.rs
@@ -329,8 +329,18 @@ impl ProtoDistributedDht<WorldError> for Libp2pNetwork {
     ) -> Result<(), WorldError> {
         let key = dht_provider_key(world_id, content_hash);
         let (sender, receiver) = mpsc::channel();
-        self.enqueue_command(Command::PublishProvider(key, sender))?;
+        self.enqueue_command(Command::PublishProvider(key, Some(sender)))?;
         block_on_command_response(receiver, "publish_provider")
+    }
+
+    fn publish_provider_best_effort(
+        &self,
+        world_id: &str,
+        content_hash: &str,
+        _provider_id: &str,
+    ) -> Result<(), WorldError> {
+        let key = dht_provider_key(world_id, content_hash);
+        self.enqueue_command(Command::PublishProvider(key, None))
     }
 
     fn get_providers(

--- a/crates/oasis7_net/src/libp2p_net/runtime_loop.rs
+++ b/crates/oasis7_net/src/libp2p_net/runtime_loop.rs
@@ -102,7 +102,7 @@ pub(super) enum Command {
         handler: Handler,
         response: CommandResponseSender<()>,
     },
-    PublishProvider(String, CommandResponseSender<()>),
+    PublishProvider(String, Option<CommandResponseSender<()>>),
     GetProviders(String, CommandResponseSender<Vec<ProviderRecord>>),
     PutWorldHead {
         key: String,
@@ -797,17 +797,14 @@ pub(super) fn handle_command(
             match swarm.behaviour_mut().kademlia.start_providing(dht_key) {
                 Ok(query_id) => {
                     provider_keys.insert(key, now_ms());
-                    pending_dht.insert(
-                        query_id,
-                        PendingDhtQuery::PublishProvider {
-                            response: Some(response),
-                        },
-                    );
+                    pending_dht.insert(query_id, PendingDhtQuery::PublishProvider { response });
                 }
                 Err(err) => {
-                    let _ = response.send(Err(WorldError::NetworkProtocolUnavailable {
-                        protocol: format!("kad start_providing failed: {err}"),
-                    }));
+                    if let Some(response) = response {
+                        let _ = response.send(Err(WorldError::NetworkProtocolUnavailable {
+                            protocol: format!("kad start_providing failed: {err}"),
+                        }));
+                    }
                 }
             }
             CommandOutcome::Continue

--- a/crates/oasis7_node/src/lib.rs
+++ b/crates/oasis7_node/src/lib.rs
@@ -864,14 +864,14 @@ fn register_replication_fetch_handlers_with_checkpoint_export(
                             let _ = thread::Builder::new()
                                 .name("replication-fetch-commit-provider-publish".to_string())
                                 .spawn(move || {
-                                    let _ = publish_handle.publish_local_content_provider(
+                                    publish_handle.publish_local_content_provider_best_effort(
                                         &publish_network_policy,
                                         publish_world_id.as_str(),
                                         payload_content_hash.as_str(),
                                     );
                                     if let Some(descriptor) = descriptor {
                                         let _ = publish_handle
-                                            .publish_checkpoint_descriptor_providers_from_root(
+                                            .publish_checkpoint_descriptor_providers_from_root_best_effort(
                                                 &publish_network_policy,
                                                 publish_root_dir.as_path(),
                                                 publish_world_id.as_str(),

--- a/crates/oasis7_node/src/network_bridge.rs
+++ b/crates/oasis7_node/src/network_bridge.rs
@@ -217,7 +217,7 @@ impl NodeReplicationNetworkHandle {
             .map_err(network_err)
     }
 
-    pub(crate) fn publish_checkpoint_descriptor_providers_from_root(
+    pub(crate) fn publish_checkpoint_descriptor_providers_from_root_best_effort(
         &self,
         network_policy: &NodeNetworkPolicy,
         root_dir: &Path,
@@ -227,7 +227,7 @@ impl NodeReplicationNetworkHandle {
         let Some(descriptor) = descriptor else {
             return Ok(());
         };
-        self.publish_checkpoint_blob_provider_from_root(
+        self.publish_checkpoint_blob_provider_from_root_best_effort(
             network_policy,
             root_dir,
             world_id,
@@ -235,7 +235,7 @@ impl NodeReplicationNetworkHandle {
             descriptor.manifest_size_bytes,
         )?;
         for blob_ref in &descriptor.blobs {
-            self.publish_checkpoint_blob_provider_from_root(
+            self.publish_checkpoint_blob_provider_from_root_best_effort(
                 network_policy,
                 root_dir,
                 world_id,
@@ -246,7 +246,7 @@ impl NodeReplicationNetworkHandle {
         Ok(())
     }
 
-    fn publish_checkpoint_blob_provider_from_root(
+    fn publish_checkpoint_blob_provider_from_root_best_effort(
         &self,
         network_policy: &NodeNetworkPolicy,
         root_dir: &Path,
@@ -267,7 +267,28 @@ impl NodeReplicationNetworkHandle {
                 ),
             });
         }
-        self.publish_local_content_provider(network_policy, world_id, content_hash)
+        self.publish_local_content_provider_best_effort(network_policy, world_id, content_hash);
+        Ok(())
+    }
+
+    pub(crate) fn publish_local_content_provider_best_effort(
+        &self,
+        network_policy: &NodeNetworkPolicy,
+        world_id: &str,
+        content_hash: &str,
+    ) {
+        let Some(dht) = self.dht.as_ref() else {
+            return;
+        };
+        let Some(local_provider_id) = self.local_provider_id.as_deref() else {
+            return;
+        };
+        if !network_policy
+            .allows_lane_operation(NetworkLane::BlobState, NetworkLaneOperation::Serve)
+        {
+            return;
+        }
+        let _ = dht.publish_provider_best_effort(world_id, content_hash, local_provider_id);
     }
 
     fn resolved_topic(&self, world_id: &str) -> String {
@@ -830,6 +851,7 @@ impl ReplicationNetworkEndpoint {
         Ok(Some(provider_ids))
     }
 
+    #[allow(dead_code)]
     pub(crate) fn publish_local_content_provider(
         &self,
         world_id: &str,
@@ -849,7 +871,19 @@ impl ReplicationNetworkEndpoint {
         world_id: &str,
         content_hash: &str,
     ) {
-        let _ = self.publish_local_content_provider(world_id, content_hash);
+        let Some(dht) = self.dht.as_ref() else {
+            return;
+        };
+        let Some(local_provider_id) = self.local_provider_id.as_deref() else {
+            return;
+        };
+        if !self
+            .network_policy
+            .allows_lane_operation(NetworkLane::BlobState, NetworkLaneOperation::Serve)
+        {
+            return;
+        }
+        let _ = dht.publish_provider_best_effort(world_id, content_hash, local_provider_id);
     }
 
     fn cached_fetch_commit_success_response(
@@ -901,55 +935,8 @@ fn cacheable_fetch_commit_success_response(
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use oasis7_distfs::FileReplicationRecord;
-
-    #[test]
-    fn publish_failure_stays_generic_replication_error() {
-        let err = network_err(WorldError::NetworkProtocolUnavailable {
-            protocol: "libp2p publish failed topic=aw.publish.fail: InsufficientPeers".to_string(),
-        });
-        assert_eq!(
-            err,
-            NodeError::Replication {
-                reason: "replication network error: NetworkProtocolUnavailable { protocol: \"libp2p publish failed topic=aw.publish.fail: InsufficientPeers\" }".to_string(),
-            }
-        );
-    }
-
-    #[test]
-    fn cacheable_fetch_commit_success_response_drops_payload_allocation() {
-        let mut payload = Vec::with_capacity(4096);
-        payload.extend_from_slice(b"replicated-commit-payload");
-        let response = FetchCommitResponse {
-            found: true,
-            message: Some(GossipReplicationMessage {
-                version: 1,
-                world_id: "world-cache".to_string(),
-                node_id: "node-a".to_string(),
-                record: FileReplicationRecord {
-                    world_id: "world-cache".to_string(),
-                    writer_id: "writer-a".to_string(),
-                    writer_epoch: 1,
-                    sequence: 1,
-                    path: "consensus/commits/00000000000000000001.json".to_string(),
-                    content_hash: "hash-1".to_string(),
-                    size_bytes: payload.len() as u64,
-                    updated_at_ms: 1,
-                },
-                payload,
-                public_key_hex: None,
-                signature_hex: None,
-            }),
-        };
-
-        let cached = cacheable_fetch_commit_success_response(&response).expect("cached response");
-        let payload = &cached.message.expect("cached message").payload;
-        assert!(payload.is_empty());
-        assert_eq!(payload.capacity(), 0);
-    }
-}
+#[path = "tests_network_bridge.rs"]
+mod tests;
 
 pub(crate) struct ConsensusNetworkEndpoint {
     network: Arc<dyn DistributedNetwork<WorldError> + Send + Sync>,

--- a/crates/oasis7_node/src/tests_network_bridge.rs
+++ b/crates/oasis7_node/src/tests_network_bridge.rs
@@ -1,0 +1,187 @@
+use super::*;
+use oasis7_distfs::FileReplicationRecord;
+use oasis7_proto::distributed_dht::{
+    MembershipDirectorySnapshot, ProviderRecord, SignedPeerRecord,
+};
+use std::sync::mpsc;
+use std::time::Duration;
+
+use crate::{NodeConfig, NodeRole};
+
+struct NoopDistributedNetwork;
+
+impl DistributedNetwork<WorldError> for NoopDistributedNetwork {
+    fn publish(&self, _topic: &str, _payload: &[u8]) -> Result<(), WorldError> {
+        Ok(())
+    }
+
+    fn subscribe(&self, topic: &str) -> Result<NetworkSubscription, WorldError> {
+        Ok(NetworkSubscription::new(
+            topic.to_string(),
+            Arc::new(Mutex::new(HashMap::new())),
+        ))
+    }
+
+    fn request(&self, protocol: &str, _payload: &[u8]) -> Result<Vec<u8>, WorldError> {
+        Err(WorldError::NetworkProtocolUnavailable {
+            protocol: protocol.to_string(),
+        })
+    }
+
+    fn register_handler(
+        &self,
+        _protocol: &str,
+        _handler: Box<dyn Fn(&[u8]) -> Result<Vec<u8>, WorldError> + Send + Sync>,
+    ) -> Result<(), WorldError> {
+        Ok(())
+    }
+}
+
+struct BlockingProviderDht {
+    entered: Mutex<mpsc::Sender<()>>,
+    release: Mutex<mpsc::Receiver<()>>,
+}
+
+impl proto_dht::DistributedDht<WorldError> for BlockingProviderDht {
+    fn publish_provider(
+        &self,
+        _world_id: &str,
+        _content_hash: &str,
+        _provider_id: &str,
+    ) -> Result<(), WorldError> {
+        let _ = self.entered.lock().expect("lock entered").send(());
+        let _ = self
+            .release
+            .lock()
+            .expect("lock release")
+            .recv_timeout(Duration::from_secs(2));
+        Ok(())
+    }
+
+    fn publish_provider_best_effort(
+        &self,
+        _world_id: &str,
+        _content_hash: &str,
+        _provider_id: &str,
+    ) -> Result<(), WorldError> {
+        let _ = self.entered.lock().expect("lock entered").send(());
+        Ok(())
+    }
+
+    fn get_providers(
+        &self,
+        _world_id: &str,
+        _content_hash: &str,
+    ) -> Result<Vec<ProviderRecord>, WorldError> {
+        Ok(Vec::new())
+    }
+
+    fn put_world_head(&self, _world_id: &str, _head: &WorldHeadAnnounce) -> Result<(), WorldError> {
+        Ok(())
+    }
+
+    fn get_world_head(&self, _world_id: &str) -> Result<Option<WorldHeadAnnounce>, WorldError> {
+        Ok(None)
+    }
+
+    fn put_membership_directory(
+        &self,
+        _world_id: &str,
+        _snapshot: &MembershipDirectorySnapshot,
+    ) -> Result<(), WorldError> {
+        Ok(())
+    }
+
+    fn get_membership_directory(
+        &self,
+        _world_id: &str,
+    ) -> Result<Option<MembershipDirectorySnapshot>, WorldError> {
+        Ok(None)
+    }
+
+    fn put_peer_record(
+        &self,
+        _world_id: &str,
+        _record: &SignedPeerRecord,
+    ) -> Result<(), WorldError> {
+        Ok(())
+    }
+
+    fn get_peer_record(
+        &self,
+        _world_id: &str,
+        _peer_id: &str,
+    ) -> Result<Option<SignedPeerRecord>, WorldError> {
+        Ok(None)
+    }
+}
+
+#[test]
+fn publish_failure_stays_generic_replication_error() {
+    let err = network_err(WorldError::NetworkProtocolUnavailable {
+        protocol: "libp2p publish failed topic=aw.publish.fail: InsufficientPeers".to_string(),
+    });
+    assert_eq!(
+        err,
+        NodeError::Replication {
+            reason: "replication network error: NetworkProtocolUnavailable { protocol: \"libp2p publish failed topic=aw.publish.fail: InsufficientPeers\" }".to_string(),
+        }
+    );
+}
+
+#[test]
+fn cacheable_fetch_commit_success_response_drops_payload_allocation() {
+    let mut payload = Vec::with_capacity(4096);
+    payload.extend_from_slice(b"replicated-commit-payload");
+    let response = FetchCommitResponse {
+        found: true,
+        message: Some(GossipReplicationMessage {
+            version: 1,
+            world_id: "world-cache".to_string(),
+            node_id: "node-a".to_string(),
+            record: FileReplicationRecord {
+                world_id: "world-cache".to_string(),
+                writer_id: "writer-a".to_string(),
+                writer_epoch: 1,
+                sequence: 1,
+                path: "consensus/commits/00000000000000000001.json".to_string(),
+                content_hash: "hash-1".to_string(),
+                size_bytes: payload.len() as u64,
+                updated_at_ms: 1,
+            },
+            payload,
+            public_key_hex: None,
+            signature_hex: None,
+        }),
+    };
+
+    let cached = cacheable_fetch_commit_success_response(&response).expect("cached response");
+    let payload = &cached.message.expect("cached message").payload;
+    assert!(payload.is_empty());
+    assert_eq!(payload.capacity(), 0);
+}
+
+#[test]
+fn best_effort_provider_publish_does_not_block_on_slow_dht() {
+    let (entered_tx, entered_rx) = mpsc::channel();
+    let (release_tx, release_rx) = mpsc::channel();
+    let dht = Arc::new(BlockingProviderDht {
+        entered: Mutex::new(entered_tx),
+        release: Mutex::new(release_rx),
+    });
+    let handle = NodeReplicationNetworkHandle::new(Arc::new(NoopDistributedNetwork))
+        .with_dht(dht)
+        .with_local_provider_id("storage-provider");
+    let config =
+        NodeConfig::new("storage-provider", "world-provider", NodeRole::Storage).expect("config");
+    let endpoint =
+        ReplicationNetworkEndpoint::new(&handle, "world-provider", false, &config.network_policy)
+            .expect("endpoint");
+
+    endpoint.publish_local_content_provider_best_effort("world-provider", "hash-1");
+
+    entered_rx
+        .recv_timeout(Duration::from_millis(250))
+        .expect("best-effort provider publish should start promptly");
+    drop(release_tx);
+}

--- a/crates/oasis7_node/src/tests_storage_replication_high_checkpoint_retained.rs
+++ b/crates/oasis7_node/src/tests_storage_replication_high_checkpoint_retained.rs
@@ -352,6 +352,18 @@ impl proto_dht::DistributedDht<WorldError> for BlockingCheckpointProviderDht {
         Ok(())
     }
 
+    fn publish_provider_best_effort(
+        &self,
+        _world_id: &str,
+        _content_hash: &str,
+        _provider_id: &str,
+    ) -> Result<(), WorldError> {
+        let (entered_lock, entered_cvar) = &*self.entered_publish;
+        *entered_lock.lock().expect("lock entered_publish") = true;
+        entered_cvar.notify_all();
+        Ok(())
+    }
+
     fn get_providers(
         &self,
         _world_id: &str,

--- a/crates/oasis7_proto/src/distributed_dht.rs
+++ b/crates/oasis7_proto/src/distributed_dht.rs
@@ -350,6 +350,15 @@ pub trait DistributedDht<E> {
         provider_id: &str,
     ) -> Result<(), E>;
 
+    fn publish_provider_best_effort(
+        &self,
+        world_id: &str,
+        content_hash: &str,
+        provider_id: &str,
+    ) -> Result<(), E> {
+        self.publish_provider(world_id, content_hash, provider_id)
+    }
+
     fn get_providers(&self, world_id: &str, content_hash: &str) -> Result<Vec<ProviderRecord>, E>;
 
     fn put_world_head(&self, world_id: &str, head: &WorldHeadAnnounce) -> Result<(), E>;


### PR DESCRIPTION
## Summary
- add a best-effort DHT provider publication API and implement it in libp2p by enqueueing provider publication without waiting for Kademlia query completion
- move replication fetch-commit provider publication paths to best-effort APIs so slow DHT publishing cannot block provider route advertisement
- add regressions for slow provider publication and fetch-commit handler nonblocking behavior

## Validation
- `env -u RUSTC_WRAPPER cargo fmt --check`
- `env -u RUSTC_WRAPPER cargo test -p oasis7_node best_effort_provider_publish_does_not_block_on_slow_dht -- --nocapture`
- `env -u RUSTC_WRAPPER cargo test -p oasis7_node fetch_commit_handler_does_not_block_on_checkpoint_provider_publish -- --nocapture`
- `env -u RUSTC_WRAPPER cargo test -p oasis7_node fetch_commit_handler_publishes_commit_payload_provider_to_dht -- --nocapture`
- `env -u RUSTC_WRAPPER cargo test -p oasis7_node fetch_blob_provider_route -- --nocapture`
- `env -u RUSTC_WRAPPER cargo test -p oasis7_node storage_challenge_gate_provider -- --nocapture`
- `env -u RUSTC_WRAPPER cargo test -p oasis7_net publish_provider -- --nocapture` (compile-only filter, 0 matching tests)

## Review
- runtime_engineer: no findings
- qa_engineer: P1 blocking fetch-commit provider publication path fixed; recheck no findings
