### PR TITLE
Harden legacy shared network terminology

### DIFF
--- a/.pm/tasks/task_d5247a8f051443c38a6d551ab75efac8.execution.md
+++ b/.pm/tasks/task_d5247a8f051443c38a6d551ab75efac8.execution.md
@@ -163,3 +163,39 @@ Example:
 - Expected Result: terminology/doc/diff checks pass; current task execution log is not reported; full PM lint may still report unrelated historical task debt.
 - Actual Result: terminology scan passed with `allowed compatibility content hits: 67`, `allowed compatibility path hits: 17`; doc governance passed; diff check passed; current task execution-log filter produced no output; full PM lint failed on historical task execution-log format issues, initially including this task before template fields were added, and after the fix no current-task lines were reported by the targeted filter.
 - Blocker / Next Action: ready to report item 5 completion; leave unrelated historical PM lint debt untouched.
+
+## 2026-06-18 11:41:22 CST / tpm
+- Review Trigger: pre-PR local role review
+- Review Scope: commit `44e606601d7d4cdd09d092a81597c1bb8d3f80a1` vs `origin/main`; changed paths: `.pm/tasks/task_d5247a8f051443c38a6d551ab75efac8.execution.md`; `.pm/tasks/task_d5247a8f051443c38a6d551ab75efac8.yaml`; `doc/p2p/blockchain/p2p-formal-network-tiers-testnet-mechanism-2026-05-14.design.md`; `doc/p2p/blockchain/p2p-formal-network-tiers-testnet-mechanism-2026-05-14.prd.md`; `doc/p2p/prd.index.md`; `doc/p2p/project.md`; `scripts/unified-world-code-terminology-scan.sh`.
+- Review Roles: `repository_health_engineer`, `qa_engineer`, `liveops_community`
+- Review Question: confirm whether the terminology scan expansion and documentation wording correctly prevent legacy `shared_devnet/shared-network` from being mistaken for target `test/public_testnet/mainnet`, without creating over-broad allowlists, invalidating verification evidence, or weakening public/player-facing claims boundaries.
+- Evidence Available: fresh `./scripts/unified-world-code-terminology-scan.sh` passed; fresh `./scripts/doc-governance-check.sh` passed; fresh `git diff --check` passed; full `./scripts/pm/lint.sh` remains blocked by pre-existing historical task execution-log debt outside this task.
+- Expected Return Contract: `findings | no_findings | residual_risk`
+- Formal Sink: this execution log; passed packet to be appended after review integration.
+
+## 2026-06-18 11:45:32 CST / tpm
+- 完成内容: Pre-PR Local Role Review integration.
+  - `repository_health_engineer` (`Zeno`, agent `019ed8d2-7855-7a30-a6b6-c7a267a2bd1b`): no_findings. Residual risk: scan intentionally does not cover all historical evidence/archive topic docs; active governance / P2P index / formal network-tier / script surfaces are covered.
+  - `qa_engineer` (`Dirac`, agent `019ed8d2-78f5-76c0-a6db-222a19b652b7`): no_findings. Residual risk: scanner is a terminology/evidence-label guard only; it does not prove live `public_testnet` or `mainnet` readiness, and full PM lint is blocked by unrelated historical task logs.
+  - `liveops_community` (`Aristotle`, agent `019ed8d2-7a29-7e50-b96e-e0580cd64cdb`): one P2 finding that `not ready` was too weak as a standalone boundary marker because it could allow a line that still implies `shared_devnet` is a current public testnet.
+  - Disposition: addressed the LiveOps P2 by removing standalone `not ready` from `scripts/unified-world-code-terminology-scan.sh` boundary markers. Reran `./scripts/unified-world-code-terminology-scan.sh`; result passed with `allowed compatibility content hits: 67`, `allowed compatibility path hits: 17`.
+- 遗留事项: full repo-wide `./scripts/pm/lint.sh` remains blocked by unrelated historical `.pm/tasks/*` execution-log format debt; later GitHub PR gates still need to run after PR creation.
+- Action: integrated all role reviews, fixed the valid P2, and prepared the pre-PR evidence packet.
+- Validation Command: `./scripts/unified-world-code-terminology-scan.sh`; `./scripts/doc-governance-check.sh`; `git diff --check`
+- Expected Result: role finding addressed and fresh local terminology/doc/diff checks pass before PR creation.
+- Actual Result: terminology scan passed after the P2 fix; doc governance passed; diff check passed.
+- Blocker / Next Action: append passed packet, commit review evidence, then run `./scripts/prepare-task-pr.sh --create`.
+
+- Pre-PR Local Role Review: passed
+- Task UID: `task_d5247a8f051443c38a6d551ab75efac8`
+- Source Worktree: `/Users/scc/ccwork/worktrees/oasis7-engineering-environment-parity-research-20260618`
+- Source Branch: `task/engineering-environment-parity-research-20260618`
+- Source Head: `44e606601d7d4cdd09d092a81597c1bb8d3f80a1` plus follow-up review evidence / LiveOps P2 fix to be committed before PR creation.
+- Comparison Ref: `origin/main`
+- Reviewed Changed Paths: `.pm/tasks/task_d5247a8f051443c38a6d551ab75efac8.execution.md`; `.pm/tasks/task_d5247a8f051443c38a6d551ab75efac8.yaml`; `doc/p2p/blockchain/p2p-formal-network-tiers-testnet-mechanism-2026-05-14.design.md`; `doc/p2p/blockchain/p2p-formal-network-tiers-testnet-mechanism-2026-05-14.prd.md`; `doc/p2p/prd.index.md`; `doc/p2p/project.md`; `scripts/unified-world-code-terminology-scan.sh`
+- Role Selection Basis: `repository_health_engineer` for cross-cutting governance/script/doc-contract scan; `qa_engineer` for evidence-label/release-readiness implications; `liveops_community` for public/player-facing claims boundaries around `shared_devnet`, `public_testnet`, and `mainnet`.
+- Review Roles: `repository_health_engineer`, `qa_engineer`, `liveops_community`
+- Review Evidence: Zeno no_findings; Dirac no_findings; Aristotle P2 finding on weak `not ready` boundary marker.
+- Review Findings Disposition: addressed
+- Finding Disposition Evidence: removed `not ready` from `scripts/unified-world-code-terminology-scan.sh` boundary markers; fresh terminology scan passed.
+- Residual Risk: historical evidence/archive docs can still contain old terminology by design; this branch hardens active governance/P2P source surfaces and does not claim live `public_testnet` or `mainnet` readiness.

