### PR TITLE
Clean up legacy world terminology

### DIFF
--- a/.pm/tasks/task_735872fee5174fc28f10166a9e54d56b.execution.md
+++ b/.pm/tasks/task_735872fee5174fc28f10166a9e54d56b.execution.md
@@ -1,0 +1,174 @@
+# task_735872fee5174fc28f10166a9e54d56b Execution Log
+
+- task_uid: task_735872fee5174fc28f10166a9e54d56b
+- title: Clean up legacy world terminology
+- owner_role: tpm
+- worktree_hint: /Users/scc/ccwork/worktrees/oasis7-core-cleanup-legacy-world-terms
+
+<!-- Append entries using:
+Example:
+  ## YYYY-MM-DD HH:MM:SS CST / role_name
+  - 完成内容: ...
+  - 遗留事项: ...
+  - Action: ...
+  - Validation Command: ...
+  - Expected Result: ...
+  - Actual Result: ...
+  - Blocker / Next Action: ...
+-->
+
+## 2026-06-18 09:18:30 CST / tpm
+- 完成内容: WORKFLOW BOOTSTRAP DECIDED
+  - Repository State Impact: repository-changing terminology cleanup across active product/player-facing docs and possibly governance docs.
+  - Isolation Decision: source main worktree was clean; created canonical task worktree `/Users/scc/ccwork/worktrees/oasis7-core-cleanup-legacy-world-terms` on branch `task/core-cleanup-legacy-world-terms`.
+  - Task Truth: owner role `tpm`; task `.pm/tasks/task_735872fee5174fc28f10166a9e54d56b.yaml`; execution log `.pm/tasks/task_735872fee5174fc28f10166a9e54d56b.execution.md`.
+  - Routed Next Phase: `repo-owned-workflow-router` -> `executing-project-tasks`, with professional product/system and repository-health slices required before edits.
+  - Required Writeback: `.pm` execution log mandatory; update formal docs only where active legacy terms are user-facing/product-facing or governance claim boundaries are ambiguous.
+- 遗留事项: Specialist slices and edits still pending; next action recorded below.
+- Action: Created task worktree with `./scripts/new-task-worktree.sh core cleanup-legacy-world-terms ... --json`.
+- Validation Command: `git status --short --branch`; `sed -n '1,260p' .agents/skills/executing-project-tasks/SKILL.md`; `sed -n '1,280p' doc/core/unified-persistent-world-terminology-upgrade-plan-2026-06-16.md`.
+- Expected Result: Task/worktree truth exists; scope maps to current unified-world terminology plan and clear acceptance criteria.
+- Actual Result: Task/worktree created; terminology plan explicitly scopes active player/product docs and preserves historical evidence, script params, manifest fields, and compatibility aliases.
+- Blocker / Next Action: Dispatch `producer_system_designer` and `repository_health_engineer` read-only slices, then perform minimal mechanical edits.
+
+## 2026-06-18 09:19:00 CST / tpm
+- 完成内容: WORKFLOW ROUTE DECIDED
+  - Task Phase: implementation-ready terminology cleanup after task bootstrap.
+  - Selected Workflow Skills: `repo-owned-workflow-router` for phase selection; `executing-project-tasks` for stepwise edits and verification.
+  - Skipped Workflow Skills: `bounded-brainstorming` skipped because canonical terminology plan already defines target terms; `tdd-test-writer` skipped because this is doc/terminology cleanup; `systematic-debugging` skipped unless verification exposes failures; closeout/PR skills deferred until implementation and verification are complete.
+  - Specialist Skills Considered: product/system wording belongs to `producer_system_designer`; classification of allowed legacy residues and governance risk belongs to `repository_health_engineer`.
+- 遗留事项: Specialist slice results and patch verification still pending; next action recorded below.
+- Action: Ran initial terminology scan.
+- Validation Command: `rg -n "hosted world|shared devnet|shared network|public testnet world|local devnet world|large shared world readiness|candidate world|clone-world|local world|本地世界|本地.*大世界|多个.*世界|玩家世界名|世界品牌|trusted_local_only|local-only playtest|local preview|legacy topic label" README.md world-rule.md doc site crates/oasis7_viewer crates/oasis7_client_launcher crates/oasis7/src/bin -g '!target'`.
+- Expected Result: Identify likely active-doc cleanup candidates and expected legal residues.
+- Actual Result: Many matches are legal compatibility/code/test/history/evidence surfaces. Likely cleanup candidates include active governance/evidence-index docs using `hosted world` and `shared network` as navigation categories, plus p2p/network documents where legacy labels may need qualifiers or replacement with `network rehearsal` / `hosted player entry`.
+- Blocker / Next Action: Record slice contracts and dispatch.
+
+### Subagent Slice Contract: producer_system_designer read_only_analysis
+- role: `producer_system_designer`
+- slice type: `read_only_analysis`
+- intended model configuration: workflow default from `.codex/config.toml` `[workflow.subagent_runtime]`, `gpt-5.5-medium`.
+- actual dispatched model/reasoning: inherited/unverified; current subagent tool inherits parent context/model and does not verify `.codex/config.toml` runtime selection.
+- context delivery mode: full-thread/full-history fork requested, plus explicit context packet below as supplement.
+- exact question: For this cleanup, classify which old world terms should be changed in active product/player-facing docs and what replacement wording should be used.
+- explicit non-goals: do not edit files; do not recommend renaming historical evidence files, script params, tests, code identifiers, or protocol fields unless they expose player-facing product wording.
+- mandatory context checklist/packet:
+  - identity and authority: assigned role `producer_system_designer`; role card `.agents/roles/producer_system_designer.md`; owner role `tpm`; TPM integration owner.
+  - workflow governance: `AGENTS.md`; `doc/engineering/workflow/source-of-truth.md`; `default-workflow-bootstrap`; `repo-owned-workflow-router`; `executing-project-tasks`.
+  - task truth: `.pm/tasks/task_735872fee5174fc28f10166a9e54d56b.yaml`; this execution log; canonical worktree `/Users/scc/ccwork/worktrees/oasis7-core-cleanup-legacy-world-terms`; branch `task/core-cleanup-legacy-world-terms`.
+  - user intent: clean up old terms and old wording mentioned in prior discussion.
+  - scoped repo context: `doc/core/unified-persistent-world-terminology-upgrade-plan-2026-06-16.md`, `doc/core/prd.md`, `doc/core/project.md`, initial `rg` output.
+  - collaboration boundary: read-only product terminology classification; TPM performs mechanical edits and verification.
+- return contract: list of must-change active docs/terms, allowed residues, replacement wording, residual risk, and suggested verification command.
+- formal sink / writeback surface: `.pm/tasks/task_735872fee5174fc28f10166a9e54d56b.execution.md`.
+- integration owner/order: TPM integrates before edits.
+
+### Subagent Slice Contract: repository_health_engineer read_only_analysis
+- role: `repository_health_engineer`
+- slice type: `read_only_analysis`
+- intended model configuration: workflow default from `.codex/config.toml` `[workflow.subagent_runtime]`, `gpt-5.5-medium`.
+- actual dispatched model/reasoning: inherited/unverified; current subagent tool inherits parent context/model and does not verify `.codex/config.toml` runtime selection.
+- context delivery mode: full-thread/full-history fork requested, plus explicit context packet below as supplement.
+- exact question: Audit the terminology cleanup surface for repository-health risk: which legacy-term matches are legal to preserve, which active docs create semantic ambiguity, and which verification should guard the patch.
+- explicit non-goals: do not edit files; do not make product-direction decisions; do not require wholesale renames of evidence or compatibility surfaces.
+- mandatory context checklist/packet:
+  - identity and authority: assigned role `repository_health_engineer`; role card `.agents/roles/repository_health_engineer.md`; owner role `tpm`; TPM integration owner.
+  - workflow governance: `AGENTS.md`; `doc/engineering/workflow/source-of-truth.md`; `default-workflow-bootstrap`; `repo-owned-workflow-router`; `executing-project-tasks`.
+  - task truth: `.pm/tasks/task_735872fee5174fc28f10166a9e54d56b.yaml`; this execution log; canonical worktree `/Users/scc/ccwork/worktrees/oasis7-core-cleanup-legacy-world-terms`; branch `task/core-cleanup-legacy-world-terms`.
+  - user intent: clean up old terms without breaking historical/compatibility evidence.
+  - scoped repo context: unified-world terminology plan, initial `rg` output, doc governance surfaces.
+  - collaboration boundary: read-only repository-health recommendations; TPM performs edits and verification.
+- return contract: findings categorized as must-fix / allowed residue / defer, with file patterns and verification commands.
+- formal sink / writeback surface: `.pm/tasks/task_735872fee5174fc28f10166a9e54d56b.execution.md`.
+- integration owner/order: TPM integrates before edits.
+
+## 2026-06-18 09:28:00 CST / producer_system_designer
+- 完成内容: Read-only product terminology slice completed.
+- 遗留事项: None for this slice; TPM integration and edits pending.
+- Action: Classified old world terms for active product/player-facing and governance/navigation docs.
+- Validation Command: Subagent read-only inspection of unified-world terminology plan plus targeted searches for `hosted world`, `shared devnet`, `shared network`, `candidate world`, `local world`, and related terms.
+- Expected Result: Identify must-change active docs and replacement wording without breaking history or compatibility.
+- Actual Result: Must-change surfaces include `doc/engineering/doc-governance/testing-evidence-path-governance-2026-04-17.{prd,design}.md`, `doc/p2p/blockchain/p2p-shared-network-release-train-minimum-2026-03-24.{prd,design,project,runbook}.md`, `doc/p2p/blockchain/p2p-governance-signer-externalization-2026-03-23.{design,project}.md`, and `doc/p2p/blockchain/p2p-mainstream-public-chain-testing-benchmark-2026-03-24.{prd,design,project}.md`. Recommended replacements: `hosted world` -> `hosted access` / `hosted player entry`; `shared network` / `shared devnet` -> `historical shared-network rehearsal evidence`, `network rehearsal`, or `release-train readiness gate`; `candidate world` -> `candidate environment` / `candidate execution instance`; preserve script params, tests, code identifiers, manifest fields, protocol fields, and historical evidence filenames.
+- Blocker / Next Action: TPM apply wording-only patch.
+
+## 2026-06-18 09:28:15 CST / repository_health_engineer
+- 完成内容: Read-only repository-health terminology audit completed.
+- 遗留事项: None for this slice; TPM integration and edits pending.
+- Action: Audited legacy-term matches for must-fix / allowed-residue / defer categories.
+- Validation Command: Subagent read-only inspection of active docs and initial grep surface.
+- Expected Result: Distinguish active semantic ambiguity from legal historical/compatibility residue.
+- Actual Result: Must-fix: active landing/governance docs still using `hosted world`, `shared devnet`, and `shared network` as navigation prose without enough qualification, especially `doc/testing/evidence/README.md`, `doc/testing/project.md`, and `doc/engineering/doc-governance/testing-evidence-path-governance-2026-04-17.{prd,design}.md`. Allowed residue: historical evidence filenames under `doc/testing/evidence`, code/tests/scripts using `trusted_local_only`, and already-qualified formal network-tier docs. Defer: wholesale renames of evidence, PRD titles, branch/task names, scripts, manifest fields, and code identifiers.
+- Blocker / Next Action: TPM apply minimal edits and verify with targeted grep, doc governance check, and `git diff --check`.
+
+## 2026-06-18 09:42:00 CST / tpm
+- 完成内容: Applied terminology cleanup patch across active governance, testing navigation, and p2p/blockchain docs.
+  - Replaced active `hosted world` wording with hosted access / hosted player entry concepts where it was not already explicitly marked as a legacy label.
+  - Replaced active `shared network` / `shared devnet` current-state wording with legacy shared-network rehearsal, network rehearsal, release-train readiness, or formal test-environment wording.
+  - Replaced `candidate world` in active signer/governance surfaces with candidate environment / execution-instance wording, while preserving `clone-world` dry-run evidence terminology.
+  - Preserved historical evidence filenames, script/template identifiers, manifest fields, formal network tier literals, and already-qualified legacy labels.
+- 遗留事项: Full `.pm` lint still fails on pre-existing unrelated task execution logs; no current-task-specific pm-lint findings remain after field completion.
+- Action: Edited scoped documentation only; did not rename evidence files, scripts, templates, or code identifiers.
+- Validation Command: `rg -n -i "hosted world|shared devnet|shared network|public testnet world|local devnet world|large shared world readiness|candidate world|local world" doc/p2p doc/engineering/doc-governance doc/testing/README.md doc/testing/project.md doc/testing/prd.index.md testing-manual.md -g '!doc/testing/evidence/**'`; `./scripts/doc-governance-check.sh`; `git diff --check`; `./scripts/pm/lint.sh`; `./scripts/pm/lint.sh 2>&1 | rg "task_735872fee5174fc28f10166a9e54d56b"`.
+- Expected Result: Targeted scan should show only explicit legacy labels / historical topic filenames outside evidence; doc governance and diff checks pass; pm lint should have no current-task-specific findings or otherwise identify only unrelated legacy failures.
+- Actual Result: Targeted scan shows only `doc/p2p/prd.md` and `doc/p2p/README.md` entries explicitly marked as legacy topic labels for `hosted world`; `doc-governance-check: OK`; `git diff --check` passed with no output; full `.pm` lint fails on many unrelated pre-existing task execution logs; current task-specific pm-lint findings were limited to missing `遗留事项` fields and were fixed.
+- Blocker / Next Action: Ready for user review; optional follow-up is a separate historical PM-log cleanup task if full `.pm` lint must be made green.
+
+## 2026-06-18 09:45:40 CST / tpm
+- 完成内容: Ran task closeout for the terminology cleanup task.
+- 遗留事项: `task-closeout.sh` exits non-zero because its post-closeout full `.pm` lint check sees pre-existing unrelated task execution-log failures; this task's YAML is marked `done`, `last_verification_status: verified`, and current-task-specific pm-lint matches are empty.
+- Action: Executed `./scripts/pm/task-closeout.sh --role tpm --task-uid task_735872fee5174fc28f10166a9e54d56b --verify-command "...";` inspected the resulting task YAML and execution log.
+- Validation Command: `./scripts/doc-governance-check.sh && git diff --check && (./scripts/pm/lint.sh 2>&1 | rg 'task_735872fee5174fc28f10166a9e54d56b'; test $? -eq 1)`; `./scripts/pm/lint.sh 2>&1 | rg "task_735872fee5174fc28f10166a9e54d56b"; true`.
+- Expected Result: Task-specific verification passes and no current-task-specific pm-lint findings remain.
+- Actual Result: Task YAML records `status: done`, `last_verification_exit_code: 0`, `last_verification_status: verified`; the current-task-specific pm-lint grep returns no matches. Full pm-lint remains blocked by unrelated historical task logs.
+- Blocker / Next Action: Proceed to commit and required pre-PR local role review; do not broaden this PR into historical `.pm` log cleanup.
+
+## 2026-06-18 09:48:30 CST / tpm
+- 完成内容: Recorded pre-PR local role review request.
+  - Review Trigger: pre-PR local role review
+  - Review Scope: commit `1bc707127e4397b0cc4de38ed248b957e0853bee` against `main`; changed paths are the task `.pm` files plus active terminology docs under `doc/engineering/doc-governance`, `doc/p2p`, and `doc/testing`.
+  - Review Roles: producer_system_designer, repository_health_engineer, qa_engineer, liveops_community
+  - Review Question: Confirm whether the committed wording-only cleanup correctly removes old player-facing world terminology, preserves historical/evidence compatibility surfaces, and does not introduce QA/navigation/runbook/public-claim ambiguity.
+  - Evidence Available: `./scripts/doc-governance-check.sh` passed; `git diff --check` passed; targeted terminology scan shows only explicit `legacy topic label` hosted-world residues outside evidence.
+  - Expected Return Contract: findings | no_findings | residual_risk
+  - Formal Sink: `.pm/tasks/task_735872fee5174fc28f10166a9e54d56b.execution.md`
+- 遗留事项: Review findings/results pending.
+- Action: Dispatched pre-PR review slices for producer_system_designer, repository_health_engineer, qa_engineer, and liveops_community.
+- Validation Command: N/A - review request entry.
+- Expected Result: Required local review slices return findings/no_findings and residual risk before PR creation.
+- Actual Result: Review slices dispatched; results to be integrated in a later execution-log entry.
+- Blocker / Next Action: Wait for review results, fix valid findings, and record passed review packet before PR creation.
+
+## 2026-06-18 10:03:30 CST / tpm
+- 完成内容: Integrated pre-PR local role review findings.
+  - `liveops_community`: no_findings; residual risk low.
+  - `qa_engineer`: no_findings; residual risk low.
+  - `producer_system_designer`: P2 finding that `doc/engineering/prd.md` still used `hosted-world/browser` and `p2p/shared-network triad` in an active engineering root PRD acceptance line.
+  - `repository_health_engineer`: P1 finding that the uncommitted pre-PR review-trigger execution-log entry lacked standard task-log fields and would make task-specific pm-lint evidence stale if staged.
+- 遗留事项: Product/repository-health follow-up confirmation pending after amend because the PR head must include the finding fixes.
+- Action: Reworded `doc/engineering/prd.md` AC-27E to `hosted access / browser` and `p2p / legacy network-rehearsal evidence`; converted the review-trigger execution-log entry into the standard field shape.
+- Validation Command: `rg -n -i "hosted world|shared devnet|shared network|public testnet world|local devnet world|large shared world readiness|candidate world|local world" doc/engineering/prd.md doc/p2p doc/engineering/doc-governance doc/testing/README.md doc/testing/project.md doc/testing/prd.index.md testing-manual.md -g '!doc/testing/evidence/**'`; `./scripts/doc-governance-check.sh`; `git diff --check && ./scripts/pm/lint.sh 2>&1 | rg "task_735872fee5174fc28f10166a9e54d56b"; test $? -eq 1`.
+- Expected Result: Only qualified legacy-label residues remain; doc governance passes; diff check passes; current-task-specific pm-lint findings are empty.
+- Actual Result: Targeted scan shows only explicit `hosted world` legacy labels in `doc/p2p/prd.md` and `doc/p2p/README.md`; `doc-governance-check: OK`; diff check passed; current-task-specific pm-lint grep returned no matches.
+- Blocker / Next Action: Amend the commit, run narrow follow-up review for the two addressed findings, then record the passed pre-PR local role review packet.
+
+## 2026-06-18 10:11:30 CST / tpm
+- 完成内容: Pre-PR local role review passed.
+- Pre-PR Local Role Review: passed
+- Task UID: task_735872fee5174fc28f10166a9e54d56b
+- Source Worktree: /Users/scc/ccwork/worktrees/oasis7-core-cleanup-legacy-world-terms
+- Source Branch: task/core-cleanup-legacy-world-terms
+- Source Head: 72440a9271f917370677a2d770a4676d4cb6eb81
+- Comparison Ref: refs/remotes/origin/main
+- Reviewed Changed Paths: .pm/tasks/task_735872fee5174fc28f10166a9e54d56b.*; doc/engineering/prd.md; doc/engineering/doc-governance/testing-evidence-path-governance-2026-04-17.{prd,design}.md; doc/p2p/blockchain/p2p-formal-network-tiers-testnet-mechanism-2026-05-14.prd.md; doc/p2p/blockchain/p2p-governance-signer-externalization-2026-03-23.{design,project}.md; doc/p2p/blockchain/p2p-hosted-world-player-access-and-session-auth-2026-03-25.prd.md; doc/p2p/blockchain/p2p-mainstream-public-chain-testing-benchmark-2026-03-24.{prd,design,project}.md; doc/p2p/blockchain/p2p-shared-network-release-train-minimum-2026-03-24.{prd,design,project,runbook}.md; doc/p2p/network/p2p-mainnet-private-reachability-architecture-2026-04-01.prd.md; doc/testing/{README,prd.index,project}.md; doc/testing/evidence/README.md
+- Role Selection Basis: product/player-facing terminology and current world model required producer_system_designer; cross-doc traceability and PM/doc governance required repository_health_engineer; testing/evidence navigation and claim-boundary verification required qa_engineer; runbook/public-claim/community-facing wording required liveops_community.
+- Review Roles: producer_system_designer,repository_health_engineer,qa_engineer,liveops_community
+- Review Evidence: liveops_community no_findings residual risk low; qa_engineer no_findings residual risk low; producer_system_designer found P2 root engineering PRD wording issue then follow-up confirmed no_findings; repository_health_engineer found P1 execution-log format issue then follow-up confirmed no_findings.
+- Review Findings Disposition: addressed
+- Finding Disposition Evidence: doc/engineering/prd.md AC-27E now uses hosted access / browser and p2p / legacy network-rehearsal evidence; this execution log's pre-PR review request now uses standard task-log fields; follow-up reviews confirmed both fixes at 551b2d8a36f377065d3351c07f67f445318b04d4.
+- Residual Risk: Low. Historical filenames and evidence/template identifiers still contain legacy terms by design, but active entry-point prose now qualifies them as legacy/evidence labels rather than current player-world brands. Full repo-wide .pm lint remains affected by unrelated historical task-log failures; current-task-specific pm-lint grep is empty.
+- 遗留事项: None for local role review; PR creation and GitHub checks/comments/mergeability still pending.
+- Action: Integrated local role review results and addressed all valid findings.
+- Validation Command: `./scripts/doc-governance-check.sh`; `git diff --check HEAD~1..HEAD`; `./scripts/pm/lint.sh 2>&1 | rg "task_735872fee5174fc28f10166a9e54d56b"; test $? -eq 1`.
+- Expected Result: Local role review packet is present; findings addressed; doc governance and diff checks pass; no current-task-specific pm-lint findings remain.
+- Actual Result: `doc-governance-check: OK`; diff check passed with no output; current-task-specific pm-lint grep returned no matches; follow-up producer and repository-health reviews returned `no_findings`.
+- Blocker / Next Action: Amend review packet into commit and run PR preflight/create.

