### PR TITLE
Keep gap sync provider sweeps within budget

### DIFF
--- a/.pm/tasks/task_c612861fd1fe4187b789ceff61a6d0f7.execution.md
+++ b/.pm/tasks/task_c612861fd1fe4187b789ceff61a6d0f7.execution.md
@@ -840,3 +840,69 @@ Example:
 - Review Findings Disposition: automated GitHub P2 accepted and fixed; no additional actionable findings in fallback review.
 - Finding Disposition Evidence: `6b01123448b7255fa080920bd060caf79bdd72f0` restricts reconnect to known paths and seeds static bootstrap paths; `oasis7_net` focused transport/request/peer-manager tests and full crate tests passed; formatting, diff whitespace, and workflow lint passed.
 - Residual Risk: Medium until a run111 package is rolled out to Windows and live health confirms static peer reconnection keeps fetch-commit peers available.
+
+## 2026-06-18 16:20:00 CST / tpm
+- 完成内容: run111 watch identified a new provider sweep budget root cause. PR #523 was merged to `main` as `248d6fe36f6732300a5dc55c0ebb713469e47510`; GitHub Actions run `27743693100` built package version `0.0.0+testnet.111.248d6fe36f67`. Linux x3, Windows observer, and local macOS observer were upgraded to run111 or local arm64 equivalent.
+- 完成内容: Health evidence: run111 improved Windows from zero connected peers to a stable direct sequencer peer, and all five nodes reported `storage_challenge_network_degraded=false`. Linux observer and fourth local reached `ready`; sequencer/storage only showed transient peer-head/recent-error gates. Windows remained at committed height `18418`, with `last_error` first reporting `no connected providers for /aw/node/replication/fetch-commit/1.0.0`, then detailed probe showing a direct sequencer connection and `request failed: Timeout protocol=/aw/node/replication/fetch-commit/1.0.0 peer=12D3KooWMyPapumCaTABq27umWdHqXDr8AoTse21eMVnXeJEsbNp`.
+- 完成内容: Code root cause: `ReplicationNetworkEndpoint::request_fetch_commit_for_gap_sync_with_policy` uses `known_peer_ids()` for provider-directed gap-sync after generic not-found, but each provider route received the full remaining shared sweep budget. When the first available provider was slow or timed out, it could consume the whole 30s remaining route budget and prevent the same poll from trying the next known provider, such as the storage node.
+- Action: New branch `codex/gap-sync-provider-budget-fairness` from `main`. Changed `crates/oasis7_node/src/network_bridge.rs` so multi-provider fetch-commit sweeps divide the remaining retry budget across the remaining provider candidates, with a 1_500ms minimum and no change to single-provider cold archive behavior.
+- Action: Added regression `gap_sync_fetch_commit_provider_sweep_preserves_budget_for_next_provider` in `crates/oasis7_node/src/tests_network_gap_sync_budget.rs`, covering first-provider timeout followed by second-provider success and asserting the first provider no longer consumes the full sweep budget.
+- 遗留事项: Package build, run112 deployment, and fresh five-node health validation remain after this PR is merged.
+- Validation Command: `env -u RUSTC_WRAPPER cargo fmt --check`
+- Expected Result: formatting passes.
+- Actual Result: passed.
+- Validation Command: `git diff --check && ./scripts/check-rust-file-size.sh`
+- Expected Result: whitespace and file-size gates pass.
+- Actual Result: passed; file-size gate reports oversized code files=0, test files=0.
+- Validation Command: `env -u RUSTC_WRAPPER cargo test -p oasis7_node gap_sync_fetch_commit -- --nocapture`
+- Expected Result: gap-sync fetch-commit tests pass, including the provider sweep regression.
+- Actual Result: passed, 12 tests.
+- Validation Command: `env -u RUSTC_WRAPPER cargo test -p oasis7_node network_gap_sync_provider -- --nocapture`
+- Expected Result: provider route tests pass.
+- Actual Result: passed, 4 tests.
+- Validation Command: `env -u RUSTC_WRAPPER cargo test -p oasis7_node libp2p_replication_network -- --nocapture`
+- Expected Result: libp2p replication network tests pass.
+- Actual Result: passed, 42 tests.
+- Validation Command: `env -u RUSTC_WRAPPER cargo test -p oasis7_node -- --nocapture`
+- Expected Result: full `oasis7_node` test suite passes.
+- Actual Result: passed, 338 tests plus doc-tests; existing warning-only output unchanged.
+- Review dispatch limitation:
+  - Intended dispatch: bounded runtime_engineer/qa_engineer/repository_health_engineer review slice for provider sweep budget fairness.
+  - Actual limitation: available subagent thread limit is already exhausted; no fresh subagent review could be spawned in this environment.
+  - Fallback evidence path: live Windows run111 timeout/no-provider evidence plus focused regression and full `oasis7_node` test suite listed above.
+  - Attribution boundary: this provider sweep budget root-cause and fix is TPM-integrated fallback evidence, not a new professional subagent conclusion.
+- Blocker / Next Action: commit, push, create PR, watch checks and review comments, then build/deploy the next testnet package after merge.
+
+## 2026-06-18 16:28:00 CST / tpm
+- 完成内容: Pre-PR Local Role Review: passed for provider sweep budget fairness branch under documented subagent dispatch limitation.
+- 遗留事项: GitHub checks/review, merge, testnet package build, deployment, and live five-node health validation remain.
+- Action: Task UID: task_c612861fd1fe4187b789ceff61a6d0f7; Source Worktree: `/Users/scc/ccwork/worktrees/oasis7-p2p-replication-transport-gap-sync-recovery`; Source Branch: `codex/gap-sync-provider-budget-fairness`; Source Head: branch HEAD at PR creation; Comparison Ref: `main`; Reviewed Changed Paths: `.pm/tasks/task_c612861fd1fe4187b789ceff61a6d0f7.execution.md`; `crates/oasis7_node/src/network_bridge.rs`; `crates/oasis7_node/src/tests_network_gap_sync_budget.rs`.
+- Action: Review Roles: intended runtime_engineer, qa_engineer, repository_health_engineer; actual fresh subagent dispatch blocked by exhausted available subagent threads. Fallback review evidence used live Windows run111 timeout/no-provider evidence, the focused provider-sweep regression, full `oasis7_node` tests, formatting, diff whitespace, file-size gate, and workflow lint.
+- Validation Command: pre-PR local role review fallback evidence packet.
+- Expected Result: no unresolved merge-blocking findings before PR creation.
+- Actual Result: passed; no additional actionable findings beyond the implemented budget split and regression coverage.
+- Blocker / Next Action: push branch, create PR, watch GitHub checks/comments, then merge/package/deploy when green.
+
+## 2026-06-18 16:40:00 CST / tpm
+- 完成内容: Addressed GitHub automated Codex review P1 on PR #526.
+- 遗留事项: PR checks/comments must be rechecked after force-push; run112 package/deployment remains after merge.
+- Action: Accepted finding that provider sweep fairness must split `retry_budget_ms` as well as `request_timeout_ms`, because libp2p uses the retry budget while waiting for a provider connection before the request timeout applies. Updated `crates/oasis7_node/src/network_bridge.rs` to pass the split budget into `request_json_with_providers_budget`, and tightened the regression to assert the first provider route has both timeout and retry budget capped.
+- Validation Command: `env -u RUSTC_WRAPPER cargo fmt --check && git diff --check && ./scripts/check-rust-file-size.sh`
+- Expected Result: formatting, whitespace, and file-size gates pass.
+- Actual Result: passed.
+- Validation Command: `env -u RUSTC_WRAPPER cargo test -p oasis7_node gap_sync_fetch_commit_provider_sweep_preserves_budget_for_next_provider -- --nocapture`
+- Expected Result: focused review regression passes.
+- Actual Result: passed, 1 test.
+- Validation Command: `env -u RUSTC_WRAPPER cargo test -p oasis7_node gap_sync_fetch_commit -- --nocapture`
+- Expected Result: gap-sync fetch-commit suite passes.
+- Actual Result: passed, 12 tests.
+- Validation Command: `env -u RUSTC_WRAPPER cargo test -p oasis7_node -- --nocapture`
+- Expected Result: full `oasis7_node` suite passes.
+- Actual Result: failed, 337 passed / 1 failed. Failing test was `runtime_gossip_tracks_peer_heads_when_replication_network_consensus_is_disabled`, a gossip peer-head timing test outside the changed provider budget path; a main-branch comparison run was started to determine whether this is pre-existing/environmental before final PR disposition.
+- Validation Command: `env -u RUSTC_WRAPPER cargo test -p oasis7_node runtime_gossip_tracks_peer_heads_when_replication_network_consensus_is_disabled -- --nocapture` on `main`
+- Expected Result: same gossip timing test result on current main.
+- Actual Result: passed, 1 test.
+- Validation Command: `env -u RUSTC_WRAPPER cargo test -p oasis7_node runtime_gossip_tracks_peer_heads_when_replication_network_consensus_is_disabled -- --nocapture` on `codex/gap-sync-provider-budget-fairness`
+- Expected Result: rerun confirms the branch is not persistently failing this unrelated gossip test.
+- Actual Result: passed, 1 test.
+- Blocker / Next Action: amend/push the review fix and continue PR checks.

