### PR TITLE
Redial static peers after final transport close

### DIFF
--- a/.pm/tasks/task_c612861fd1fe4187b789ceff61a6d0f7.execution.md
+++ b/.pm/tasks/task_c612861fd1fe4187b789ceff61a6d0f7.execution.md
@@ -786,3 +786,35 @@ Example:
   - Actual limitation: available subagent thread limit is already exhausted; no fresh subagent review could be spawned in this environment.
   - Fallback evidence path: live Windows startup failure evidence plus focused archive persistence regression suite listed above.
   - Attribution boundary: this archive recovery root-cause and fix is TPM-integrated fallback evidence, not a new professional subagent conclusion.
+
+## 2026-06-18 15:00:00 CST / run110 watch + static peer reconnect root cause
+- PR #522 was merged to `main` as `b3d2a4a44f7a869c24e0a5d484b148cc3ef3379c`; GitHub Actions run `27739672759` built package version `0.0.0+testnet.110.b3d2a4a44f7a`.
+- Deployment evidence:
+  - Linux sequencer, Linux storage, and Linux observer were upgraded with `.tmp/upgrade_linux_nodes_run110.py`; all three installed the run110 Linux runtime sha256 `d9e4e74cbcd03484a9a88a9d9a417cba32d52f4bc19446ad5b25d2212b2e47b4`.
+  - Fourth local macOS arm64 node was rebuilt locally from merged `main`, runtime sha256 `c558cd5a17610b48a117d92816a4fd12c9ecbf012dd94be6a37b73c55ebad09e`, and deployed as `0.0.0+testnet.110.b3d2a4a44f7a-macos-arm64-local`.
+  - Windows observer installed run110 and started after restoring missing archive segment files from the local fourth node's same-network tick-consensus archive.
+- Health evidence:
+  - `.tmp/collect_run110_health.py` after archive restoration: sequencer, storage, Linux observer, and fourth local advanced to committed height `18559`; `storage_challenge_network_degraded=false` on all five nodes.
+  - Windows observer remained at committed height `18418`, with `last_error` = no connected peers for `/aw/node/replication/fetch-commit/1.0.0`, empty `connected_peers`, empty `registered_protocols`, and `storage_challenge_network_degraded=false`.
+  - Windows recent p2p errors showed direct storage transport established, peer record request failed with `ConnectionClosed`, then the peer manager reported missing peer record / insufficient active discovery sources and fetch-commit had no connected peer.
+- Code root cause:
+  - `ConnectionClosed` final-close handling refreshed `active_transport_paths` before calling failover. With `num_established=0`, this removed the peer's active path, so `failover_transport_path` immediately returned `None`.
+  - For a static single-path peer, the failover logic also suppressed redial when the next path label equaled the just-closed path. Windows therefore could drop from a briefly established static peer into a no-active-path state, leaving fetch-commit with no connected or active peer candidate until slow bootstrap redial.
+- Code follow-up:
+  - New branch `codex/p2p-static-peer-redial-recovery` from `origin/main`.
+  - Changed `crates/oasis7_net/src/libp2p_net.rs`, `crates/oasis7_net/src/libp2p_net/connection_lifecycle.rs`, and `crates/oasis7_net/src/libp2p_net/transport_paths.rs` so final close captures the just-disconnected active path and failover can immediately redial it.
+  - Single static paths are now retryable after final close; alternate known paths are still preferred when available.
+  - Added regression `reconnect_after_final_close_retries_single_disconnected_static_path`.
+- Verification:
+  - `env -u RUSTC_WRAPPER cargo test -p oasis7_net reconnect_after_final_close_retries_single_disconnected_static_path -- --nocapture` passed.
+  - `env -u RUSTC_WRAPPER cargo test -p oasis7_net transport_path -- --nocapture` passed, 10 tests.
+  - `env -u RUSTC_WRAPPER cargo test -p oasis7_net request_peer_filter -- --nocapture` passed, 6 tests.
+  - `env -u RUSTC_WRAPPER cargo test -p oasis7_net refresh_peer_manager_healths -- --nocapture` passed, 2 tests.
+  - `env -u RUSTC_WRAPPER cargo test -p oasis7_net -- --nocapture` passed, 165 tests.
+  - `env -u RUSTC_WRAPPER cargo fmt --check` passed.
+  - `git diff --check` passed.
+- Review dispatch limitation:
+  - Intended dispatch: bounded runtime_engineer/qa_engineer review slice for p2p final-close reconnect behavior.
+  - Actual limitation: available subagent thread limit is already exhausted; no fresh subagent review could be spawned in this environment.
+  - Fallback evidence path: live Windows run110 p2p status evidence plus focused and full `oasis7_net` test suite listed above.
+  - Attribution boundary: this p2p final-close reconnect root-cause and fix is TPM-integrated fallback evidence, not a new professional subagent conclusion.

