### PR TITLE
Recover storage challenge on empty provider lookup

### DIFF
--- a/.pm/tasks/task_c612861fd1fe4187b789ceff61a6d0f7.execution.md
+++ b/.pm/tasks/task_c612861fd1fe4187b789ceff61a6d0f7.execution.md
@@ -320,3 +320,35 @@ Example:
 - Expected Result: fetch-commit handler still publishes commit payload provider route.
 - Actual Result: passed, 1 test.
 - Blocker / Next Action: amend/force-push and recheck PR #510.
+
+## 2026-06-18 run100 live follow-up: empty provider lookup storage challenge root fix
+- Phase: execution / live-debug follow-up after package run100 deployment.
+- Live evidence captured in `.tmp/run100_health_deep/`: sequencer had 3 active direct replication peers and registered fetch-blob/fetch-commit handlers, but readiness stayed not_ready with `storage_challenge_network_degraded` reason `blob fetch provider routes exhausted ... before retryable provider failure`; storage had active direct peers but recent replication transport warnings; linux observer was ready; Windows/fourth were observer_light with `registered_protocols=[]` under current lane Serve policy.
+- runtime_engineer slice (Mencius): no file edits. Findings: `ObserverLight` not serving `Sync`/`BlobState` is current policy (`DistributedNetRoleClaim::ObserverLight` does not allow Serve), so do not make observers serve lanes by default; `registered_protocols` is local handler state, not remote capability. Recommended fixing storage challenge fallback and later adding handler skip reasons / route attempt observability.
+- qa_engineer slice (Bohr): no file edits. Findings: empty-provider lookup fallback needs positive and negative coverage: empty providers + generic success recovers; generic not-found degrades; wrong generic blob remains hard failure; explicit provider not-found must not fall back to generic.
+- Code action: On branch `codex/storage-challenge-empty-provider-fallback`, updated `crates/oasis7_node/src/replication_probe_gate.rs` so `request_fetch_blob_with_storage_challenge_routes` distinguishes "provider lookup supplied but no provider route was attempted" from "a provider route was attempted but no retryable failure occurred". Empty provider lists now continue to bounded generic route fallback; missing provider lookup still does not probe generic; explicit provider not-found still does not fall through to generic.
+- Tests added/updated: `fetch_blob_storage_challenge_empty_provider_routes_probe_bounded_generic_route`; `EmptyProviderLookupDht`; `runtime_replication_storage_challenge_gate_empty_provider_lookup_uses_generic_fallback`; `runtime_replication_storage_challenge_gate_empty_provider_lookup_generic_not_found_degrades`; `runtime_replication_storage_challenge_gate_empty_provider_lookup_wrong_generic_blob_hard_fails`.
+- Verification passed: `cargo test -p oasis7_node storage_challenge_gate -- --nocapture`; `cargo test -p oasis7_node fetch_blob_storage_challenge -- --nocapture`; `cargo test -p oasis7_node fetch_blob_provider_route -- --nocapture`; `cargo fmt --check`; `./scripts/check-rust-file-size.sh`.
+
+## 2026-06-18 pre-PR local role review request / storage challenge empty-provider fallback
+- Review Trigger: pre-PR local role review
+- Review Scope: `crates/oasis7_node/src/replication_probe_gate.rs`; `crates/oasis7_node/src/tests_fetch_blob_chunking.rs`; `crates/oasis7_node/src/tests_storage_challenge_gate/provider_lookup_fallback.rs`; `crates/oasis7_node/src/tests_storage_challenge_gate/provider_route_mocks.rs`; task execution log evidence.
+- Review Roles: runtime_engineer, qa_engineer
+- Review Question: confirm the empty-provider lookup fallback fixes the live sequencer `before retryable provider failure` storage challenge degradation without weakening provider not-found, missing lookup, or wrong-blob hard-failure boundaries.
+- Evidence Available: live run100 status in `.tmp/run100_health_deep/`; passing `cargo test -p oasis7_node storage_challenge_gate -- --nocapture`; `fetch_blob_storage_challenge`; `fetch_blob_provider_route`; `cargo fmt --check`; `./scripts/check-rust-file-size.sh`.
+- Expected Return Contract: findings | no_findings | residual_risk
+- Formal Sink: `.pm/tasks/task_c612861fd1fe4187b789ceff61a6d0f7.execution.md`
+
+- Pre-PR Local Role Review: passed
+- Task UID: task_c612861fd1fe4187b789ceff61a6d0f7
+- Source Worktree: /Users/scc/ccwork/worktrees/oasis7-p2p-replication-transport-gap-sync-recovery
+- Source Branch: codex/storage-challenge-empty-provider-fallback
+- Source Head: 9549b70ccfdc6d215b74140cbc1b6fed20fc389d plus execution-log-only review packet updates
+- Comparison Ref: origin/main
+- Reviewed Changed Paths: crates/oasis7_node/src/replication_probe_gate.rs; crates/oasis7_node/src/tests_fetch_blob_chunking.rs; crates/oasis7_node/src/tests_storage_challenge_gate/provider_lookup_fallback.rs; crates/oasis7_node/src/tests_storage_challenge_gate/provider_route_mocks.rs; .pm/tasks/task_c612861fd1fe4187b789ceff61a6d0f7.execution.md
+- Role Selection Basis: runtime/storage challenge fallback code path changed; tests and release-readiness claim changed; task history includes live replication/storage challenge degradation.
+- Review Roles: runtime_engineer, qa_engineer
+- Review Evidence: runtime_engineer (Tesla) no_findings, verified empty_provider_lookup and empty_provider_routes targeted tests; qa_engineer (Nash) no_findings, targeted tests passed for empty-provider generic recovery, generic not-found degrade, wrong generic blob hard-fail, endpoint provider-route not-found no-generic-fallback, and gate-level provider-route not-found degrade paths.
+- Review Findings Disposition: no_findings
+- Finding Disposition Evidence: no code changes required after review; local verification passed before and after review: `cargo fmt --check`, `./scripts/check-rust-file-size.sh`, `cargo test -p oasis7_node storage_challenge_gate -- --nocapture`, `cargo test -p oasis7_node fetch_blob_storage_challenge -- --nocapture`, `cargo test -p oasis7_node fetch_blob_provider_route -- --nocapture`, `git diff --check`.
+- Residual Risk: Low; full crate/workspace suite not run in this cycle, but changed behavior is covered by targeted runtime and helper tests.

