### PR TITLE
Align restored PoS clock state to fixed genesis

### DIFF
--- a/.pm/tasks/task_c612861fd1fe4187b789ceff61a6d0f7.execution.md
+++ b/.pm/tasks/task_c612861fd1fe4187b789ceff61a6d0f7.execution.md
@@ -696,3 +696,34 @@ Example:
   - `./scripts/check-rust-file-size.sh` passed.
   - `./scripts/pm/workflow-lint.sh --task-uid task_c612861fd1fe4187b789ceff61a6d0f7 --phase current` passed.
   - `./scripts/doc-governance-check.sh` passed.
+
+## 2026-06-18 11:48:00 CST / run107 rollout watch + follow-up root cause
+- PR #516 was merged to `main` as `a0a8fa7bc4251bbe93b9e43f3f7c8edd56738e3d`; GitHub Actions run `27732550379` built package version `0.0.0+testnet.107.a0a8fa7bc425`.
+- Deployment evidence:
+  - Linux sequencer, Linux storage, and Linux observer were upgraded with `.tmp/upgrade_linux_nodes_run107.py`; all services installed run107. Storage initially failed the strict 120s readiness gate with `consensus_peer_head_unavailable`, then recovered in later health.
+  - Fourth local macOS arm64 node was rebuilt locally from merged `main`, runtime sha256 `21640a77d8c9195025474096fbefc2fde983996ec52174c33017032c2e920051`, and deployed as `0.0.0+testnet.107.a0a8fa7bc425-macos-arm64-local`.
+  - Windows observer was upgraded with `.tmp/upgrade_windows_run107.ps1`, runtime sha256 `d1ffa68cfd36666a552508274d19189c8efe70af6509dbfcf2f2ce0080074bd1`, package version `0.0.0+testnet.107.a0a8fa7bc425`.
+- Health evidence:
+  - `.tmp/run107_health_deep/summary.json` first pass: storage challenge degraded was false on all nodes; Linux observer and fourth local were ready; sequencer/storage had transient `consensus_peer_head_*` and `replication_recent_errors`; Windows observer had no connected replication peers and lagged at height `18185`.
+  - Second pass after 45s: sequencer, storage, Linux observer, and fourth local were all `ready`; all had `storage_challenge_network_degraded=false`; Windows observer remained `not_ready`.
+- Windows follow-up diagnosis:
+  - Windows `oasis7-chain-governed-env-run.cmd` initially omitted `--pos-slot-clock-genesis-unix-ms`; after adding the argument, the running command line included `--pos-slot-clock-genesis-unix-ms 1779068751846`.
+  - Windows nevertheless stayed at slot `1455` because persisted `C:\oasis7-deploy\windows-observer\replication\node_pos_state.json` contained stale `next_slot`, `last_observed_slot`, and `last_observed_tick`.
+  - Manual state correction moved Windows slot to current wall-clock slot `223815`; this cleared the slot mismatch but Windows still had no stable replication peers, so a separate p2p peer-record/connection-retention issue remains for that node.
+- Code follow-up:
+  - New branch `codex/pos-state-clock-recovery` from `origin/main`.
+  - Changed `crates/oasis7_node/src/pos_state_store.rs` restore logic so fixed-genesis restore aligns persisted slot/tick state to the wall-clock slot/tick, preventing stale low slot snapshots from pinning a node after restart.
+  - Added `restore_state_snapshot_advances_stale_clock_state_when_fixed_genesis_is_configured` in `crates/oasis7_node/src/tests_pos_engine_guardrails.rs`.
+- Verification:
+  - `env -u RUSTC_WRAPPER cargo test -p oasis7_node restore_state_snapshot_ -- --nocapture` passed, 5 tests.
+  - `env -u RUSTC_WRAPPER cargo test -p oasis7_node restart_reconcile -- --nocapture` passed, 3 tests.
+  - `env -u RUSTC_WRAPPER cargo test -p oasis7_node pos_engine_aligns_missed_slots_to_wall_clock -- --nocapture` passed.
+  - `env -u RUSTC_WRAPPER cargo test -p oasis7_node pos_engine_observed_slot_does_not_backtrack_on_clock_rewind -- --nocapture` passed.
+  - `env -u RUSTC_WRAPPER cargo fmt --check` passed.
+- Review dispatch limitation:
+  - Intended dispatch: bounded runtime_engineer/qa_engineer pre-PR review slice, full-thread context, scope limited to `pos_state_store.rs` and `tests_pos_engine_guardrails.rs`.
+  - Actual limitation: `multi_agent_v1.spawn_agent` failed with `agent thread limit reached`; no fresh subagent review could be spawned in this environment.
+  - Fallback evidence path: local diff review plus the focused restore/restart/wall-clock tests listed above.
+  - Attribution boundary: follow-up clock restore conclusion is TPM-integrated fallback evidence, not a new professional subagent conclusion.
+- Residual risk:
+  - The code fix addresses stale-low fixed-genesis slot restore. Windows still needs a separate replication peer retention / peer-record availability investigation because it establishes direct transport briefly but does not keep connected peers.