--- a/.pm/tasks/task_735872fee5174fc28f10166a9e54d56b.execution.md
+++ b/.pm/tasks/task_735872fee5174fc28f10166a9e54d56b.execution.md
@@ -157,7 +157,7 @@ Example:
 - Task UID: task_735872fee5174fc28f10166a9e54d56b
 - Source Worktree: /Users/scc/ccwork/worktrees/oasis7-core-cleanup-legacy-world-terms
 - Source Branch: task/core-cleanup-legacy-world-terms
-- Source Head: 982cbdae4f8a9ce30c4b8a8b3406bf5a38854575
+- Source Head: bf1f28104e5f6c8b9c6f0cfc8c1ec10770a14d1e
 - Comparison Ref: refs/remotes/origin/main
 - Reviewed Changed Paths: .pm/tasks/task_735872fee5174fc28f10166a9e54d56b.*; doc/engineering/prd.md; doc/engineering/doc-governance/testing-evidence-path-governance-2026-04-17.{prd,design}.md; doc/p2p/blockchain/p2p-formal-network-tiers-testnet-mechanism-2026-05-14.prd.md; doc/p2p/blockchain/p2p-governance-signer-externalization-2026-03-23.{design,project}.md; doc/p2p/blockchain/p2p-hosted-world-player-access-and-session-auth-2026-03-25.prd.md; doc/p2p/blockchain/p2p-mainstream-public-chain-testing-benchmark-2026-03-24.{prd,design,project}.md; doc/p2p/blockchain/p2p-shared-network-release-train-minimum-2026-03-24.{prd,design,project,runbook}.md; doc/p2p/network/p2p-mainnet-private-reachability-architecture-2026-04-01.prd.md; doc/testing/{README,prd.index,project}.md; doc/testing/evidence/README.md
 - Role Selection Basis: product/player-facing terminology and current world model required producer_system_designer; cross-doc traceability and PM/doc governance required repository_health_engineer; testing/evidence navigation and claim-boundary verification required qa_engineer; runbook/public-claim/community-facing wording required liveops_community.
@@ -181,3 +181,12 @@ Example:
 - Expected Result: If the task is still open, `claim-ready.sh` records `ready_for_pr`; if already closed, it rejects mutation and leaves the prior verified closeout record authoritative.
 - Actual Result: `claim-ready: closed task claim evidence is immutable for non-completion claims: task_735872fee5174fc28f10166a9e54d56b status=done claim_type=ready_for_pr`; existing closeout record remains the authoritative verified claim evidence.
 - Blocker / Next Action: Rerun workflow-lint/preflight and create PR.
+
+## 2026-06-18 10:23:30 CST / repository_health_engineer
+- 完成内容: Narrow follow-up review of PR readiness/project trace evidence passed.
+- 遗留事项: None for repository-health PR readiness evidence.
+- Action: Reviewed `doc/core/project.md` traced row, task YAML `doc_refs`, and execution-log immutable claim-ready evidence at HEAD `bf1f28104e5f6c8b9c6f0cfc8c1ec10770a14d1e`.
+- Validation Command: `./scripts/doc-governance-check.sh`; `./scripts/pm/workflow-lint.sh --task-uid task_735872fee5174fc28f10166a9e54d56b --phase pr-ready`; `git diff --check HEAD~1..HEAD`; re-run `claim-ready.sh --claim-type ready_for_pr` to confirm expected immutable closed-task message.
+- Expected Result: PR readiness/project trace evidence is repo-health safe and no blockers remain.
+- Actual Result: no_findings. `doc/core/project.md` has a single completed traced row; task YAML `doc_refs` resolves to that project file; execution log accurately records `claim-ready` immutable closed-task behavior; doc-governance, workflow-lint pr-ready, and diff check pass.
+- Blocker / Next Action: Commit this evidence-only execution-log update, rerun PR preflight/create.

--- a/.pm/tasks/task_735872fee5174fc28f10166a9e54d56b.execution.md
+++ b/.pm/tasks/task_735872fee5174fc28f10166a9e54d56b.execution.md
@@ -172,3 +172,12 @@ Example:
 - Expected Result: Local role review packet is present; findings addressed; doc governance and diff checks pass; no current-task-specific pm-lint findings remain.
 - Actual Result: `doc-governance-check: OK`; diff check passed with no output; current-task-specific pm-lint grep returned no matches; follow-up producer and repository-health reviews returned `no_findings`.
 - Blocker / Next Action: Amend review packet into commit and run PR preflight/create.
+
+## 2026-06-18 10:19:30 CST / tpm
+- 完成内容: Recorded PR-ready workflow evidence required by `workflow-lint --phase pr-ready`.
+- 遗留事项: `claim-ready.sh --claim-type ready_for_pr` cannot mutate this task because `task-closeout.sh` has already closed it with immutable `task_complete` evidence; task YAML already records `last_claim_type: task_complete`, `last_verification_status: verified`, and `last_closed_at`.
+- Action: Added `doc/core/project.md` as the task project reference and added a traced project row for this terminology-cleanup task; attempted `claim-ready.sh --claim-type ready_for_pr` and recorded the immutable-closeout result.
+- Validation Command: `./scripts/pm/claim-ready.sh --claim-type ready_for_pr --verify-command "./scripts/doc-governance-check.sh && git diff --check HEAD~1..HEAD && (./scripts/pm/lint.sh 2>&1 | rg 'task_735872fee5174fc28f10166a9e54d56b'; test $? -eq 1)" --task-uid task_735872fee5174fc28f10166a9e54d56b --json`
+- Expected Result: If the task is still open, `claim-ready.sh` records `ready_for_pr`; if already closed, it rejects mutation and leaves the prior verified closeout record authoritative.
+- Actual Result: `claim-ready: closed task claim evidence is immutable for non-completion claims: task_735872fee5174fc28f10166a9e54d56b status=done claim_type=ready_for_pr`; existing closeout record remains the authoritative verified claim evidence.
+- Blocker / Next Action: Rerun workflow-lint/preflight and create PR.

--- a/.pm/tasks/task_735872fee5174fc28f10166a9e54d56b.execution.md
+++ b/.pm/tasks/task_735872fee5174fc28f10166a9e54d56b.execution.md
@@ -157,7 +157,7 @@ Example:
 - Task UID: task_735872fee5174fc28f10166a9e54d56b
 - Source Worktree: /Users/scc/ccwork/worktrees/oasis7-core-cleanup-legacy-world-terms
 - Source Branch: task/core-cleanup-legacy-world-terms
-- Source Head: 72440a9271f917370677a2d770a4676d4cb6eb81
+- Source Head: 982cbdae4f8a9ce30c4b8a8b3406bf5a38854575
 - Comparison Ref: refs/remotes/origin/main
 - Reviewed Changed Paths: .pm/tasks/task_735872fee5174fc28f10166a9e54d56b.*; doc/engineering/prd.md; doc/engineering/doc-governance/testing-evidence-path-governance-2026-04-17.{prd,design}.md; doc/p2p/blockchain/p2p-formal-network-tiers-testnet-mechanism-2026-05-14.prd.md; doc/p2p/blockchain/p2p-governance-signer-externalization-2026-03-23.{design,project}.md; doc/p2p/blockchain/p2p-hosted-world-player-access-and-session-auth-2026-03-25.prd.md; doc/p2p/blockchain/p2p-mainstream-public-chain-testing-benchmark-2026-03-24.{prd,design,project}.md; doc/p2p/blockchain/p2p-shared-network-release-train-minimum-2026-03-24.{prd,design,project,runbook}.md; doc/p2p/network/p2p-mainnet-private-reachability-architecture-2026-04-01.prd.md; doc/testing/{README,prd.index,project}.md; doc/testing/evidence/README.md
 - Role Selection Basis: product/player-facing terminology and current world model required producer_system_designer; cross-doc traceability and PM/doc governance required repository_health_engineer; testing/evidence navigation and claim-boundary verification required qa_engineer; runbook/public-claim/community-facing wording required liveops_community.

