### PR TITLE
Keep bootstrap peers admitted during record exchange

### DIFF
--- a/.pm/tasks/task_c612861fd1fe4187b789ceff61a6d0f7.execution.md
+++ b/.pm/tasks/task_c612861fd1fe4187b789ceff61a6d0f7.execution.md
@@ -727,3 +727,35 @@ Example:
   - Attribution boundary: follow-up clock restore conclusion is TPM-integrated fallback evidence, not a new professional subagent conclusion.
 - Residual risk:
   - The code fix addresses stale-low fixed-genesis slot restore. Windows still needs a separate replication peer retention / peer-record availability investigation because it establishes direct transport briefly but does not keep connected peers.
+
+## 2026-06-18 12:50:00 CST / run108 rollout watch + p2p admitted-peer root cause
+- PR #520 was merged to `main` as `8b12584d0742d7231463a059d7c60ebef94e98ef`; GitHub Actions run `27735675302` built package version `0.0.0+testnet.108.8b12584d0742`.
+- Deployment evidence:
+  - Linux sequencer, Linux storage, and Linux observer were upgraded with `.tmp/upgrade_linux_nodes_run108.py`; all three reported runtime sha256 `3fd1f8395b986796f8c6c29aaea1fdeb1d2131ed8136ded0075b62796e6aa110` and `post_restart_readiness=ready`.
+  - Fourth local macOS arm64 node was rebuilt locally from merged `main`, runtime sha256 `11dc87bbfa8ba0872021abcf6772f8d6a4e6975f7d02bc9de95bf5d0223fd401`, and deployed as `0.0.0+testnet.108.8b12584d0742-macos-arm64-local`.
+  - Windows observer was upgraded with `.tmp/upgrade_windows_run108.ps1`, runtime sha256 `0212c60bacfd77dc97e07b4450c97afe6f0587c8f2298af2b87d9a8bebd0a1ac`, package version `0.0.0+testnet.108.8b12584d0742`; script now kills stale runtime processes and ensures `--pos-slot-clock-genesis-unix-ms %POS_SLOT_CLOCK_GENESIS_UNIX_MS%` is present in `oasis7-chain-governed-env-run.cmd`.
+- Health evidence:
+  - `.tmp/run108_health_deep/summary.json`: all five nodes report run108 version metadata; `storage_challenge_network_degraded=false` on all nodes.
+  - Sequencer/storage/Linux observer/fourth local advanced around height `18469-18470` but had transient `consensus_peer_head_unavailable` / `consensus_peer_head_stale` immediately after the rolling restart.
+  - Windows observer remained at committed height `18185` with `runtime_last_error` = no connected peers for `/aw/node/replication/fetch-commit/1.0.0`; slot was current (`224065+`), proving PR #520 addressed the fixed-genesis stale slot restore.
+- Windows p2p diagnosis:
+  - `diag_windows_run108.ps1` showed Windows runtime command line includes fixed genesis and static replication peers for sequencer/storage.
+  - Windows status showed `connected_peers=[]`, `registered_protocols=[]`, recent errors: connection established to storage, peer manager suspect with `[MissingPeerRecord, InsufficientActiveDiscoverySources { observed_sources: 0, required_sources: 2 }]`, peer-record request `ConnectionClosed`, then no fetch-commit peer.
+  - Fourth local status showed the same suspect pattern early but later recovered an active direct storage peer. This points to a code-level bootstrap/admitted-peer retention race, not a storage challenge failure.
+- Code follow-up:
+  - New branch `codex/p2p-static-peer-record-quarantine` from `origin/main`.
+  - Changed `crates/oasis7_net/src/libp2p_net/runtime_loop.rs` so an already-active transport path whose health issues are only peer-record exchange pending (`MissingPeerRecord`, `InsufficientActiveDiscoverySources`, `SingleSourceDiscovery`) is admitted into the active set while record exchange completes. This avoids the startup loop where a static direct peer is needed to obtain peer records/commits but is excluded from the admitted active set until those peer records arrive.
+  - Added regression `refresh_peer_manager_healths_admits_record_exchange_pending_active_peer` and updated the existing missing-record fallback test to assert the unverified active peer remains admitted but still carries `MissingPeerRecord` and is not quarantined.
+- Verification:
+  - `env -u RUSTC_WRAPPER cargo test -p oasis7_net refresh_peer_manager_healths_admits_record_exchange_pending_active_peer -- --nocapture` passed.
+  - `env -u RUSTC_WRAPPER cargo test -p oasis7_net peer_requires_active_quarantine -- --nocapture` passed.
+  - `env -u RUSTC_WRAPPER cargo test -p oasis7_net request_peer_filter -- --nocapture` passed, 6 tests.
+  - `env -u RUSTC_WRAPPER cargo test -p oasis7_net refresh_peer_manager_healths -- --nocapture` passed, 2 tests.
+  - `env -u RUSTC_WRAPPER cargo test -p oasis7_net -- --nocapture` passed, 164 tests.
+  - `env -u RUSTC_WRAPPER cargo fmt --check` passed.
+  - `git diff --check` passed.
+- Review dispatch limitation:
+  - Intended dispatch: bounded runtime_engineer/qa_engineer review slice for p2p active-set admission behavior.
+  - Actual limitation: available subagent thread limit was already reached earlier in this task; no fresh subagent review could be spawned in this environment.
+  - Fallback evidence path: live Windows/fourth-local status evidence plus the focused and full `oasis7_net` test suite listed above.
+  - Attribution boundary: this p2p root-cause and fix is TPM-integrated fallback evidence, not a new professional subagent conclusion.

