### PR TITLE
Preserve tick consensus archive recovery copy

### DIFF
--- a/.pm/tasks/task_c612861fd1fe4187b789ceff61a6d0f7.execution.md
+++ b/.pm/tasks/task_c612861fd1fe4187b789ceff61a6d0f7.execution.md
@@ -759,3 +759,30 @@ Example:
   - Actual limitation: available subagent thread limit was already reached earlier in this task; no fresh subagent review could be spawned in this environment.
   - Fallback evidence path: live Windows/fourth-local status evidence plus the focused and full `oasis7_net` test suite listed above.
   - Attribution boundary: this p2p root-cause and fix is TPM-integrated fallback evidence, not a new professional subagent conclusion.
+
+## 2026-06-18 14:05:00 CST / run109 rollout watch + tick-consensus archive recovery root cause
+- PR #521 was merged to `main` as `47dc299e41fbde565efb9e57bec52176866c0360`; GitHub Actions run `27737458803` built package version `0.0.0+testnet.109.47dc299e41fb`.
+- Deployment evidence:
+  - Linux sequencer, Linux storage, and Linux observer were upgraded with `.tmp/upgrade_linux_nodes_run109.py`; all three installed the run109 Linux runtime sha256 `4e5ea76a35b6700396bac2cb2c35f11a152d5022533a946424f3964f8e8fee71`.
+  - Fourth local macOS arm64 node was rebuilt locally from merged `main`, runtime sha256 `20553104f91c04b59d2450f63408aae1f91cd4d0bc005c58b4ef2568a88cc553`, and deployed as `0.0.0+testnet.109.47dc299e41fb-macos-arm64-local`.
+  - Windows observer package files were copied and `CURRENT_VERSION` advanced to `0.0.0+testnet.109.47dc299e41fb`, but the runtime process exited before exposing `127.0.0.1:5121`.
+- Health / root-cause evidence:
+  - Linux storage post-restart strict readiness timed out with transient `consensus_peer_head_unavailable` and `replication_transport_unstable`; `storage_challenge_network_degraded=false`.
+  - Fourth local immediate restart sample had `runtime_last_error=null`, `storage_challenge_network_degraded=false`, and restart transient `consensus_peer_head_unavailable` / `reward_runtime_degraded`.
+  - Windows runtime stderr was empty; stdout showed startup failed while loading `C:\oasis7-deploy\windows-observer\state` with `DistributedValidationFailed { reason: "tick consensus archive segment missing: path=C:\\oasis7-deploy\\windows-observer\\state\\tick-consensus.archive.segments/segment-00000000000000015297-00000000000000015360.json" }`.
+  - This is a tick-consensus cold archive persistence/recovery failure, not a `storage_challenge_network_degraded` or replication-transport admission failure. Direct hot-window truncation was tested locally and rejected because it breaks the tick-consensus parent-hash chain.
+  - Follow-up Windows SSH diagnostics are currently blocked by the host resetting port 22 connections; existing Windows state likely needs either the missing same-network archive segment restored or a controlled state rebuild after code/package rollout.
+- Code follow-up:
+  - New branch `codex/tick-consensus-archive-recovery` from `main`.
+  - Changed `crates/oasis7/src/runtime/world/persistence.rs` so tick-consensus archive persistence keeps a same-generation legacy `tick-consensus.archive.json` alongside the indexed segment files.
+  - Added safe fallback in archive hydration: if an indexed segment is missing and a same-generation legacy archive exists with the expected count, load the legacy archive; hash/range/order/tamper failures still remain hard failures.
+  - Added regression `persist_uses_legacy_tick_consensus_archive_when_index_segment_is_missing` and updated archive-split expectations to assert the recovery archive is persisted.
+- Verification:
+  - `env -u RUSTC_WRAPPER cargo test -p oasis7 tick_consensus_archive -- --nocapture` passed, 7 tests.
+  - `env -u RUSTC_WRAPPER cargo fmt --check` passed.
+  - `git diff --check` passed.
+- Review dispatch limitation:
+  - Intended dispatch: bounded runtime_engineer/qa_engineer review slice for tick-consensus persistence/recovery behavior.
+  - Actual limitation: available subagent thread limit is already exhausted; no fresh subagent review could be spawned in this environment.
+  - Fallback evidence path: live Windows startup failure evidence plus focused archive persistence regression suite listed above.
+  - Attribution boundary: this archive recovery root-cause and fix is TPM-integrated fallback evidence, not a new professional subagent conclusion.

--- a/crates/oasis7/src/runtime/tests/persistence.rs
+++ b/crates/oasis7/src/runtime/tests/persistence.rs
@@ -272,7 +272,7 @@ fn persist_splits_tick_consensus_records_into_hot_snapshot_and_archive() {
         })
         .sum::<usize>();
     assert_eq!(indexed_record_count, archived_record_count);
-    assert!(!dir.join("tick-consensus.archive.json").exists());
+    assert!(dir.join("tick-consensus.archive.json").exists());
     assert!(dir.join("tick-consensus.archive.index.json").exists());
     assert!(dir.join("tick-consensus.archive.segments").exists());
 