--- a/.pm/tasks/task_735872fee5174fc28f10166a9e54d56b.yaml
+++ b/.pm/tasks/task_735872fee5174fc28f10166a9e54d56b.yaml
@@ -10,7 +10,8 @@ source_refs:
   - doc/core/unified-persistent-world-terminology-upgrade-plan-2026-06-16.md
   - doc/core/prd.md
   - doc/core/project.md
-doc_refs: []
+doc_refs:
+  - doc/core/project.md
 related_prd: []
 acceptance:
   - "Active product/player-facing docs use unified persistent world terminology and no longer present hosted/shared/local/testnet terms as player world brands."

--- a/.pm/tasks/task_735872fee5174fc28f10166a9e54d56b.yaml
+++ b/.pm/tasks/task_735872fee5174fc28f10166a9e54d56b.yaml
@@ -1,0 +1,26 @@
+task_uid: task_735872fee5174fc28f10166a9e54d56b
+title: "Clean up legacy world terminology"
+owner_role: tpm
+worktree_hint: /Users/scc/ccwork/worktrees/oasis7-core-cleanup-legacy-world-terms
+execution_log_path: .pm/tasks/task_735872fee5174fc28f10166a9e54d56b.execution.md
+status: done
+priority: P2
+source_signal: null
+source_refs:
+  - doc/core/unified-persistent-world-terminology-upgrade-plan-2026-06-16.md
+  - doc/core/prd.md
+  - doc/core/project.md
+doc_refs: []
+related_prd: []
+acceptance:
+  - "Active product/player-facing docs use unified persistent world terminology and no longer present hosted/shared/local/testnet terms as player world brands."
+  - "Historical evidence, compatibility script parameters, code identifiers, tests, and operator-only technical surfaces are preserved unless they expose player-facing wording."
+handoff_to: []
+updated_at: 2026-06-18T09:45:29+08:00
+last_started_at: 2026-06-18T09:17:39+08:00
+last_claim_type: task_complete
+last_verify_command: "./scripts/doc-governance-check.sh && git diff --check && (./scripts/pm/lint.sh 2>&1 | rg 'task_735872fee5174fc28f10166a9e54d56b'; test $? -eq 1)"
+last_verified_at: 2026-06-18T09:45:28+08:00
+last_verification_exit_code: 0
+last_verification_status: verified
+last_closed_at: 2026-06-18T09:45:29+08:00

--- a/doc/core/project.md
+++ b/doc/core/project.md
@@ -3,6 +3,7 @@
 审计轮次: 6
 
 ## 任务拆解（含 PRD-ID 映射）
+- [x] legacy-world-terminology-cleanup (PRD-CORE-003) [test_tier_required]: Clean up old hosted/shared/local/testnet world terminology in active docs while preserving historical evidence and compatibility identifiers. Trace: .pm/tasks/task_735872fee5174fc28f10166a9e54d56b.yaml
 - [x] TASK-CORE-001 (PRD-CORE-001) [test_tier_required]: 完成 core PRD 改写，固化跨模块治理基线。
 - [x] TASK-CORE-002 (PRD-CORE-001/002/003) [test_tier_required]: 将 core PRD 扩展为项目全局总览入口（模块地图/关键链路/关键分册导航）。
 - [x] TASK-CORE-003 (PRD-CORE-001/002) [test_tier_required]: 建立跨模块变更影响检查清单（设计/代码/测试/发布），并固化 N/A、整改项与特殊备注机制。

--- a/doc/engineering/doc-governance/testing-evidence-path-governance-2026-04-17.design.md
+++ b/doc/engineering/doc-governance/testing-evidence-path-governance-2026-04-17.design.md
@@ -28,8 +28,8 @@
   - 维护约定
 - 推荐主题簇:
   - `release-gate`: release evidence bundle、candidate gate、trust gate
-  - `hosted-world-and-web`: hosted world browser/auth/abuse/web surface 与主链 web validation
-  - `p2p-and-shared-network`: triad snapshot、mixed topology、shared devnet、upgrade 与 rollout follow-up
+  - `hosted-access-and-web`: hosted access browser/auth/abuse/web surface 与主链 web validation
+  - `p2p-and-legacy-network-rehearsal`: triad snapshot、mixed topology、legacy shared-devnet rehearsal、upgrade 与 rollout follow-up
   - `governance-drill`: clone/live world drill、finality、foundation ops 等治理演练留痕
   - `claim-and-audit`: claim abuse/restricted grant matrix、token allocation audit、quality baseline
   - `targeted-validation`: provider recertification、pure-api parity、software-safe web entry、headless smoke、launcher UX

--- a/doc/engineering/doc-governance/testing-evidence-path-governance-2026-04-17.prd.md
+++ b/doc/engineering/doc-governance/testing-evidence-path-governance-2026-04-17.prd.md
@@ -6,8 +6,8 @@
 审计轮次: 1
 
 ## 1. Executive Summary
-- Problem Statement: `doc-corpus-maintenance-governance` 已把文档治理债界定为“入口减重之后的存量维护成本”，而 `doc/testing/evidence/` 仍是当前 `testing` 模块内最高密度热点路径，当前快照已有 49 份 Markdown 文件。虽然 `doc/testing/README.md` 与 `prd.index.md` 已完成模块级首读分流，但 `evidence/` 子目录内部仍缺少一个 canonical 子域入口，读者进入该路径后依然会直接面对 release gate、hosted world、shared network triad、claim matrix 与 assorted validation evidence 的平铺文件面。
-- Proposed Solution: 建立 `testing-evidence-path-governance` 专题，把 `evidence/` 作为 `PRD-ENGINEERING-025` 的第四条已执行 follow-up；新增 `doc/testing/evidence/README.md` 作为热点子域 landing page，按“release gate / hosted-world & web / p2p & shared-network / governance drill / claim & audit matrix / 定向验证”分流读者，并同步回写 `testing` 与 `engineering` 上游入口。
+- Problem Statement: `doc-corpus-maintenance-governance` 已把文档治理债界定为“入口减重之后的存量维护成本”，而 `doc/testing/evidence/` 仍是当前 `testing` 模块内最高密度热点路径，当前快照已有 49 份 Markdown 文件。虽然 `doc/testing/README.md` 与 `prd.index.md` 已完成模块级首读分流，但 `evidence/` 子目录内部仍缺少一个 canonical 子域入口，读者进入该路径后依然会直接面对 release gate、hosted access / web evidence、legacy shared-network rehearsal triad、claim matrix 与 assorted validation evidence 的平铺文件面。
+- Proposed Solution: 建立 `testing-evidence-path-governance` 专题，把 `evidence/` 作为 `PRD-ENGINEERING-025` 的第四条已执行 follow-up；新增 `doc/testing/evidence/README.md` 作为热点子域 landing page，按“release gate / hosted access & web / p2p & legacy network rehearsal / governance drill / claim & audit matrix / 定向验证”分流读者，并同步回写 `testing` 与 `engineering` 上游入口。
 - Success Criteria:
   - SC-1: engineering 存在正式 `testing-evidence-path-governance` 专题三件套，冻结为什么优先处理 `testing/evidence`、这批动作边界以及后续顺序。
   - SC-2: `doc/testing/evidence/README.md` 成为 `evidence/` 子目录 canonical 入口，能把进入该路径的默认阅读方式从“文件系统平铺浏览”收口到“按问题分流”。
@@ -17,19 +17,19 @@
 
 ## 2. User Experience & Functionality
 - User Personas:
-  - 项目经理 / `producer_system_designer`: 需要在高密度 evidence 路径里快速判断“先看 release gate、hosted world、shared network triad 还是 claim/audit matrix”，而不是把留痕目录当文件仓库顺扫。
+  - 项目经理 / `producer_system_designer`: 需要在高密度 evidence 路径里快速判断“先看 release gate、hosted access、legacy shared-network rehearsal triad 还是 claim/audit matrix”，而不是把留痕目录当文件仓库顺扫。
   - `qa_engineer` / `liveops_community`: 需要先进入正确证据簇，再决定是否下钻到某个具体 evidence 文件，而不是在近 50 份文档里凭文件名碰运气。
   - 文档治理评审者: 需要识别 `evidence/` 的主要阅读簇，判断哪些是活跃入口，哪些只是保留可检索性。
 - User Scenarios & Frequency:
   - 查看 release/preview/trust gate 证据: 高频，在 release readiness 和口径评审中触发。
-  - 查看 hosted world / browser / web surface 证据: 高频，在接入边界、权限与滥用分析中触发。
-  - 查看 p2p/shared-network triad 证据: 高频，在 rollout、same-window snapshot 和 mixed-topology 讨论中触发。
+  - 查看 hosted access / browser / web surface 证据: 高频，在接入边界、权限与滥用分析中触发。
+  - 查看 p2p / legacy shared-network rehearsal triad 证据: 高频，在 rollout、same-window snapshot 和 mixed-topology 讨论中触发。
   - 精确追溯某份矩阵、incident 或 validation evidence: 中低频，但需要一个稳定的定向检索入口，而不是平铺浏览。
 - User Stories:
   - PRD-ENGINEERING-029: As a 项目经理/Testing owner, I want a canonical `doc/testing/evidence/` path entrypoint, so that I can navigate the densest testing hotspot path by intent instead of scanning nearly 50 evidence files blindly.
 - Critical User Flows:
   1. Flow-TEPG-001:
-     `进入 doc/testing/evidence/README.md -> 根据“release gate / hosted-world & web / p2p & shared-network / governance drill / claim & audit matrix / 定向验证”选择簇 -> 再进入对应证据`
+     `进入 doc/testing/evidence/README.md -> 根据“release gate / hosted access & web / p2p & legacy network rehearsal / governance drill / claim & audit matrix / 定向验证”选择簇 -> 再进入对应证据`
   2. Flow-TEPG-002:
      `从 doc/testing/README.md 进入 evidence 热点子域 -> 命中 evidence/README.md -> 再决定看某一簇还是回到 prd.index`
   3. Flow-TEPG-003:
@@ -39,7 +39,7 @@
 | 对象/能力 | 字段定义 | 动作/行为 | 状态转换 | 排序/计算规则 | 权限逻辑 |
 | --- | --- | --- | --- | --- | --- |
 | `doc/testing/evidence/README.md` | 首读分流、主题簇、现行边界、定向检索入口 | 作为 `evidence/` 子域 landing page | `missing -> canonical -> maintained` | 先按读者问题，再按推荐文档 | 所有人可读，治理 owner 可更新 |
-| `evidence/` 主题簇导航 | `release-gate`、`hosted-world-and-web`、`p2p-shared-network`、`governance-drill`、`claim-and-audit`、`targeted-validation` | 把近 50 份 evidence 文档压成有限入口组 | `flat -> clustered` | 先高频问题，再按具体留痕下钻 | 所有人可读 |
+| `evidence/` 主题簇导航 | `release-gate`、`hosted-access-and-web`、`p2p-legacy-network-rehearsal`、`governance-drill`、`claim-and-audit`、`targeted-validation` | 把近 50 份 evidence 文档压成有限入口组 | `flat -> clustered` | 先高频问题，再按具体留痕下钻 | 所有人可读 |
 | 模块上游回链 | `testing/README.md`、`testing/prd.index.md`、engineering 根入口 | 把 `evidence/README.md` 提升为热点子域默认入口 | `module_only -> path_entrypoint` | `evidence` 热点优先命中子域入口 | 所有人可读 |
 | 路径级治理专题 | 问题定义、边界、验证、后续顺序 | 明确 `evidence/` 是当前 `testing` 热点路径治理切片 | `implicit -> formalized` | `devlog -> viewer -> p2p/node -> testing/evidence -> quarterly review` | 仅治理 owner 可写 |
 - Acceptance Criteria:
@@ -57,7 +57,7 @@
 - Tool Requirements: 主要依赖 `find`、`rg` 与库存报告结果做 `evidence/` 目录体量统计与簇级分流，配合 Markdown 入口文档回写。
 - Evaluation Strategy:
   - 复算 `doc/testing/evidence/` 文件数与主要主题簇，确认 `evidence/README.md` 的分流说明与当前路径结构一致。
-  - 人工验证从 `doc/testing/README.md` 进入 `evidence/README.md` 后，能在 2 分钟内命中 release gate、hosted world 或 p2p/shared-network 入口。
+  - 人工验证从 `doc/testing/README.md` 进入 `evidence/README.md` 后，能在 2 分钟内命中 release gate、hosted access 或 p2p / legacy network rehearsal 入口。
 
 ## 4. Technical Specifications
 - Architecture Overview:

--- a/doc/engineering/prd.md
+++ b/doc/engineering/prd.md
@@ -190,7 +190,7 @@
   - AC-27B: `doc/devlog` 必须存在一个 canonical archive entrypoint，用于按月份和高体量热点导航历史日文件；该入口只能承担历史归档职责，不得重新成为运行态真值。
   - AC-27C: 对已进入路径级治理的热点子域，必须存在一个子目录级 canonical landing page；至少 `doc/world-simulator/viewer/` 需要通过 `viewer/README.md` 把 `manual`、`software_safe`、runtime live 与定向检索区分开来，避免继续由 `viewer-manual.manual.md` 或 `prd.index.md` 单独承担全部首读分流。
   - AC-27D: `doc/p2p/node/` 必须存在一个 canonical 子目录入口 `node/README.md`，能把节点奖励/资产、复制链路、PoS 时间、身份引导与 WASM 编译护栏分开导航，避免继续让 `p2p` 模块 README 或 `prd.index.md` 单独承担整个热点子域的首读分流。
-  - AC-27E: `doc/testing/evidence/` 必须存在一个 canonical 子目录入口 `evidence/README.md`，能把 release gate、hosted-world/browser、p2p/shared-network triad、governance drill、claim/audit matrix 与定向验证 evidence 分开导航，避免继续让 `testing` 模块 README 或 `prd.index.md` 单独承担整个热点子域的首读分流。
+  - AC-27E: `doc/testing/evidence/` 必须存在一个 canonical 子目录入口 `evidence/README.md`，能把 release gate、hosted access / browser、p2p / legacy network-rehearsal evidence、governance drill、claim/audit matrix 与定向验证 evidence 分开导航，避免继续让 `testing` 模块 README 或 `prd.index.md` 单独承担整个热点子域的首读分流。
   - AC-27F: `doc/readme/governance/` 必须存在一个 canonical 子目录入口 `governance/README.md`，能把治理控制、release communication、Moltbook、limited preview/reward、小红书与公开定位入口分开导航，避免继续让 `readme` 模块 README 或 `prd.index.md` 单独承担整个热点子域的首读分流。
   - AC-28: `.pm/registry/tasks.yaml` 与 `.pm/roles/*/backlog/*.yaml` 必须降级为 git-ignored 的本地生成视图；PM lint/report/read-path 在这些文件缺失时必须可自动重建，而 engineering 根 `project.md` 不再手工追加 `最新完成` 长列表热点。
   - AC-29: 根 `AGENTS.md`、角色职责卡与 handoff 模板必须显式要求“先创建/绑定 `.pm` task，再执行 `workflow-report --phase start`”，并明确一个 task 收口后若继续 `project.md` 下一个任务，默认重新开独立 `worktree` 与 `.pm` task；任何当前态 checklist 不得再把 `doc/devlog/*.md` 当必写项。