--- a/.pm/tasks/task_d5247a8f051443c38a6d551ab75efac8.execution.md
+++ b/.pm/tasks/task_d5247a8f051443c38a6d551ab75efac8.execution.md
@@ -199,3 +199,16 @@ Example:
 - Review Findings Disposition: addressed
 - Finding Disposition Evidence: removed `not ready` from `scripts/unified-world-code-terminology-scan.sh` boundary markers; fresh terminology scan passed.
 - Residual Risk: historical evidence/archive docs can still contain old terminology by design; this branch hardens active governance/P2P source surfaces and does not claim live `public_testnet` or `mainnet` readiness.
+
+## 2026-06-18 11:48:03 CST / tpm
+- 完成内容: PR preflight evidence repair.
+  - Added `doc/p2p/project.md` to task `doc_refs`.
+  - Added a one-hop completed task Trace to `doc/p2p/project.md` for this terminology guard slice.
+  - Confirmed task closeout used `./scripts/pm/task-closeout.sh --role tpm --task-uid task_d5247a8f051443c38a6d551ab75efac8 --verify-command "./scripts/unified-world-code-terminology-scan.sh" --no-lint`, with `claim_verification_status: verified`, `claim_type: task_complete`, and `last_closed_at: 2026-06-18T11:40:39+08:00`.
+  - Attempted `./scripts/pm/claim-ready.sh --claim-type ready_for_pr --verify-command "./scripts/unified-world-code-terminology-scan.sh" --task-uid task_d5247a8f051443c38a6d551ab75efac8`; script rejected it because closed task claim evidence is immutable for non-completion claims.
+- 遗留事项: full repo-wide PM lint remains blocked by unrelated historical task logs; PR preflight must be rerun after this evidence repair.
+- Action: repaired task/project trace evidence and recorded claim-ready/task-closeout command evidence required by workflow-lint.
+- Validation Command: `./scripts/pm/claim-ready.sh --claim-type ready_for_pr --verify-command "./scripts/unified-world-code-terminology-scan.sh" --task-uid task_d5247a8f051443c38a6d551ab75efac8`; `./scripts/pm/task-closeout.sh --role tpm --task-uid task_d5247a8f051443c38a6d551ab75efac8 --verify-command "./scripts/unified-world-code-terminology-scan.sh" --no-lint`
+- Expected Result: workflow-lint can locate claim-ready and closeout evidence; immutable closed-task claim behavior is recorded rather than retried destructively.
+- Actual Result: claim-ready ready-for-PR writeback was rejected by immutable closed-task guard; existing task-closeout evidence remains verified and recorded.
+- Blocker / Next Action: commit evidence repair and rerun PR preflight.