@@ -470,6 +470,41 @@ fn persist_loads_legacy_tick_consensus_archive_without_index() {
     let loaded_records = World::load_tick_consensus_records_from_dir(&dir, None, None)
         .expect("load tick consensus records from legacy archive");
     assert_eq!(loaded_records, world.tick_consensus_records());
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn persist_uses_legacy_tick_consensus_archive_when_index_segment_is_missing() {
+    let mut world = World::new();
+    for _ in 0..260 {
+        world.step().expect("step");
+    }
+
+    let dir = temp_dir("persist-tick-consensus-missing-segment-legacy-fallback");
+    world
+        .save_to_dir(&dir)
+        .expect("save world with archive index");
+
+    let archive_index: serde_json::Value = serde_json::from_slice(
+        &fs::read(dir.join("tick-consensus.archive.index.json"))
+            .expect("read tick consensus archive index json"),
+    )
+    .expect("decode tick consensus archive index json");
+    let missing_segment_path = archive_index
+        .get("archived_segments")
+        .and_then(|value| value.as_array())
+        .and_then(|segments| segments.first())
+        .and_then(|segment| segment.get("relative_path"))
+        .and_then(|value| value.as_str())
+        .expect("first segment relative path");
+    fs::remove_file(dir.join(missing_segment_path)).expect("remove archive segment");
+
+    let restored = World::load_from_dir(&dir).expect("restore world from legacy archive");
+    assert_eq!(
+        restored.tick_consensus_records(),
+        world.tick_consensus_records()
+    );
 
     let _ = fs::remove_dir_all(&dir);
 }

--- a/crates/oasis7/src/runtime/world/persistence.rs
+++ b/crates/oasis7/src/runtime/world/persistence.rs
@@ -297,9 +297,7 @@ fn persist_tick_consensus_archive(
                 write_json_to_path(&segment_file, dir.join(relative_path.as_str()).as_path())?;
             }
             write_json_to_path(&archive_index, archive_index_path.as_path())?;
-            if legacy_archive_path.exists() {
-                fs::remove_file(legacy_archive_path.as_path())?;
-            }
+            write_json_to_path(archive, legacy_archive_path.as_path())?;
             Ok(())
         }
         _ => {
@@ -442,6 +440,36 @@ fn load_tick_consensus_archive_records_from_index(
     Ok(Some(archived_records))
 }
 
+fn tick_consensus_archive_segment_missing(reason: &str) -> bool {
+    reason.starts_with("tick consensus archive segment missing:")
+}
+
+fn load_tick_consensus_legacy_archive_records(
+    dir: &Path,
+    snapshot: &Snapshot,
+) -> Result<Vec<TickConsensusRecord>, WorldError> {
+    let archive_path = tick_consensus_archive_path(dir);
+    if !archive_path.exists() {
+        return Err(WorldError::DistributedValidationFailed {
+            reason: format!(
+                "tick consensus archive missing: path={}",
+                archive_path.display()
+            ),
+        });
+    }
+    let archive: TickConsensusArchiveFile = read_json_from_path(archive_path.as_path())?;
+    if archive.archived_records.len() != snapshot.tick_consensus_archived_record_count {
+        return Err(WorldError::DistributedValidationFailed {
+            reason: format!(
+                "tick consensus archive count mismatch: expected={} actual={}",
+                snapshot.tick_consensus_archived_record_count,
+                archive.archived_records.len(),
+            ),
+        });
+    }
+    Ok(archive.archived_records)
+}
+
 fn hydrate_tick_consensus_snapshot_from_archive(
     dir: &Path,
     snapshot: &mut Snapshot,
@@ -473,30 +501,19 @@ fn hydrate_tick_consensus_snapshot_from_archive(
         return Ok(());
     }
 
-    let archived_records = match load_tick_consensus_archive_records_from_index(dir, snapshot)? {
-        Some(records) => records,
-        None => {
-            let archive_path = tick_consensus_archive_path(dir);
-            if !archive_path.exists() {
-                return Err(WorldError::DistributedValidationFailed {
-                    reason: format!(
-                        "tick consensus archive missing: path={}",
-                        archive_path.display(),
-                    ),
-                });
+    let archived_records = match load_tick_consensus_archive_records_from_index(dir, snapshot) {
+        Ok(Some(records)) => records,
+        Ok(None) => load_tick_consensus_legacy_archive_records(dir, snapshot)?,
+        Err(WorldError::DistributedValidationFailed { reason })
+            if tick_consensus_archive_segment_missing(reason.as_str()) =>
+        {
+            if tick_consensus_archive_path(dir).exists() {
+                load_tick_consensus_legacy_archive_records(dir, snapshot)?
+            } else {
+                return Err(WorldError::DistributedValidationFailed { reason });
             }
-            let archive: TickConsensusArchiveFile = read_json_from_path(archive_path.as_path())?;
-            if archive.archived_records.len() != snapshot.tick_consensus_archived_record_count {
-                return Err(WorldError::DistributedValidationFailed {
-                    reason: format!(
-                        "tick consensus archive count mismatch: expected={} actual={}",
-                        snapshot.tick_consensus_archived_record_count,
-                        archive.archived_records.len(),
-                    ),
-                });
-            }
-            archive.archived_records
         }
+        Err(err) => return Err(err),
     };
     let mut records = archived_records;
     records.extend(snapshot.tick_consensus_records.clone());


### PR DESCRIPTION
## Summary
- keep a same-generation legacy tick consensus archive alongside segmented archive files
- fall back to the legacy archive when an indexed segment is missing, while preserving hard failures for tamper/hash/range errors
- record run109 Windows startup evidence and subagent dispatch limitation in the task log

## Verification
- env -u RUSTC_WRAPPER cargo test -p oasis7 tick_consensus_archive -- --nocapture
- env -u RUSTC_WRAPPER cargo fmt --check
- git diff --check
- ./scripts/pm/workflow-lint.sh --task-uid task_c612861fd1fe4187b789ceff61a6d0f7 --phase current