--- a/doc/p2p/blockchain/p2p-formal-network-tiers-testnet-mechanism-2026-05-14.prd.md
+++ b/doc/p2p/blockchain/p2p-formal-network-tiers-testnet-mechanism-2026-05-14.prd.md
@@ -17,7 +17,7 @@
 
 ## 2. User Experience & Functionality
 - User Personas:
-  - `producer_system_designer`：需要把“什么时候叫 shared devnet，什么时候才叫 public testnet / mainnet”冻结成正式口径。
+  - `producer_system_designer`：需要把“旧 shared_devnet rehearsal 字段何时只能作为历史共享预演，什么时候才叫 public_testnet / mainnet”冻结成正式口径。
   - `runtime_engineer`：需要知道一个网络 tier 至少要固定哪些字段，后续 runtime/config 才能围绕单一 manifest 接线。
   - `qa_engineer`：需要知道 testnet/mainnet 的 promotion gate、reset/faucet 边界和 current verdict，避免把 rehearsal 当上线。
   - `liveops_community`：需要知道哪些 tier 可以公开给外部访问，哪些还只能作为团队内部共享轨道。

--- a/doc/p2p/blockchain/p2p-governance-signer-externalization-2026-03-23.design.md
+++ b/doc/p2p/blockchain/p2p-governance-signer-externalization-2026-03-23.design.md
@@ -12,7 +12,7 @@
 ## 当前治理 signer 真值
 | Governance scope | 当前来源 | 当前问题 | 生产结论 |
 | --- | --- | --- | --- |
-| `finality signer` | execution world `governance_finality_signer_registry` + `governance_validator_admissions` 解析出的 effective registry（存在时）; 否则回退 `world/governance` deterministic local seed | runtime admission / activation 已可把 membership、governed stake 与 signer binding 落到 world-state，但 shared-network probation 与治理证据链仍未完全闭环 | partial |
+| `finality signer` | execution world `governance_finality_signer_registry` + `governance_validator_admissions` 解析出的 effective registry（存在时）; 否则回退 `world/governance` deterministic local seed | runtime admission / activation 已可把 membership、governed stake 与 signer binding 落到 world-state，但 network-rehearsal probation 与治理证据链仍未完全闭环 | partial |
 | `controller signer` | execution world `governance_main_token_controller_registry`（存在时）; 否则回退 `NodeConfig.main_token_controller_binding.controller_signer_policies` | controller policy 真值也可由 world-state 恢复，但 appointment / freeze / ceremony 仍未闭环 | partial |
 
 ## 目标态
@@ -51,7 +51,7 @@
 | --- | --- | --- | --- |
 | `applied` | 申请人已提交材料，但未审核 | 提交 node identity、公网/可达性信息、governed stake、finality signer 公钥、operator ownership、public manifest | 审核驳回或进入 `approved_candidate` |
 | `approved_candidate` | 通过治理审核，但尚未进入活跃 validator set | producer/runtime/QA 联合确认材料完整、角色边界正确 | 进入 `probation_ready` 或撤销 |
-| `probation_ready` | 候选节点已完成 reachability/同步/演练检查，可排期激活 | candidate world / shared network 演练通过，activation epoch 已冻结 | 激活进入 `active` 或回退 |
+| `probation_ready` | 候选节点已完成 reachability/同步/演练检查，可排期激活 | candidate environment / network rehearsal 通过，activation epoch 已冻结 | 激活进入 `active` 或回退 |
 | `active` | 已在 world-state registry 内成为正式 validator/finality signer | governance action / world-state registry update 生效 | 轮换、撤销、failover 或退场 |
 | `rotating_out` / `revoked` | 正在退出或已撤销 | compromise、离岗、运维替换或治理决议 | restore/replacement 完成或永久移除 |
 
@@ -68,7 +68,7 @@
 1. 申请人提交 node identity、governed stake、finality signer 公钥和 public-only manifest，不提交私钥材料。
 2. `producer_system_designer` 冻结角色与容量策略，确认当前 validator set 是否允许扩容或替换。
 3. `runtime_engineer` 校验 signer key 与 node identity 没有混用，且 candidate 配置符合当前 reachability / bootstrap 架构。
-4. `qa_engineer` 在 candidate world、clone-world 或 shared network 上执行 reachability、同步、registry import/audit 与 failover smoke。
+4. `qa_engineer` 在 candidate environment、clone-world dry-run 或 network rehearsal 上执行 reachability、同步、registry import/audit 与 failover smoke。
 5. 审核通过后，把 candidate 以非活跃形式写入 execution world `governance_validator_admissions`；真正激活时，由 `activation_epoch` 驱动 effective `governance_finality_signer_registry` 把该候选的 membership、stake 与 signer binding 并入 active validator set。
 6. 到达 activation epoch 后，runtime 通过 world-state registry 恢复新的 validator membership / governed stake / signer binding；`--node-validator*` 不能再作为正式准入动作。
 7. 若发生 compromise、失联或替换，则走 rotation / revocation / failover，同样通过 world-state registry 留痕并生效。

--- a/doc/p2p/blockchain/p2p-governance-signer-externalization-2026-03-23.project.md
+++ b/doc/p2p/blockchain/p2p-governance-signer-externalization-2026-03-23.project.md
@@ -23,7 +23,7 @@
   - 默认 execution world `output/chain-runtime/viewer-live-node/reward-runtime-execution-world` 已导入 `governance.finality.v1` 与 8 个 controller slot 的 world-state registry；`chain runtime` 现在已支持在启动/恢复时优先读取该 world registry 来覆盖 validator membership / signer binding 与 controller signer policy，但这仍不等于 rotation / revocation / ceremony / QA gate 全部通过
   - finality signer 的 production signing material 仍由人工离线 custody 持有；runtime 不再把 local seed 视为 registry 存在时的真值，且默认 world 首轮真实 finality drill 已完成，但更大范围 rotation / revocation / ceremony / QA gate 仍未收口
   - controller signer policy 虽已支持由 execution world 注入 `NodeRuntime`，但真实 governance account / recipient binding、genesis ceremony 和最终 QA `pass` 仍未完成
-  - validator / finality signer 的 runtime admission 闭环现已落到 execution world：`WorldState` 持久化 `governance_validator_admissions`，runtime 提供 `submit/approve/activate/revoke` 治理动作，admission payload 持久化 governed `stake`，effective finality registry 会在 activation epoch 到期后自动把 `probation_ready` 候选的 membership、stake 与 signer binding 并入正式 validator truth；剩余未收口的是更大范围 shared-network probation 证据、更多 controller/finality drill 变体，以及最终 ceremony / QA `pass`
+  - validator / finality signer 的 runtime admission 闭环现已落到 execution world：`WorldState` 持久化 `governance_validator_admissions`，runtime 提供 `submit/approve/activate/revoke` 治理动作，admission payload 持久化 governed `stake`，effective finality registry 会在 activation epoch 到期后自动把 `probation_ready` 候选的 membership、stake 与 signer binding 并入正式 validator truth；剩余未收口的是更大范围 network-rehearsal probation 证据、更多 controller/finality drill 变体，以及最终 ceremony / QA `pass`
 
 ## Transition Freeze Snapshot（public-only）
 - batch id: `oasis7-governance-batch-20260323-01`
@@ -77,7 +77,7 @@
 1. 申请人提交 `node_id`、`stake`、`finality_signer_public_key`、reachability 信息、`operator_owner` 和 public-only manifest。
 2. `producer_system_designer` 判断当前 validator set 是否允许扩容或替换，并冻结预期 `activation_epoch` 窗口。
 3. `runtime_engineer` 校验 node identity 与 finality signer 没有混用，且 bootstrap / reachability / registry 结构符合当前网络架构。
-4. `qa_engineer` 在 candidate world、clone-world 或 shared network 对候选节点执行 registry import/audit、同步和 failover smoke。
+4. `qa_engineer` 在 candidate environment、clone-world dry-run 或 network rehearsal 对候选节点执行 registry import/audit、同步和 failover smoke。
 5. 通过后先把 candidate 写入 execution world `governance_validator_admissions`，状态进入 `approved_candidate` / `probation_ready`；只有到达 activation 条件时，effective `governance_finality_signer_registry` 才会把该候选的 membership、stake 与 signer binding 并入 active validator set。
 6. runtime 在启动/恢复时从 world-state registry 恢复生效后的 validator membership / governed stake / signer binding；首轮冷启动用 genesis validator registry 写入 world-state，之后 `--node-validator*` / `NODE_VALIDATORS_CSV` 不再充当 public tier 的正式 admission 机制。
 7. 退出路径统一走 rotation / revocation / failover，并在 world-state registry 留痕。
@@ -141,5 +141,5 @@
 ## 状态
 - 当前阶段: completed
 - 执行状态: in_progress
-- 下一步: 将真实 drill 从 `msig.foundation_ops.v1` 与当前 finality single-signer / failover / rejoin 样本继续扩到更多 controller slot，并补 shared-network probation 与更正式的 governance approval / operator evidence bundle。
+- 下一步: 将真实 drill 从 `msig.foundation_ops.v1` 与当前 finality single-signer / failover / rejoin 样本继续扩到更多 controller slot，并补 network-rehearsal probation 与更正式的 governance approval / operator evidence bundle。
 - 最近更新: 2026-05-06（world-registry truth bootstrap + validator admission runtime implementation）

--- a/doc/p2p/blockchain/p2p-hosted-world-player-access-and-session-auth-2026-03-25.prd.md
+++ b/doc/p2p/blockchain/p2p-hosted-world-player-access-and-session-auth-2026-03-25.prd.md
@@ -110,7 +110,7 @@
   - MVP: 冻结三层平面、会话梯度、动作能力矩阵和 claims boundary。
   - v1.1: 落地 `guest session` + `player session`，把浏览器长期私钥 bootstrap 从 hosted access 路径移除。
   - v1.2: 落地 runtime capability enforcement、entity bind/reconnect/revoke。
-  - v2.0: 落地 `strong auth` 与 hosted access runbook/QA abuse suite，并与 shared network 轨道衔接。
+  - v2.0: 落地 `strong auth` 与 hosted access runbook/QA abuse suite，并与 legacy network-rehearsal 轨道衔接。
 - Technical Risks:
   - 风险-1: 如果继续让 public player plane 和 control plane 共用同一入口，任何部署细节失误都会直接变成 world 控制泄露。
   - 风险-2: 如果只把私钥从 UI 隐掉但后端仍默认代签，仍然只是“看不见私钥”的假隔离。

--- a/doc/p2p/blockchain/p2p-mainstream-public-chain-testing-benchmark-2026-03-24.design.md
+++ b/doc/p2p/blockchain/p2p-mainstream-public-chain-testing-benchmark-2026-03-24.design.md
@@ -47,7 +47,7 @@
 3. 因此下一步优先级应是：
    - `真实 governance drill 证据`
    - `negative/fault drill`
-   - `shared network/release train`
+   - `network rehearsal / release-train readiness`
    - `fuzz/property gate`
 
 ## 对外口径影响

--- a/doc/p2p/blockchain/p2p-mainstream-public-chain-testing-benchmark-2026-03-24.prd.md
+++ b/doc/p2p/blockchain/p2p-mainstream-public-chain-testing-benchmark-2026-03-24.prd.md
@@ -12,13 +12,13 @@
 
 ## 1. Executive Summary
 - Problem Statement: oasis7 近几轮已经补齐签名交易、生产 signer custody、治理 signer 外部化和创世 ceremony 的专题规格，也已经开始做真实 governance registry import/audit/runbook，但团队仍缺一份“主流公链到底怎样分层测试、oasis7 当前已经覆盖到哪一层、还缺什么才能把 preview 做成更像主流链的工程体系”的正式基准。若继续只用零散 required/full、长跑和 drill 结果沟通，很容易把“局部门禁已存在”误判成“整体测试体系已接近主流公链”。
-- Proposed Solution: 新建 producer-owned 的测试体系对标 PRD，把主流公链常见测试层拆成 `spec/reference -> deterministic/unit/integration -> distributed/multi-node -> ui/playability -> longrun/chaos/drill -> shared network/release train` 六层，再把 oasis7 当前命令、证据与缺口映射进去，形成后续 `MAINNET-1~3` execution workstreams 的测试优先级。
+- Proposed Solution: 新建 producer-owned 的测试体系对标 PRD，把主流公链常见测试层拆成 `spec/reference -> deterministic/unit/integration -> distributed/multi-node -> ui/playability -> longrun/chaos/drill -> network rehearsal / release-train readiness` 六层，再把 oasis7 当前命令、证据与缺口映射进去，形成后续 `MAINNET-1~3` execution workstreams 的测试优先级。
 - Success Criteria:
   - SC-1: 明确给出不少于 6 层的“主流公链测试体系”分层模型，并区分“单客户端项目的等价替代要求”与“多客户端公链的原生做法”。
   - SC-2: 明确给出 oasis7 当前 `已有 / 部分具备 / 缺失` 的测试矩阵，而不是只给抽象建议。
   - SC-3: 明确指出当前强项至少包括：`required/full 基础门禁`、`分布式子系统库测试`、`Web-first UI 闭环`、`长跑套件`、`governance registry audit + drill runbook`。
   - SC-4: 明确指出当前缺口至少包括：`fuzz/property-based gate 缺失`、formal `public_testnet` / `mainnet` readiness 仍需独立 gate、`真实 ceremony/drill 证据仍未完成`。
-  - SC-5: 形成 producer 可直接使用的下一步顺序：`先补 drill evidence -> 再补 fault/chaos/negative gate -> 再补 shared network / release train`。
+  - SC-5: 形成 producer 可直接使用的下一步顺序：`先补 drill evidence -> 再补 fault/chaos/negative gate -> 再补 network rehearsal / release-train readiness`。
 
 ## 2. User Experience & Functionality
 - User Personas:
@@ -29,7 +29,7 @@
 - User Scenarios & Frequency:
   - 每次有人提“现在是不是已经接近主流主链测试体系”时，先对照本专题。
   - 每次 `MAINNET-1~3` execution workstream 完成一个阶段时，回填本专题矩阵。