--- a/.pm/tasks/task_d5247a8f051443c38a6d551ab75efac8.execution.md
+++ b/.pm/tasks/task_d5247a8f051443c38a6d551ab75efac8.execution.md
@@ -1,0 +1,165 @@
+# task_d5247a8f051443c38a6d551ab75efac8 Execution Log
+
+- task_uid: task_d5247a8f051443c38a6d551ab75efac8
+- title: Research environment parity for local test production
+- owner_role: tpm
+- worktree_hint: /Users/scc/ccwork/worktrees/oasis7-engineering-environment-parity-research-20260618
+
+<!-- Append entries using:
+Example:
+  ## YYYY-MM-DD HH:MM:SS CST / role_name
+  - 完成内容: ...
+  - 遗留事项: ...
+  - Action: ...
+  - Validation Command: ...
+  - Expected Result: ...
+  - Actual Result: ...
+  - Blocker / Next Action: ...
+-->
+
+## 2026-06-18 10:35:40 CST / tpm
+- 完成内容: WORKFLOW BOOTSTRAP DECIDED
+  - Repository State Impact: read-only research/professional answer; repository state changes limited to required `.pm` execution-log evidence.
+  - Isolation Decision: source workspace was `/Users/scc/ccwork/oasis7` on `main`; created dedicated canonical task worktree `/Users/scc/ccwork/worktrees/oasis7-engineering-environment-parity-research-20260618` on branch `task/engineering-environment-parity-research-20260618`.
+  - Task Truth: owner role `tpm`; `.pm` task `task_d5247a8f051443c38a6d551ab75efac8`; formal refs `AGENTS.md` and `doc/engineering/workflow/source-of-truth.md`.
+  - Routed Next Phase: `repo-owned-workflow-router` read-only professional/domain judgment route, because environment parity across local/test/production touches runtime, QA/release, product promises, and LiveOps/community risk.
+- 完成内容: WORKFLOW ROUTE DECIDED
+  - Current phase: read-only research and professional answer.
+  - Selected workflow skills: `default-workflow-bootstrap` completed; `repo-owned-workflow-router` selected bounded read-only specialist slices plus external source research.
+  - Skipped workflow skills: `bounded-brainstorming` not needed as final answer can directly provide a comparison matrix; `tdd-test-writer` not needed because no repo behavior change requested; implementation/verification/closeout/PR skills not needed unless user asks to codify the policy in docs.
+  - Required Writeback: `.pm/tasks/task_d5247a8f051443c38a6d551ab75efac8.execution.md` is the mandatory sink for route, contracts, evidence, and final integration.
+- 完成内容: TPM TODO decomposition and integration order
+  - TODO 1: collect external same-genre/live-service practice from official/credible sources.
+  - TODO 2: collect oasis7 repo environment-tier truth and current local/test/production boundaries.
+  - TODO 3: dispatch `runtime_engineer` bounded read-only slice for deterministic/runtime/chain parity.
+  - TODO 4: dispatch `qa_engineer` bounded read-only slice for test gating, environment matrix, and release-risk parity.
+  - TODO 5: dispatch `producer_system_designer` + `liveops_community` bounded read-only slices for product promise/player-facing and ops/community boundaries.
+  - TODO 6: integrate into a concise answer: same/different matrix, recommended oasis7 environment tiers, and rationale with citations.
+- 完成内容: Subagent Slice Contract - runtime_engineer
+  - role: `runtime_engineer`; slice type: bounded read-only professional explorer.
+  - intended model configuration: workflow default `.codex/config.toml` `gpt-5.5` / `medium`.
+  - actual dispatched model/reasoning: to be recorded after dispatch; use inherited/unverified if full-history fork tool prevents explicit model selection.
+  - context delivery mode: full-thread/full-history fork via subagent tool; mandatory checklist recorded here.
+  - mandatory context checklist/packet: identity/authority from `AGENTS.md`; workflow governance from `doc/engineering/workflow/source-of-truth.md`; task truth `task_d5247a8f051443c38a6d551ab75efac8`; user intent asks which local/test/production environment properties should match/differ and wants similar-game practice; scoped repo context includes `doc/world-runtime/*`, `testing-manual.md`, `doc/p2p/*network tiers*`, launcher/runtime scripts; collaboration boundary read-only, no edits.
+  - return contract: runtime same/different recommendations for local/test/prod, especially determinism, world id/genesis, storage, chain/P2P, secrets, observability, migration/replay.
+  - formal sink / integration owner/order: TPM integrates into this execution log after QA/product/liveops slices.
+- 完成内容: Subagent Slice Contract - qa_engineer
+  - role: `qa_engineer`; slice type: bounded read-only professional explorer.
+  - intended model configuration: workflow default `.codex/config.toml` `gpt-5.5` / `medium`.
+  - actual dispatched model/reasoning: to be recorded after dispatch; use inherited/unverified if full-history fork tool prevents explicit model selection.
+  - context delivery mode: full-thread/full-history fork via subagent tool; mandatory checklist recorded here.
+  - mandatory context checklist/packet: identity/authority from `AGENTS.md`; workflow governance; task truth; user intent; scoped repo context includes `testing-manual.md`, `doc/testing/*`, release/playability evidence, CI tiers; collaboration boundary read-only, no edits.
+  - return contract: QA parity matrix and release/test environment recommendations, including which differences are allowed and which invalidate test evidence.
+  - formal sink / integration owner/order: TPM integrates after external source research.
+- 完成内容: Subagent Slice Contract - producer_system_designer + liveops_community
+  - roles: `producer_system_designer`, `liveops_community`; slice type: bounded read-only professional explorer.
+  - intended model configuration: workflow default `.codex/config.toml` `gpt-5.5` / `medium`.
+  - actual dispatched model/reasoning: to be recorded after dispatch; use inherited/unverified if full-history fork tool prevents explicit model selection.
+  - context delivery mode: full-thread/full-history fork via subagent tool; mandatory checklist recorded here.
+  - mandatory context checklist/packet: identity/authority from `AGENTS.md`; workflow governance; task truth; user intent; scoped repo context includes `README.md`, `world-rule.md`, `doc/core/*`, `doc/readme/*`, public/testnet/mainnet docs, and LiveOps runbooks; collaboration boundary read-only, no edits.
+  - return contract: product/player promise and LiveOps communication boundaries: what must not differ between test and production claims, what should differ for safety/cost/community risk.
+  - formal sink / integration owner/order: TPM integrates last into the user-facing answer.
+- 遗留事项: waiting on bounded professional slices and external source synthesis.
+- Action: dispatched/recorded required slice contracts and moved into read-only evidence collection.
+- Validation Command: `./scripts/pm/workflow-report.sh --phase start --role tpm --task-uid task_d5247a8f051443c38a6d551ab75efac8`
+- Expected Result: task start evidence records current workflow state.
+- Actual Result: passed; task status committed, stage `internal_playable_alpha_late`, gate status `draft`.
+- Blocker / Next Action: dispatch bounded read-only professional slices and run external research.
+
+## 2026-06-18 10:49:20 CST / tpm
+- 完成内容: Professional slice integration
+  - `runtime_engineer` (`Pauli`, agent `019ed895-bbcf-7f43-855d-b0c0d58b8546`) verdict: local/test/prod should share runtime semantics but differ in environment identity and risk boundary. Same: code/bundle, world rules, validation, committed-state semantics, replay/state-root, WASM ABI/hash, viewer protocol, observability structure. Different: world/chain/network ids, genesis, validator set, peers, secrets/signer/custody, data stores, endpoints, faucet/reset, scale, public exposure, claims wording.
+  - `qa_engineer` (`Cicero`, agent `019ed895-e1aa-7461-973f-0e39a764cbb8`) verdict: oasis7 should collapse to `local_devnet`, `public_testnet`, `mainnet`; evidence validity depends on labeling local-only/synthetic/proxy/debug/source-mode/mock/quick/skip differences and not using them for release/mainnet claims.
+  - `producer_system_designer` + `liveops_community` (`Ptolemy`, agent `019ed896-0dbc-72c0-95bb-10f06ebac6d1`) verdict: similar live-service/MMO experience is "test should resemble production, but test assets/progress/entry/promise must not be production"; for oasis7, code/rules/protocol/verification should be as congruent as possible while data, secrets, value, reset rights, and public promises are strictly isolated.
+- 完成内容: External source synthesis
+  - Similar practice used: EVE Singularity mirrors account/character data but remains independent from production and may use seeded/modified test rules; League PBE is for upcoming patch tests and may be incomplete/buggy/deactivated, with PBE currency limited to PBE; Unity UGS environments isolate service data between testing/staging/production; Twelve-Factor recommends keeping dev/staging/prod as similar as possible while config differs by environment; AWS Games Lens recommends production or production-like staging for load/performance tests and account/environment isolation.
+- Evidence:
+  - `testing-manual.md:860-865`: oasis7 runtime/operator network tiers are `local_devnet -> public_testnet -> mainnet`; rehearsal evidence does not equal live public_testnet/mainnet/public launch.
+  - `testing-manual.md:166-186`: L4A/L4B/L5 playability boundaries; synthetic/agent evidence cannot answer true real-world player willingness.
+  - `testing-manual.md:459-495`: local LetAI wrapper is canonical local real-play path; mock/local bridge differences must be labeled.
+  - `doc/p2p/blockchain/p2p-hosted-public-join-managed-identity-custody-2026-05-18.prd.md:120-134`: dev/staging/production account/custody tiers; production shares approved artifacts only, not staging data plane.
+  - `doc/p2p/blockchain/p2p-hosted-public-join-managed-identity-custody-2026-05-18.prd.md:151`: dev/staging/production must isolate SMTP, account store/table, signer/approval secret, risk thresholds, and public claims.
+  - `doc/p2p/blockchain/p2p-mainnet-grade-readiness-hardening-2026-03-23.prd.md:42-47`: mainnet-grade requires readiness gates for signer custody, governance signer, genesis freeze, ceremony/QA, and public claims.
+  - `doc/world-runtime/prd.md:52-60`: chain-linked viewer, unified observability, WASM observability, fixed genesis/unified-world bootstrap requirements.
+  - `doc/world-runtime/prd.md:215-223`: production runtime/node policy hardening and committed-only visibility boundaries.
+- 遗留事项: user follow-up may choose to codify the policy in docs.
+- Action: integrated professional slices and external sources into the user-facing environment-parity answer.
+- Validation Command: Read-only repo evidence inspection, external source lookup, and three bounded professional explorer slices.
+- Expected Result: final user answer can distinguish "same" from "different" and map oasis7 local/test/prod to concrete claims.
+- Actual Result: all professional slices align; no live process or cloud endpoint was inspected.
+- Blocker / Next Action: answer user; if user wants, future work can codify this into an environment policy doc.
+
+## 2026-06-18 10:55:40 CST / tpm
+- 完成内容: Follow-up integration for "current project arrangement"
+  - Current project source of truth already maps all subsystem terms into three project environments: `local`, `test`, `production` in `doc/engineering/governance/environment-lanes-and-inventory-2026-05-29.md`.
+  - Recommended arrangement:
+    - `local`: developer/operator local playtest and CI/pre-PR verification only; includes `local_devnet`, localhost, file backend, trusted-local playtest, provider local/local-mock.
+    - `test`: controlled pre-release and public-testnet rehearsal lane; includes hosted-login test, provider test, public_testnet readiness work, resettable test data, guarded faucet when public_testnet is ready.
+    - `production`: internal production lanes and future user-facing mainnet; currently only hosted-login prod lane is deployed, not a user-facing production game/mainnet; mainnet remains readiness target.
+  - Hard separation: test/prod state stores, SMTP/OTP, account tables, signer/approval secrets, risk thresholds, public claims, and incident channels must remain separate.
+  - Hard claim boundary: hosted-login prod or provider prod does not imply mainnet/live production; public_testnet evidence must pass six-lane readiness before live-candidate wording.
+- Evidence:
+  - `doc/engineering/governance/environment-lanes-and-inventory-2026-05-29.md:27-34`: current three-environment overview and status.
+  - `doc/engineering/governance/environment-lanes-and-inventory-2026-05-29.md:36-42`: deployment mode/network tier/provider lane are subsystem dimensions, not project environment names.
+  - `doc/engineering/governance/environment-lanes-and-inventory-2026-05-29.md:57-66`: subsystem mapping table.
+  - `doc/engineering/governance/environment-lanes-and-inventory-2026-05-29.md:68-75`: user-confirmed decisions that shared_devnet is not a target environment and there is no current user-facing production environment.
+  - `doc/engineering/governance/environment-lanes-and-inventory-2026-05-29.md:89-95`: hard rules for test/prod split and mainnet declaration.
+  - `doc/engineering/governance/environment-lanes-and-inventory-2026-05-29.md:99-107`: current cloud inventory and caveats.
+  - `doc/engineering/governance/environment-lanes-and-inventory-2026-05-29.md:109-139`: hosted-login test/prod matrix and minimum validation.
+  - `doc/p2p/blockchain/p2p-formal-network-tiers-testnet-mechanism-2026-05-14.runbook.md:17-27`: formal public_testnet is still not ready_for_live_candidate.
+- 遗留事项: item 5 cleanup remains available if user asks to implement it.
+- Action: inspected current environment-truth docs and answered current local/test/production arrangement.
+- Validation Command: Read-only inspection of current environment truth docs.
+- Expected Result: answer can propose current three-environment arrangement without inventing a new tier.
+- Actual Result: passed; current docs support three project environments with network/provider/deployment sub-dimensions.
+- Blocker / Next Action: answer user.
+
+## 2026-06-18 11:03:20 CST / tpm
+- 完成内容: Route update for user request "先做5"
+  - Scope changed from read-only answer to repository change: clean up / harden legacy `shared_devnet` wording so it cannot be mistaken for target `test` / `public_testnet`.
+  - Selected workflow skill: `executing-project-tasks`, because the task already has `.pm` truth and now needs scoped implementation plus verification.
+  - Plan-gap review: current source-of-truth already says `shared_devnet` is legacy/rehearsal only; existing `scripts/unified-world-code-terminology-scan.sh` protects active code/templates but does not scan the environment/source-of-truth docs that now carry the project-level policy.
+  - Atomic implementation plan:
+    1. Extend terminology scan to cover environment/network-tier source docs.
+    2. Keep intentional legacy references allowlisted only when the line explicitly says legacy/rehearsal/not target/not public_testnet/not live.
+    3. Run terminology scan and doc/governance checks.
+- 完成内容: Subagent Slice Contract - repository_health_engineer
+  - role: `repository_health_engineer`; slice type: bounded read-only review of planned/actual cleanup.
+  - intended model configuration: workflow default `.codex/config.toml` `gpt-5.5` / `medium`.
+  - actual dispatched model/reasoning: to be recorded after dispatch; use inherited/unverified if full-history fork tool prevents explicit model selection.
+  - context delivery mode: full-thread/full-history fork via subagent tool; mandatory checklist recorded here.
+  - mandatory context checklist/packet: identity/authority from `AGENTS.md`; workflow governance from `doc/engineering/workflow/source-of-truth.md`; task truth `task_d5247a8f051443c38a6d551ab75efac8`; user intent "先做5" meaning clean shared_devnet legacy wording; scoped repo context includes `scripts/unified-world-code-terminology-scan.sh`, `doc/engineering/governance/environment-lanes-and-inventory-2026-05-29.md`, `doc/p2p/blockchain/p2p-formal-network-tiers-testnet-mechanism-2026-05-14.*`, `testing-manual.md`; collaboration boundary read-only review, no edits.
+  - return contract: identify whether the cleanup plan misses active misleading surfaces, whether allowlist criteria are too broad/narrow, and what verification commands should pass.
+  - formal sink / integration owner/order: TPM integrates before final user response.
+- 遗留事项: repository_health_engineer slice result pending.
+- Action: shifted task to implementation route, recorded plan-gap review, and prepared terminology-scan patch.
+- Validation Command: `./scripts/unified-world-code-terminology-scan.sh`
+- Expected Result: current scan baseline passes before edits.
+- Actual Result: passed; `allowed compatibility content hits: 17`, `allowed compatibility path hits: 17`.
+- Blocker / Next Action: patch terminology scan and run verification.
+
+## 2026-06-18 11:10:02 CST / tpm
+- 完成内容: Implementation step - harden legacy `shared_devnet` cleanup.
+  - Extended `scripts/unified-world-code-terminology-scan.sh` so active environment/network-tier source docs are scanned in addition to active code/templates.
+  - Added boundary-marker gating for those docs: legacy `shared_devnet`/`shared_network` hits are only allowed when the line itself carries legacy/rehearsal/history/not-target/not-replacement style wording, or when a narrow compatibility snippet covers a historical wrapper/path/reference.
+  - Tightened formal network-tier wording in `doc/p2p/blockchain/p2p-formal-network-tiers-testnet-mechanism-2026-05-14.design.md` and `.prd.md` so legacy `shared_devnet` is explicitly framed as legacy/non-target and not a renameable `testnet`.
+- 遗留事项: repository_health_engineer slice result and required workflow checks still pending at this step.
+- Action: patched terminology scan and formal network-tier wording, then reran the targeted terminology scan.
+- Validation Command: `./scripts/unified-world-code-terminology-scan.sh`
+- Expected Result: scan rejects ambiguous legacy terminology and passes only explicit compatibility/boundary references.
+- Actual Result: first post-edit run failed on five ambiguous lines in formal network-tier docs; after tightening wording and adding one narrow project verification-command snippet, rerun passed with `allowed compatibility content hits: 57`, `allowed compatibility path hits: 17`.
+- Blocker / Next Action: run required workflow checks and integrate repository_health_engineer review result.
+
+## 2026-06-18 11:16:16 CST / tpm
+- 完成内容: Repository-health review integration and final cleanup.
+  - `repository_health_engineer` (`Confucius`, agent `019ed8b2-0fd1-7870-bc9b-ae437cf631da`) verdict: extending `scripts/unified-world-code-terminology-scan.sh` to environment governance docs is the correct minimal patch for item 5.
+  - Review adjustment accepted: removed standalone `rehearsal` as a broad boundary marker; legacy terms in governance/network-tier docs now require `legacy`/历史/旧 or explicit negative boundary wording such as 不再/不是/不能/不得/不等于/不替代/not a target/no longer/does not replace/not public_testnet/not mainnet.
+  - Review adjustment accepted: added `doc/p2p/prd.md`, `doc/p2p/project.md`, and `doc/p2p/prd.index.md` to the terminology scan.
+  - Follow-up scan caught two newly covered active lines without explicit legacy framing; updated `doc/p2p/prd.index.md` and `doc/p2p/project.md` to say `legacy shared-network`.
+  - Historical evidence archives with old `shared_devnet_pass` semantics remain out of scope and were not mass-rewritten.
+- 遗留事项: full `./scripts/pm/lint.sh` still fails on pre-existing historical `.pm/tasks/*` execution-log format debt outside this task.
+- Action: integrated repository-health review, tightened scan policy, expanded active P2P entry coverage, and reran targeted plus governance checks.
+- Validation Command: `./scripts/unified-world-code-terminology-scan.sh`; `./scripts/doc-governance-check.sh`; `git diff --check`; `python3 scripts/pm/pm_store.py task-execution-log-lint . 2>&1 | rg 'task_d5247a8f051443c38a6d551ab75efac8' || true`; `./scripts/pm/lint.sh`
+- Expected Result: terminology/doc/diff checks pass; current task execution log is not reported; full PM lint may still report unrelated historical task debt.
+- Actual Result: terminology scan passed with `allowed compatibility content hits: 67`, `allowed compatibility path hits: 17`; doc governance passed; diff check passed; current task execution-log filter produced no output; full PM lint failed on historical task execution-log format issues, initially including this task before template fields were added, and after the fix no current-task lines were reported by the targeted filter.
+- Blocker / Next Action: ready to report item 5 completion; leave unrelated historical PM lint debt untouched.