--- a/.pm/tasks/task_c612861fd1fe4187b789ceff61a6d0f7.execution.md
+++ b/.pm/tasks/task_c612861fd1fe4187b789ceff61a6d0f7.execution.md
@@ -817,6 +817,10 @@ Example:
 - GitHub review disposition:
   - Automated Codex review raised P2 that the initial fallback could redial an inbound-only transient listener address when no known transport path existed.
   - Disposition: accepted and fixed in `6b01123448b7255fa080920bd060caf79bdd72f0`. Final-close reconnect now selects only known transport paths, and static bootstrap paths are seeded into `known_transport_paths` before peer-record exchange.
+- CI disposition:
+  - PR #523 second Rust `required-gate` failed in `./scripts/check-rust-file-size.sh` because `crates/oasis7_net/src/libp2p_net.rs` reached 1205 lines.
+  - Disposition: moved static bootstrap path-state initialization into `transport_paths::bootstrap_transport_path_state`, bringing oversized code files back to zero.
+  - Fresh verification after fix: `./scripts/check-rust-file-size.sh` passed; `env -u RUSTC_WRAPPER cargo test -p oasis7_net transport_path -- --nocapture` passed, 11 tests; `env -u RUSTC_WRAPPER cargo test -p oasis7_net -- --nocapture` passed, 166 tests; `env -u RUSTC_WRAPPER cargo fmt --check`, `git diff --check`, and workflow lint passed.
 - Review dispatch limitation:
   - Intended dispatch: bounded runtime_engineer/qa_engineer review slice for p2p final-close reconnect behavior.
   - Actual limitation: available subagent thread limit is already exhausted; no fresh subagent review could be spawned in this environment.

--- a/.pm/tasks/task_c612861fd1fe4187b789ceff61a6d0f7.execution.md
+++ b/.pm/tasks/task_c612861fd1fe4187b789ceff61a6d0f7.execution.md
@@ -818,3 +818,17 @@ Example:
   - Actual limitation: available subagent thread limit is already exhausted; no fresh subagent review could be spawned in this environment.
   - Fallback evidence path: live Windows run110 p2p status evidence plus focused and full `oasis7_net` test suite listed above.
   - Attribution boundary: this p2p final-close reconnect root-cause and fix is TPM-integrated fallback evidence, not a new professional subagent conclusion.
+
+- Pre-PR Local Role Review: passed
+- Task UID: task_c612861fd1fe4187b789ceff61a6d0f7
+- Source Worktree: /Users/scc/ccwork/worktrees/oasis7-p2p-replication-transport-gap-sync-recovery
+- Source Branch: codex/p2p-static-peer-redial-recovery
+- Source Head: 0ecefcb025d7179ab4eb9135e3db80a2ed609876
+- Comparison Ref: refs/remotes/origin/main
+- Reviewed Changed Paths: `.pm/tasks/task_c612861fd1fe4187b789ceff61a6d0f7.execution.md`; `crates/oasis7_net/src/libp2p_net.rs`; `crates/oasis7_net/src/libp2p_net/connection_lifecycle.rs`; `crates/oasis7_net/src/libp2p_net/transport_paths.rs`; `crates/oasis7_net/src/libp2p_net/tests/transport_path_refresh_tests.rs`
+- Role Selection Basis: p2p transport lifecycle and request-peer recovery behavior changed under live testnet incident pressure; verification and rollout readiness are part of the claim.
+- Review Roles: runtime_engineer, qa_engineer
+- Review Evidence: Intended bounded runtime_engineer/qa_engineer subagent slices could not be spawned because the available subagent thread limit was exhausted. Fallback evidence reviewed the code diff, live Windows run110 no-connected-peer loop, and the fresh verification suite listed above.
+- Review Findings Disposition: no actionable findings in fallback review.
+- Finding Disposition Evidence: `oasis7_net` focused transport/request/peer-manager tests and full crate tests passed; formatting, diff whitespace, and workflow lint passed.
+- Residual Risk: Medium until a run111 package is rolled out to Windows and live health confirms static peer reconnection keeps fetch-commit peers available.

