### PR TITLE
Relax recovered replication transport readiness

### DIFF
--- a/.pm/tasks/task_c612861fd1fe4187b789ceff61a6d0f7.execution.md
+++ b/.pm/tasks/task_c612861fd1fe4187b789ceff61a6d0f7.execution.md
@@ -514,3 +514,88 @@ Example:
   - `env -u RUSTC_WRAPPER cargo fmt --check` passed.
   - `git diff --check` passed.
   - `./scripts/check-rust-file-size.sh` passed.
+
+### Run105 package/deploy/live-health evidence
+- PR #514 merged to main at `10ff37ced266e63b0fd99b32c123c3854966c7f3`.
+- Testnet Packages run `27726358631` completed successfully for `package_scope=all_existing`, package version `0.0.0+testnet.105.10ff37ced266`.
+- Deployment:
+  - Linux sequencer/storage/linux_observer upgraded with `scripts/p2p-public-testnet-package-node-upgrade.sh`; runtime sha `8a32b8806f7d58c71167e46b6cda33f2b4ce1b1ba8197727eb28e2f9bcd0760b`; services active, strict post-restart readiness timed out.
+  - fourth local upgraded from local macOS arm64 release build; runtime sha `c6d949a1b4cee0e32fcb7d1f67fd8ae311fceac216e0d5308881d2de77f8af7f`; launchd service running.
+  - Windows observer upgraded with run105 installer; runtime sha `78897713ca1a8307e6e034eaf63ed154f84d6bee8b76ce68bf521a1414902464`; scheduled task running.
+- Health script: `.tmp/collect_run105_health.py`.
+- Health evidence: `.tmp/run105_health_deep/summary.json`.
+- Result:
+  - All five nodes report run105 package version (fourth local uses `0.0.0+testnet.105.10ff37ced266-macos-arm64-local`).
+  - `storage_challenge_network_degraded=false` and degraded height/reason are null on all five nodes.
+  - `sequencer_ecs` and `fourth_local` are `ready`.
+  - `storage_ecs` and `linux_observer` are running with `last_error=null`, committed height caught up, active direct peers, and no storage challenge degradation, but remain `not_ready` due only to `replication_recent_errors` and `replication_transport_unstable`.
+  - `windows_observer` is running on run105 but remains `not_ready` with `last_error=libp2p-replication no connected peers for /aw/node/replication/fetch-commit/1.0.0`; the same no-connected-peers pattern existed in the run103 health snapshot before run105 deployment.
+
+### Slice: run105 replication readiness remaining warning root-cause
+- role: runtime_engineer / repository_health_engineer
+- intended dispatch: bounded subagent slice via multi_agent_v1, full-thread context inherited.
+- actual dispatch: spawned agent `019ed80d-b932-78a0-b980-fd5341024071` (Kepler).
+- mandatory context checklist: run105 health artifacts under `.tmp/run105_health_deep/`, storage/linux observer have `last_error=null`, active direct peers, `storage_challenge_network_degraded=false`, and only `replication_recent_errors` / `replication_transport_unstable` failed gates.
+- requested output: determine whether readiness failures are expected sliding-window decay, over-sensitive readiness gate, or active transport bug; identify files/functions and minimal code fix.
+- result: Kepler attributed storage/linux readiness warning to status/readiness over-sensitivity: long-lived deduplicated `recent_errors` debug buffer is used as current health input; no time-window decay exists, and active direct peers with no cooldown still get blocked by old timeout/EOF request failures.
+- integration: implemented code-level recovery signal in `crates/oasis7/src/bin/oasis7_chain_runtime/status_payload_observability.rs`: request timeout/EOF/connection request failures are no longer blocking once there is an active requestable peer outside protocol/transport cooldown with score > 0; no-connected-peer, all-cooldown, `last_error`, network lag, storage challenge degraded, and storage degraded paths remain strict.
+- tests:
+  - Added `classify_transport_stability_recovers_when_active_request_peer_is_healthy`.
+  - Added `classify_transport_stability_keeps_request_errors_blocking_without_requestable_peer`.
+  - Adjusted existing payload fixture to keep its replication error assertion in a no-requestable-peer cooldown scenario.
+- verification:
+  - `env -u RUSTC_WRAPPER cargo test -p oasis7 --bin oasis7_chain_runtime classify_transport_stability -- --nocapture` passed, 4 tests.
+  - `env -u RUSTC_WRAPPER cargo test -p oasis7 --bin oasis7_chain_runtime observability -- --nocapture` passed, 17 tests.
+  - `env -u RUSTC_WRAPPER cargo test -p oasis7 --bin oasis7_chain_runtime -- --nocapture` passed, 191 tests.
+  - `cargo fmt --check` passed.
+  - `git diff --check` passed.
+  - `./scripts/check-rust-file-size.sh` passed.
+  - `./scripts/pm/workflow-lint.sh --task-uid task_c612861fd1fe4187b789ceff61a6d0f7 --phase current` passed.
+  - `./scripts/doc-governance-check.sh` passed.
+
+### Slice: windows observer replication no-connected-peers investigation
+- role: blockchain_ops_engineer / runtime_engineer
+- intended dispatch: bounded subagent slice via multi_agent_v1, full-thread context inherited.
+- actual dispatch: spawned agent `019ed80d-dded-7831-9d59-345641c0bfe3` (Einstein).
+- mandatory context checklist: run105 Windows status reports local peer id `12D3KooWBTPMund1jKKydc1sQvTjEgBPTqCsn6vvDneciMB4wxsj`, connected peers `[]`, direct transports established then `ConnectionClosed`; run103 snapshot had same no-connected-peer pattern; Windows task command includes two ECS replication peer multiaddrs.
+- requested output: determine likely code/config root cause and whether code fix is needed versus node identity/config/firewall operational remediation.
+- result: Einstein attributed Windows observer no-connected-peers to topology/policy rather than run105 code. ECS peer manager quarantines/disconnects Windows peer `12D3KooWBTPMund1jKKydc1sQvTjEgBPTqCsn6vvDneciMB4wxsj` for `Ipv4SubnetConcentration { subnet: "111.199.105", peers_in_bucket: 3, active_peer_count: 4, limit_per_mille: 500 }`; Windows sees that as `ConnectionClosed` and then `no connected peers`.
+- relevant code:
+  - `crates/oasis7_net/src/libp2p_net/peer_manager.rs`: default `block_ipv4_subnet_share_per_mille=500` and hard-block logic for subnet concentration.
+  - `crates/oasis7_net/src/libp2p_net/runtime_loop.rs`: peer manager health/admission/quarantine calculation.
+  - `crates/oasis7_net/src/libp2p_net/connection_lifecycle.rs`: quarantine-triggered disconnect.
+  - `crates/oasis7_node/src/libp2p_replication_network/net_impl.rs`: replication request reports no connected/admissible peer after quarantine.
+- integration: no code change for Windows topology; preserving subnet-concentration protection is preferred unless product explicitly authorizes a governed testnet override. Operational remediation is to move Windows observer to a different public /24 or stop enough same-/24 observers, then restart and recheck.
+
+## 2026-06-18 08:15:31 CST / runtime_engineer + repository_health_engineer
+- Review Trigger: pre-PR local role review
+- Review Scope: `crates/oasis7/src/bin/oasis7_chain_runtime/status_payload_observability.rs`; `crates/oasis7/src/bin/oasis7_chain_runtime/oasis7_chain_runtime_observability_transport_tests.rs`; `crates/oasis7/src/bin/oasis7_chain_runtime/oasis7_chain_runtime_observability_tests.rs`; `.pm/tasks/task_c612861fd1fe4187b789ceff61a6d0f7.execution.md`
+- Review Roles: runtime_engineer, repository_health_engineer, qa_engineer
+- Review Question: Confirm the readiness recovery patch correctly stops stale request timeout/EOF debug-buffer entries from blocking `replication_transport_unstable` when there is an active requestable peer, while preserving strict blocking for no requestable peers, cooldowns, last_error, network lag, and storage challenge degradation.
+- Evidence Available: run105 health artifacts `.tmp/run105_health_deep/`; Kepler and Einstein root-cause slices; `cargo test -p oasis7 --bin oasis7_chain_runtime classify_transport_stability`; `cargo test -p oasis7 --bin oasis7_chain_runtime observability`; `cargo fmt --check`; `git diff --check`; `./scripts/check-rust-file-size.sh`; workflow/doc gates.
+- Expected Return Contract: findings | no_findings | residual_risk
+- Formal Sink: `.pm/tasks/task_c612861fd1fe4187b789ceff61a6d0f7.execution.md`
+
+## 2026-06-18 08:15:31 CST / qa_engineer
+- Review Trigger: pre-PR local role review
+- Review Scope: focused transport stability tests and adjusted observability payload fixture.
+- Review Roles: runtime_engineer, repository_health_engineer, qa_engineer
+- Review Question: Confirm tests cover the run105 live regression signature and still cover the non-recovered/no-requestable-peer boundary.
+- Evidence Available: `cargo test -p oasis7 --bin oasis7_chain_runtime classify_transport_stability`; `cargo test -p oasis7 --bin oasis7_chain_runtime observability`; fmt/diff/file-size/workflow/doc gates.
+- Expected Return Contract: findings | no_findings | residual_risk
+- Formal Sink: `.pm/tasks/task_c612861fd1fe4187b789ceff61a6d0f7.execution.md`
+
+- Pre-PR Local Role Review: passed
+- Task UID: task_c612861fd1fe4187b789ceff61a6d0f7
+- Source Worktree: /Users/scc/ccwork/worktrees/oasis7-p2p-replication-transport-gap-sync-recovery
+- Source Branch: codex/replication-transport-readiness-recovery
+- Source Head: 10ff37ced266e63b0fd99b32c123c3854966c7f3 plus working-tree diff reviewed before commit
+- Comparison Ref: refs/remotes/origin/main
+- Reviewed Changed Paths: `.pm/tasks/task_c612861fd1fe4187b789ceff61a6d0f7.execution.md`; `crates/oasis7/src/bin/oasis7_chain_runtime/status_payload_observability.rs`; `crates/oasis7/src/bin/oasis7_chain_runtime/oasis7_chain_runtime_observability_transport_tests.rs`; `crates/oasis7/src/bin/oasis7_chain_runtime/oasis7_chain_runtime_observability_tests.rs`
+- Role Selection Basis: runtime status/readiness logic changed after live run105 health showed stale replication debug errors blocking ready despite active peers; tests/release readiness require QA coverage review; cross-cutting observability/readiness behavior requires repository health review.
+- Review Roles: runtime_engineer, repository_health_engineer, qa_engineer
+- Review Evidence: runtime_engineer/repository_health_engineer Laplace returned `no_findings`, confirming strict gates remain preserved and the recovery heuristic is scoped to stale request-path failures with active requestable peers; qa_engineer Noether returned `no_findings`, confirming tests cover the run105 live signature and the no-requestable-peer boundary.
+- Review Findings Disposition: no_findings
+- Finding Disposition Evidence: no code changes required after reviews; fresh local verification passed: `cargo test -p oasis7 --bin oasis7_chain_runtime classify_transport_stability -- --nocapture`; `cargo test -p oasis7 --bin oasis7_chain_runtime observability -- --nocapture`; `cargo test -p oasis7 --bin oasis7_chain_runtime -- --nocapture`; `cargo fmt --check`; `git diff --check`; `./scripts/check-rust-file-size.sh`; workflow/doc gates.
+- Residual Risk: Low; this is a status-layer recovery heuristic for long-lived debug buffers, and a future source-level cleanup should timestamp or age out replication debug errors.
+