-  - 每次准备做更高安全口径或创世前评审时，先复查 shared network、drill、chaos、QA 证据是否到位。
+  - 每次准备做更高安全口径或创世前评审时，先复查 network rehearsal、drill、chaos、QA 证据是否到位。
 - User Stories:
   - PRD-P2P-BENCH-001: As a `producer_system_designer`, I want one explicit benchmark for mainstream public-chain testing systems, so that oasis7 phase decisions are grounded in testing reality rather than intuition.
   - PRD-P2P-BENCH-002: As a `qa_engineer`, I want oasis7 suites mapped to benchmark layers, so that release gates and missing evidence are visible.
@@ -38,16 +38,16 @@
 - Critical User Flows:
   1. Flow-P2P-BENCH-001: `读取 testing-manual 与安全/readiness 专题 -> 提炼 oasis7 当前测试层 -> 对照主流公链分层模型 -> 形成 gap matrix`
   2. Flow-P2P-BENCH-002: `有人提出“接近主流公链测试体系” -> 检查 benchmark layers -> 若关键层仍缺失则直接 block 该口径`
-  3. Flow-P2P-BENCH-003: `execution workstream 完成一次 drill/chaos/shared-network 里程碑 -> 回填 benchmark 状态 -> producer 重新排序下一步`
+  3. Flow-P2P-BENCH-003: `execution workstream 完成一次 drill/chaos/network-rehearsal 里程碑 -> 回填 benchmark 状态 -> producer 重新排序下一步`
 - Functional Specification Matrix:
 | 功能点 | 字段定义 | 动作行为 | 状态转换 | 计算/判定规则 | 权限逻辑 |
 | --- | --- | --- | --- | --- | --- |
 | 主流公链分层模型 | `layer_id/layer_name/mainstream_expectation/oasis7_equivalent` | 冻结主流链常见测试层，并给出 oasis7 的等价要求 | `draft -> frozen` | 单客户端项目不得照搬“多客户端”字面要求，必须给出本项目等价替代层 | `producer_system_designer` 拍板，`qa_engineer` 联审 |
 | oasis7 当前映射 | `layer_id/current_coverage/evidence_paths/status` | 将 `required/full/S4/S6/S9/S10/governance audit` 映射到 benchmark | `unknown -> mapped` | 必须引用仓库内已有命令、手册或专题文档 | `qa_engineer` 主持，producer 收口 |
 | 缺口矩阵 | `gap_id/layer_id/severity/owner/next_action` | 为每个缺失层给出 owner、优先级和下一动作 | `identified -> prioritized` | 若缺口直接影响安全口径或创世 gate，则至少记为 `high` | `producer_system_designer` 拍板 |
-| 口径门禁 | `claim_phrase/min_layer_status/reject_reason` | 根据 benchmark 覆盖状态决定是否允许某类外部表述 | `draft -> enforced` | 只要 shared network、chaos/drill 或真实 ceremony evidence 未完成，就不得宣称“对标主流公链测试成熟度” | `liveops_community` 执行，producer 审批 |
+| 口径门禁 | `claim_phrase/min_layer_status/reject_reason` | 根据 benchmark 覆盖状态决定是否允许某类外部表述 | `draft -> enforced` | 只要 network rehearsal、chaos/drill 或真实 ceremony evidence 未完成，就不得宣称“对标主流公链测试成熟度” | `liveops_community` 执行，producer 审批 |
 - Acceptance Criteria:
-  - AC-1: 本专题必须明确写出主流公链测试体系至少包含六层：`spec/reference`、`deterministic/unit/integration`、`distributed/multi-node`、`ui/playability`、`longrun/chaos/drill`、`shared network/release train`。
+  - AC-1: 本专题必须明确写出主流公链测试体系至少包含六层：`spec/reference`、`deterministic/unit/integration`、`distributed/multi-node`、`ui/playability`、`longrun/chaos/drill`、`network rehearsal / release-train readiness`。
   - AC-2: 本专题必须明确写出 oasis7 当前已具备 `S0/S1/S2/S4/S6/S9/S10 + governance registry audit/runbook` 这一类基础，但这些还不足以推导出“主流公链级测试体系已完成”。
   - AC-3: 本专题必须明确写出：仓库当前没有冻结成正式 gate 的 fuzz/property-based 测试层。
   - AC-4: 本专题必须明确写出：仓库当前没有共享 `devnet/testnet/canary release train` 的正式执行层。
@@ -55,7 +55,7 @@
   - AC-6: 本专题必须输出一份 `已有/部分具备/缺失/下一步` 矩阵，可直接给 producer 排序。
   - AC-7: `testing-manual.md` 必须能找到本专题入口，避免测试分层与对标口径继续分离。
 - Non-Goals:
-  - 不在本专题内直接实现 fuzz 框架、shared devnet/testnet 或新的 chaos 平台。
+  - 不在本专题内直接实现 fuzz 框架、legacy shared_devnet rehearsal / formal test environment 或新的 chaos 平台。
   - 不把当前 verdict 从 `not_mainnet_grade` 升级为任何更高级别。
   - 不替代具体 execution workstream 的详细测试卡。
 
@@ -76,7 +76,7 @@
   - 若引用“主流公链多客户端一致性测试”，必须同时说明 oasis7 当前是单实现栈，因此等价要求应落在 `独立 replay/verifier`、`跨 world/节点副本一致性` 与 `共享网络升级演练`，而不是伪造不存在的第二客户端。
   - 若 oasis7 某层已有命令，但没有固定成 release gate、没有周期执行、没有证据模板，则该层最多只能记为 `partial`。
   - 若某项 drill 只有 clone-world 脚本，没有 default/live execution world 真实证据，则仍不得记为完成。
-  - 若某项 shared-network 能力只有本地单机 smoke，没有共享节点、升级窗口或版本漂移管理，则不得记为 `devnet/testnet/release train complete`。
+  - 若某项 network rehearsal 能力只有本地单机 smoke，没有共享节点、升级窗口或版本漂移管理，则不得记为 `devnet/testnet/release train complete`。
 - Non-Functional Requirements:
   - NFR-P2P-BENCH-1: 所有“已有/缺失”判断都必须能回链到仓库命令、手册或正式专题文档。
   - NFR-P2P-BENCH-2: benchmark 必须同时给出 `mainstream expectation` 与 `oasis7 equivalent`，避免机械照搬其他链结构。
@@ -88,10 +88,10 @@
 - Phased Rollout:
   - MVP: 建立 benchmark 文档、冻结 oasis7 当前映射与缺口矩阵。
   - v1.1: 补首轮真实 governance drill / negative drill / QA evidence。
-  - v1.2: 补 shared network / release train / 升级演练定义。
+  - v1.2: 补 network rehearsal / release-train readiness / 升级演练定义。
   - v2.0: 再决定是否需要引入 fuzz/property-based gate 或独立 verifier 路径。
 - Technical Risks:
-  - 风险-1: 若把 `required/full` 当成“主流公链完整测试体系”，会低估 shared network、事故 drill、release train 的工程成本。
+  - 风险-1: 若把 `required/full` 当成“主流公链完整测试体系”，会低估 network rehearsal、事故 drill、release train 的工程成本。
   - 风险-2: 若只在 clone-world 做 drill，不在真实 default/live execution world 留证据，readiness 评估会继续停在 spec-heavy 状态。
   - 风险-3: 若不把 fuzz/property-based 或 chaos 层明确记为缺口，后续很容易一直不补。
 
@@ -108,4 +108,4 @@
 | --- | --- | --- | --- |
 | DEC-P2P-BENCH-001 | 用“主流公链测试分层 + oasis7 等价映射”做 benchmark | 直接照抄多客户端公链 checklist | oasis7 当前是单实现栈，必须给出等价要求才有执行意义。 |
 | DEC-P2P-BENCH-002 | 当前把 `governance audit/runbook` 记为强正向信号，但仍不等于 drill 完成 | 因为已有 import/audit 工具就直接记完成 | 缺真实 execution evidence，不能跨越 QA gate。 |
-| DEC-P2P-BENCH-003 | 把 `shared network/release train` 记为当前明显缺口 | 继续只在本地/clone-world 评估 readiness | 主流公链的成熟度很大一部分来自共享环境、升级窗口和持续演练。 |
+| DEC-P2P-BENCH-003 | 把 `network rehearsal / release-train readiness` 记为当前明显缺口 | 继续只在本地/clone-world dry-run 评估 readiness | 主流公链的成熟度很大一部分来自共享环境、升级窗口和持续演练。 |

--- a/doc/p2p/blockchain/p2p-mainstream-public-chain-testing-benchmark-2026-03-24.project.md
+++ b/doc/p2p/blockchain/p2p-mainstream-public-chain-testing-benchmark-2026-03-24.project.md
@@ -23,7 +23,7 @@
   - 总 verdict: `not_mainnet_grade`
 - 当前 benchmark 结论:
   - `L0/L1/L3`: 已有正式基础
-  - `L2`: 已有基础，但仍偏库测/长跑，缺 shared network 维度
+  - `L2`: 已有基础，但仍偏库测/长跑，缺 network rehearsal 维度
   - `L4`: 长跑已有，controller slot 与 finality slot 的 clone-world / default-live 首轮 governance drill 已完成；finality 已补到两条独立 single-signer recovery 样本、一条 multi-signer loss import-policy reject 样本、一条 `2-of-2 -> 2-of-3` non-baseline rejoin 样本，以及一条 baseline rejoin 样本，但覆盖范围仍有限
   - `L5`: first `shared_devnet` dry run 最初为 `partial`；2026-05-24 legacy rehearsal 追溯结论已补到 `pass / eligible_for_promotion`，但它只作 benchmark L5 / legacy rehearsal evidence，不能替代 formal `public_testnet` 或 public large-world launch readiness
 
@@ -35,7 +35,7 @@
 - `doc/p2p/blockchain/p2p-mainnet-public-claims-policy-2026-03-23.prd.md`
 
 ## 验收命令（本轮）
-- `rg -n "shared network|release train|fuzz/property|governance drill|mainstream public-chain" doc/p2p/blockchain/p2p-mainstream-public-chain-testing-benchmark-2026-03-24.prd.md doc/p2p/blockchain/p2p-mainstream-public-chain-testing-benchmark-2026-03-24.design.md doc/p2p/blockchain/p2p-mainstream-public-chain-testing-benchmark-2026-03-24.project.md doc/p2p/prd.md doc/p2p/project.md testing-manual.md`
+- `rg -n "network rehearsal|release train|fuzz/property|governance drill|mainstream public-chain|legacy shared_devnet" doc/p2p/blockchain/p2p-mainstream-public-chain-testing-benchmark-2026-03-24.prd.md doc/p2p/blockchain/p2p-mainstream-public-chain-testing-benchmark-2026-03-24.design.md doc/p2p/blockchain/p2p-mainstream-public-chain-testing-benchmark-2026-03-24.project.md doc/p2p/prd.md doc/p2p/project.md testing-manual.md`
 - `./scripts/doc-governance-check.sh`
 - `git diff --check`
 

--- a/doc/p2p/blockchain/p2p-shared-network-release-train-minimum-2026-03-24.design.md
+++ b/doc/p2p/blockchain/p2p-shared-network-release-train-minimum-2026-03-24.design.md
@@ -1,4 +1,4 @@
-# oasis7 shared network / release train 最小执行形态（设计文档）
+# oasis7 legacy shared-network rehearsal / release-train background（设计文档）
 
 - 对应需求文档: `doc/p2p/blockchain/p2p-shared-network-release-train-minimum-2026-03-24.prd.md`
 - 对应项目管理文档: `doc/p2p/blockchain/p2p-shared-network-release-train-minimum-2026-03-24.project.md`
@@ -13,8 +13,8 @@
 > or public large-world readiness.
 
 ## 设计目标
-- 把 benchmark 中 `L5 shared network/release train` 的缺口落成正式执行模型，而不是继续停留在口头 backlog。
-- 明确 oasis7 下一阶段的最小 shared track、promotion 规则、rollback 规则与 claims gate。
+- 把 benchmark 中 `L5 network rehearsal / release-train readiness` 的缺口落成正式执行模型，而不是继续停留在口头 backlog。
+- 明确 oasis7 下一阶段的最小 legacy rehearsal track、promotion 规则、rollback 规则与 claims gate。
 
 ## 当前结论
 | 维度 | 当前状态 | 结论 |
@@ -24,10 +24,10 @@
 | shared_devnet/staging/canary | 作为 legacy/rehearsal evidence，`shared_devnet` 已有 2026-05-24 `pass / eligible_for_promotion` 追溯结论；`staging/canary` 仍未正式执行，且该轨不再是目标 test 环境 | `legacy_rehearsal_pass` |
 | public claims | 仍受 preview policy 限制 | `limited playable technical preview` + `crypto-hardened preview` |
 
-## 三层 shared track
+## 三层 legacy rehearsal track
 | Track | 目标 | 最小入口 | 最小通过标准 | 不算完成的情况 |
 | --- | --- | --- | --- | --- |
-| `shared_devnet` | 首次把统一 candidate 放到多人共享环境中运行 | 本地 gate 通过、candidate bundle 完整、共享访问路径明确 | 能被共享访问、版本固定、QA 有 `pass/block` 结论、可回滚到前一 bundle | 仍是单机私有 world、只有运行命令没有结论 |
+| `shared_devnet` | 首次把统一 candidate 放到多人 network rehearsal 环境中运行 | 本地 gate 通过、candidate bundle 完整、共享访问路径明确 | 能被共享访问、版本固定、QA 有 `pass/block` 结论、可回滚到前一 bundle | 仍是单机私有 execution instance、只有运行命令没有结论 |
 | `staging` | 做升级窗口、恢复、回滚和彩排 | `shared_devnet=pass`、升级窗口与 owner 值班明确 | promotion/rollback 各至少一轮，证据完整，liveops 认可 | 只是复用 shared_devnet、没有独立升级/恢复演练 |
 | `canary` | 小范围真实发布轨道，验证 freeze/incident 响应 | `staging=pass`、duration/freeze 条件/incident owner 明确 | 有固定观察窗、可执行 freeze/rollback、incident 结论闭环 | 没有观察窗、没有 incident 结论、没有 fallback bundle |
 
@@ -52,7 +52,7 @@
   - `./scripts/release-gate.sh --candidate-bundle <bundle.json>`
 - 当前设计含义:
   - `release_candidate_bundle` 现在已具备机器可读 JSON 工件、路径哈希与 `git_commit` pinning。
-  - `release-gate` 已可在进入 shared track 前先校验 bundle 存在性、引用路径与 hash 漂移。
+  - `release-gate` 已可在进入 rehearsal track 前先校验 bundle 存在性、引用路径与 hash 漂移。
   - 本段记录 RTMIN-1 当时的实现入口；当前网络层 verdict 不在本文维护，见 formal network-tier project。
 
 ## 当前实现入口（RTMIN-2）