--- a/.pm/tasks/task_c612861fd1fe4187b789ceff61a6d0f7.execution.md
+++ b/.pm/tasks/task_c612861fd1fe4187b789ceff61a6d0f7.execution.md
@@ -802,17 +802,21 @@ Example:
   - For a static single-path peer, the failover logic also suppressed redial when the next path label equaled the just-closed path. Windows therefore could drop from a briefly established static peer into a no-active-path state, leaving fetch-commit with no connected or active peer candidate until slow bootstrap redial.
 - Code follow-up:
   - New branch `codex/p2p-static-peer-redial-recovery` from `origin/main`.
-  - Changed `crates/oasis7_net/src/libp2p_net.rs`, `crates/oasis7_net/src/libp2p_net/connection_lifecycle.rs`, and `crates/oasis7_net/src/libp2p_net/transport_paths.rs` so final close captures the just-disconnected active path and failover can immediately redial it.
-  - Single static paths are now retryable after final close; alternate known paths are still preferred when available.
-  - Added regression `reconnect_after_final_close_retries_single_disconnected_static_path`.
+  - Changed `crates/oasis7_net/src/libp2p_net.rs`, `crates/oasis7_net/src/libp2p_net/connection_lifecycle.rs`, and `crates/oasis7_net/src/libp2p_net/transport_paths.rs` so final close captures the just-disconnected active path and failover can immediately redial known static paths.
+  - Static bootstrap `/p2p/<peer>` addresses are seeded into known transport paths before peer-record exchange, so configured static peers can be retried without trusting arbitrary inbound-only transient listener addresses.
+  - Single known static paths are now retryable after final close; alternate known paths are still preferred when available.
+  - Added regressions `reconnect_after_final_close_retries_single_disconnected_static_path` and `static_bootstrap_paths_are_known_before_peer_record_exchange`.
 - Verification:
   - `env -u RUSTC_WRAPPER cargo test -p oasis7_net reconnect_after_final_close_retries_single_disconnected_static_path -- --nocapture` passed.
-  - `env -u RUSTC_WRAPPER cargo test -p oasis7_net transport_path -- --nocapture` passed, 10 tests.
+  - `env -u RUSTC_WRAPPER cargo test -p oasis7_net transport_path -- --nocapture` passed, 11 tests.
   - `env -u RUSTC_WRAPPER cargo test -p oasis7_net request_peer_filter -- --nocapture` passed, 6 tests.
   - `env -u RUSTC_WRAPPER cargo test -p oasis7_net refresh_peer_manager_healths -- --nocapture` passed, 2 tests.
-  - `env -u RUSTC_WRAPPER cargo test -p oasis7_net -- --nocapture` passed, 165 tests.
+  - `env -u RUSTC_WRAPPER cargo test -p oasis7_net -- --nocapture` passed, 166 tests.
   - `env -u RUSTC_WRAPPER cargo fmt --check` passed.
   - `git diff --check` passed.
+- GitHub review disposition:
+  - Automated Codex review raised P2 that the initial fallback could redial an inbound-only transient listener address when no known transport path existed.
+  - Disposition: accepted and fixed in `6b01123448b7255fa080920bd060caf79bdd72f0`. Final-close reconnect now selects only known transport paths, and static bootstrap paths are seeded into `known_transport_paths` before peer-record exchange.
 - Review dispatch limitation:
   - Intended dispatch: bounded runtime_engineer/qa_engineer review slice for p2p final-close reconnect behavior.
   - Actual limitation: available subagent thread limit is already exhausted; no fresh subagent review could be spawned in this environment.
