### PR TITLE
Harden replication cold-index recovery

### DIFF
--- a/.pm/tasks/task_c612861fd1fe4187b789ceff61a6d0f7.execution.md
+++ b/.pm/tasks/task_c612861fd1fe4187b789ceff61a6d0f7.execution.md
@@ -599,3 +599,100 @@ Example:
 - Finding Disposition Evidence: no code changes required after reviews; fresh local verification passed: `cargo test -p oasis7 --bin oasis7_chain_runtime classify_transport_stability -- --nocapture`; `cargo test -p oasis7 --bin oasis7_chain_runtime observability -- --nocapture`; `cargo test -p oasis7 --bin oasis7_chain_runtime -- --nocapture`; `cargo fmt --check`; `git diff --check`; `./scripts/check-rust-file-size.sh`; workflow/doc gates.
 - Residual Risk: Low; this is a status-layer recovery heuristic for long-lived debug buffers, and a future source-level cleanup should timestamp or age out replication debug errors.
 
+### Run106 package/deploy/live-health evidence
+- PR #515 merged to main at `4a3e98477d152cc407be0529bf7a9419093936a1`.
+- Testnet Packages run `27728713857` completed successfully for `package_scope=all_existing`, package version `0.0.0+testnet.106.4a3e98477d15`.
+- Deployment:
+  - Linux sequencer/storage/linux_observer upgraded with `scripts/p2p-public-testnet-package-node-upgrade.sh`; runtime sha `b83f75719993f41048ba1a152b051ba830e7d09fc01e62e79f23b95f3c0d0115`; services active. Temporary run106 driver used stale `/status` post-restart URLs, so strict post-restart checks timed out even though `/v1/chain/status` was live.
+  - fourth local upgraded from local macOS arm64 release build; version `0.0.0+testnet.106.4a3e98477d15-macos-arm64-local`; launchd service running and `/v1/chain/status` reachable.
+  - Windows observer upgraded with run106 installer; runtime sha `80fffe1969f09fd16afa8e81aa22628198f3b9b32ac7bcd332cd81f9460bf4d1`; scheduled task running.
+- Health script: `.tmp/collect_run106_health.py`.
+- Health evidence: `.tmp/run106_health_deep/summary.json` and `.tmp/run106_health_deep/summary-after-120s.json`.
+- Result after 120s:
+  - All five nodes report run106 package version (fourth local uses `0.0.0+testnet.106.4a3e98477d15-macos-arm64-local`).
+  - `storage_challenge_network_degraded=false` and degraded height/reason are null on all five nodes.
+  - `linux_observer` and `fourth_local` are `ready`.
+  - `sequencer_ecs` and `storage_ecs` are running with `last_error=null`, but remain `not_ready`; sequencer gates are `consensus_peer_head_unavailable` and `consensus_peer_head_stale`, storage gates are `consensus_peer_head_unavailable` and `replication_transport_unstable`.
+  - Both validators stayed at committed height `18273` across the 120s watch window.
+  - `windows_observer` is running on run106 but remains `not_ready` with `last_error=libp2p-replication no connected providers for /aw/node/replication/fetch-commit/1.0.0`; it advanced from height `18121` to `18131` but remains behind.
+- Additional live evidence:
+  - Storage status has active direct peers but all request peer scores are `0`, fetch-commit/head protocol cooldowns include all active peers, and transport stability score is `0`.
+  - Sequencer status has `known_peer_heads=1` but network head decision `degraded` because the only observed peer head is stale.
+  - Sequencer runtime log includes cold-index parse failures: `parse /opt/oasis7/p2p-testnet/data/replication-root/replication_commit_messages.cold-index/index.json failed: EOF while parsing a string`.
+  - Storage runtime log has historical repeated gap-sync fetch-commit request budget exhaustion/timeouts against sequencer/observer peers.
+
+### Slice: run106 validator stall / cold-index replication root-cause
+- role: runtime_engineer
+- intended dispatch: bounded subagent slice via multi_agent_v1, full-thread context inherited.
+- mandatory context checklist: run106 health artifacts under `.tmp/run106_health_deep/`; Linux and Windows deployment evidence above; validator committed height stuck at `18273`; sequencer cold-index EOF parse failures; storage request peer scores `0` and fetch-commit/head protocol cooldowns; `storage_challenge_network_degraded=false` on all nodes.
+- requested output: determine whether cold-index parse failure/request cooldown is a runtime code bug, identify files/functions, and propose or implement the minimal code-level root fix with tests.
+- Formal Sink: `.pm/tasks/task_c612861fd1fe4187b789ceff61a6d0f7.execution.md`
+
+### Slice: run106 live recovery evidence / operations boundary
+- role: blockchain_ops_engineer
+- intended dispatch: bounded subagent slice via multi_agent_v1, full-thread context inherited.
+- mandatory context checklist: same run106 health/log evidence; distinguish code root fix from temporary recovery; Windows subnet/topology prior finding remains in scope only as residual environment fact.
+- requested output: provide current live-state diagnosis, safe temporary recovery options if needed, and identify any script/runbook fixes for stale `/status` upgrade driver usage without masking runtime root cause.
+- Formal Sink: `.pm/tasks/task_c612861fd1fe4187b789ceff61a6d0f7.execution.md`
+- actual dispatch: reused existing subagent `019ed80d-b932-78a0-b980-fd5341024071` (Kepler) for runtime_engineer and `019ed80d-dded-7831-9d59-345641c0bfe3` (Einstein) for blockchain_ops_engineer because the subagent thread limit prevented a new spawn.
+- runtime_engineer result: Kepler returned findings. Root cause is runtime code-level fragility in replication cold-index persistence/readback: `write_json_compact` used non-atomic `fs::write`, `load_commit_message_cold_index_from_root` hard-failed on canonical parse EOF without trying compat alias, and `load_latest_commit_message_from_root` loaded cold index before returning hot latest commit, so a truncated cold-index could poison fetch-head/fetch-commit and drive peer scores/cooldowns down to `0`.
+- blockchain_ops_engineer result: Einstein confirmed run106 deployment/package state and storage challenge recovery; identified stale `/status` in temporary Linux upgrade driver as a script/runbook bug; advised preserving evidence and avoiding destructive cold-index/root resets while runtime root-cause fix proceeds.
+- integration:
+  - Changed `crates/oasis7_node/src/replication_support.rs` JSON persistence to write same-directory temp files, `sync_all`, then rename, for compact and pretty replication JSON writes.
+  - Changed `crates/oasis7_node/src/replication/commit_retention.rs` to recover a corrupted canonical cold-index from the compat alias and rewrite canonical.
+  - Changed `crates/oasis7_node/src/replication.rs` to return a readable hot latest commit before consulting cold-index for older candidates.
+  - Added regression tests in `crates/oasis7_node/src/replication/tests.rs` for truncated canonical recovery and hot-latest fetch-head resilience when cold-index is corrupt.
+- verification:
+  - `env -u RUSTC_WRAPPER cargo test -p oasis7_node load_commit_message_cold_index_recovers_truncated_canonical_from_compat_alias -- --nocapture` passed.
+  - `env -u RUSTC_WRAPPER cargo test -p oasis7_node load_latest_commit_message_reads_hot_latest_before_corrupt_cold_index -- --nocapture` passed.
+  - `env -u RUSTC_WRAPPER cargo test -p oasis7_node replication::tests -- --nocapture` passed, 26 tests.
+  - `env -u RUSTC_WRAPPER cargo test -p oasis7_node --lib -- --nocapture` passed, 335 tests.
+  - `env -u RUSTC_WRAPPER cargo fmt --check` passed.
+  - `git diff --check` passed.
+  - `./scripts/check-rust-file-size.sh` passed.
+  - `./scripts/pm/workflow-lint.sh --task-uid task_c612861fd1fe4187b789ceff61a6d0f7 --phase current` passed.
+  - `./scripts/doc-governance-check.sh` passed.
+- live watch after run106:
+  - `.tmp/run106_health_deep/summary-after-recovery.json`: sequencer/storage/fourth local recovered to `ready`; validators advanced to height `18279`; storage challenge degraded stayed false on all nodes.
+  - `.tmp/run106_health_deep/summary-after-cold-index-fix-watch.json`: sequencer/storage/fourth local stayed `ready` and advanced to height `18289`; Linux observer remained not_ready with no connected peers/private reachability; Windows observer remained not_ready but continued slow catch-up to height `18184`.
+- residual risk:
+  - The patch prevents future truncation and recovers single-side canonical corruption when compat alias survives. If both canonical and alias are corrupt, pack-segment scanning/rebuild remains a follow-up.
+  - Linux observer and Windows observer no-peer/provider availability are still live topology/admission problems, not closed by this runtime patch.
+
+## 2026-06-18 09:58:00 CST / runtime_engineer + repository_health_engineer
+- Review Trigger: pre-PR local role review
+- Review Scope: `crates/oasis7_node/src/replication_support.rs`; `crates/oasis7_node/src/replication/commit_retention.rs`; `crates/oasis7_node/src/replication.rs`; `crates/oasis7_node/src/replication/tests.rs`; `crates/oasis7_node/Cargo.toml`; `.pm/tasks/task_c612861fd1fe4187b789ceff61a6d0f7.execution.md`
+- Review Roles: runtime_engineer, repository_health_engineer, qa_engineer
+- Review Question: Confirm the cold-index EOF root fix prevents non-atomic JSON truncation, recovers canonical cold-index from compat alias, avoids hot-head poisoning by corrupted cold-index, and preserves hard corruption boundaries.
+- Evidence Available: run106 health/log evidence; Kepler and Einstein slices; `cargo test -p oasis7_node replication::tests`; `cargo test -p oasis7_node --lib`; fmt/diff/file-size/workflow/doc gates.
+- Expected Return Contract: findings | no_findings | residual_risk
+- Formal Sink: `.pm/tasks/task_c612861fd1fe4187b789ceff61a6d0f7.execution.md`
+
+- Pre-PR Local Role Review: passed
+- Task UID: task_c612861fd1fe4187b789ceff61a6d0f7
+- Source Worktree: /Users/scc/ccwork/worktrees/oasis7-p2p-replication-transport-gap-sync-recovery
+- Source Branch: codex/replication-cold-index-recovery
+- Comparison Ref: refs/remotes/origin/main
+- Reviewed Changed Paths: `.pm/tasks/task_c612861fd1fe4187b789ceff61a6d0f7.execution.md`; `crates/oasis7_node/Cargo.toml`; `crates/oasis7_node/src/replication.rs`; `crates/oasis7_node/src/replication/commit_retention.rs`; `crates/oasis7_node/src/replication/tests.rs`; `crates/oasis7_node/src/replication_support.rs`
+- Role Selection Basis: runtime replication persistence/readback semantics changed after live run106 logs showed cold-index EOF poisoning; JSON persistence also affects repo-wide replication state health; tests/release readiness require QA review.
+- Review Roles: runtime_engineer, repository_health_engineer, qa_engineer
+- Review Evidence: QA Noether returned `no_findings`, confirming truncated canonical recovery, hot latest with corrupt cold-index, and existing compat alias restoration coverage. Runtime/repo-health Laplace initially found P2 Windows replace risk in the atomic helper; implementation was changed to use Windows-only `MoveFileExW(..., MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH)` with a target-scoped `windows-sys` dependency, then Laplace re-reviewed and returned `no_findings`.
+- Review Findings Disposition: all findings resolved.
+- Finding Disposition Evidence: P2 fixed in `crates/oasis7_node/src/replication_support.rs` and `crates/oasis7_node/Cargo.toml`; fresh verification passed after the fix: `cargo test -p oasis7_node replication::tests -- --nocapture`; `cargo test -p oasis7_node --lib -- --nocapture`; `cargo fmt --check`; `git diff --check`; `./scripts/check-rust-file-size.sh`; workflow/doc gates.
+- Residual Risk: Low. Windows behavior now uses the intended replacement API but was not built on Windows in this pass; if both canonical and compat alias are corrupt, a future pack-segment scan/rebuild path is still needed.
+
+## 2026-06-18 10:02:00 CST / PR #516 watch-fix loop
+- PR: https://github.com/eng-cc/oasis7/pull/516
+- Initial CI: Rust `required-gate` passed; Wasm Determinism Gate `plan-wasm-determinism-scope`, `collect-wasm-summaries` for m1/m4/m5, and `verify-wasm-determinism` for m1/m4/m5 passed.
+- Review finding: automated Codex review raised P2 on `load_commit_message_cold_index_from_root`: recovering from a potentially stale compat alias rewrote the canonical cold-index and then performed destructive legacy cleanup and pack pruning against only the alias-derived membership. In a crash window where canonical had newer pack refs but alias was stale, truncating canonical could make recovery delete newer pack segments that the stale alias did not reference.
+- Disposition: accepted and fixed. Alias recovery now rewrites canonical/alias from the recovered index but skips `delete_legacy_cold_commit_blobs_if_unreferenced` and `prune_unreferenced_commit_message_pack_files` because alias freshness cannot prove the absence of newer pack refs. Normal canonical load and alias-absent migration still perform cleanup/pruning.
+- Regression added: `replication::recovery_tests::cold_index_alias_recovery_does_not_prune_newer_pack_segments` constructs a stale-alias/truncated-canonical recovery and asserts a newer pack segment remains on disk.
+- File-size disposition: the new regression was split into `crates/oasis7_node/src/replication/recovery_tests.rs` so `replication/tests.rs` stays below the 1200-line test-file limit.
+- Verification after fix:
+  - `env -u RUSTC_WRAPPER cargo test -p oasis7_node replication:: -- --nocapture` passed, 31 tests.
+  - `env -u RUSTC_WRAPPER cargo test -p oasis7_node --lib -- --nocapture` passed, 336 tests.
+  - `env -u RUSTC_WRAPPER cargo fmt --check` passed.
+  - `git diff --check` passed.
+  - `./scripts/check-rust-file-size.sh` passed.
+  - `./scripts/pm/workflow-lint.sh --task-uid task_c612861fd1fe4187b789ceff61a6d0f7 --phase current` passed.
+  - `./scripts/doc-governance-check.sh` passed.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6273,6 +6273,7 @@ dependencies = [
  "serde",
  "serde_cbor",
  "serde_json",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/crates/oasis7_node/Cargo.toml
+++ b/crates/oasis7_node/Cargo.toml
@@ -21,3 +21,6 @@ serde_json = "1"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 oasis7_net = { path = "../oasis7_net", default-features = false, features = ["libp2p"] }
+
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.59", features = ["Win32_Storage_FileSystem"] }

--- a/crates/oasis7_node/src/replication.rs
+++ b/crates/oasis7_node/src/replication.rs
@@ -66,13 +66,18 @@ pub(crate) fn load_latest_commit_message_from_root(
         .hot_window
         .latest_height
         .unwrap_or(0);
+    if hot_height > 0 {
+        if let Some(message) = load_commit_message_from_root(root_dir, world_id, hot_height)? {
+            return Ok(Some(message));
+        }
+    }
     let cold_height = load_commit_message_cold_index_from_root(root_dir)?
         .by_height
         .keys()
         .next_back()
         .copied()
         .unwrap_or(0);
-    let mut candidate = hot_height.max(cold_height);
+    let mut candidate = hot_height.saturating_sub(1).max(cold_height);
     while candidate > 0 {
         if let Some(message) = load_commit_message_from_root(root_dir, world_id, candidate)? {
             return Ok(Some(message));
@@ -1177,5 +1182,7 @@ fn commit_height_from_payload(payload: &[u8]) -> Option<u64> {
 
 #[cfg(test)]
 mod checkpoint_tests;
+#[cfg(test)]
+mod recovery_tests;
 #[cfg(test)]
 mod tests;

--- a/crates/oasis7_node/src/replication/commit_retention.rs
+++ b/crates/oasis7_node/src/replication/commit_retention.rs
@@ -183,10 +183,30 @@ pub(super) fn load_commit_message_cold_index_from_root(
     let canonical_path = commit_message_cold_index_manifest_path_from_root(root_dir);
     let compat_alias_path = commit_message_cold_index_compat_alias_path_from_root(root_dir);
     if canonical_path.exists() {
-        let loaded = load_json_or_default::<CommitMessageColdIndex>(canonical_path.as_path())?;
+        let mut recovered_from_compat_alias = false;
+        let loaded = match load_json_or_default::<CommitMessageColdIndex>(canonical_path.as_path())
+        {
+            Ok(loaded) => loaded,
+            Err(canonical_err) if compat_alias_path.exists() => {
+                recovered_from_compat_alias = true;
+                load_json_or_default::<CommitMessageColdIndex>(compat_alias_path.as_path())
+                    .map_err(|alias_err| NodeError::Replication {
+                        reason: format!(
+                            "load commit message cold index failed: canonical={} error={:?}; compat_alias={} error={:?}",
+                            canonical_path.display(),
+                            canonical_err,
+                            compat_alias_path.display(),
+                            alias_err
+                        ),
+                    })?
+            }
+            Err(err) => return Err(err),
+        };
         let mut cold_index = normalize_commit_message_cold_index(loaded.clone());
         let migrated_hashes = migrate_legacy_cold_entries_to_packs(root_dir, &mut cold_index)?;
-        if !compat_alias_path.exists() || cold_index != loaded {
+        if recovered_from_compat_alias {
+            write_commit_message_cold_index_to_root(root_dir, &cold_index)?;
+        } else if !compat_alias_path.exists() || cold_index != loaded {
             write_commit_message_cold_index_to_root(root_dir, &cold_index)?;
             delete_legacy_cold_commit_blobs_if_unreferenced(root_dir, &migrated_hashes)?;
             prune_unreferenced_commit_message_pack_files(root_dir, &cold_index)?;

--- a/crates/oasis7_node/src/replication/recovery_tests.rs
+++ b/crates/oasis7_node/src/replication/recovery_tests.rs
@@ -1,0 +1,128 @@
+use super::commit_retention::{self, CommitMessageColdIndex};
+use super::*;
+use oasis7_proto::storage_cold_index::{
+    storage_cold_index_dir_name, STORAGE_COLD_INDEX_MANIFEST_FILE,
+};
+use std::path::PathBuf;
+
+fn temp_dir(prefix: &str) -> PathBuf {
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("duration")
+        .as_nanos();
+    std::env::temp_dir().join(format!(
+        "oasis7-replication-recovery-tests-{prefix}-{unique}"
+    ))
+}
+
+fn signed_remote_message(
+    seed: u8,
+    world_id: &str,
+    node_id: &str,
+    sequence: u64,
+) -> GossipReplicationMessage {
+    let bytes = [seed; 32];
+    let signing_key = SigningKey::from_bytes(&bytes);
+    let private_hex = hex::encode(signing_key.to_bytes());
+    let public_hex = hex::encode(signing_key.verifying_key().to_bytes());
+    let signer = ReplicationSigningKey {
+        signing_key: signing_key_from_hex(private_hex.as_str()).expect("signing key"),
+        public_key_hex: public_hex.clone(),
+    };
+    let payload = format!("payload-{seed}-{sequence}").into_bytes();
+    let path = format!("{COMMIT_FILE_PREFIX}/{:020}.json", sequence.max(1));
+    let record = build_replication_record_with_epoch(
+        world_id,
+        public_hex.as_str(),
+        1,
+        sequence.max(1),
+        path.as_str(),
+        payload.as_slice(),
+        1_000,
+    )
+    .expect("record");
+    let mut message = GossipReplicationMessage {
+        version: REPLICATION_VERSION,
+        world_id: world_id.to_string(),
+        node_id: node_id.to_string(),
+        record,
+        payload,
+        public_key_hex: Some(public_hex),
+        signature_hex: None,
+    };
+    message.signature_hex = Some(sign_replication_message(&message, &signer).expect("sign"));
+    message
+}
+
+#[test]
+fn cold_index_alias_recovery_does_not_prune_newer_pack_segments() {
+    let dir = temp_dir("cold-index-alias-recovery-no-prune");
+    let world_id = "world-cold-index-alias-recovery-no-prune";
+    let config = NodeReplicationConfig::new(&dir)
+        .expect("config")
+        .with_max_hot_commit_messages(2)
+        .expect("hot commit cap");
+    let runtime = ReplicationRuntime::new(&config, "node-a").expect("runtime");
+
+    for (seed, height) in [(100, 1), (101, 300)] {
+        runtime
+            .persist_commit_message(
+                height,
+                &signed_remote_message(seed, world_id, "node-b", height),
+            )
+            .expect("persist initial message");
+    }
+    let compat_alias_path = dir.join("replication_commit_messages_cold_index.json");
+    let stale_alias = std::fs::read(&compat_alias_path).expect("read stale compat alias");
+
+    for (seed, height) in [(102, 301), (103, 302)] {
+        runtime
+            .persist_commit_message(
+                height,
+                &signed_remote_message(seed, world_id, "node-b", height),
+            )
+            .expect("persist later message");
+    }
+
+    let canonical_path = dir
+        .join(storage_cold_index_dir_name(COMMIT_MESSAGE_DIR))
+        .join(STORAGE_COLD_INDEX_MANIFEST_FILE);
+    let canonical_before =
+        load_json_or_default::<CommitMessageColdIndex>(&canonical_path).expect("canonical before");
+    let newer_pack = match canonical_before
+        .by_height
+        .get(&300)
+        .expect("newer cold height")
+    {
+        commit_retention::CommitMessageColdEntry::PackRef(pack_ref) => pack_ref,
+        _ => panic!("newer cold height should be packed"),
+    };
+    let newer_segment_path = dir
+        .join(storage_cold_index_dir_name(COMMIT_MESSAGE_DIR))
+        .join("segments")
+        .join(format!("{}.pack", newer_pack.segment_id));
+    assert!(
+        newer_segment_path.exists(),
+        "newer pack segment should exist"
+    );
+
+    std::fs::write(&compat_alias_path, stale_alias).expect("restore stale compat alias");
+    std::fs::write(&canonical_path, b"{\"by_height\":{\"1\"").expect("truncate canonical");
+    let recovered = load_commit_message_cold_index_from_root(dir.as_path())
+        .expect("recover from stale compat alias");
+
+    assert!(
+        recovered.by_height.contains_key(&1),
+        "stale alias should recover height 1"
+    );
+    assert!(
+        !recovered.by_height.contains_key(&300),
+        "stale alias should not prove height 300"
+    );
+    assert!(
+        newer_segment_path.exists(),
+        "alias recovery must not prune pack segments that the stale alias cannot reference"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}

--- a/crates/oasis7_node/src/replication/tests.rs
+++ b/crates/oasis7_node/src/replication/tests.rs
@@ -1,3 +1,4 @@
+use super::commit_retention::CommitMessageColdIndex;
 use super::*;
 use crate::NodeExecutionCheckpointBlob;
 use oasis7_proto::storage_cold_index::{
@@ -857,6 +858,80 @@ fn load_commit_message_cold_index_restores_compat_alias_from_canonical_manifest(
         compat_alias_path.exists(),
         "canonical load should restore compat alias"
     );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn load_commit_message_cold_index_recovers_truncated_canonical_from_compat_alias() {
+    let dir = temp_dir("commit-cold-index-truncated-canonical");
+    let world_id = "world-commit-cold-index-truncated-canonical";
+    let config = NodeReplicationConfig::new(&dir)
+        .expect("config")
+        .with_max_hot_commit_messages(2)
+        .expect("hot commit cap");
+    let runtime = ReplicationRuntime::new(&config, "node-a").expect("runtime");
+
+    runtime
+        .persist_commit_message(1, &signed_remote_message(96, world_id, "node-b", 1))
+        .expect("persist message 1");
+    runtime
+        .persist_commit_message(100, &signed_remote_message(97, world_id, "node-b", 100))
+        .expect("persist message 100");
+
+    let canonical_path = dir
+        .join(storage_cold_index_dir_name(COMMIT_MESSAGE_DIR))
+        .join(STORAGE_COLD_INDEX_MANIFEST_FILE);
+    let compat_alias_path = dir.join("replication_commit_messages_cold_index.json");
+    let alias_before = std::fs::read(&compat_alias_path).expect("read compat alias");
+    std::fs::write(&canonical_path, b"{\"by_height\":{\"1\"").expect("truncate canonical");
+
+    let cold_index = load_commit_message_cold_index_from_root(dir.as_path())
+        .expect("recover cold index from compat alias");
+    assert!(
+        cold_index.by_height.contains_key(&1),
+        "compat alias should preserve cold height 1"
+    );
+    assert_eq!(
+        std::fs::read(&compat_alias_path).expect("read compat alias after recovery"),
+        alias_before,
+        "recovery should not rewrite a valid compat alias differently"
+    );
+    let canonical_after = load_json_or_default::<CommitMessageColdIndex>(&canonical_path)
+        .expect("canonical repaired");
+    assert_eq!(canonical_after, cold_index);
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn load_latest_commit_message_reads_hot_latest_before_corrupt_cold_index() {
+    let dir = temp_dir("latest-commit-hot-before-corrupt-cold-index");
+    let world_id = "world-latest-commit-hot-before-corrupt-cold-index";
+    let config = NodeReplicationConfig::new(&dir)
+        .expect("config")
+        .with_max_hot_commit_messages(2)
+        .expect("hot commit cap");
+    let runtime = ReplicationRuntime::new(&config, "node-a").expect("runtime");
+
+    runtime
+        .persist_commit_message(1, &signed_remote_message(98, world_id, "node-b", 1))
+        .expect("persist message 1");
+    runtime
+        .persist_commit_message(100, &signed_remote_message(99, world_id, "node-b", 100))
+        .expect("persist message 100");
+
+    let canonical_path = dir
+        .join(storage_cold_index_dir_name(COMMIT_MESSAGE_DIR))
+        .join(STORAGE_COLD_INDEX_MANIFEST_FILE);
+    let compat_alias_path = dir.join("replication_commit_messages_cold_index.json");
+    std::fs::write(&canonical_path, b"{\"by_height\":{\"1\"").expect("truncate canonical");
+    std::fs::remove_file(&compat_alias_path).expect("remove compat alias");
+
+    let latest = load_latest_commit_message_from_root(dir.as_path(), world_id, 2)
+        .expect("load hot latest despite corrupt cold index")
+        .expect("latest message");
+    assert_eq!(latest.record.sequence, 100);
 
     let _ = std::fs::remove_dir_all(&dir);
 }

--- a/crates/oasis7_node/src/replication_support.rs
+++ b/crates/oasis7_node/src/replication_support.rs
@@ -1,4 +1,7 @@
 use super::*;
+use std::io::Write as _;
+#[cfg(windows)]
+use std::os::windows::ffi::OsStrExt as _;
 
 pub(super) fn signing_key_from_hex(private_key_hex: &str) -> Result<SigningKey, NodeError> {
     let private_key = decode_hex_array::<32>(private_key_hex, "replication private key")?;
@@ -243,31 +246,108 @@ where
 }
 
 pub(super) fn write_json_pretty<T: Serialize>(path: &Path, value: &T) -> Result<(), NodeError> {
-    if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent).map_err(|err| NodeError::Replication {
-            reason: format!("create dir {} failed: {}", parent.display(), err),
-        })?;
-    }
     let bytes = serde_json::to_vec_pretty(value).map_err(|err| NodeError::Replication {
         reason: format!("serialize {} failed: {}", path.display(), err),
     })?;
-    fs::write(path, bytes).map_err(|err| NodeError::Replication {
-        reason: format!("write {} failed: {}", path.display(), err),
-    })
+    write_json_bytes_atomically(path, bytes.as_slice())
 }
 
 pub(super) fn write_json_compact<T: Serialize>(path: &Path, value: &T) -> Result<(), NodeError> {
+    let bytes = serde_json::to_vec(value).map_err(|err| NodeError::Replication {
+        reason: format!("serialize {} failed: {}", path.display(), err),
+    })?;
+    write_json_bytes_atomically(path, bytes.as_slice())
+}
+
+fn write_json_bytes_atomically(path: &Path, bytes: &[u8]) -> Result<(), NodeError> {
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent).map_err(|err| NodeError::Replication {
             reason: format!("create dir {} failed: {}", parent.display(), err),
         })?;
     }
-    let bytes = serde_json::to_vec(value).map_err(|err| NodeError::Replication {
-        reason: format!("serialize {} failed: {}", path.display(), err),
-    })?;
-    fs::write(path, bytes).map_err(|err| NodeError::Replication {
-        reason: format!("write {} failed: {}", path.display(), err),
+
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    let file_name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("replication-json");
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or(0);
+    let tmp_path = parent.join(format!(".{file_name}.tmp-{}-{unique}", std::process::id()));
+
+    let write_result = (|| -> Result<(), NodeError> {
+        let mut file = fs::File::create(&tmp_path).map_err(|err| NodeError::Replication {
+            reason: format!("create {} failed: {}", tmp_path.display(), err),
+        })?;
+        file.write_all(bytes)
+            .map_err(|err| NodeError::Replication {
+                reason: format!("write {} failed: {}", tmp_path.display(), err),
+            })?;
+        file.sync_all().map_err(|err| NodeError::Replication {
+            reason: format!("sync {} failed: {}", tmp_path.display(), err),
+        })?;
+        drop(file);
+        replace_file_atomically(&tmp_path, path)?;
+        if let Ok(parent_dir) = fs::File::open(parent) {
+            let _ = parent_dir.sync_all();
+        }
+        Ok(())
+    })();
+
+    if write_result.is_err() {
+        let _ = fs::remove_file(&tmp_path);
+    }
+    write_result.map_err(|err| match err {
+        NodeError::Replication { reason } => NodeError::Replication {
+            reason: format!("write {} failed: {}", path.display(), reason),
+        },
+        other => other,
     })
+}
+
+#[cfg(not(windows))]
+fn replace_file_atomically(tmp_path: &Path, path: &Path) -> Result<(), NodeError> {
+    fs::rename(tmp_path, path).map_err(|err| NodeError::Replication {
+        reason: format!(
+            "rename {} to {} failed: {}",
+            tmp_path.display(),
+            path.display(),
+            err
+        ),
+    })
+}
+
+#[cfg(windows)]
+fn replace_file_atomically(tmp_path: &Path, path: &Path) -> Result<(), NodeError> {
+    use windows_sys::Win32::Storage::FileSystem::{
+        MoveFileExW, MOVEFILE_REPLACE_EXISTING, MOVEFILE_WRITE_THROUGH,
+    };
+
+    let source = tmp_path
+        .as_os_str()
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect::<Vec<_>>();
+    let target = path
+        .as_os_str()
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect::<Vec<_>>();
+    let flags = MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH;
+    let replaced = unsafe { MoveFileExW(source.as_ptr(), target.as_ptr(), flags) };
+    if replaced == 0 {
+        return Err(NodeError::Replication {
+            reason: format!(
+                "replace {} with {} failed: {}",
+                path.display(),
+                tmp_path.display(),
+                std::io::Error::last_os_error()
+            ),
+        });
+    }
+    Ok(())
 }
 
 pub(super) fn distfs_error_to_node_error<E>(err: E) -> NodeError


### PR DESCRIPTION
## Summary
- make replication JSON writes atomic, including Windows `MoveFileExW` replacement with write-through
- recover a truncated canonical cold-index from the compat alias and rewrite the canonical index
- prefer hot latest commit messages before consulting cold-index so a stale/corrupt index cannot poison fetch-head/fetch-commit recovery

## Verification
- `env -u RUSTC_WRAPPER cargo test -p oasis7_node replication::tests -- --nocapture`
- `env -u RUSTC_WRAPPER cargo test -p oasis7_node --lib -- --nocapture`
- `env -u RUSTC_WRAPPER cargo fmt --check`
- `git diff --check`
- `./scripts/check-rust-file-size.sh`
- `./scripts/pm/workflow-lint.sh --task-uid task_c612861fd1fe4187b789ceff61a6d0f7 --phase current`
- `./scripts/doc-governance-check.sh`

## Live testnet context
- run106 packages were deployed before this PR; storage challenge degraded cleared on all five nodes
- sequencer/storage/fourth recovered readiness; observer nodes still show topology/provider issues rather than the cold-index corruption path
- old sequencer logs showed `replication_commit_messages.cold-index/index.json failed: EOF while parsing a string`, matching the code path hardened here