--- a/crates/oasis7/src/bin/oasis7_chain_runtime/oasis7_chain_runtime_observability_tests.rs
+++ b/crates/oasis7/src/bin/oasis7_chain_runtime/oasis7_chain_runtime_observability_tests.rs
@@ -253,7 +253,7 @@ fn assert_chain_status_payload_consensus_health_metrics() {
         ],
         registered_protocols: vec!["/oasis7/fetch-commit/1".to_string()],
         protocol_retry_cooldown_peers: BTreeMap::new(),
-        transport_retry_cooldown_peers: Vec::new(),
+        transport_retry_cooldown_peers: vec!["peer-a".to_string()],
         request_peer_scores: BTreeMap::new(),
         recent_errors: vec!["request failed: Timeout".to_string()],
     };

--- a/crates/oasis7/src/bin/oasis7_chain_runtime/oasis7_chain_runtime_observability_transport_tests.rs
+++ b/crates/oasis7/src/bin/oasis7_chain_runtime/oasis7_chain_runtime_observability_transport_tests.rs
@@ -78,3 +78,69 @@ fn classify_transport_stability_ignores_reachability_diagnostics() {
     assert_eq!(stability.connection_closed_count, 0);
     assert_eq!(stability.protocol_error_count, 0);
 }
+
+#[test]
+fn classify_transport_stability_recovers_when_active_request_peer_is_healthy() {
+    let stability =
+        super::status_payload::classify_transport_stability(&super::ChainReplicationDebugStatus {
+            local_peer_id: "peer-local".to_string(),
+            connected_peers: vec!["peer-a".to_string()],
+            peer_healths: vec![super::ChainPeerHealthStatus {
+                peer_id: "peer-a".to_string(),
+                status: "active".to_string(),
+                issues: Vec::new(),
+                discovery_sources: vec!["static_bootstrap".to_string()],
+                active_path_kind: Some("direct".to_string()),
+                source_operator: None,
+                source_asn: None,
+            }],
+            registered_protocols: Vec::new(),
+            protocol_retry_cooldown_peers: BTreeMap::new(),
+            transport_retry_cooldown_peers: Vec::new(),
+            request_peer_scores: BTreeMap::from([("peer-a".to_string(), 100)]),
+            recent_errors: vec![
+                "request failed: Timeout protocol=/aw/node/replication/fetch-commit/1.0.0 peer=peer-b".to_string(),
+                "request failed: Io(Custom { kind: UnexpectedEof, error: Eof { name: \"map\" } }) protocol=/aw/node/replication/fetch-commit/head/1.0.0 peer=peer-b".to_string(),
+            ],
+        });
+
+    assert!(stability.stable);
+    assert_eq!(stability.score, 100);
+    assert_eq!(stability.blocking_error_count, 0);
+    assert_eq!(stability.timeout_count, 0);
+    assert_eq!(stability.protocol_error_count, 0);
+}
+
+#[test]
+fn classify_transport_stability_keeps_request_errors_blocking_without_requestable_peer() {
+    let stability =
+        super::status_payload::classify_transport_stability(&super::ChainReplicationDebugStatus {
+            local_peer_id: "peer-local".to_string(),
+            connected_peers: vec!["peer-a".to_string()],
+            peer_healths: vec![super::ChainPeerHealthStatus {
+                peer_id: "peer-a".to_string(),
+                status: "active".to_string(),
+                issues: Vec::new(),
+                discovery_sources: vec!["static_bootstrap".to_string()],
+                active_path_kind: Some("direct".to_string()),
+                source_operator: None,
+                source_asn: None,
+            }],
+            registered_protocols: Vec::new(),
+            protocol_retry_cooldown_peers: BTreeMap::new(),
+            transport_retry_cooldown_peers: vec!["peer-a".to_string()],
+            request_peer_scores: BTreeMap::from([("peer-a".to_string(), 100)]),
+            recent_errors: vec![
+                "request failed: Timeout protocol=/aw/node/replication/fetch-commit/1.0.0 peer=peer-a".to_string(),
+                "request failed: Io(Custom { kind: UnexpectedEof, error: Eof { name: \"map\" } }) protocol=/aw/node/replication/fetch-commit/head/1.0.0 peer=peer-a".to_string(),
+                "request failed: Timeout protocol=/aw/node/replication/fetch-commit/head/1.0.0 peer=peer-a".to_string(),
+                "request failed: Timeout protocol=/aw/node/replication/fetch-commit/1.0.0 peer=peer-a".to_string(),
+            ],
+        });
+
+    assert!(!stability.stable);
+    assert!(stability.score < 70);
+    assert_eq!(stability.blocking_error_count, 4);
+    assert_eq!(stability.timeout_count, 3);
+    assert_eq!(stability.protocol_error_count, 4);
+}