--- a/crates/oasis7_net/src/libp2p_net/runtime_loop.rs
+++ b/crates/oasis7_net/src/libp2p_net/runtime_loop.rs
@@ -284,6 +284,14 @@ fn peer_health_is_hard_request_blocked(health: &PeerManagerPeerHealth) -> bool {
                 .all(peer_health_issue_is_record_exchange_pending))
 }
 
+fn peer_health_is_record_exchange_pending(health: &PeerManagerPeerHealth) -> bool {
+    !health.issues.is_empty()
+        && health
+            .issues
+            .iter()
+            .all(peer_health_issue_is_record_exchange_pending)
+}
+
 pub(super) fn peer_requires_active_quarantine(
     peer_id: PeerId,
     peer_healths: &HashMap<PeerId, PeerManagerPeerHealth>,
@@ -405,6 +413,14 @@ pub(super) fn refresh_peer_manager_healths(
         let Some(path) = active_transport_paths.get(&peer_id) else {
             continue;
         };
+        if raw_healths
+            .get(&peer_id)
+            .is_some_and(peer_health_is_record_exchange_pending)
+        {
+            admitted_paths.insert(peer_id, path.clone());
+            admitted_active_peers.insert(peer_id);
+            continue;
+        }
         let Some(record) = discovered_peer_records.get(&peer_id) else {
             continue;
         };

--- a/crates/oasis7_net/src/libp2p_net/tests.rs
+++ b/crates/oasis7_net/src/libp2p_net/tests.rs
@@ -573,7 +573,7 @@ fn refresh_peer_manager_healths_keeps_missing_record_active_peer_soft_blocked_fo
         .iter()
         .any(|issue| matches!(issue, PeerManagerHealthIssue::MissingPeerRecord)));
     assert!(quarantined.is_empty());
-    assert_eq!(admitted, HashSet::from([healthy_peer]));
+    assert_eq!(admitted, HashSet::from([healthy_peer, unverified_peer]));
     let event_healths = event_peer_healths.lock().expect("lock peer healths");
     let unverified_health = event_healths
         .get(unverified_peer.to_string().as_str())
@@ -583,6 +583,43 @@ fn refresh_peer_manager_healths_keeps_missing_record_active_peer_soft_blocked_fo
         unverified_peer,
         &healths
     ));
+}
+
+#[test]
+fn refresh_peer_manager_healths_admits_record_exchange_pending_active_peer() {
+    let bootstrap_peer = PeerId::random();
+    let active_transport_paths = HashMap::from([(
+        bootstrap_peer,
+        active_transport_path_from_endpoint(
+            &HashMap::new(),
+            bootstrap_peer,
+            &"/ip4/10.0.0.2/tcp/6832"
+                .parse()
+                .expect("bootstrap endpoint"),
+        ),
+    )]);
+    let event_peer_healths = Arc::new(Mutex::new(HashMap::new()));
+    let event_block_artifacts = Arc::new(Mutex::new(HashMap::new()));
+    let event_errors = Arc::new(Mutex::new(Vec::new()));
+
+    let (healths, quarantined, admitted) = refresh_peer_manager_healths(
+        &HashMap::new(),
+        &active_transport_paths,
+        &HashSet::new(),
+        &PeerManagerPolicy::default(),
+        &event_peer_healths,
+        &event_block_artifacts,
+        &event_errors,
+        32,
+    );
+
+    assert!(healths[&bootstrap_peer]
+        .issues
+        .iter()
+        .any(|issue| matches!(issue, PeerManagerHealthIssue::MissingPeerRecord)));
+    assert!(quarantined.is_empty());
+    assert_eq!(admitted, HashSet::from([bootstrap_peer]));
+    assert!(!peer_requires_active_quarantine(bootstrap_peer, &healths));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- keep active bootstrap/direct peers admitted while peer-record exchange is still pending
- avoid excluding the only connected static peer during startup before cached peer records arrive
- add regression coverage for record-exchange-pending active peers

## Verification
- env -u RUSTC_WRAPPER cargo test -p oasis7_net refresh_peer_manager_healths_admits_record_exchange_pending_active_peer -- --nocapture
- env -u RUSTC_WRAPPER cargo test -p oasis7_net peer_requires_active_quarantine -- --nocapture
- env -u RUSTC_WRAPPER cargo test -p oasis7_net request_peer_filter -- --nocapture
- env -u RUSTC_WRAPPER cargo test -p oasis7_net refresh_peer_manager_healths -- --nocapture
- env -u RUSTC_WRAPPER cargo test -p oasis7_net -- --nocapture
- env -u RUSTC_WRAPPER cargo fmt --check
- git diff --check
- ./scripts/pm/workflow-lint.sh --task-uid task_c612861fd1fe4187b789ceff61a6d0f7 --phase current