@@ -94,7 +94,7 @@
   - `./scripts/shared-devnet-rehearsal-smoke.sh`
 - 当前设计含义:
   - 同一条命令现在可以围绕一个 `candidate_id` 串起 `release-candidate-bundle create/validate`、可选 `release-gate --dry-run`、same-candidate `headed Web + no-ui + pure_api` 复跑或证据复用、lane scaffold、`lanes.shared_devnet.tsv` 和 `shared-network-track-gate` 输出。
-  - 它默认仍对 `shared_access`、`mixed_topology_baseline`、`governance_live_drill`、`short_window_longrun`、`rollback_target_ready` 维持保守语义；编排入口本身不等于 shared-network `pass` 或 claims 升级。
+  - 它默认仍对 `shared_access`、`mixed_topology_baseline`、`governance_live_drill`、`short_window_longrun`、`rollback_target_ready` 维持保守语义；编排入口本身不等于 network-rehearsal `pass` 或 claims 升级。
 
 ## Track QA Required Lanes
 | Track | Required lanes | Gate 结论规则 |
@@ -160,8 +160,8 @@
 - 当前允许：
   - `limited playable technical preview`
   - `crypto-hardened preview`
-  - `shared network / release train is specified but not yet executed`
+  - `network rehearsal / release train is specified but not yet executed`
 - 当前禁止：
   - `production release train is established`
-  - `shared network validated`
+  - `network rehearsal validated`
   - `mainnet-grade testing maturity`

--- a/doc/p2p/blockchain/p2p-shared-network-release-train-minimum-2026-03-24.prd.md
+++ b/doc/p2p/blockchain/p2p-shared-network-release-train-minimum-2026-03-24.prd.md
@@ -1,4 +1,4 @@
-# oasis7 shared network / release train 最小执行形态（2026-03-24）
+# oasis7 legacy shared-network rehearsal / release-train background（2026-03-24）
 
 - 对应设计文档: `doc/p2p/blockchain/p2p-shared-network-release-train-minimum-2026-03-24.design.md`
 - 对应项目管理文档: `doc/p2p/blockchain/p2p-shared-network-release-train-minimum-2026-03-24.project.md`
@@ -12,30 +12,30 @@
 > public launch, or public large-world readiness.
 
 ## 1. Executive Summary
-- Problem Statement: oasis7 现在已经具备 `required/full`、Web-first 闭环、S9/S10 长跑和首轮真实 governance drill 证据，但这些验证大多仍停留在本地或单 owner 控制的 execution world。即便 `P2PARCH-6` 已补出 mixed-topology matrix，shared network / release train 若没有把 mixed-topology 作为显式 required lane，团队仍可能把“本地矩阵通过”误记成“共享环境已准备好 promotion”。
-- Proposed Solution: 冻结一份 producer-owned 的 shared network / release train minimum PRD，定义 `shared_devnet -> staging -> canary` 三层最小执行轨道、`release_candidate_bundle` 单一真值、promotion/rollback/freeze 规则和 QA/liveops 证据门禁，并把 mixed-topology baseline / rehearsal / claim review 升级为各轨必经 lane，让 oasis7 把 benchmark 中的 `L5 shared network/release train` 从“仅有缺口描述”升级成正式 execution workstream。
+- Problem Statement: oasis7 现在已经具备 `required/full`、Web-first 闭环、S9/S10 长跑和首轮真实 governance drill 证据，但这些验证大多仍停留在本地或单 owner 控制的 execution world。即便 `P2PARCH-6` 已补出 mixed-topology matrix，legacy network rehearsal / release-train readiness 若没有把 mixed-topology 作为显式 required lane，团队仍可能把“本地矩阵通过”误记成“共享环境已准备好 promotion”。
+- Proposed Solution: 冻结一份 producer-owned 的 legacy network rehearsal / release-train readiness PRD，定义 `shared_devnet -> staging -> canary` 三层历史 rehearsal track、`release_candidate_bundle` 单一真值、promotion/rollback/freeze 规则和 QA/liveops 证据门禁，并把 mixed-topology baseline / rehearsal / claim review 升级为各轨必经 lane，让 oasis7 把 benchmark 中的 `L5 network rehearsal / release-train readiness` 从“仅有缺口描述”升级成正式 execution workstream。
 - Success Criteria:
   - SC-1: 明确冻结不少于三层的 shared execution track：`shared_devnet`、`staging`、`canary`，并写清各层目标、输入、owner 和通过标准。
   - SC-2: 明确冻结统一的 `release_candidate_bundle` 字段集合，要求同一候选版本在三个轨道之间可追溯、可回滚、不可口头漂移。
-  - SC-3: 明确区分 `complete / partial / blocked` 三种 shared-network 状态，避免把“单机 smoke”误记成 release train。
-  - SC-4: 明确当前 public claims 在 shared network 未执行前仍只能维持 `limited playable technical preview` 与 `crypto-hardened preview`。
+  - SC-3: 明确区分 `complete / partial / blocked` 三种 network-rehearsal 状态，避免把“单机 smoke”误记成 release train。
+  - SC-4: 明确当前 public claims 在 network rehearsal 未执行前仍只能维持 `limited playable technical preview` 与 `crypto-hardened preview`。
   - SC-5: 输出 producer 可直接排任务的 project 拆解，至少覆盖 `runtime_engineer`、`qa_engineer`、`liveops_community` 三个角色。
   - SC-6: 明确 shared-devnet / staging / canary 三轨都必须包含 mixed-topology required lane；仅有 matrix baseline 时最多记为 `partial`，不得直接 promotion 或升级 claims。
 
 ## 2. User Experience & Functionality
 - User Personas:
-  - `producer_system_designer`：需要知道 shared network 最小完成态是什么，才能决定下一个阶段投入。
+  - `producer_system_designer`：需要知道 network rehearsal 最小完成态是什么，才能决定下一个阶段投入。
   - `runtime_engineer`：需要知道一个候选版本必须带哪些 build/world/governance 真值，才能进入共享轨道。
-  - `qa_engineer`：需要知道 shared devnet/staging/canary 各自的 `pass/block/partial` 判定和证据模板。
+  - `qa_engineer`：需要知道 legacy shared_devnet rehearsal / staging / canary 各自的 `pass/block/partial` 判定和证据模板。
   - `liveops_community`：需要知道什么时候能做 canary，对外还能说什么，事故时如何 freeze/rollback。
 - User Scenarios & Frequency:
   - 每次准备把一个 runtime/world/governance 组合升级成共享候选版本时执行一次。
   - 每次准备从 `shared_devnet` 推到 `staging` 或 `canary` 时执行一次 promotion gate 复核。
   - 每次发生候选版本事故、回滚或外部口径复评时执行一次 freeze/review。
 - User Stories:
-  - PRD-P2P-RTMIN-001: As a `producer_system_designer`, I want a minimum shared-network model, so that release-train discussions stop relying on vague intuition.
+  - PRD-P2P-RTMIN-001: As a `producer_system_designer`, I want a minimum network-rehearsal model, so that release-train discussions stop relying on vague intuition.
   - PRD-P2P-RTMIN-002: As a `runtime_engineer`, I want one immutable candidate bundle definition, so that shared tracks run the same versioned truth instead of ad hoc local state.
-  - PRD-P2P-RTMIN-003: As a `qa_engineer`, I want per-track pass/partial/block rules and evidence expectations, so that shared-network readiness can be audited.
+  - PRD-P2P-RTMIN-003: As a `qa_engineer`, I want per-track pass/partial/block rules and evidence expectations, so that network-rehearsal readiness can be audited.
   - PRD-P2P-RTMIN-004: As a `liveops_community`, I want explicit promotion/freeze/rollback rules and claims boundaries, so that external communication stays behind execution truth.
 - Critical User Flows:
   1. Flow-P2P-RTMIN-001: `本地 required/full + governance drill + baseline docs 通过 -> 生成 release_candidate_bundle -> 提交 shared_devnet`
@@ -45,25 +45,25 @@
 - Functional Specification Matrix:
 | 功能点 | 字段定义 | 动作行为 | 状态转换 | 计算/判定规则 | 权限逻辑 |
 | --- | --- | --- | --- | --- | --- |
-| Shared track 定义 | `track_id/purpose/world_scope/access_mode/owner_roles/min_entry_gate` | 冻结 `shared_devnet`、`staging`、`canary` 的用途与入口门禁 | `draft -> frozen` | 至少三层；缺任一层则 release train 仍为 `blocked` | `producer_system_designer` 拍板，`runtime_engineer`/`qa_engineer`/`liveops_community` 联审 |
+| Legacy rehearsal track 定义 | `track_id/purpose/world_scope/access_mode/owner_roles/min_entry_gate` | 冻结 `shared_devnet`、`staging`、`canary` 的历史用途与入口门禁 | `draft -> frozen` | 至少三层；缺任一层则 release train 仍为 `blocked` | `producer_system_designer` 拍板，`runtime_engineer`/`qa_engineer`/`liveops_community` 联审 |
 | Release candidate bundle | `candidate_id/git_commit/runtime_build/world_snapshot_ref/governance_manifest_ref/evidence_refs` | 把单一候选版本推进到共享轨道 | `draft -> promoted -> retired` | 三个轨道必须引用同一 `candidate_id`；字段缺失则不得 promotion | `runtime_engineer` 生成，`qa_engineer` 校验 |
 | Promotion gate | `from_track/to_track/gate_inputs/gate_result/approved_by` | 根据证据决定是否升级到下一轨道 | `pending -> pass/block` | 上一轨道未 `pass`、无 rollback bundle、缺 mixed-topology required lane、或 evidence 不全时一律 `block/hold` | `qa_engineer` 给出结论，`producer_system_designer`/`liveops_community` 审批 |
 | Freeze / rollback | `incident_id/affected_track/fallback_candidate_id/fallback_class/freeze_reason/recovery_status` | 事故时冻结 promotion 并回滚到前一 bundle，或在首条 `shared_devnet pass` 前回退到受审计 bootstrap fallback | `idle -> frozen -> restored` | `staging/canary` 的回滚目标必须是最近一次 `pass` 的 candidate；首条 `shared_devnet pass` 允许使用受审计 `bootstrap_restore_ready` fallback，但必须固定 restore steps、owner ref 与恢复范围；只有“停在当前环境观察”不算恢复 | `liveops_community` 执行，`runtime_engineer` 支持 |
-| Claims gate | `claim_phrase/min_track_status/reject_reason` | 根据 shared-network 真值决定对外口径 | `draft -> enforced` | 只要 `shared_devnet/staging/canary` 任一缺失或仅 `partial`，就不得说 release train 已建立 | `liveops_community` 执行，producer 审批 |
+| Claims gate | `claim_phrase/min_track_status/reject_reason` | 根据 network-rehearsal 真值决定对外口径 | `draft -> enforced` | 只要 `shared_devnet/staging/canary` 任一缺失或仅 `partial`，就不得说 release train 已建立 | `liveops_community` 执行，producer 审批 |
 - Acceptance Criteria:
-  - AC-1: 本专题必须冻结 `shared_devnet`、`staging`、`canary` 三层 shared track 的目标、owner、最小入口门禁和通过标准。
+  - AC-1: 本专题必须冻结 `shared_devnet`、`staging`、`canary` 三层 legacy rehearsal track 的目标、owner、最小入口门禁和通过标准。
   - AC-2: 本专题必须冻结统一的 `release_candidate_bundle` 字段集合，至少包含 `candidate_id`、`git_commit`、`runtime_build`、`world_snapshot_ref`、`governance_manifest_ref`、`evidence_refs`。
   - AC-3: 本专题必须明确什么情况只能记为 `partial`，至少包括：仅本地单机运行、没有共享访问、没有固定 candidate id、没有可审计 rollback target、没有 QA 证据。
-  - AC-4: 本专题必须明确：shared network / release train 未完成前，仍不得使用 `production release train is established`、`mainnet-grade testing maturity` 或任何高于当前 preview 的口径。
+  - AC-4: 本专题必须明确：network rehearsal / release train 未完成前，仍不得使用 `production release train is established`、`mainnet-grade testing maturity` 或任何高于当前 preview 的口径。
   - AC-5: `testing-manual.md` 必须能找到本专题入口，并明确它是 benchmark `L5` 的正式 execution 入口，而不是已完成能力。
   - AC-6: `doc/p2p/project.md` 必须建立 `TASK-P2P-040` 任务链，并拆出后续 runtime/QA/liveops 子任务。
-  - AC-7: 本专题必须明确 shared-network 当前状态仍是 `specified_not_executed`，不得把建档误写成完成执行。
+  - AC-7: 本专题必须明确 network-rehearsal 当前状态仍是 `specified_not_executed`，不得把建档误写成完成执行。
   - AC-8: 本专题必须给出 first shared-devnet dry run、first staging rehearsal、first canary rehearsal 的顺序与阻断条件。
-  - AC-9: 本专题必须明确 mixed-topology 是 `shared_devnet/staging/canary` 的 required lane；`P2PARCH-6` matrix baseline 只能作为 shared-devnet 的起始输入，不能单独构成 shared-network `pass` 或 public claim 升级依据。
+  - AC-9: 本专题必须明确 mixed-topology 是 `shared_devnet/staging/canary` 的 required lane；`P2PARCH-6` matrix baseline 只能作为 legacy shared-devnet rehearsal 的起始输入，不能单独构成 network-rehearsal `pass` 或 public claim 升级依据。
   - AC-10: 本专题必须明确 `mixed_topology_baseline` 从 `partial` 升到 `pass` 时，至少同时固定 same-window shared evidence、producer/QA 联审通过的 `pass_uplift_decision_ref`，并在 evidence 模板/脚本中保留为显式字段。
   - AC-11: 本专题必须明确 `shared_access` 从 `partial` 升到 `pass` 时，至少同时固定 shared endpoint、independent operator handoff 与 access evidence，并在 evidence 模板/脚本中保留为显式字段。
 - Non-Goals:
-  - 不在本专题内直接搭建真实 shared devnet/testnet/canary 环境。
+  - 不在本专题内直接搭建真实 shared_devnet rehearsal / test environment / canary 环境。
   - 不在本专题内升级 `limited playable technical preview` 或 `crypto-hardened preview` 口径。
   - 不替代 `governance drill`、`genesis ceremony` 或 `fuzz/property` 各自专题。
 
@@ -72,7 +72,7 @@
 - Evaluation Strategy: 不适用。
 
 ## 4. Technical Specifications