@@ -823,12 +827,12 @@ Example:
 - Task UID: task_c612861fd1fe4187b789ceff61a6d0f7
 - Source Worktree: /Users/scc/ccwork/worktrees/oasis7-p2p-replication-transport-gap-sync-recovery
 - Source Branch: codex/p2p-static-peer-redial-recovery
-- Source Head: 0ecefcb025d7179ab4eb9135e3db80a2ed609876
+- Source Head: 6b01123448b7255fa080920bd060caf79bdd72f0
 - Comparison Ref: refs/remotes/origin/main
 - Reviewed Changed Paths: `.pm/tasks/task_c612861fd1fe4187b789ceff61a6d0f7.execution.md`; `crates/oasis7_net/src/libp2p_net.rs`; `crates/oasis7_net/src/libp2p_net/connection_lifecycle.rs`; `crates/oasis7_net/src/libp2p_net/transport_paths.rs`; `crates/oasis7_net/src/libp2p_net/tests/transport_path_refresh_tests.rs`
 - Role Selection Basis: p2p transport lifecycle and request-peer recovery behavior changed under live testnet incident pressure; verification and rollout readiness are part of the claim.
 - Review Roles: runtime_engineer, qa_engineer
-- Review Evidence: Intended bounded runtime_engineer/qa_engineer subagent slices could not be spawned because the available subagent thread limit was exhausted. Fallback evidence reviewed the code diff, live Windows run110 no-connected-peer loop, and the fresh verification suite listed above.
-- Review Findings Disposition: no actionable findings in fallback review.
-- Finding Disposition Evidence: `oasis7_net` focused transport/request/peer-manager tests and full crate tests passed; formatting, diff whitespace, and workflow lint passed.
+- Review Evidence: Intended bounded runtime_engineer/qa_engineer subagent slices could not be spawned because the available subagent thread limit was exhausted. Fallback evidence reviewed the code diff, live Windows run110 no-connected-peer loop, the automated GitHub P2 finding, and the fresh verification suite listed above.
+- Review Findings Disposition: automated GitHub P2 accepted and fixed; no additional actionable findings in fallback review.
+- Finding Disposition Evidence: `6b01123448b7255fa080920bd060caf79bdd72f0` restricts reconnect to known paths and seeds static bootstrap paths; `oasis7_net` focused transport/request/peer-manager tests and full crate tests passed; formatting, diff whitespace, and workflow lint passed.
 - Residual Risk: Medium until a run111 package is rolled out to Windows and live health confirms static peer reconnection keeps fetch-commit peers available.

--- a/crates/oasis7_net/src/libp2p_net.rs
+++ b/crates/oasis7_net/src/libp2p_net.rs
@@ -101,7 +101,9 @@ pub use traffic_metrics::{
     TrafficDirectionMetricsSnapshot, TrafficLaneMetricsSnapshot, WireByteDirectionMetricsSnapshot,
     WireByteLaneMetricsSnapshot,
 };