--- a/.pm/tasks/task_d5247a8f051443c38a6d551ab75efac8.execution.md
+++ b/.pm/tasks/task_d5247a8f051443c38a6d551ab75efac8.execution.md
@@ -213,3 +213,16 @@ Example:
 - Expected Result: workflow-lint can locate claim-ready and closeout evidence; immutable closed-task claim behavior is recorded rather than retried destructively.
 - Actual Result: claim-ready ready-for-PR writeback was rejected by immutable closed-task guard; existing task-closeout evidence remains verified and recorded.
 - Blocker / Next Action: commit evidence repair and rerun PR preflight.
+
+## 2026-06-18 11:52:49 CST / tpm
+- 完成内容: PR created and PR purpose recorded.
+  - Created GitHub PR: https://github.com/eng-cc/oasis7/pull/519
+  - PR title: `Harden legacy shared network terminology`
+  - PR purpose decision: `normal_pr_ci_watch`; this is an ordinary documentation/workflow guard PR, not a manual packaging/release CI hold.
+  - Initial PR state from GitHub connector: open, not draft, mergeable=true, no top-level comments, no review threads, combined commit statuses empty at first poll.
+- 遗留事项: continue watching GitHub Actions/check runs, mergeability, comments, and review threads; `REVIEW_REQUIRED` or branch behind alone is informational under repo policy.
+- Action: created PR through GitHub connector after local `gh` was unavailable, then polled PR metadata/comments/threads/status.
+- Validation Command: `./scripts/prepare-task-pr.sh --json`; GitHub connector `_create_pull_request`; `_fetch_pr`; `_get_commit_combined_status`; `_fetch_pr_comments`; `_list_pull_request_review_threads`
+- Expected Result: PR exists, local role review is passed, PR purpose is recorded, and normal PR watch loop can begin.
+- Actual Result: PR #519 created; preflight passed before creation; initial comments and review threads were empty; mergeability was true at first fetch.
+- Blocker / Next Action: commit/push this PR evidence update, then watch new PR head checks/comments/mergeability.