-- Architecture Overview: shared network / release train minimum 是一条位于本地验证之后、公开口径之前的执行轨道。输入是已通过 `required/full`、S6、S9/S10、governance drill 基线的 `release_candidate_bundle`；中间经过 `shared_devnet -> staging -> canary` 逐级 promotion；输出是 `pass/block/rollback` 证据与 claims decision。它不新增共识协议，而是把版本固定、world 真值、治理 manifest、证据留档和升级窗口管理纳入统一流程。
+- Architecture Overview: legacy network rehearsal / release train minimum 是一条位于本地验证之后、公开口径之前的历史执行轨道。输入是已通过 `required/full`、S6、S9/S10、governance drill 基线的 `release_candidate_bundle`；中间经过 `shared_devnet -> staging -> canary` 逐级 promotion；输出是 `pass/block/rollback` 证据与 claims decision。它不新增共识协议，而是把版本固定、world 真值、治理 manifest、证据留档和升级窗口管理纳入统一流程。
 - Integration Points:
   - `testing-manual.md`
   - `doc/p2p/blockchain/p2p-mainstream-public-chain-testing-benchmark-2026-03-24.prd.md`
@@ -83,22 +83,22 @@
   - `doc/p2p/blockchain/p2p-genesis-freeze-ceremony-qa-gate-2026-03-23.prd.md`
   - `doc/p2p/project.md`
 - Edge Cases & Error Handling:
-  - 若一个环境只有单 owner 本地访问、没有共享节点或共享运维窗口，则最多记为 `partial_local_only`，不能记为 shared track。
+  - 若一个环境只有单 owner 本地访问、没有共享节点或共享运维窗口，则最多记为 `partial_local_only`，不能记为 rehearsal track。
   - 若 `shared_devnet`、`staging`、`canary` 跑的是不同 commit、不同 world snapshot 或不同 governance manifest，则 promotion 直接 `block_version_drift`。
   - 若 `staging/canary` 没有最近一次 `pass` 的 fallback candidate，就不得进入下一轨道；若 `shared_devnet` 还在争取首条 `pass`，则至少要固定一条受审计的 `bootstrap_restore_ready` fallback，并写清 restore steps / owner ref / restoration scope，否则只能维持 `partial`。
   - 若 staging 只是 shared_devnet 的别名、没有独立升级窗口/恢复演练/QA 判定，则不得记为 `staging_ready`。
   - 若 canary 没有明确的 duration、incident review 与 freeze 条件，则不得记为 `canary_complete`。
   - 若 governance truth、genesis truth 或 claims boundary 发生变化但未更新 candidate bundle 编号，则该 bundle 失效，必须重新编号。
-  - 若 shared-network 证据只包含命令记录，没有 `summary/status/incident` 结论，则 promotion 只能记为 `partial_evidence_missing`。
+  - 若 network-rehearsal 证据只包含命令记录，没有 `summary/status/incident` 结论，则 promotion 只能记为 `partial_evidence_missing`。
   - 若 shared-devnet 只引用 `P2PARCH-6` matrix baseline、没有 same-window mixed-topology 结论，则最多记为 `partial_mixed_topology_baseline_only`。
   - 若 shared-devnet 试图把 mixed-topology lane 记为 `pass`，但没有 producer/QA 联审留下的 pass-uplift decision ref，则必须回退到 `partial_missing_pass_decision_ref`。
 - Non-Functional Requirements:
   - NFR-P2P-RTMIN-1: 每个 track 的每次 promotion 必须对应唯一 `candidate_id`，且能回链到 `git_commit/runtime_build/world_snapshot_ref/governance_manifest_ref`。
   - NFR-P2P-RTMIN-2: 任一 track 若无共享访问方式、无 owner、无 evidence path、无 rollback target，则不得标记为 `pass`。
   - NFR-P2P-RTMIN-3: `shared_devnet -> staging -> canary` 必须保持严格单向 promotion；不得跳级进入 canary。
-  - NFR-P2P-RTMIN-4: 所有 shared-network 结论必须使用 `pass/partial/block/frozen/restored` 这些显式状态，不得使用 `looks_good` 一类口头结论。
-  - NFR-P2P-RTMIN-5: 在 `shared_devnet/staging/canary` 三层都有最新审计轮次的正式证据前，公开口径不得出现 `release train established`、`shared network validated` 或更高成熟度描述。
-  - NFR-P2P-RTMIN-6: shared-network 证据不得包含私钥、助记词、离线签名材料或 operator 私密基础设施细节。
+  - NFR-P2P-RTMIN-4: 所有 network-rehearsal 结论必须使用 `pass/partial/block/frozen/restored` 这些显式状态，不得使用 `looks_good` 一类口头结论。
+  - NFR-P2P-RTMIN-5: 在 `shared_devnet/staging/canary` 三层都有最新审计轮次的正式证据前，公开口径不得出现 `release train established`、`network rehearsal fully validated` 或更高成熟度描述。
+  - NFR-P2P-RTMIN-6: network-rehearsal 证据不得包含私钥、助记词、离线签名材料或 operator 私密基础设施细节。
 - NFR-P2P-RTMIN-7: mixed-topology required lane 必须显式区分 `baseline/rehearsal/claim review` 三种阶段；proxy drill 不得在 runbook 或 claims gate 中冒充 dedicated sentry/NAT lab 真值。
 - NFR-P2P-RTMIN-8: 任何把 shared-devnet mixed-topology lane 提升为 `pass` 的结论，都必须同时固定 same-window evidence ref 与 producer/QA 审计通过的 pass-uplift decision ref，避免仅靠脚本开关改变 gate 语义。
 - NFR-P2P-RTMIN-10: mixed-topology 的 `pass_uplift_decision_ref` 必须进入模板、草稿脚本与编排输出的正式字段集合；不得只在自由文本备注里出现，避免 QA/liveops 在后续 promotion 审计时丢失合同真值。
@@ -111,11 +111,11 @@
   - MVP: 冻结 three-track model、candidate bundle、promotion/freeze/rollback 规则和 claims gate。
   - v1.1: 执行 first shared-devnet dry run，产出正式 QA/evidence 模板。
   - v1.2: 执行 first staging rehearsal 与 rollback drill，补齐 liveops 窗口与 incident 模板。
-  - v2.0: 执行 first canary rehearsal，并把 shared-network gate 接入常规 release 评审。
+  - v2.0: 执行 first canary rehearsal，并把 network-rehearsal gate 接入常规 release 评审。
 - Technical Risks:
-  - 风险-1: 若不冻结 candidate bundle 真值，shared-network 很容易退化成“每层各跑各的版本”。
+  - 风险-1: 若不冻结 candidate bundle 真值，network rehearsal 很容易退化成“每层各跑各的版本”。
   - 风险-2: 若没有 rollback/freeze 机制，canary 一旦出事故就只能靠口头操作，不可审计。
-  - 风险-3: 若把“共享聊天群里有人能连上”误记为 shared network 完成，会继续高估测试成熟度。
+  - 风险-3: 若把“共享聊天群里有人能连上”误记为 network rehearsal 完成，会继续高估测试成熟度。
 
 ## 6. Validation & Decision Record
 - Test Plan & Traceability:
@@ -123,11 +123,11 @@
 | --- | --- | --- | --- | --- |
 | PRD-P2P-RTMIN-001 | RTMIN-0/1 | `test_tier_required` | PRD/design/project 建档，three-track model 与 current verdict 冻结 | producer 发布阶段判断 |
 | PRD-P2P-RTMIN-002 | RTMIN-1 | `test_tier_required` | candidate bundle schema、version pin 与 drift blocker 设计冻结 | runtime release artifact 管理 |
-| PRD-P2P-RTMIN-003 | RTMIN-2/4/5 | `test_tier_required` + `test_tier_full` | QA pass/partial/block 模板、shared-devnet/staging/canary rehearsal 证据 | shared-network 审计与回归 |
+| PRD-P2P-RTMIN-003 | RTMIN-2/4/5 | `test_tier_required` + `test_tier_full` | QA pass/partial/block 模板、shared-devnet/staging/canary rehearsal 证据 | network-rehearsal 审计与回归 |
 | PRD-P2P-RTMIN-004 | RTMIN-3/5 | `test_tier_required` | promotion/freeze/rollback/claims gate 冻结与 liveops runbook | 对外口径与事故响应 |
 - Decision Log:
 | 决策ID | 选定方案 | 备选方案（否决） | 依据 |
 | --- | --- | --- | --- |
-| DEC-P2P-RTMIN-001 | 先冻结 `shared_devnet -> staging -> canary` 的最小三层模型 | 继续只说“以后做 devnet/testnet” | 只有明确轨道、owner 和 gate，shared network 才能从概念变成执行面。 |
+| DEC-P2P-RTMIN-001 | 先冻结 `shared_devnet -> staging -> canary` 的最小三层历史 rehearsal 模型 | 继续只说“以后做 devnet/testnet” | 只有明确轨道、owner 和 gate，network rehearsal 才能从概念变成执行面。 |
 | DEC-P2P-RTMIN-002 | 采用统一 `release_candidate_bundle` 作为 promotion 单一真值 | 每个轨道各自记录版本 | 多轨道若没有统一 candidate id，就无法审计漂移、回滚和 claims 归因。 |
-| DEC-P2P-RTMIN-003 | 在 shared-network 完成前继续维持 preview claims | 因为已有 drill 与 benchmark 就提前升级 testing/public claims | benchmark 已明确 `L5` 仍缺失，不能跨过 shared-network 真实执行。 |
+| DEC-P2P-RTMIN-003 | 在 network rehearsal 完成前继续维持 preview claims | 因为已有 drill 与 benchmark 就提前升级 testing/public claims | benchmark 已明确 `L5` 仍缺失，不能跨过 network-rehearsal 真实执行。 |

--- a/doc/p2p/blockchain/p2p-shared-network-release-train-minimum-2026-03-24.project.md
+++ b/doc/p2p/blockchain/p2p-shared-network-release-train-minimum-2026-03-24.project.md
@@ -1,4 +1,4 @@
-# oasis7 shared network / release train 最小执行形态（项目管理文档）
+# oasis7 legacy shared-network rehearsal / release-train background（项目管理文档）
 
 - 对应设计文档: `doc/p2p/blockchain/p2p-shared-network-release-train-minimum-2026-03-24.design.md`
 - 对应需求文档: `doc/p2p/blockchain/p2p-shared-network-release-train-minimum-2026-03-24.prd.md`
@@ -13,7 +13,7 @@
 > public large-world readiness.
 
 ## 任务拆解（含 PRD-ID 映射）
-- [x] RTMIN-0 (PRD-P2P-RTMIN-001/002/003/004) [test_tier_required]: 新建 shared network / release train minimum 专题 PRD / design / project，并接入 `doc/p2p` 模块主追踪与 `testing-manual`。
+- [x] rtmin-0 (PRD-P2P-RTMIN-001/002/003/004) [test_tier_required]: 新建 legacy network rehearsal / release-train readiness 专题 PRD / design / project，并接入 `doc/p2p` 模块主追踪与 `testing-manual`。 Trace: .pm/tasks/task_735872fee5174fc28f10166a9e54d56b.yaml
 - [x] RTMIN-1 (PRD-P2P-RTMIN-001/002) [test_tier_required]: `runtime_engineer` 落地 `release_candidate_bundle` 真值、版本 pinning 与 drift blocker，并把 bundle 校验接入 `release-gate` 前置步骤。
 - [x] RTMIN-2 (PRD-P2P-RTMIN-003) [test_tier_required]: `qa_engineer` 冻结 `shared_devnet/staging/canary` 的 `pass/partial/block` 证据模板与 gate 表，并落地统一 `summary.json/md` scaffold。
 - [x] RTMIN-3 (PRD-P2P-RTMIN-004) [test_tier_required]: `liveops_community` 冻结 promotion/freeze/rollback/run window/public claims runbook。
@@ -100,7 +100,7 @@
 - 当前阶段:
   - 游戏阶段口径: `limited playable technical preview`
   - 安全阶段口径: `crypto-hardened preview`
-  - shared network verdict: `pass`
+  - legacy network-rehearsal verdict: `pass`
 - 当前缺口:
   - `shared_devnet` 已到 `pass`
   - 当前 formal gate 已更新到 `candidate_id=shared-devnet-live-reset-20260523-01`，见 `doc/testing/evidence/generated-shared-network-gates/shared_devnet-20260524-101652/summary.md`；aggregate 结论为 `pass / eligible_for_promotion`
@@ -109,7 +109,7 @@
   - `governance_live_drill` 已基于同窗 post-reset finality drill 升到 `pass`
   - 2026-05-23 的 live triad 卡死事件已通过 `doc/testing/evidence/shared-network-shared-devnet-triad-reset-recovery-2026-05-23.md` 收口：旧链历史被放弃，三节点已在 fresh shared-devnet chain 上恢复推进；因此当前 `shared_devnet` 不再被“observer retention window / sequencer predecessor-gap”这组运行时故障阻断
   - `rollback_target_ready` 已通过 `doc/testing/evidence/shared-network-shared-devnet-rollback-contract-2026-05-23.md` 升到 first-pass 允许的 `bootstrap_restore_ready` `pass`：当前 live-reset candidate 的 fallback bundle/gate、owner、restore steps 与 restoration scope 都已固定
-  - `P2PARCH-6` matrix baseline 已成为 shared-network required lane，但它当前只足以阻止 claims 越界，不等价于 shared-window `pass`
+  - `P2PARCH-6` matrix baseline 已成为 legacy network-rehearsal required lane，但它当前只足以阻止 claims 越界，不等价于 same-window `pass`
   - `shared_access / rollback_target_ready / short_window_longrun` 已全部在当前 candidate 窗口内转为 `pass`
   - `mixed_topology_baseline` 现已通过 `doc/testing/evidence/shared-network-shared-devnet-mixed-topology-2026-05-23.md` 升到 `pass`：同窗 live repair 后，本地 workstation validator 与两台 ECS validator 已在 `2026-05-24 10:13:55 CST` 收敛到 `committed_height=1280 / network_committed_height=1280 / last_execution_height=1280`，并已补齐 producer/QA `pass_uplift_decision_ref`
   - `shared_access` 的 endpoint / operator handoff / access evidence 现在已在同窗 candidate 上闭环；后续不再需要围绕 shared access 本身补结构

--- a/doc/p2p/blockchain/p2p-shared-network-release-train-minimum-2026-03-24.runbook.md
+++ b/doc/p2p/blockchain/p2p-shared-network-release-train-minimum-2026-03-24.runbook.md
@@ -1,4 +1,4 @@
-# oasis7 shared network / release train 最小执行形态（LiveOps Runbook）
+# oasis7 legacy shared-network rehearsal / release-train background（LiveOps Runbook）
 
 - 对应需求文档: `doc/p2p/blockchain/p2p-shared-network-release-train-minimum-2026-03-24.prd.md`
 - 对应设计文档: `doc/p2p/blockchain/p2p-shared-network-release-train-minimum-2026-03-24.design.md`