--- a/crates/oasis7_node/src/pos_state_store.rs
+++ b/crates/oasis7_node/src/pos_state_store.rs
@@ -228,9 +228,9 @@ impl PosNodeEngine {
                 .saturating_mul(self.ticks_per_slot as u128))
                 / self.slot_duration_ms as u128) as u64;
             let wall_clock_slot = wall_clock_tick / self.ticks_per_slot;
-            restored_next_slot = restored_next_slot.min(wall_clock_slot);
-            restored_last_observed_slot = restored_last_observed_slot.min(wall_clock_slot);
-            restored_last_observed_tick = restored_last_observed_tick.min(wall_clock_tick);
+            restored_next_slot = wall_clock_slot;
+            restored_last_observed_slot = wall_clock_slot;
+            restored_last_observed_tick = wall_clock_tick;
         }
 
         self.pending = None;

--- a/crates/oasis7_node/src/tests_pos_engine_guardrails.rs
+++ b/crates/oasis7_node/src/tests_pos_engine_guardrails.rs
@@ -657,6 +657,45 @@ fn restore_state_snapshot_clamps_future_clock_state_when_fixed_genesis_is_config
 }
 
 #[test]
+fn restore_state_snapshot_advances_stale_clock_state_when_fixed_genesis_is_configured() {
+    let mut config = NodeConfig::new("node-a", "world-restore-clock-advance", NodeRole::Observer)
+        .expect("config");
+    config.pos_config.slot_duration_ms = 100;
+    config.pos_config.ticks_per_slot = 10;
+    config.pos_config.slot_clock_genesis_unix_ms = Some(1_000);
+    let mut engine = PosNodeEngine::new(&config).expect("engine");
+
+    let snapshot = super::pos_state_store::PosNodeStateSnapshot {
+        next_height: 4,
+        next_slot: 1,
+        last_observed_slot: 1,
+        missed_slot_count: 0,
+        last_observed_tick: 10,
+        missed_tick_count: 0,
+        committed_height: 3,
+        network_committed_height: 3,
+        last_broadcast_proposal_height: 3,
+        last_broadcast_local_attestation_height: 3,
+        last_broadcast_committed_height: 3,
+        last_committed_block_hash: Some("committed-3".to_string()),
+        last_execution_height: 3,
+        last_execution_block_hash: Some("exec-3".to_string()),
+        last_execution_state_root: Some("state-3".to_string()),
+    };
+
+    engine
+        .restore_state_snapshot(snapshot, Some(1_230))
+        .expect("fixed genesis restore should advance stale clock state");
+
+    assert_eq!(engine.next_height, 4);
+    assert_eq!(engine.committed_height, 3);
+    assert_eq!(engine.network_committed_height, 3);
+    assert_eq!(engine.next_slot, 2);
+    assert_eq!(engine.last_observed_slot, 2);
+    assert_eq!(engine.last_observed_tick, 23);
+}
+
+#[test]
 fn restore_state_snapshot_clamps_stale_heights_and_broadcast_cursors() {
     let config = NodeConfig::new("node-a", "world-restore-stale-heights", NodeRole::Observer)
         .expect("config");


### PR DESCRIPTION
## Summary
- Align restored PoS slot/tick state to the configured fixed slot-clock genesis on restart.
- Add a regression test for stale low persisted slot state being advanced to wall-clock time.
- Record run107 rollout evidence and the Windows stale-slot diagnosis in the task log.

## Verification
- `env -u RUSTC_WRAPPER cargo test -p oasis7_node restore_state_snapshot_ -- --nocapture`
- `env -u RUSTC_WRAPPER cargo test -p oasis7_node restart_reconcile -- --nocapture`
- `env -u RUSTC_WRAPPER cargo test -p oasis7_node pos_engine_aligns_missed_slots_to_wall_clock -- --nocapture`
- `env -u RUSTC_WRAPPER cargo test -p oasis7_node pos_engine_observed_slot_does_not_backtrack_on_clock_rewind -- --nocapture`
- `env -u RUSTC_WRAPPER cargo fmt --check`
- `git diff --check`
- `./scripts/pm/workflow-lint.sh --task-uid task_c612861fd1fe4187b789ceff61a6d0f7 --phase current`

## Notes
Windows run107 exposed a persisted `node_pos_state.json` with slot 1455 despite the fixed genesis configuration. The runtime command line included `--pos-slot-clock-genesis-unix-ms 1779068751846`; this patch prevents stale-low persisted slot state from pinning the node after restart. Windows still has a separate replication peer retention issue after manual slot correction.