--- a/.pm/tasks/task_d5247a8f051443c38a6d551ab75efac8.execution.md
+++ b/.pm/tasks/task_d5247a8f051443c38a6d551ab75efac8.execution.md
@@ -187,11 +187,12 @@ Example:
 - Blocker / Next Action: append passed packet, commit review evidence, then run `./scripts/prepare-task-pr.sh --create`.
 
 - Pre-PR Local Role Review: passed
-- Task UID: `task_d5247a8f051443c38a6d551ab75efac8`
-- Source Worktree: `/Users/scc/ccwork/worktrees/oasis7-engineering-environment-parity-research-20260618`
-- Source Branch: `task/engineering-environment-parity-research-20260618`
-- Source Head: `44e606601d7d4cdd09d092a81597c1bb8d3f80a1` plus follow-up review evidence / LiveOps P2 fix to be committed before PR creation.
-- Comparison Ref: `origin/main`
+- Task UID: task_d5247a8f051443c38a6d551ab75efac8
+- Source Worktree: /Users/scc/ccwork/worktrees/oasis7-engineering-environment-parity-research-20260618
+- Source Branch: task/engineering-environment-parity-research-20260618
+- Source Head: b369a9a96d4e723dec68a76b8489db65754a37c4
+- Source Head ancestor of b369a9a96d4e723dec68a76b8489db65754a37c4
+- Comparison Ref: refs/remotes/origin/main
 - Reviewed Changed Paths: `.pm/tasks/task_d5247a8f051443c38a6d551ab75efac8.execution.md`; `.pm/tasks/task_d5247a8f051443c38a6d551ab75efac8.yaml`; `doc/p2p/blockchain/p2p-formal-network-tiers-testnet-mechanism-2026-05-14.design.md`; `doc/p2p/blockchain/p2p-formal-network-tiers-testnet-mechanism-2026-05-14.prd.md`; `doc/p2p/prd.index.md`; `doc/p2p/project.md`; `scripts/unified-world-code-terminology-scan.sh`
 - Role Selection Basis: `repository_health_engineer` for cross-cutting governance/script/doc-contract scan; `qa_engineer` for evidence-label/release-readiness implications; `liveops_community` for public/player-facing claims boundaries around `shared_devnet`, `public_testnet`, and `mainnet`.
 - Review Roles: `repository_health_engineer`, `qa_engineer`, `liveops_community`