@@ -20,8 +20,8 @@
   - `testing-manual.md`
 
 ## 1. 适用范围
-- 本 runbook 只定义 shared-network / release-train 的执行方法；它不定义 formal `public_testnet`、`mainnet` 或玩家意义上的公开大世界上线。
-- 当前 `shared_devnet` legacy rehearsal 已在 2026-05-24 追溯结论中达到 `pass / eligible_for_promotion`；这只证明 legacy shared-network rehearsal evidence 已闭环，不等于 live `public_testnet`、`mainnet`、public launch 或赛季上线。
+- 本 runbook 只定义 legacy network-rehearsal / release-train 的执行方法；它不定义 formal `public_testnet`、`mainnet` 或玩家意义上的公开大世界上线。
+- 当前 `shared_devnet` legacy rehearsal 已在 2026-05-24 追溯结论中达到 `pass / eligible_for_promotion`；这只证明 historical network-rehearsal evidence 已闭环，不等于 live `public_testnet`、`mainnet`、public launch 或赛季上线。
 - 当前总 verdict 已更新为 `shared_devnet legacy rehearsal pass; formal public_testnet/mainnet still gated`。
 - 在 formal `public_testnet` live-candidate readiness 与后续 release/public claims gate 通过前，对外只允许：
   - `limited playable technical preview`
@@ -156,7 +156,7 @@
 - 没有 producer 新批复前，不因单次 shared window 或单次 canary 观察而升级 public claim。
 - 公开沟通禁止出现：
   - `production release train is established`
-  - `shared network validated`
+  - `network rehearsal fully validated`
   - `mainnet-grade testing maturity`
   - `public_testnet is live`
   - `public large shared world is launched`
@@ -185,7 +185,7 @@
   - 2026-05-24 legacy `shared_devnet` pass / eligible-for-promotion 追溯结论
 - 当前 `mixed_topology_baseline` 已有正式 pass evidence：
   - `doc/testing/evidence/shared-network-shared-devnet-mixed-topology-2026-05-23.md`
-- shared-network legacy `shared_devnet` verdict 当前是 `pass / eligible_for_promotion`；但该 pass 不升级 public claims，也不等于 `public_testnet` 或正式在线大世界。
+- legacy network-rehearsal `shared_devnet` verdict 当前是 `pass / eligible_for_promotion`；但该 pass 不升级 public claims，也不等于 `public_testnet` 或正式在线大世界。
 - 当前 release-train 剩余边界:
   - `staging/canary` 仍需要按本 runbook 另行开窗验证
   - formal `public_testnet` readiness 由 network-tier six-lane gate 单独判定

--- a/doc/p2p/network/p2p-mainnet-private-reachability-architecture-2026-04-01.prd.md
+++ b/doc/p2p/network/p2p-mainnet-private-reachability-architecture-2026-04-01.prd.md
@@ -31,7 +31,7 @@
   - 每次设计 validator / sentry / relay 部署形态时，先看本专题角色边界。
   - 每次网络层计划从点状补丁进入框架重构时，先以本专题冻结目标态和非目标。
   - 每次新用户首次启动节点、切换网络环境或重新检测公网/NAT 条件时，系统都应自动重算默认模式。
-  - 每次 shared network / release train / chaos drill 设计新门禁时，把本专题当作流量分层和 reachability 真值。
+  - 每次 network rehearsal / release-train / chaos drill 设计新门禁时，把本专题当作流量分层和 reachability 真值。
 - User Stories:
   - PRD-P2P-024-A: As a `producer_system_designer`, I want one public-chain-grade private-reachability architecture, so that oasis7 不会因为家宽/NAT 现实被迫退回“全员公网节点”假设。
   - PRD-P2P-024-B: As a `runtime_engineer`, I want identity, discovery, transport and relay semantics separated from consensus logic, so that the framework can support different main-chain data planes without重写底层可达性。

--- a/doc/testing/README.md
+++ b/doc/testing/README.md
@@ -13,7 +13,7 @@
 - 想跑真实本地栈 + Playwright + 玩家 UI 操作流程，并把这些用例作为一个长期系列管理：`doc/testing/manual/web-ui-playwright-closure-manual.manual.md`
 - 想看当前活跃任务、阻断与最新完成项：`doc/testing/project.md`
 - 想先判断要跑哪套测试或查操作步骤：`testing-manual.md`、`doc/testing/manual/web-ui-agent-browser-closure-manual.manual.md`、`doc/testing/manual/web-ui-playwright-closure-manual.manual.md`
-- 想先进入 `evidence` 热点子域，并按 release gate / hosted access / legacy p2p network-rehearsal rehearsal / governance drill / claim-audit 问题分流：`doc/testing/evidence/README.md`
+- 想先进入 `evidence` 热点子域，并按 release gate / hosted access / legacy p2p network rehearsal / governance drill / claim-audit 问题分流：`doc/testing/evidence/README.md`
 - 想先看当前 QA 阻断摘要：`doc/testing/provider-dual-mode-t4-blocker-2026-03-16.md`
 - 想先确认云上测试/正式环境、hosted-login 服务清单与 testnet/mainnet 口径边界：`doc/engineering/governance/environment-lanes-and-inventory-2026-05-29.md`
 - 想按子域或文件名继续下钻，而不是从长表里逐行找：`doc/testing/prd.index.md`
@@ -29,7 +29,7 @@
 - `prd.md` 是模块权威规格入口，适合先理解 required/full 分层、证据包与跨模块测试边界。
 - `project.md` 是执行台账，适合确认当前 QA 阻断、活跃测试治理任务与最新完成项。
   当前窗口只保留 blocker、next step 与少量高价值收口摘要；更细的近期完成历史应回到对应 topic `*.project.md` 与 `.pm/tasks/*.yaml` / execution log 追溯。
-- `evidence/README.md` 是当前最高密度热点子域 `evidence/` 的 canonical 入口，适合先按“release gate / hosted access / legacy p2p network-rehearsal rehearsal / governance drill / claim-audit / 定向验证”分流，再进入具体留痕文件。
+- `evidence/README.md` 是当前最高密度热点子域 `evidence/` 的 canonical 入口，适合先按“release gate / hosted access / legacy p2p network rehearsal / governance drill / claim-audit / 定向验证”分流，再进入具体留痕文件。
 - `testing-manual.md` 与 `manual/*.manual.md` 是 operator 手册层，用于决定跑哪套测试、按什么步骤执行；其中 Playwright 实跑系列入口是 `doc/testing/manual/web-ui-playwright-closure-manual.manual.md`。
 - `prd.index.md` 是定向检索索引，适合已知主题后按文件名查找，不是新读者的首读入口。
 

--- a/doc/testing/evidence/README.md
+++ b/doc/testing/evidence/README.md
@@ -5,7 +5,7 @@
 ## 从这里开始
 - 想确认 release readiness、candidate/trust gate 或 release 证据包：先读 `release-evidence-bundle-task-game-018-2026-03-10.md`、`closed-beta-candidate-release-gate-2026-03-22.md` 或 `gameplay-ten-minute-trust-gate-2026-04-09.md`
 - 想确认 hosted access、浏览器鉴权、web surface 或滥用矩阵：先读 `hosted-world-browser-auth-surface-2026-03-26.md`、`hosted-world-abuse-suite-matrix-2026-03-27.md` 或 `mainchain-token-signed-transfer-web-validation-2026-03-23.md`
-- 想确认 p2p/legacy shared-network rehearsal triad、mixed-topology、public testnet live candidate 或 rollout follow-up：先读 `public-testnet-live-candidate-endpoint-deploy-2026-05-19.md`、`public-testnet-claims-boundary-review-2026-05-21.md`、`p2p-real-env-triad-current-version-full-game-nodes-2026-05-16.md`、`shared-network-ecs-triad-chain-status-metrics-rollout-2026-04-23.md` 或 `p2p-mixed-topology-validation-matrix-2026-04-07.md`
+- 想确认 p2p / legacy shared-network rehearsal triad、mixed-topology、public testnet live candidate 或 rollout follow-up：先读 `public-testnet-live-candidate-endpoint-deploy-2026-05-19.md`、`public-testnet-claims-boundary-review-2026-05-21.md`、`p2p-real-env-triad-current-version-full-game-nodes-2026-05-16.md`、`shared-network-ecs-triad-chain-status-metrics-rollout-2026-04-23.md` 或 `p2p-mixed-topology-validation-matrix-2026-04-07.md`
 - 想确认治理演练、live world drill 或 finality 证据：先读 `governance-registry-live-world-drill-finality-2026-03-24.md`、`governance-registry-live-world-drill-foundation-ops-2026-03-24.md` 或 `governance-registry-clone-world-drill-foundation-ops-2026-03-24.md`
 - 想确认 claim/restricted grant、token allocation audit 或质量基线：先读 `game-agent-claim-abuse-matrix-2026-03-27.md`、`token-genesis-allocation-audit-template-2026-03-22.md` 或 `testing-quality-trend-baseline-2026-03-11.md`
 - 想确认 provider recertification、software-safe web entry、pure-api parity、headless smoke 或 launcher UX：先读 `provider-agent-dual-mode-recertification-evidence-2026-04-07.md`、`software-safe-primary-web-entry-evidence-2026-04-07.md` 或 `post-onboarding-headless-smoke-2026-03-19.md`
@@ -59,8 +59,8 @@
   - 三节点现在跑的是哪一版 runtime，链状态 metrics 是否已经真实部署
   - same-window triad snapshot / rollout confirm 该看哪里
   - 新增 `/v1/chain/status` metrics contract 有没有真实三节点证据
-  - mixed-topology、shared devnet、observer gap sync 或 blob root cause 在哪组 evidence
-  - shared-network ECS triad 与 shared-devnet 相关留痕怎么进入
+  - mixed-topology、legacy shared-devnet rehearsal、observer gap sync 或 blob root cause 在哪组 evidence
+  - historical shared-network ECS triad 与 legacy shared-devnet 相关留痕怎么进入
 - 归档边界:
   - `public-testnet-live-candidate-lanes-2026-05-21.tsv` 与 2026-05-22 live-candidate bundle / manifest / bootstrap-peers / lanes 文件保留为 public-testnet 演进链证据；当前默认首读入口应优先使用 2026-06-06 governed bootstrap 证据和本节列出的 live-candidate 说明文档。
   - `archive/visual-cleanup-2026-06-14/manifest.md` 记录从 active evidence path 移出的历史 visual evidence；这些文件只作为追溯归档，不作为当前 release / viewer / gameplay 首读证据。

--- a/doc/testing/prd.index.md
+++ b/doc/testing/prd.index.md
@@ -21,7 +21,7 @@
 - 想快速判断“现有性能测试覆盖到哪、哪些功能面最值得补性能测试、哪些更适合进 scoped gate”：先读 `doc/testing/performance/performance-coverage-gap-matrix-2026-06-09.md`
 - 想先回答当前在推进什么、哪些测试治理任务或 QA 阻断仍在影响收口：先读 `doc/testing/project.md`
 - 想直接决定要跑哪套测试或按步骤执行：先读 `testing-manual.md`、`doc/testing/manual/web-ui-agent-browser-closure-manual.manual.md` 与 `doc/testing/manual/web-ui-playwright-closure-manual.manual.md`
-- 想先进入 `evidence` 热点子域，并按 release gate / hosted access / legacy p2p network-rehearsal rehearsal / governance drill / claim-audit 问题分流：先读 `doc/testing/evidence/README.md`
+- 想先进入 `evidence` 热点子域，并按 release gate / hosted access / legacy p2p network rehearsal / governance drill / claim-audit 问题分流：先读 `doc/testing/evidence/README.md`
 - 想继续按子域或文件名下钻：使用下方热点子域导航，再跳到对应清单区域
 
 ## 密度说明
@@ -42,7 +42,7 @@
 | `chaos-plans/` | 专项 chaos plan 入口 |
 
 ## 活跃补充文档
-- `doc/testing/evidence/README.md`：`evidence/` 热点子域 landing page，按 release gate、hosted access、legacy p2p network-rehearsal rehearsal、governance drill 与 claim/audit 分流读者。
+- `doc/testing/evidence/README.md`：`evidence/` 热点子域 landing page，按 release gate、hosted access、legacy p2p network rehearsal、governance drill 与 claim/audit 分流读者。
 - `testing-manual.md`：仓库级系统测试手册，不并入下方模块 PRD 三件套长表。
 - `doc/testing/manual/web-ui-agent-browser-closure-manual.manual.md`：Web UI 闭环 canonical 操作手册，不并入下方模块 PRD 三件套长表。
 - `doc/testing/manual/web-ui-playwright-closure-manual.manual.md`：Playwright 实跑测试系列入口，用于管理真实本地栈、真实 UI 输入和后续玩家操作流程矩阵，不并入下方模块 PRD 三件套长表。

--- a/doc/testing/project.md
+++ b/doc/testing/project.md
@@ -28,7 +28,7 @@
 | Launcher / Web UI / release gate hardening 批次 (`TASK-TESTING-041` 至 `TASK-TESTING-065`) | `doc/testing/launcher/*.project.md`、`doc/testing/manual/web-ui-agent-browser-closure-manual.project.md`、相关 `.pm/tasks/task_<32hex>.*` |
 | 2026-03-02 / 2026-03-03 / 2026-03-06 专题任务映射 | `doc/testing/prd.index.md` 按文件名检索对应 `*.project.md`；旧 `SUBTASK-TESTING-*` 映射保留在专题 project 文档与 task evidence 中 |
 | Playability evidence stack / L4A-L4B / model visual review | `doc/testing/governance/playability-*.project.md`、`doc/testing/manual/model-visual-review-sop-2026-05-29.manual.md`、`doc/testing/templates/model-visual-review-card-template.md` |
-| Shared network / hosted-world / release evidence | `doc/testing/evidence/README.md` 先分流，再进入具体 evidence 文件 |
+| Legacy shared-network rehearsal / hosted access / release evidence | `doc/testing/evidence/README.md` 先分流，再进入具体 evidence 文件 |
 | Performance coverage and baselines | `doc/testing/performance/performance-coverage-gap-matrix-2026-06-09.md`、`testing-manual.md` 的 required-gate / Viewer performance probe 段落 |
 
 ## 最近高价值完成摘要


### PR DESCRIPTION
## Summary
- Align active docs around the unified persistent world terminology.
- Reword hosted/shared/local/testnet world labels into hosted access, legacy network rehearsal, and formal test-environment language.
- Preserve historical evidence filenames and compatibility identifiers while adding PR-ready task trace evidence.

## Validation
- `./scripts/doc-governance-check.sh`
- `git diff --check`
- `./scripts/pm/workflow-lint.sh --task-uid task_735872fee5174fc28f10166a9e54d56b --phase pr-ready`

Pre-PR local role review: passed (`producer_system_designer`, `repository_health_engineer`, `qa_engineer`, `liveops_community`).