-use transport_paths::{retry_transport_path_after_error, TransportPath};
+use transport_paths::{
+    retry_transport_path_after_error, sync_static_bootstrap_transport_paths, TransportPath,
+};
 use utils::{
     decode_membership_directory, decode_world_head, now_ms, push_bounded_clone,
     push_bounded_string_with_keyed_cooldown, should_republish, try_send_command,
@@ -200,6 +202,12 @@ impl Libp2pNetwork {
             let mut provider_keys: HashMap<String, i64> = HashMap::new();
             let mut discovered_peer_records: HashMap<PeerId, SignedPeerRecord> = HashMap::new();
             let mut known_transport_paths: HashMap<PeerId, Vec<TransportPath>> = HashMap::new();
+            let mut failed_transport_path_labels: HashSet<String> = HashSet::new();
+            sync_static_bootstrap_transport_paths(
+                &mut known_transport_paths,
+                &mut failed_transport_path_labels,
+                &config_clone.bootstrap_peers,
+            );
             let mut last_dialed_transport_paths: HashMap<PeerId, TransportPath> = HashMap::new();
             let mut active_transport_paths: HashMap<PeerId, TransportPath> = HashMap::new();
             let mut established_transport_paths_by_connection: HashMap<
@@ -213,7 +221,6 @@ impl Libp2pNetwork {
             let mut peer_healths_by_id: HashMap<PeerId, PeerManagerPeerHealth> = HashMap::new();
             let mut quarantined_active_peers: HashSet<PeerId> = HashSet::new();
             let mut admitted_active_peers: HashSet<PeerId> = HashSet::new();
-            let mut failed_transport_path_labels: HashSet<String> = HashSet::new();
             let mut pending_quarantine_disconnects: HashSet<PeerId> = HashSet::new();
             let mut pending_discovery_peer_records: HashSet<PeerId> = HashSet::new();
             let mut pending_connected_peer_records: HashSet<PeerId> = HashSet::new();

--- a/crates/oasis7_net/src/libp2p_net.rs
+++ b/crates/oasis7_net/src/libp2p_net.rs
@@ -102,7 +102,7 @@ pub use traffic_metrics::{
     WireByteLaneMetricsSnapshot,
 };
 use transport_paths::{
-    retry_transport_path_after_error, sync_static_bootstrap_transport_paths, TransportPath,
+    bootstrap_transport_path_state, retry_transport_path_after_error, TransportPath,
 };
 use utils::{
     decode_membership_directory, decode_world_head, now_ms, push_bounded_clone,
@@ -201,13 +201,8 @@ impl Libp2pNetwork {
             let mut peers: Vec<PeerId> = Vec::new();
             let mut provider_keys: HashMap<String, i64> = HashMap::new();
             let mut discovered_peer_records: HashMap<PeerId, SignedPeerRecord> = HashMap::new();
-            let mut known_transport_paths: HashMap<PeerId, Vec<TransportPath>> = HashMap::new();
-            let mut failed_transport_path_labels: HashSet<String> = HashSet::new();
-            sync_static_bootstrap_transport_paths(
-                &mut known_transport_paths,
-                &mut failed_transport_path_labels,
-                &config_clone.bootstrap_peers,
-            );
+            let (mut known_transport_paths, mut failed_transport_path_labels) =
+                bootstrap_transport_path_state(&config_clone.bootstrap_peers);
             let mut last_dialed_transport_paths: HashMap<PeerId, TransportPath> = HashMap::new();
             let mut active_transport_paths: HashMap<PeerId, TransportPath> = HashMap::new();
             let mut established_transport_paths_by_connection: HashMap<

--- a/crates/oasis7_net/src/libp2p_net.rs
+++ b/crates/oasis7_net/src/libp2p_net.rs
@@ -1023,6 +1023,8 @@ impl Libp2pNetwork {
                                             LIFECYCLE_EVENT_ERROR_COOLDOWN_MS,
                                         );
                                     } else {
+                                        let disconnected_path =
+                                            active_transport_paths.get(&peer_id).cloned();
                                         established_transport_paths_by_connection
                                             .remove(&connection_id);
                                         established_connections_by_peer.remove(&peer_id);
@@ -1062,6 +1064,7 @@ impl Libp2pNetwork {
                                                 &event_errors,
                                                 max_error_messages,
                                                 peer_id,
+                                                disconnected_path,
                                             );
                                         }
                                         push_bounded_string_with_keyed_cooldown(

--- a/crates/oasis7_net/src/libp2p_net/connection_lifecycle.rs
+++ b/crates/oasis7_net/src/libp2p_net/connection_lifecycle.rs
@@ -11,7 +11,7 @@ use super::reachability::refresh_active_transport_snapshot;
 use super::runtime_loop::{enforce_peer_manager_quarantine, refresh_peer_manager_healths};
 use super::swarm_behaviour::Behaviour;
 use super::transport_paths::{
-    failover_transport_path, note_established_transport_path,
+    failover_transport_path_after_close, note_established_transport_path,
     recompute_active_transport_path_for_peer, TransportPath,
 };
 use super::utils::{push_bounded_clone, push_bounded_string_with_keyed_cooldown};
@@ -296,21 +296,26 @@ pub(super) fn failover_after_disconnect(
     event_errors: &Arc<Mutex<Vec<String>>>,
     max_error_messages: usize,
     peer_id: PeerId,
+    disconnected_path: Option<TransportPath>,
 ) {
-    match failover_transport_path(
+    match failover_transport_path_after_close(
         swarm,
         known_transport_paths,
         active_transport_paths,
         last_dialed_transport_paths,
         failed_transport_path_labels,
         peer_id,
+        disconnected_path,
     ) {
-        Ok(Some((active_path, next_path))) => {
+        Ok(Some((previous_path, next_path))) => {
+            let previous_addr = previous_path
+                .map(|path| path.addr.to_string())
+                .unwrap_or_else(|| "none".to_string());
             push_bounded_clone(
                 event_errors,
                 format!(
                     "libp2p transport failover peer={peer_id} from={} to={}",
-                    active_path.addr, next_path.addr,
+                    previous_addr, next_path.addr,
                 ),
                 max_error_messages,
                 "lock errors",

--- a/crates/oasis7_net/src/libp2p_net/tests/transport_path_refresh_tests.rs
+++ b/crates/oasis7_net/src/libp2p_net/tests/transport_path_refresh_tests.rs
@@ -3,6 +3,7 @@ use libp2p::swarm::ConnectionId;
 
 use crate::libp2p_net::transport_paths::{
     recompute_active_transport_path_for_peer, select_reconnect_transport_path_after_close,
+    sync_static_bootstrap_transport_paths,
 };
 
 #[test]
@@ -37,15 +38,54 @@ fn reconnect_after_final_close_retries_single_disconnected_static_path() {
 
     known.clear();
     failed.clear();
-    let (_, next_path) = select_reconnect_transport_path_after_close(
+    assert!(select_reconnect_transport_path_after_close(
         &known,
         &mut active_transport_paths,
         &mut failed,
         peer_id,
         Some(direct_path.clone()),
     )
-    .expect("disconnected path should be enough to retry after final close");
-    assert_eq!(next_path, direct_path);
+    .is_none());
+}
+
+#[test]
+fn static_bootstrap_paths_are_known_before_peer_record_exchange() {
+    let peer_id = PeerId::random();
+    let direct_addr: Multiaddr = format!("/ip4/39.104.204.172/tcp/6831/p2p/{peer_id}")
+        .parse()
+        .expect("direct addr");
+    let transient_peer = PeerId::random();
+    let transient_addr: Multiaddr = format!("/ip4/10.0.0.42/tcp/49200/p2p/{transient_peer}")
+        .parse()
+        .expect("transient addr");
+    let mut known = HashMap::new();
+    let mut failed = HashSet::from([direct_addr.to_string()]);
+
+    sync_static_bootstrap_transport_paths(
+        &mut known,
+        &mut failed,
+        &[direct_addr.clone(), transient_addr.clone()],
+    );
+
+    assert_eq!(
+        known
+            .get(&peer_id)
+            .expect("static bootstrap peer path")
+            .first()
+            .expect("static bootstrap path")
+            .addr,
+        direct_addr
+    );
+    assert_eq!(
+        known
+            .get(&transient_peer)
+            .expect("configured peer path")
+            .first()
+            .expect("configured path")
+            .addr,
+        transient_addr
+    );
+    assert!(!failed.contains(&direct_addr.to_string()));
 }
 
 #[test]

--- a/crates/oasis7_net/src/libp2p_net/tests/transport_path_refresh_tests.rs
+++ b/crates/oasis7_net/src/libp2p_net/tests/transport_path_refresh_tests.rs
@@ -1,12 +1,51 @@
 use super::*;
 use libp2p::swarm::ConnectionId;
 
-use crate::libp2p_net::transport_paths::recompute_active_transport_path_for_peer;
+use crate::libp2p_net::transport_paths::{
+    recompute_active_transport_path_for_peer, select_reconnect_transport_path_after_close,
+};
 
 #[test]
 fn libp2p_network_generates_peer_id() {
     let network = Libp2pNetwork::new(Libp2pNetworkConfig::default());
     assert!(!network.peer_id().to_string().is_empty());
+}
+
+#[test]
+fn reconnect_after_final_close_retries_single_disconnected_static_path() {
+    let peer_id = PeerId::random();
+    let direct_addr = format!("/ip4/39.104.204.172/tcp/6831/p2p/{peer_id}")
+        .parse()
+        .expect("direct addr");
+    let direct_path = active_transport_path_from_endpoint(&HashMap::new(), peer_id, &direct_addr);
+    let mut known = HashMap::from([(peer_id, vec![direct_path.clone()])]);
+    let mut active_transport_paths = HashMap::new();
+    let mut failed = HashSet::new();
+
+    let (previous_path, next_path) = select_reconnect_transport_path_after_close(
+        &known,
+        &mut active_transport_paths,
+        &mut failed,
+        peer_id,
+        Some(direct_path.clone()),
+    )
+    .expect("single static path should be redialable");
+
+    assert_eq!(previous_path, Some(direct_path.clone()));
+    assert_eq!(next_path, direct_path);
+    assert!(failed.contains(&direct_addr.to_string()));
+
+    known.clear();
+    failed.clear();
+    let (_, next_path) = select_reconnect_transport_path_after_close(
+        &known,
+        &mut active_transport_paths,
+        &mut failed,
+        peer_id,
+        Some(direct_path.clone()),
+    )
+    .expect("disconnected path should be enough to retry after final close");
+    assert_eq!(next_path, direct_path);
 }
 
 #[test]

--- a/crates/oasis7_net/src/libp2p_net/transport_paths.rs
+++ b/crates/oasis7_net/src/libp2p_net/transport_paths.rs
@@ -211,6 +211,19 @@ pub(super) fn sync_static_bootstrap_transport_paths(
     }
 }
 
+pub(super) fn bootstrap_transport_path_state(
+    bootstrap_peers: &[Multiaddr],
+) -> (HashMap<PeerId, Vec<TransportPath>>, HashSet<String>) {
+    let mut known_transport_paths = HashMap::new();
+    let mut failed_transport_path_labels = HashSet::new();
+    sync_static_bootstrap_transport_paths(
+        &mut known_transport_paths,
+        &mut failed_transport_path_labels,
+        bootstrap_peers,
+    );
+    (known_transport_paths, failed_transport_path_labels)
+}
+
 pub(super) fn select_preferred_transport_path(
     paths: &[TransportPath],
     failed_transport_path_labels: &HashSet<String>,

--- a/crates/oasis7_net/src/libp2p_net/transport_paths.rs
+++ b/crates/oasis7_net/src/libp2p_net/transport_paths.rs
@@ -190,6 +190,27 @@ pub(super) fn sync_known_transport_paths(
     known_transport_paths.insert(peer_id, paths);
 }
 
+pub(super) fn sync_static_bootstrap_transport_paths(
+    known_transport_paths: &mut HashMap<PeerId, Vec<TransportPath>>,
+    failed_transport_path_labels: &mut HashSet<String>,
+    bootstrap_peers: &[Multiaddr],
+) {
+    for addr in bootstrap_peers {
+        let Some(peer_id) = split_peer_id(addr.clone()).0 else {
+            continue;
+        };
+        let path = active_transport_path_from_endpoint(known_transport_paths, peer_id, addr);
+        let label = path.label();
+        let paths = known_transport_paths.entry(peer_id).or_default();
+        if paths.iter().any(|known| known.label() == label) {
+            continue;
+        }
+        failed_transport_path_labels.remove(&label);
+        paths.push(path);
+        paths.sort_unstable_by_key(TransportPath::preference_rank);
+    }
+}
+
 pub(super) fn select_preferred_transport_path(
     paths: &[TransportPath],
     failed_transport_path_labels: &HashSet<String>,
@@ -364,12 +385,9 @@ pub(super) fn select_reconnect_transport_path_after_close(
     if let Some(path) = &previous_path {
         failed_transport_path_labels.insert(path.label());
     }
-    let next_path = known_transport_paths
-        .get(&peer_id)
-        .and_then(|paths| {
-            select_preferred_transport_path(paths.as_slice(), failed_transport_path_labels)
-        })
-        .or_else(|| previous_path.clone())?;
+    let next_path = known_transport_paths.get(&peer_id).and_then(|paths| {
+        select_preferred_transport_path(paths.as_slice(), failed_transport_path_labels)
+    })?;
     Some((previous_path, next_path))
 }
 

--- a/crates/oasis7_net/src/libp2p_net/transport_paths.rs
+++ b/crates/oasis7_net/src/libp2p_net/transport_paths.rs
@@ -329,28 +329,48 @@ pub(super) fn dial_transport_path(
     Ok(())
 }
 
-pub(super) fn failover_transport_path(
+pub(super) fn failover_transport_path_after_close(
     swarm: &mut Swarm<Behaviour>,
     known_transport_paths: &HashMap<PeerId, Vec<TransportPath>>,
     active_transport_paths: &mut HashMap<PeerId, TransportPath>,
     last_dialed_transport_paths: &mut HashMap<PeerId, TransportPath>,
     failed_transport_path_labels: &mut HashSet<String>,
     peer_id: PeerId,
-) -> Result<Option<(TransportPath, TransportPath)>, WorldError> {
-    let Some(active_path) = active_transport_paths.remove(&peer_id) else {
+    disconnected_path: Option<TransportPath>,
+) -> Result<Option<(Option<TransportPath>, TransportPath)>, WorldError> {
+    let Some((previous_path, next_path)) = select_reconnect_transport_path_after_close(
+        known_transport_paths,
+        active_transport_paths,
+        failed_transport_path_labels,
+        peer_id,
+        disconnected_path,
+    ) else {
         return Ok(None);
     };
-    failed_transport_path_labels.insert(active_path.label());
-    let Some(next_path) = known_transport_paths.get(&peer_id).and_then(|paths| {
-        select_preferred_transport_path(paths.as_slice(), failed_transport_path_labels)
-    }) else {
-        return Ok(None);
-    };
-    if next_path.label() == active_path.label() {
-        return Ok(None);
-    }
     dial_transport_path(swarm, last_dialed_transport_paths, next_path.clone())?;
-    Ok(Some((active_path, next_path)))
+    Ok(Some((previous_path, next_path)))
+}
+
+pub(super) fn select_reconnect_transport_path_after_close(
+    known_transport_paths: &HashMap<PeerId, Vec<TransportPath>>,
+    active_transport_paths: &mut HashMap<PeerId, TransportPath>,
+    failed_transport_path_labels: &mut HashSet<String>,
+    peer_id: PeerId,
+    disconnected_path: Option<TransportPath>,
+) -> Option<(Option<TransportPath>, TransportPath)> {
+    let previous_path = active_transport_paths
+        .remove(&peer_id)
+        .or(disconnected_path);
+    if let Some(path) = &previous_path {
+        failed_transport_path_labels.insert(path.label());
+    }
+    let next_path = known_transport_paths
+        .get(&peer_id)
+        .and_then(|paths| {
+            select_preferred_transport_path(paths.as_slice(), failed_transport_path_labels)
+        })
+        .or_else(|| previous_path.clone())?;
+    Some((previous_path, next_path))
 }
 
 pub(super) fn retry_transport_path_after_error(


### PR DESCRIPTION
## Summary
- preserve the just-closed active transport path through final ConnectionClosed handling
- allow static single-path peers to be redialed immediately after disconnect instead of silently skipping failover
- add a regression for final-close redial recovery

## Verification
- env -u RUSTC_WRAPPER cargo test -p oasis7_net reconnect_after_final_close_retries_single_disconnected_static_path -- --nocapture
- env -u RUSTC_WRAPPER cargo test -p oasis7_net transport_path -- --nocapture
- env -u RUSTC_WRAPPER cargo test -p oasis7_net request_peer_filter -- --nocapture
- env -u RUSTC_WRAPPER cargo test -p oasis7_net refresh_peer_manager_healths -- --nocapture
- env -u RUSTC_WRAPPER cargo test -p oasis7_net -- --nocapture
- env -u RUSTC_WRAPPER cargo fmt --check
- git diff --check
- ./scripts/pm/workflow-lint.sh --task-uid task_c612861fd1fe4187b789ceff61a6d0f7 --phase current