--- a/.pm/tasks/task_d5247a8f051443c38a6d551ab75efac8.yaml
+++ b/.pm/tasks/task_d5247a8f051443c38a6d551ab75efac8.yaml
@@ -10,6 +10,7 @@ source_refs:
   - AGENTS.md
 doc_refs:
   - doc/engineering/workflow/source-of-truth.md
+  - doc/p2p/project.md
 related_prd: []
 acceptance:
   - "Answer which local, test, and production environment properties should match or differ for oasis7, grounded in similar game/live-service practice and role-attributed repo analysis."

--- a/.pm/tasks/task_d5247a8f051443c38a6d551ab75efac8.yaml
+++ b/.pm/tasks/task_d5247a8f051443c38a6d551ab75efac8.yaml
@@ -1,0 +1,24 @@
+task_uid: task_d5247a8f051443c38a6d551ab75efac8
+title: "Research environment parity for local test production"
+owner_role: tpm
+worktree_hint: /Users/scc/ccwork/worktrees/oasis7-engineering-environment-parity-research-20260618
+execution_log_path: .pm/tasks/task_d5247a8f051443c38a6d551ab75efac8.execution.md
+status: done
+priority: P2
+source_signal: null
+source_refs:
+  - AGENTS.md
+doc_refs:
+  - doc/engineering/workflow/source-of-truth.md
+related_prd: []
+acceptance:
+  - "Answer which local, test, and production environment properties should match or differ for oasis7, grounded in similar game/live-service practice and role-attributed repo analysis."
+handoff_to: []
+updated_at: 2026-06-18T11:40:39+08:00
+last_started_at: 2026-06-18T10:35:06+08:00
+last_claim_type: task_complete
+last_verify_command: ./scripts/unified-world-code-terminology-scan.sh
+last_verified_at: 2026-06-18T11:40:38+08:00
+last_verification_exit_code: 0
+last_verification_status: verified
+last_closed_at: 2026-06-18T11:40:39+08:00

--- a/doc/p2p/blockchain/p2p-formal-network-tiers-testnet-mechanism-2026-05-14.design.md
+++ b/doc/p2p/blockchain/p2p-formal-network-tiers-testnet-mechanism-2026-05-14.design.md
@@ -62,8 +62,8 @@ Network tier 是统一持久大世界的运行/验证载体分层，不是玩家
 - 规则-6: validator/remote writer 准入仍由 validator set、governance registry 或显式 writer allowlist 控制；observer 自动入网不得授予 gossip write、共识签名或 validator 身份。
 
 ## 与现有专题的关系
-- `p2p-shared-network-release-train-minimum-2026-03-24`：
-  - 负责 `shared_devnet/staging/canary` 内部 shared release-train。
+- legacy topic `p2p-shared-network-release-train-minimum-2026-03-24`：
+  - 负责 legacy `shared_devnet/staging/canary` 内部 shared release-train。
   - 现在只作为 legacy/rehearsal evidence 追溯，不作为 `public_testnet` 的必需 promotion gate。
 - `p2p-mainnet-grade-readiness-hardening-2026-03-23`：
   - 负责 `MAINNET-1~4` 的安全/治理/创世 readiness gates。
@@ -85,7 +85,7 @@ Network tier 是统一持久大世界的运行/验证载体分层，不是玩家
   - `doc/testing/templates/network-tier-mainnet.example.json`
 
 ## 被否决方案
-- 否决-1: 直接把现有 `shared_devnet` 改名为 `testnet`。
+- 否决-1: 直接把现有 legacy `shared_devnet` 改名为 `testnet`；这会把非目标测试环境误写成目标环境。
   - 原因: 这会把内部 shared access / partial rehearsal 与 public availability 混在一起。
 - 否决-2: 先做 live public testnet，再考虑 manifest。
   - 原因: 没有统一 manifest，后续 runtime / QA / liveops 无法共享同一套 tier 真值。

--- a/doc/p2p/blockchain/p2p-formal-network-tiers-testnet-mechanism-2026-05-14.prd.md
+++ b/doc/p2p/blockchain/p2p-formal-network-tiers-testnet-mechanism-2026-05-14.prd.md
@@ -43,7 +43,7 @@
 | `shared_devnet` boundary | `visibility=shared_operator`、`value_semantics=preview`、`faucet_mode=none|operator_grant` | 只保留 legacy/rehearsal evidence 语义，不再作为目标 test 环境 | `legacy -> referenced` | 即便已有 shared access，也不自动等于 public RPC/faucet/testnet claim | `runtime_engineer`/`qa_engineer` 维护 |
 | `public_testnet` policy | `visibility=public`、`value_semantics=testnet`、`faucet_mode=guarded_testnet_faucet`、`reset_policy=resettable`、`validator_admission=allowlist_or_governed_candidate` | 对外开放 public testnet，并明确它仍可重置、资产无 mainnet 价值承诺 | `planned -> specified_skeleton_only -> rehearsal -> live` | 没有 public RPC/explorer/faucet/reset policy 时不得叫 public testnet | `liveops_community` 执行公开面，producer 审批 |
 | `mainnet` policy | `visibility=public`、`value_semantics=production`、`faucet_mode=none`、`reset_policy=frozen`、`validator_admission=governance_registry_only` | 宣告正式价值网络 | `planned -> gated -> live` | 只有 `MAINNET-1~4`、frozen genesis、no-reset commitment 全部具备时才允许 | `producer_system_designer` 审批，`qa_engineer` 阻断 |
-| Claims gate | `allowed_claims/denied_claims/required_gates` | 根据 tier 决定允许哪些公开口径 | `draft -> enforced` | `shared_devnet` 与 `public_testnet` 默认 deny `mainnet-grade live network` | `liveops_community` 执行，producer 审批 |
+| Claims gate | `allowed_claims/denied_claims/required_gates` | 根据 tier 决定允许哪些公开口径 | `draft -> enforced` | legacy `shared_devnet` 与 `public_testnet` 默认 deny `mainnet-grade live network` | `liveops_community` 执行，producer 审批 |
 - Acceptance Criteria:
   - AC-1: 本专题必须落地 PRD / design / project，并接入 `doc/p2p/prd.md`、`doc/p2p/project.md`、`doc/p2p/prd.index.md` 与 `testing-manual.md`。
   - AC-2: 本专题必须明确 `local_devnet -> public_testnet -> mainnet` 三层 operator/runtime network-tier 模型，且明确 `shared_devnet` 只作为 legacy/rehearsal evidence，不是目标 test 环境，也不是玩家世界模型。