--- a/crates/oasis7_node/src/network_bridge.rs
+++ b/crates/oasis7_node/src/network_bridge.rs
@@ -48,6 +48,7 @@ pub(crate) const REPLICATION_NETWORK_ROUTE_UNAVAILABLE_PREFIX: &str =
     "replication network route unavailable: ";
 const FETCH_COMMIT_GENERIC_ROUTE_ATTEMPTS: usize = 4;
 const GAP_SYNC_FETCH_COMMIT_MAX_PROVIDER_ROUTES_PER_POLL: usize = 8;
+const GAP_SYNC_FETCH_COMMIT_MIN_PROVIDER_ROUTE_TIMEOUT_MS: u64 = 1_500;
 const GAP_SYNC_FETCH_HEAD_REQUEST_TIMEOUT_MS: u64 = 1_500;
 const GAP_SYNC_FETCH_HEAD_RETRY_BUDGET_MS: u64 = 3_000;
 const GAP_SYNC_FETCH_HEAD_MAX_PROVIDER_ROUTES_PER_POLL: usize = 2;
@@ -599,7 +600,8 @@ impl ReplicationNetworkEndpoint {
             peer_ids.dedup();
             peer_ids.retain(|peer_id| !peer_id.trim().is_empty());
             peer_ids.truncate(GAP_SYNC_FETCH_COMMIT_MAX_PROVIDER_ROUTES_PER_POLL);
-            for peer_id in peer_ids {
+            let peer_count = peer_ids.len();
+            for (peer_index, peer_id) in peer_ids.into_iter().enumerate() {
                 let provider_route = [peer_id.clone()];
                 let Some((request_timeout_ms, retry_budget_ms)) = route_budget() else {
                     if last_err.is_none() {
@@ -607,6 +609,13 @@ impl ReplicationNetworkEndpoint {
                     }
                     break;
                 };
+                let remaining_provider_routes = peer_count.saturating_sub(peer_index).max(1);
+                let retry_budget_ms = split_provider_route_timeout_ms(
+                    retry_budget_ms,
+                    remaining_provider_routes,
+                    GAP_SYNC_FETCH_COMMIT_MIN_PROVIDER_ROUTE_TIMEOUT_MS,
+                );
+                let request_timeout_ms = request_timeout_ms.min(retry_budget_ms);
                 match self
                     .request_json_with_providers_budget::<FetchCommitRequest, FetchCommitResponse>(
                         REPLICATION_FETCH_COMMIT_PROTOCOL,
@@ -1168,4 +1177,14 @@ fn replication_network_error_detail(err: &WorldError) -> &str {
         WorldError::Io(message) | WorldError::Serde(message) => message.as_str(),
         WorldError::SignatureKeyInvalid => "invalid signature key",
     }
+}
+
+fn split_provider_route_timeout_ms(
+    retry_budget_ms: u64,
+    remaining_provider_routes: usize,
+    min_timeout_ms: u64,
+) -> u64 {
+    let remaining_provider_routes = remaining_provider_routes.max(1) as u64;
+    let divided = retry_budget_ms / remaining_provider_routes;
+    divided.max(min_timeout_ms).min(retry_budget_ms)
 }

--- a/crates/oasis7_node/src/tests_network_gap_sync_budget.rs
+++ b/crates/oasis7_node/src/tests_network_gap_sync_budget.rs
@@ -80,6 +80,95 @@ impl oasis7_proto::distributed_net::DistributedNetwork<WorldError>
     }
 }
 
+#[derive(Clone)]
+struct SlowFirstProviderFetchCommitNetwork {
+    budgets: Arc<Mutex<Vec<(u64, u64, Vec<String>)>>>,
+}
+
+impl oasis7_proto::distributed_net::DistributedNetwork<WorldError>
+    for SlowFirstProviderFetchCommitNetwork
+{
+    fn publish(&self, _topic: &str, _payload: &[u8]) -> Result<(), WorldError> {
+        Ok(())
+    }
+
+    fn subscribe(&self, topic: &str) -> Result<NetworkSubscription, WorldError> {
+        Ok(NetworkSubscription::new(
+            topic.to_string(),
+            Arc::new(Mutex::new(HashMap::new())),
+        ))
+    }
+
+    fn request(&self, protocol: &str, _payload: &[u8]) -> Result<Vec<u8>, WorldError> {
+        if protocol != super::replication::REPLICATION_FETCH_COMMIT_PROTOCOL {
+            return Err(WorldError::NetworkProtocolUnavailable {
+                protocol: protocol.to_string(),
+            });
+        }
+        serde_json::to_vec(&super::replication::FetchCommitResponse {
+            found: false,
+            message: None,
+        })
+        .map_err(|err| WorldError::DistributedValidationFailed {
+            reason: format!("encode generic fetch commit response failed: {err}"),
+        })
+    }
+
+    fn known_peer_ids(&self) -> Vec<String> {
+        vec!["peer-a".to_string(), "peer-b".to_string()]
+    }
+
+    fn request_with_providers_budget(
+        &self,
+        protocol: &str,
+        _payload: &[u8],
+        providers: &[String],
+        request_timeout_ms: u64,
+        retry_budget_ms: u64,
+    ) -> Result<Vec<u8>, WorldError> {
+        self.budgets
+            .lock()
+            .expect("lock budget captures")
+            .push((request_timeout_ms, retry_budget_ms, providers.to_vec()));
+        if protocol != super::replication::REPLICATION_FETCH_COMMIT_PROTOCOL {
+            return Err(WorldError::NetworkProtocolUnavailable {
+                protocol: protocol.to_string(),
+            });
+        }
+        if providers.is_empty() {
+            return serde_json::to_vec(&super::replication::FetchCommitResponse {
+                found: false,
+                message: None,
+            })
+            .map_err(|err| WorldError::DistributedValidationFailed {
+                reason: format!("encode generic fetch commit response failed: {err}"),
+            });
+        }
+        if providers.first().map(String::as_str) == Some("peer-a") {
+            return Err(WorldError::NetworkRequestFailed {
+                code: DistributedErrorCode::ErrTimeout,
+                message: protocol.to_string(),
+                retryable: true,
+            });
+        }
+        serde_json::to_vec(&super::replication::FetchCommitResponse {
+            found: true,
+            message: None,
+        })
+        .map_err(|err| WorldError::DistributedValidationFailed {
+            reason: format!("encode provider fetch commit response failed: {err}"),
+        })
+    }
+
+    fn register_handler(
+        &self,
+        _protocol: &str,
+        _handler: Box<dyn Fn(&[u8]) -> Result<Vec<u8>, WorldError> + Send + Sync>,
+    ) -> Result<(), WorldError> {
+        Ok(())
+    }
+}
+
 #[test]
 fn gap_sync_fetch_commit_uses_cold_archive_request_budget() {
     let dir_remote = temp_dir("gap-sync-fetch-commit-cold-budget-remote");
@@ -133,6 +222,52 @@ fn gap_sync_fetch_commit_uses_cold_archive_request_budget() {
             .iter()
             .any(|(_, _, providers)| providers == &vec!["peer-a".to_string()]),
         "expected provider-directed gap-sync fetch-commit attempt, got {captures:?}"
+    );
+
+    let _ = fs::remove_dir_all(&dir_remote);
+    let _ = fs::remove_dir_all(&dir_local);
+}
+
+#[test]
+fn gap_sync_fetch_commit_provider_sweep_preserves_budget_for_next_provider() {
+    let dir_remote = temp_dir("gap-sync-fetch-commit-provider-budget-remote");
+    let dir_local = temp_dir("gap-sync-fetch-commit-provider-budget-local");
+    let world_id = "world-gap-sync-fetch-commit-provider-budget";
+    let budgets = Arc::new(Mutex::new(Vec::<(u64, u64, Vec<String>)>::new()));
+    let (_, _, endpoint, _) = network_gap_sync_tests::build_fetch_commit_success_cache_fixture(
+        world_id,
+        dir_remote.as_path(),
+        dir_local.as_path(),
+        140,
+        141,
+        Arc::new(SlowFirstProviderFetchCommitNetwork {
+            budgets: Arc::clone(&budgets),
+        }),
+    );
+    let request = signed_fetch_commit_request_for_test(world_id, 1, 141);
+
+    let response = endpoint
+        .request_fetch_commit_for_gap_sync(&request)
+        .expect("provider sweep should continue after first provider timeout");
+    assert!(
+        response.response.found,
+        "second provider should recover the missing commit"
+    );
+
+    let captures = budgets.lock().expect("lock budget captures").clone();
+    assert!(
+        captures
+            .iter()
+            .any(|(timeout_ms, budget_ms, providers)| *timeout_ms <= 15_000
+                && *budget_ms <= 15_000
+                && providers == &vec!["peer-a".to_string()]),
+        "first provider route should not consume the full sweep budget: {captures:?}"
+    );
+    assert!(
+        captures
+            .iter()
+            .any(|(_, _, providers)| providers == &vec!["peer-b".to_string()]),
+        "provider sweep should try the next provider after timeout: {captures:?}"
     );
 
     let _ = fs::remove_dir_all(&dir_remote);


### PR DESCRIPTION
## Summary
- split provider-directed fetch-commit sweep timeout across remaining provider candidates
- preserve single-provider cold archive behavior while preventing one slow provider from consuming the whole sweep
- add regression for first-provider timeout followed by second-provider recovery

## Verification
- env -u RUSTC_WRAPPER cargo fmt --check
- git diff --check && ./scripts/check-rust-file-size.sh
- env -u RUSTC_WRAPPER cargo test -p oasis7_node gap_sync_fetch_commit -- --nocapture
- env -u RUSTC_WRAPPER cargo test -p oasis7_node network_gap_sync_provider -- --nocapture
- env -u RUSTC_WRAPPER cargo test -p oasis7_node libp2p_replication_network -- --nocapture
- env -u RUSTC_WRAPPER cargo test -p oasis7_node -- --nocapture

Live follow-up after merge: build/deploy next testnet package and recheck five-node health, especially Windows gap-sync catch-up.