--- a/crates/oasis7_node/src/replication_probe_gate.rs
+++ b/crates/oasis7_node/src/replication_probe_gate.rs
@@ -367,6 +367,7 @@ fn request_fetch_blob_chunk_with_route_fallback(
     let mut last_retryable_error: Option<NodeError> = None;
     let mut attempted_provider_ids = std::collections::BTreeSet::new();
     let provider_lookup_supplied = provider_ids.is_some();
+    let mut provider_route_attempted = false;
 
     if let Some(provider_ids) = provider_ids {
         for provider_id in provider_ids {
@@ -374,6 +375,7 @@ fn request_fetch_blob_chunk_with_route_fallback(
             if provider_id.is_empty() || !attempted_provider_ids.insert(provider_id.to_string()) {
                 continue;
             }
+            provider_route_attempted = true;
             let provider_route = [provider_id.to_string()];
             match endpoint
                 .request_json_with_providers_budget::<FetchBlobRequest, FetchBlobResponse>(
@@ -403,7 +405,10 @@ fn request_fetch_blob_chunk_with_route_fallback(
         }
     }
 
-    if policy.require_retryable_provider_route_before_fallback && last_retryable_error.is_none() {
+    if policy.require_retryable_provider_route_before_fallback
+        && last_retryable_error.is_none()
+        && (provider_route_attempted || !provider_lookup_supplied)
+    {
         return Err(NodeError::Replication {
             reason: format!(
                 "blob fetch provider routes exhausted without response for world_id={} hash={} before retryable provider failure",
@@ -412,7 +417,7 @@ fn request_fetch_blob_chunk_with_route_fallback(
         });
     }
 
-    if provider_lookup_supplied && last_retryable_error.is_none() {
+    if provider_lookup_supplied && last_retryable_error.is_none() && provider_route_attempted {
         return Err(NodeError::Replication {
             reason: format!(
                 "blob fetch provider routes exhausted without response for world_id={} hash={}",

--- a/crates/oasis7_node/src/tests_fetch_blob_chunking.rs
+++ b/crates/oasis7_node/src/tests_fetch_blob_chunking.rs
@@ -436,7 +436,7 @@ fn fetch_blob_storage_challenge_without_provider_lookup_does_not_probe_generic_r
 }
 
 #[test]
-fn fetch_blob_storage_challenge_empty_provider_routes_do_not_probe_generic_route() {
+fn fetch_blob_storage_challenge_empty_provider_routes_probe_bounded_generic_route() {
     let world_id = "world-blob-provider-empty-routes";
     let dir = temp_dir("blob-provider-empty-routes-endpoint");
     let generic_attempts = Arc::new(Mutex::new(0usize));
@@ -465,25 +465,23 @@ fn fetch_blob_storage_challenge_empty_provider_routes_do_not_probe_generic_route
     };
 
     let provider_ids: Vec<String> = Vec::new();
-    let err = super::request_fetch_blob_with_storage_challenge_routes(
+    let response = super::request_fetch_blob_with_storage_challenge_routes(
         &endpoint,
         world_id,
         "checkpoint-payload",
         &request,
         Some(provider_ids.as_slice()),
     )
-    .expect_err(
-        "storage challenge fallback requires at least one retryable provider route failure",
-    );
+    .expect("empty DHT provider lookup should allow bounded generic recovery");
 
     assert!(
-        should_fallback_provider_aware_replication_request(&err),
-        "empty provider routes should remain a retryable/degraded storage challenge condition: {err:?}"
+        !response.found,
+        "generic fallback miss should remain observable as blob-not-found"
     );
     assert_eq!(
         *generic_attempts.lock().expect("lock generic attempts"),
-        0,
-        "storage challenge should not probe generic lane when DHT has no non-local providers"
+        3,
+        "storage challenge should spend only the bounded generic attempts when DHT has no non-local providers"
     );
     assert!(
         provider_attempts

--- a/crates/oasis7_node/src/tests_storage_challenge_gate/provider_lookup_fallback.rs
+++ b/crates/oasis7_node/src/tests_storage_challenge_gate/provider_lookup_fallback.rs
@@ -201,6 +201,303 @@ fn runtime_replication_storage_challenge_gate_provider_lookup_timeout_fallback_c
 }
 
 #[test]
+fn runtime_replication_storage_challenge_gate_empty_provider_lookup_uses_generic_fallback() {
+    let dir = temp_dir("challenge-gate-empty-provider-lookup-fallback");
+    let world_id = "world-challenge-empty-provider-lookup-fallback";
+    let pos_config = signed_pos_config_with_signer_seeds(
+        vec![PosValidator {
+            validator_id: "node-a".to_string(),
+            stake: 100,
+        }],
+        &[("node-a", 126)],
+    );
+
+    let seed_config = NodeConfig::new("node-a", world_id, NodeRole::Sequencer)
+        .expect("seed config")
+        .with_tick_interval(Duration::from_millis(10))
+        .expect("seed tick")
+        .with_pos_config(pos_config.clone())
+        .expect("seed pos config")
+        .with_auto_attest_all_validators(true)
+        .with_replication(signed_replication_config(dir.clone(), 126));
+    let mut seed_runtime = with_noop_execution_hook(NodeRuntime::new(seed_config));
+    seed_runtime.start().expect("start seed runtime");
+    let seeded = wait_until(Instant::now() + Duration::from_secs(2), || {
+        seed_runtime.snapshot().consensus.committed_height >= 6
+    });
+    assert!(seeded, "seed runtime did not build enough local commits");
+    seed_runtime.stop().expect("stop seed runtime");
+
+    let replication = super::replication::ReplicationRuntime::new(
+        &signed_replication_config(dir.clone(), 126),
+        "node-a",
+    )
+    .expect("restart replication runtime");
+    let mut fallback_blobs = HashMap::<String, Vec<u8>>::new();
+    for (_, content_hash) in replication
+        .recent_replicated_content_refs(world_id, STORAGE_GATE_NETWORK_SAMPLES_PER_CHECK)
+        .expect("load recent replicated refs")
+    {
+        let blob = replication
+            .load_blob_by_hash(content_hash.as_str())
+            .expect("load local blob")
+            .expect("blob payload");
+        fallback_blobs.insert(content_hash, blob);
+    }
+
+    let network_impl = Arc::new(ProviderLookupFailureGenericBlobNetwork::new(fallback_blobs));
+    let network: Arc<
+        dyn oasis7_proto::distributed_net::DistributedNetwork<WorldError> + Send + Sync,
+    > = network_impl.clone();
+    let config = NodeConfig::new("node-a", world_id, NodeRole::Sequencer)
+        .expect("config")
+        .with_pos_config(pos_config)
+        .expect("pos config")
+        .with_replication(signed_replication_config(dir.clone(), 126));
+    let handle = NodeReplicationNetworkHandle::new(Arc::clone(&network))
+        .with_dht(Arc::new(EmptyProviderLookupDht))
+        .with_local_provider_id("node-a");
+    let endpoint =
+        ReplicationNetworkEndpoint::new(&handle, world_id, false, &config.network_policy)
+            .expect("endpoint");
+    let mut engine = PosNodeEngine::new(&config).expect("engine");
+    engine.committed_height = STORAGE_GATE_NETWORK_WARMUP_HEIGHT + 8;
+    engine.network_committed_height = STORAGE_GATE_NETWORK_WARMUP_HEIGHT + 8;
+    engine.peer_heads.insert(
+        "observer-fallback-peer".to_string(),
+        PeerCommittedHead {
+            height: STORAGE_GATE_NETWORK_WARMUP_HEIGHT + 8,
+            block_hash: "observer-empty-provider-fallback-peer-head".to_string(),
+            committed_at_ms: 1_234,
+            observed_at_ms: 1_234,
+            execution_block_hash: None,
+            execution_state_root: None,
+            action_root: empty_action_root(),
+            public_key_hex: None,
+            signature_hex: None,
+        },
+    );
+
+    let gate_result = engine.enforce_storage_challenge_gate(
+        &replication,
+        Some(&endpoint),
+        "node-a",
+        world_id,
+        1_234,
+    );
+
+    assert!(
+        gate_result.is_ok(),
+        "empty provider lookup should recover through generic fallback: {gate_result:?}"
+    );
+    assert!(
+        network_impl.generic_attempts() > 0,
+        "storage challenge should use generic fallback when DHT returns no providers"
+    );
+    assert!(
+        network_impl.generic_attempts() <= STORAGE_GATE_NETWORK_SAMPLES_PER_CHECK,
+        "empty provider lookup should use one bounded generic request per successful sample"
+    );
+    let snapshot = engine.snapshot_from_decision(&engine.idle_pending_decision().expect("decision"));
+    assert_eq!(snapshot.storage_challenge_network_degraded_height, None);
+    assert_eq!(snapshot.storage_challenge_network_degraded_reason, None);
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn runtime_replication_storage_challenge_gate_empty_provider_lookup_generic_not_found_degrades() {
+    let dir = temp_dir("challenge-gate-empty-provider-lookup-not-found");
+    let world_id = "world-challenge-empty-provider-lookup-not-found";
+    let pos_config = signed_pos_config_with_signer_seeds(
+        vec![PosValidator {
+            validator_id: "node-a".to_string(),
+            stake: 100,
+        }],
+        &[("node-a", 127)],
+    );
+
+    let seed_config = NodeConfig::new("node-a", world_id, NodeRole::Sequencer)
+        .expect("seed config")
+        .with_tick_interval(Duration::from_millis(10))
+        .expect("seed tick")
+        .with_pos_config(pos_config.clone())
+        .expect("seed pos config")
+        .with_auto_attest_all_validators(true)
+        .with_replication(signed_replication_config(dir.clone(), 127));
+    let mut seed_runtime = with_noop_execution_hook(NodeRuntime::new(seed_config));
+    seed_runtime.start().expect("start seed runtime");
+    let seeded = wait_until(Instant::now() + Duration::from_secs(2), || {
+        seed_runtime.snapshot().consensus.committed_height >= 6
+    });
+    assert!(seeded, "seed runtime did not build enough local commits");
+    seed_runtime.stop().expect("stop seed runtime");
+
+    let network_impl = Arc::new(ProviderLookupFailureGenericBlobNetwork::new(HashMap::new()));
+    let network: Arc<
+        dyn oasis7_proto::distributed_net::DistributedNetwork<WorldError> + Send + Sync,
+    > = network_impl.clone();
+    let config = NodeConfig::new("node-a", world_id, NodeRole::Sequencer)
+        .expect("config")
+        .with_pos_config(pos_config)
+        .expect("pos config")
+        .with_replication(signed_replication_config(dir.clone(), 127));
+    let handle = NodeReplicationNetworkHandle::new(Arc::clone(&network))
+        .with_dht(Arc::new(EmptyProviderLookupDht))
+        .with_local_provider_id("node-a");
+    let endpoint =
+        ReplicationNetworkEndpoint::new(&handle, world_id, false, &config.network_policy)
+            .expect("endpoint");
+    let mut engine = PosNodeEngine::new(&config).expect("engine");
+    engine.committed_height = STORAGE_GATE_NETWORK_WARMUP_HEIGHT + 8;
+    engine.network_committed_height = STORAGE_GATE_NETWORK_WARMUP_HEIGHT + 8;
+    engine.peer_heads.insert(
+        "observer-fallback-peer".to_string(),
+        PeerCommittedHead {
+            height: STORAGE_GATE_NETWORK_WARMUP_HEIGHT + 8,
+            block_hash: "observer-empty-provider-not-found-peer-head".to_string(),
+            committed_at_ms: 1_234,
+            observed_at_ms: 1_234,
+            execution_block_hash: None,
+            execution_state_root: None,
+            action_root: empty_action_root(),
+            public_key_hex: None,
+            signature_hex: None,
+        },
+    );
+    let replication = super::replication::ReplicationRuntime::new(
+        &signed_replication_config(dir.clone(), 127),
+        "node-a",
+    )
+    .expect("restart replication runtime");
+
+    let gate_result = engine.enforce_storage_challenge_gate(
+        &replication,
+        Some(&endpoint),
+        "node-a",
+        world_id,
+        1_234,
+    );
+
+    assert!(
+        gate_result.is_ok(),
+        "empty provider lookup generic not-found should degrade, not hard-block: {gate_result:?}"
+    );
+    assert_eq!(
+        network_impl.generic_attempts(),
+        3,
+        "empty provider lookup generic not-found should spend the bounded generic route attempts"
+    );
+    let snapshot = engine.snapshot_from_decision(&engine.idle_pending_decision().expect("decision"));
+    assert_eq!(
+        snapshot.storage_challenge_network_degraded_height,
+        Some(STORAGE_GATE_NETWORK_WARMUP_HEIGHT + 8)
+    );
+    assert!(
+        snapshot
+            .storage_challenge_network_degraded_reason
+            .as_deref()
+            .map(|reason| reason.contains("network blob not found"))
+            .unwrap_or(false),
+        "expected generic not-found to remain observable as degraded, got {:?}",
+        snapshot.storage_challenge_network_degraded_reason
+    );
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn runtime_replication_storage_challenge_gate_empty_provider_lookup_wrong_generic_blob_hard_fails()
+{
+    let dir = temp_dir("challenge-gate-empty-provider-lookup-wrong-blob");
+    let world_id = "world-challenge-empty-provider-lookup-wrong-blob";
+    let pos_config = signed_pos_config_with_signer_seeds(
+        vec![PosValidator {
+            validator_id: "node-a".to_string(),
+            stake: 100,
+        }],
+        &[("node-a", 128)],
+    );
+
+    let seed_config = NodeConfig::new("node-a", world_id, NodeRole::Sequencer)
+        .expect("seed config")
+        .with_tick_interval(Duration::from_millis(10))
+        .expect("seed tick")
+        .with_pos_config(pos_config.clone())
+        .expect("seed pos config")
+        .with_auto_attest_all_validators(true)
+        .with_replication(signed_replication_config(dir.clone(), 128));
+    let mut seed_runtime = with_noop_execution_hook(NodeRuntime::new(seed_config));
+    seed_runtime.start().expect("start seed runtime");
+    let seeded = wait_until(Instant::now() + Duration::from_secs(2), || {
+        seed_runtime.snapshot().consensus.committed_height >= 6
+    });
+    assert!(seeded, "seed runtime did not build enough local commits");
+    seed_runtime.stop().expect("stop seed runtime");
+
+    let network_impl = Arc::new(ProviderRouteFailureGenericTrapNetwork::new());
+    let network: Arc<
+        dyn oasis7_proto::distributed_net::DistributedNetwork<WorldError> + Send + Sync,
+    > = network_impl.clone();
+    let config = NodeConfig::new("node-a", world_id, NodeRole::Sequencer)
+        .expect("config")
+        .with_pos_config(pos_config)
+        .expect("pos config")
+        .with_replication(signed_replication_config(dir.clone(), 128));
+    let handle = NodeReplicationNetworkHandle::new(Arc::clone(&network))
+        .with_dht(Arc::new(EmptyProviderLookupDht))
+        .with_local_provider_id("node-a");
+    let endpoint =
+        ReplicationNetworkEndpoint::new(&handle, world_id, false, &config.network_policy)
+            .expect("endpoint");
+    let mut engine = PosNodeEngine::new(&config).expect("engine");
+    engine.committed_height = STORAGE_GATE_NETWORK_WARMUP_HEIGHT + 8;
+    engine.network_committed_height = STORAGE_GATE_NETWORK_WARMUP_HEIGHT + 8;
+    engine.peer_heads.insert(
+        "observer-fallback-peer".to_string(),
+        PeerCommittedHead {
+            height: STORAGE_GATE_NETWORK_WARMUP_HEIGHT + 8,
+            block_hash: "observer-empty-provider-wrong-blob-peer-head".to_string(),
+            committed_at_ms: 1_234,
+            observed_at_ms: 1_234,
+            execution_block_hash: None,
+            execution_state_root: None,
+            action_root: empty_action_root(),
+            public_key_hex: None,
+            signature_hex: None,
+        },
+    );
+    let replication = super::replication::ReplicationRuntime::new(
+        &signed_replication_config(dir.clone(), 128),
+        "node-a",
+    )
+    .expect("restart replication runtime");
+
+    let gate_result = engine.enforce_storage_challenge_gate(
+        &replication,
+        Some(&endpoint),
+        "node-a",
+        world_id,
+        1_234,
+    );
+
+    assert!(
+        matches!(gate_result, Err(NodeError::Consensus { .. })),
+        "wrong blob from empty-provider generic fallback must hard-fail: {gate_result:?}"
+    );
+    assert_eq!(
+        network_impl.generic_attempts(),
+        1,
+        "wrong generic blob should stop after the first hard-failure sample"
+    );
+    assert!(
+        format!("{gate_result:?}").contains("network blob hash mismatch"),
+        "expected wrong generic blob to remain a hard mismatch, got {gate_result:?}"
+    );
+    let snapshot = engine.snapshot_from_decision(&engine.idle_pending_decision().expect("decision"));
+    assert_eq!(snapshot.storage_challenge_network_degraded_reason, None);
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
 fn runtime_replication_storage_challenge_gate_provider_lookup_timeout_fallback_local_corruption_hard_fails(
 ) {
     let dir = temp_dir("challenge-gate-provider-lookup-fallback-local-corrupt");

--- a/crates/oasis7_node/src/tests_storage_challenge_gate/provider_route_mocks.rs
+++ b/crates/oasis7_node/src/tests_storage_challenge_gate/provider_route_mocks.rs
@@ -68,6 +68,70 @@ impl proto_dht::DistributedDht<WorldError> for ProviderLookupFailureDht {
     }
 }
 
+pub(super) struct EmptyProviderLookupDht;
+
+impl proto_dht::DistributedDht<WorldError> for EmptyProviderLookupDht {
+    fn publish_provider(
+        &self,
+        _world_id: &str,
+        _content_hash: &str,
+        _provider_id: &str,
+    ) -> Result<(), WorldError> {
+        Ok(())
+    }
+
+    fn get_providers(
+        &self,
+        _world_id: &str,
+        _content_hash: &str,
+    ) -> Result<Vec<ProviderRecord>, WorldError> {
+        Ok(Vec::new())
+    }
+
+    fn put_world_head(
+        &self,
+        _world_id: &str,
+        _head: &WorldHeadAnnounce,
+    ) -> Result<(), WorldError> {
+        Ok(())
+    }
+
+    fn get_world_head(&self, _world_id: &str) -> Result<Option<WorldHeadAnnounce>, WorldError> {
+        Ok(None)
+    }
+
+    fn put_membership_directory(
+        &self,
+        _world_id: &str,
+        _snapshot: &MembershipDirectorySnapshot,
+    ) -> Result<(), WorldError> {
+        Ok(())
+    }
+
+    fn get_membership_directory(
+        &self,
+        _world_id: &str,
+    ) -> Result<Option<MembershipDirectorySnapshot>, WorldError> {
+        Ok(None)
+    }
+
+    fn put_peer_record(
+        &self,
+        _world_id: &str,
+        _record: &SignedPeerRecord,
+    ) -> Result<(), WorldError> {
+        Ok(())
+    }
+
+    fn get_peer_record(
+        &self,
+        _world_id: &str,
+        _peer_id: &str,
+    ) -> Result<Option<SignedPeerRecord>, WorldError> {
+        Ok(None)
+    }
+}
+
 #[derive(Clone, Default)]
 pub(super) struct ProviderLookupFailureGenericBlobNetwork {
     blobs: Arc<Mutex<HashMap<String, Vec<u8>>>>,


### PR DESCRIPTION
## Summary
- Fixes the live sequencer `storage_challenge_network_degraded` path where DHT provider lookup succeeds but returns no usable provider routes, causing `blob fetch provider routes exhausted ... before retryable provider failure` before any bounded fallback can run.
- Allows the storage challenge path to continue to the existing bounded generic fetch route only when no provider route was actually attempted.
- Keeps stricter safety boundaries: missing provider lookup still does not probe generic, explicit provider-route not-found still does not fall through to generic, and wrong fallback blobs still hard-fail.

## Validation
- `env -u RUSTC_WRAPPER cargo fmt --check`
- `./scripts/check-rust-file-size.sh`
- `env -u RUSTC_WRAPPER cargo test -p oasis7_node storage_challenge_gate -- --nocapture`
- `env -u RUSTC_WRAPPER cargo test -p oasis7_node fetch_blob_storage_challenge -- --nocapture`
- `env -u RUSTC_WRAPPER cargo test -p oasis7_node fetch_blob_provider_route -- --nocapture`
- `git diff --check`

## Local Review
- runtime_engineer pre-PR review: no findings; residual risk limited to broader integration outside scoped provider lookup/storage challenge paths.
- qa_engineer pre-PR review: no findings; residual risk low, targeted tests cover empty-provider recovery, generic miss degradation, wrong-blob hard failure, and provider-route not-found boundaries.