@@ -96,7 +96,7 @@
   - v1.2: 落第一轮 public testnet rehearsal，补齐 public RPC/explorer/faucet/reset evidence。
   - v2.0: 在 `public_testnet` exit review 与 `MAINNET-1~4` 全绿后，再讨论 mainnet manifest 激活。
 - Technical Risks:
-  - 风险-1: 如果继续把 `shared_devnet` 和 `public_testnet` 混用，团队会在 claims、faucet、reset 承诺上持续越界。
+  - 风险-1: 如果继续把 legacy `shared_devnet` 和 `public_testnet` 混用，团队会在 claims、faucet、reset 承诺上持续越界。
   - 风险-2: 如果 `mainnet` 没有单独 schema 约束，后续很容易把 preview/testnet 运行习惯直接带进正式网络。
   - 风险-3: 如果只有文档没有 manifest skeleton，后续 runtime/liveops 会再次把 tier 真值散落到各自脚本里。
 

--- a/doc/p2p/prd.index.md
+++ b/doc/p2p/prd.index.md
@@ -35,7 +35,7 @@
 - `doc/p2p/blockchain/p2p-formal-network-tiers-testnet-mechanism-2026-05-14.runbook.md`：formal `public_testnet` 从规格骨架进入候选状态前的 companion checklist/runbook。
 - `doc/p2p/blockchain/p2p-public-testnet-governed-bootstrap-2026-06-06.runbook.md`：formal `public_testnet` governed bootstrap operator path，定义四节点重建输入、deployment truth、hard rules 与 evidence 闭包；不表示 `public_testnet` 已 live 或 ready。
 - `doc/p2p/blockchain/p2p-shared-network-release-train-minimum-2026-03-24.runbook.md`：共享网络最小发布列车的 legacy 执行 companion runbook；`shared_devnet` pass 仅作 rehearsal evidence，不等于 formal `public_testnet` / `mainnet` readiness。
-- `doc/testing/evidence/README.md`：QA evidence landing page，负责 public-testnet / shared-network / claims-boundary / mixed-topology 证据的当前入口与归档边界。
+- `doc/testing/evidence/README.md`：QA evidence landing page，负责 public-testnet / legacy shared-network / claims-boundary / mixed-topology 证据的当前入口与归档边界。
 - `doc/p2p/token/mainchain-token-ideal-transaction-upgrade-2026-06-08.design.md`：不受当前实现约束的理想化交易目标态，覆盖字段分组、完整 JSON 草案、理想签名域、理想回执与 phased rollout。
 - `doc/p2p/token/mainchain-token-newapi-quota-bridge-2026-05-06.runbook.md`：LetAI Run OpenAPI bridge 的 operator companion runbook，覆盖独立部署、首次演练、manual review 与回滚边界。
 

--- a/doc/p2p/project.md
+++ b/doc/p2p/project.md
@@ -19,7 +19,7 @@
 - [x] testnet-auto-high-state-sync (PRD-P2P-001/003) [test_tier_required]: 允许 cold observer 自动探测 retained execution checkpoint。 Trace: .pm/tasks/task_761375d25bc24fe59147a853e8c8acb0.yaml
 - [x] testnet-high-state-peer-retry (PRD-P2P-001/003) [test_tier_required]: 支持 observer 从 storage/full-storage peer 获得 checkpoint descriptor。 Trace: .pm/tasks/task_96c772c830e043f9b1e40b03e6f73d38.yaml
 - [x] testnet-storage-challenge-degraded-readiness (PRD-P2P-001/003/028) [test_tier_required]: 修复 public testnet storage challenge 在 provider/DHT/fetch route retryable 不可用时误 hard-block sequencer 的问题。 Trace: .pm/tasks/task_8d92c7fdfbc742e3866ef1162faedd66.yaml
-- [x] p2p-evidence-doc-cleanup (PRD-P2P-001/003) [test_tier_required]: 清理无外部引用的 generated shared-network gate 中间快照并刷新 p2p 首读证据链。 Trace: .pm/tasks/task_1f333657aba5468aa74bd2435fcbbbcf.yaml
+- [x] p2p-evidence-doc-cleanup (PRD-P2P-001/003) [test_tier_required]: 清理无外部引用的 generated legacy shared-network gate 中间快照并刷新 p2p 首读证据链。 Trace: .pm/tasks/task_1f333657aba5468aa74bd2435fcbbbcf.yaml
 - [x] p2p-peer-head-readiness-doc-cleanup (PRD-P2P-001/003) [test_tier_required]: 删除已失去当前权威入口职责的 peer-head readiness 历史叙事 design 文档。 Trace: .pm/tasks/task_56f67be67a5a43c09027cb224f1416ad.yaml
 - [x] p2p-stale-evidence-reference-cleanup (PRD-P2P-001/003/028) [test_tier_required]: 删除被新 evidence/docs 取代的 stale evidence 引用。 Trace: .pm/tasks/task_deab30d82bd54824b5be64fac1b2c961.yaml
 - [x] p2p-shared-world-doc-boundary-cleanup (PRD-P2P-028) [test_tier_required]: 精简 legacy shared-network / benchmark / testing manual 重复叙事，明确 `shared_devnet` 仅是 legacy rehearsal evidence，不等同 `public_testnet`、mainnet、public launch 或公开统一大世界上线。 Trace: .pm/tasks/task_d3129d0dff0f4111bcd87b1d2658179c.yaml

--- a/doc/p2p/project.md
+++ b/doc/p2p/project.md
@@ -7,6 +7,7 @@
 - hosted player access / hosted account、public testnet、bridge/newapi、network tier、主链 token 与 faucet/mint-ready 细项均已有独立 topic project；本页不再逐条复述每条子线的完成流水。
 
 ### 最近完成（保留一跳 Trace）