--- a/crates/oasis7/src/bin/oasis7_chain_runtime/status_payload_observability.rs
+++ b/crates/oasis7/src/bin/oasis7_chain_runtime/status_payload_observability.rs
@@ -245,6 +245,10 @@ fn replication_error_is_blocking(
         return false;
     }
     let lower = error.to_ascii_lowercase();
+    let recovered_request_path = replication_has_recovered_request_path(replication);
+    if recovered_request_path && replication_error_is_recovered_request_path_failure(&lower) {
+        return false;
+    }
     let active_peer_available = replication
         .peer_healths
         .iter()
@@ -260,6 +264,53 @@ fn replication_error_is_blocking(
         return false;
     }
     true
+}
+
+fn replication_has_recovered_request_path(
+    replication: &super::super::ChainReplicationDebugStatus,
+) -> bool {
+    let protocol_cooldown_peer_ids = replication
+        .protocol_retry_cooldown_peers
+        .values()
+        .flat_map(|peers| peers.iter().map(String::as_str))
+        .collect::<BTreeSet<_>>();
+    let transport_cooldown_peer_ids = replication
+        .transport_retry_cooldown_peers
+        .iter()
+        .map(String::as_str)
+        .collect::<BTreeSet<_>>();
+    let peer_is_requestable = |peer_id: &str| {
+        !protocol_cooldown_peer_ids.contains(peer_id)
+            && !transport_cooldown_peer_ids.contains(peer_id)
+            && replication
+                .request_peer_scores
+                .get(peer_id)
+                .copied()
+                .unwrap_or(100)
+                > 0
+    };
+    replication
+        .peer_healths
+        .iter()
+        .any(|health| health.status == "active" && peer_is_requestable(health.peer_id.as_str()))
+        || (replication.peer_healths.is_empty()
+            && replication
+                .connected_peers
+                .iter()
+                .any(|peer_id| peer_is_requestable(peer_id.as_str())))
+}
+
+fn replication_error_is_recovered_request_path_failure(lower: &str) -> bool {
+    (lower.contains("request failed:")
+        || lower.contains("outbound request failed")
+        || lower.contains("network request failed"))
+        && (lower.contains("timeout")
+            || lower.contains("unexpectedeof")
+            || lower.contains("unexpected eof")
+            || lower.contains("eof")
+            || lower.contains("connectionclosed")
+            || lower.contains("connection closed")
+            || lower.contains("connection reset"))
 }
 
 fn replication_error_is_diagnostic(error: &str) -> bool {


### PR DESCRIPTION
## Summary
- Treat stale replication request timeout/EOF debug-buffer entries as recovered once an active requestable peer is available.
- Keep no-requestable-peer/cooldown cases blocking for transport readiness.
- Record run105 package/deploy/health evidence and Windows observer subnet-concentration finding in the task log.

## Validation
- `env -u RUSTC_WRAPPER cargo test -p oasis7 --bin oasis7_chain_runtime classify_transport_stability -- --nocapture`
- `env -u RUSTC_WRAPPER cargo test -p oasis7 --bin oasis7_chain_runtime observability -- --nocapture`
- `env -u RUSTC_WRAPPER cargo test -p oasis7 --bin oasis7_chain_runtime -- --nocapture`
- `cargo fmt --check`
- `git diff --check`
- `./scripts/check-rust-file-size.sh`
- `./scripts/pm/workflow-lint.sh --task-uid task_c612861fd1fe4187b789ceff61a6d0f7 --phase current`
- `./scripts/doc-governance-check.sh`