+- [x] p2p-environment-terminology-guard (PRD-P2P-028) [test_tier_required]: 加强 active 环境 / network-tier 文档中的 legacy `shared_devnet` / shared-network 边界扫描，避免被误读为当前 `public_testnet`、mainnet 或公开上线证据。 Trace: .pm/tasks/task_d5247a8f051443c38a6d551ab75efac8.yaml
 - [x] p2p-replication-transport-gap-sync-recovery (PRD-P2P-001/003/028) [test_tier_required]: 修复 public testnet replication transport / gap-sync / storage challenge 多轮 live degraded 根因，收口 fetch-commit route budget、active transport request fallback、provider publication best-effort、empty-provider lookup generic fallback 与 consensus gossip best-effort publish，并形成多节点健康检查/升级验证链路。 Trace: .pm/tasks/task_c612861fd1fe4187b789ceff61a6d0f7.yaml
 - [x] p2p-provider-route-exhaustion-recovery (PRD-P2P-001/003/028) [test_tier_required]: 修复 public testnet storage challenge 在 retryable provider-route exhausted 后长期 degraded；storage challenge 可走 bounded generic fallback，同时保留 provider not-found、gap sync strictness 与 wrong blob hard-failure 边界。 Trace: .pm/tasks/task_4cc7d5297e084dd1945223f5769c4e9c.yaml
 - [x] p2p-storage-challenge-provider-routing-hardening (PRD-P2P-001/003/028) [test_tier_required]: 收口 public testnet storage challenge / replication fetch provider route，不再让 observer/light、非 provider 或低分 peer 消耗 fetch budget，并为 provider-route blocked 增加 bounded retry cooldown。 Trace: .pm/tasks/task_22699e838c6746fa8491befacfce985b.yaml

--- a/scripts/unified-world-code-terminology-scan.sh
+++ b/scripts/unified-world-code-terminology-scan.sh
@@ -48,7 +48,6 @@ boundary_markers = (
     "不等于",
     "不替代",
     "not a target",
-    "not ready",
     "no longer",
     "does not replace",
     "not public_testnet",

--- a/scripts/unified-world-code-terminology-scan.sh
+++ b/scripts/unified-world-code-terminology-scan.sh
@@ -16,9 +16,44 @@ scan_paths = [
     "crates",
     "scripts",
     "doc/testing/templates",
+    "doc/engineering/governance/environment-lanes-and-inventory-2026-05-29.md",
+    "doc/p2p/prd.md",
+    "doc/p2p/project.md",
+    "doc/p2p/prd.index.md",
+    "doc/p2p/blockchain/p2p-formal-network-tiers-testnet-mechanism-2026-05-14.prd.md",
+    "doc/p2p/blockchain/p2p-formal-network-tiers-testnet-mechanism-2026-05-14.design.md",
+    "doc/p2p/blockchain/p2p-formal-network-tiers-testnet-mechanism-2026-05-14.project.md",
+    "doc/p2p/blockchain/p2p-formal-network-tiers-testnet-mechanism-2026-05-14.runbook.md",
     "testing-manual.md",
 ]
 pattern = r"shared_devnet|shared_network|shared-devnet|shared-network"
+boundary_files = {
+    "doc/engineering/governance/environment-lanes-and-inventory-2026-05-29.md",
+    "doc/p2p/prd.md",
+    "doc/p2p/project.md",
+    "doc/p2p/prd.index.md",
+    "doc/p2p/blockchain/p2p-formal-network-tiers-testnet-mechanism-2026-05-14.prd.md",
+    "doc/p2p/blockchain/p2p-formal-network-tiers-testnet-mechanism-2026-05-14.design.md",
+    "doc/p2p/blockchain/p2p-formal-network-tiers-testnet-mechanism-2026-05-14.project.md",
+    "doc/p2p/blockchain/p2p-formal-network-tiers-testnet-mechanism-2026-05-14.runbook.md",
+}
+boundary_markers = (
+    "legacy",
+    "旧",
+    "历史",
+    "不再",
+    "不是",
+    "不能",
+    "不得",
+    "不等于",
+    "不替代",
+    "not a target",
+    "not ready",
+    "no longer",
+    "does not replace",
+    "not public_testnet",
+    "not mainnet",
+)
 allowed_snippets = {
     "testing-manual.md": (
         "summary.json.evidence_contract.claim_readiness.shared_network_pass_blockers",
@@ -57,6 +92,24 @@ allowed_snippets = {
     ),
     "scripts/shared-network-track-gate-smoke.sh": (
         'shared_network_track_gate_smoke',
+    ),
+    "doc/p2p/blockchain/p2p-formal-network-tiers-testnet-mechanism-2026-05-14.prd.md": (
+        "doc/p2p/blockchain/p2p-shared-network-release-train-minimum-2026-03-24.prd.md",
+        "scripts/shared-network-track-gate.sh",
+    ),
+    "doc/p2p/blockchain/p2p-formal-network-tiers-testnet-mechanism-2026-05-14.project.md": (
+        "doc/p2p/blockchain/p2p-shared-network-release-train-minimum-2026-03-24.prd.md",
+        'rg -n "public_testnet|mainnet|shared_devnet|specified_skeleton_only|network_tier_manifest"',
+    ),
+    "doc/p2p/prd.md": (
+        "doc/p2p/blockchain/p2p-shared-network-release-train-minimum-2026-03-24.prd.md",
+        "doc/p2p/blockchain/p2p-shared-network-release-train-minimum-2026-03-24.runbook.md",
+    ),
+    "doc/p2p/project.md": (
+        "doc/p2p/blockchain/p2p-shared-network-release-train-minimum-2026-03-24.prd.md",
+    ),
+    "doc/p2p/prd.index.md": (
+        "doc/p2p/blockchain/p2p-shared-network-release-train-minimum-2026-03-24",
     ),
 }
 allowed_path_names = {
@@ -109,6 +162,8 @@ for path in scan_files:
             continue
         rendered = f"{rel}:{line_no}:{text_line}"
         if any(snippet in text_line for snippet in snippets):
+            allowed_hits.append(rendered)
+        elif rel in boundary_files and any(marker in text_line for marker in boundary_markers):
             allowed_hits.append(rendered)
         else:
             unexpected.append(rendered)


### PR DESCRIPTION
## Summary
- Expand the legacy shared-world terminology scan to cover active environment governance, P2P index, and formal network-tier docs.
- Tighten `shared_devnet` / shared-network wording so active docs frame it as legacy evidence, not current `public_testnet`, mainnet, or launch readiness.
- Record task closeout and pre-PR local role review evidence.

## Verification
- `./scripts/unified-world-code-terminology-scan.sh`
- `./scripts/doc-governance-check.sh`
- `git diff --check`

## Notes
- Full repo-wide `./scripts/pm/lint.sh` is still blocked by unrelated historical `.pm/tasks/*` execution-log format debt; current task-specific execution-log filtering did not report this task.
- This PR does not claim live `public_testnet` or `mainnet` readiness.