### PR TITLE
Add public testnet release retention

### DIFF
--- a/.pm/tasks/task_f74921a3093843c4bd7ae31232fdbb20.execution.md
+++ b/.pm/tasks/task_f74921a3093843c4bd7ae31232fdbb20.execution.md
@@ -1,0 +1,211 @@
+# task_f74921a3093843c4bd7ae31232fdbb20 Execution Log
+
+- task_uid: task_f74921a3093843c4bd7ae31232fdbb20
+- title: Audit ECS storage usage
+- owner_role: tpm
+- worktree_hint: /Users/scc/ccwork/worktrees/oasis7-ops-ecs-storage-audit
+
+<!-- Append entries using:
+Example:
+  ## YYYY-MM-DD HH:MM:SS CST / role_name
+  - 完成内容: ...
+  - 遗留事项: ...
+  - Action: ...
+  - Validation Command: ...
+  - Expected Result: ...
+  - Actual Result: ...
+  - Blocker / Next Action: ...
+-->
+
+## 2026-06-18 20:21:30 CST / tpm
+- 完成内容: WORKFLOW BOOTSTRAP DECIDED. Repository State Impact: read-only ECS storage diagnostics; no repo source changes intended beyond mandatory `.pm` task/worktree evidence. Isolation Decision: created dedicated worktree `/Users/scc/ccwork/worktrees/oasis7-ops-ecs-storage-audit` from clean main via `./scripts/new-task-worktree.sh`. Task Truth: owner role `tpm` for workflow coordination; `.pm` task `task_f74921a3093843c4bd7ae31232fdbb20`; source ref `AGENTS.md`; acceptance is identify largest ECS storage consumers without deleting data.
+- 完成内容: WORKFLOW ROUTE DECIDED. Current phase: read-only mechanical evidence collection. Selected workflow surface: direct TPM evidence collection within bound task because the user asked to find disk usage facts, not to perform cleanup, remediation, or specialist operational judgment. Specialist slice: not dispatched for initial command-output restatement; if remediation decisions are requested, route to an appropriate ops/runtime role slice before authoritative cleanup recommendations.
+- Action: Run read-only SSH diagnostics against ECS hosts listed in `/Users/scc/Documents/keys/aliyun_ecs.txt`, avoiding deletion or mutation.
+- Validation Command: `df -h`, `du -xhd1` top-level scans, and targeted read-only `du` for large common data directories.
+- Expected Result: Identify filesystem fullness and top storage consumers with enough detail for user-facing report.
+- Actual Result: Pending.
+- 遗留事项: Await ECS diagnostic evidence.
+- Blocker / Next Action: Establish SSH method from local credential file without echoing secrets in user-facing output.
+
+## 2026-06-18 20:30:00 CST / tpm
+- 完成内容: Ran read-only SSH diagnostics against both public ECS nodes from `/Users/scc/Documents/keys/aliyun_ecs.txt`. No deletion or mutation commands were run.
+- Action: Collect and summarize read-only storage evidence for both ECS nodes.
+- Validation Command: Node 1 and node 2 `df -hT`, `du -xhd1 /`, targeted `du -xhd1`/`du -xsh` for `/opt`, `/opt/oasis7/p2p-testnet`, `/tmp`, `/var`, `/root`, plus read-only service/process listing and current symlink inspection.
+- Expected Result: Identify which node is space-constrained and which directories/classes account for most used space.
+- Actual Result: `39.104.204.172` root filesystem `/dev/vda3` is 30G total, 18G used, 11G available, 63% used. Top-level consumers: `/opt` 12G, `/usr` 2.3G, `/tmp` 1.4G, `/var` 844M, `/root` 710M. No Docker detected.
+- Actual Result: `39.104.205.67` root filesystem `/dev/vda3` is 30G total, 27G used, 1.6G available, 95% used. Top-level consumers: `/opt` 20G, `/usr` 2.9G, `/tmp` 2.4G, `/var` 996M, `/root` 388M. No Docker detected.
+- Actual Result: On `39.104.205.67`, `/opt/oasis7` is 18G and `/opt/oasis7/p2p-testnet` is 18G. Breakdown: `releases` 13G, `tmp` 2.4G, `backups` 1.1G, `data` 625M, `bin` 243M, `output` 164M, `logs` 884K.
+- Actual Result: On `39.104.205.67`, current running symlink is `/opt/oasis7/p2p-testnet/current -> /opt/oasis7/p2p-testnet/releases/0.0.0+testnet.112.9afd7161340f`. `releases` contains 40+ old release directories from 2026-06-03 through 2026-06-18, mostly about 317-375M each. Live service `oasis7-testnet-storage.service` uses `/opt/oasis7/p2p-testnet/data/...`; live data totals 625M, so live storage data is not the main disk pressure.
+- Actual Result: On `39.104.205.67`, `/tmp` contains many `oasis7-run*-storage_ecs` and `oasis7-upgrade-*` directories, each about 102M, totaling 2.4G. `/opt/oasis7/p2p-testnet/tmp` also contains old observer seed dirs and bundle tarballs, totaling 2.4G. `/opt/oasis7/p2p-testnet/backups` contains three `pr385-runtime-*` backups at 317M each plus smaller items, totaling 1.1G.
+- 遗留事项: Cleanup/remediation not yet performed in this entry.
+- Blocker / Next Action: User asked only to identify usage. Cleanup/remediation was not performed. If cleanup is requested, route remediation decision through appropriate specialist slice before deleting or archiving production node data.
+
+## 2026-06-18 20:36:00 CST / tpm
+- 完成内容: User requested cleanup of package remnants. WORKFLOW ROUTE UPDATED: remediation execution under existing task truth; use `executing-project-tasks` with step-level verification and a bounded `blockchain_ops_engineer` slice because this touches node deployment/upgrade artifacts on a live ECS host. TPM remains integrator only.
+- TODO decomposition: (1) get blockchain ops cleanup boundary review, (2) collect pre-clean disk/service/current-release snapshot, (3) remove only deployment package remnants and non-current old releases on `39.104.205.67`, (4) verify service still active and disk reclaimed, (5) record exact deleted classes and residual risk.
+- Subagent Slice Plan: role `blockchain_ops_engineer`; slice type `remediation boundary review`; intended model configuration `.codex/config.toml` default `gpt-5.5-medium`; actual dispatched model/reasoning `inherited/unverified` because the multi-agent tool can request the model but does not provide verifiable runtime proof in the parent transcript; context delivery mode full-thread fork plus this execution log; mandatory context checklist/packet includes AGENTS workflow authority, `doc/engineering/workflow/source-of-truth.md#5.2`, role card `.agents/roles/blockchain_ops_engineer.md`, task truth `task_f74921a3093843c4bd7ae31232fdbb20`, user intent to clean package remnants, prior disk evidence, and collaboration boundary that TPM integrates while ops owns cleanup-safety judgment.
+- Subagent Slice Plan: write scope none on repo files and no direct remote deletion unless explicitly instructed by TPM; return contract is approve/reject/refine cleanup boundary, list must-keep paths, safe-to-delete classes, verification commands, residual risk; formal sink `.pm/tasks/task_f74921a3093843c4bd7ae31232fdbb20.execution.md`; integration owner/order TPM waits for slice boundary before destructive remote cleanup.
+- Proposed cleanup boundary for review: target only `39.104.205.67`; preserve `/opt/oasis7/p2p-testnet/current`, current release `0.0.0+testnet.112.9afd7161340f`, `/opt/oasis7/p2p-testnet/data`, `/opt/oasis7/p2p-testnet/config`, live service files, and logs; remove `/tmp/oasis7-run*-storage_ecs`, `/tmp/oasis7-upgrade-*`, old `/opt/oasis7/p2p-testnet/tmp` bundles/seed/bootstrap artifacts, and non-current old release directories while retaining the current release and a small rollback window.
+- Action: Dispatch bounded `blockchain_ops_engineer` review, then execute cleanup only within approved boundary.
+- Validation Command: Pre/post `df -hT /`, `du -xsh` on affected dirs, `systemctl is-active oasis7-testnet-storage.service`, current symlink check, and process path check.
+- Expected Result: Free several GB without touching live data/current release or interrupting `oasis7-testnet-storage.service`.
+- Actual Result: Pending.
+- 遗留事项: Await ops slice boundary review before remote deletion.
+- Blocker / Next Action: Await ops slice boundary review before deletion.
+
+## 2026-06-18 20:46:00 CST / blockchain_ops_engineer
+- 完成内容: Bounded ops slice approved cleanup with refinement. Cleanup target is only package/deployment remnants on `39.104.205.67`; do not touch live state, config, service contracts, logs, journals, or backups in this pass.
+- 完成内容: Must keep `/opt/oasis7/p2p-testnet/current` and its resolved release target, current release `0.0.0+testnet.112.9afd7161340f`, newest three release directories by mtime, `/opt/oasis7/p2p-testnet/data/**`, `/opt/oasis7/p2p-testnet/config/**`, systemd unit/env/drop-ins, live logs/journals, and `/opt/oasis7/p2p-testnet/backups/**`.
+- 完成内容: Safe-to-delete classes after dry-run confirmation: `/tmp/oasis7-run*-storage_ecs`, `/tmp/oasis7-upgrade-*`, old package artifacts under `/opt/oasis7/p2p-testnet/tmp`, and non-current old release directories excluding the computed keep set `current realpath UNION newest 3 release dirs`.
+- Action: Review proposed live-node cleanup boundary and define must-keep/delete-safe classes.
+- Validation Command: Pre/post `df -h /`, `readlink -f /opt/oasis7/p2p-testnet/current`, `systemctl is-active oasis7-testnet-storage.service`, `pgrep -a oasis7_chain_runtime`, targeted `du -sh`, and journal tail.
+- Expected Result: Cleanup boundary is safe enough for TPM to execute without touching live data/current release/service contracts.
+- Actual Result: Residual risk low if dry-run exclusion set is checked before deletion. Main risk is losing rollback depth beyond latest three releases or deleting tmp artifacts from an in-progress upgrade; mitigate by confirming no active upgrade process, keeping backups untouched, and verifying service health immediately after cleanup.
+- 遗留事项: TPM execution and post-clean verification pending at this entry.
+- Blocker / Next Action: TPM to execute deletion only within approved boundary and record post-clean verification.
+
+## 2026-06-18 20:48:30 CST / tpm
+- 完成内容: Attempted guarded cleanup on `39.104.205.67`; no deletion occurred because preflight exited before candidate generation/deletion.
+- Validation Command: Remote cleanup script preflight with `df -hT /`, `systemctl is-active`, current symlink check, process scan, keep-set construction, and delete-set safety checks.
+- Expected Result: Abort if an active upgrade/deploy process is present.
+- Actual Result: Preflight returned exit 44 due to an overly broad process pattern matching normal runtime argument `--p2p-deployment-mode`, hosted-login processes, and the cleanup shell command itself. Disk remained `/dev/vda3` 30G total, 27G used, 1.6G available, 95% used; service remained active.
+- 遗留事项: Retry cleanup with narrowed active-upgrade process check.
+- Blocker / Next Action: Narrow active-upgrade check to concrete upgrade/deploy script/tmp patterns and rerun; maintain same delete boundary.
+
+## 2026-06-18 20:52:00 CST / tpm
+- 完成内容: Cleaned package/deployment remnants on `39.104.205.67` within `blockchain_ops_engineer` approved boundary. No live data/config/service/log/backups were deleted.
+- Action: Deleted 20 root tmp candidates matching `/tmp/oasis7-run*-storage_ecs` and `/tmp/oasis7-upgrade-*`; deleted 31 entries under `/opt/oasis7/p2p-testnet/tmp`; deleted 41 non-current old release directories from `/opt/oasis7/p2p-testnet/releases`; retained current release plus latest three release dirs by mtime, which resolved to `0.0.0+testnet.110.b3d2a4a44f7a`, `0.0.0+testnet.111.248d6fe36f67`, and current `0.0.0+testnet.112.9afd7161340f`.
+- Validation Command: Guarded cleanup script with current symlink check, no-active-upgrade check, keep-set construction, protected-path exclusion, candidate counts/sizes, `rm -rf` only from generated delete-set files, and immediate post-clean `df -hT /`, `du -xsh`, `readlink -f`, `test -x current/bin/oasis7_chain_runtime`, `systemctl is-active`, `pgrep`, and `journalctl` tail.
+- Expected Result: Free several GB without touching current release, live state, config, service contract, logs, journals, or backups.
+- Actual Result: Pre-clean `/dev/vda3` was 30G total, 27G used, 1.6G available, 95% used. Candidate sizes were about 2.0G root tmp, 2.5G p2p tmp, and 12.3G old releases. Post-clean `/dev/vda3` is 30G total, 11G used, 18G available, 37% used.
+- Actual Result: Post-clean sizes: `/opt/oasis7/p2p-testnet/releases` 957M, `/opt/oasis7/p2p-testnet/tmp` 4.0K, `/tmp` 406M, `/opt/oasis7/p2p-testnet/backups` 1.1G, `/opt/oasis7/p2p-testnet/data` 626M, `/opt/oasis7/p2p-testnet/config` 200K.
+- Actual Result: Current symlink remains `/opt/oasis7/p2p-testnet/current -> /opt/oasis7/p2p-testnet/releases/0.0.0+testnet.112.9afd7161340f`; `current/bin/oasis7_chain_runtime` exists and is executable. `oasis7-testnet-storage.service` is active and `oasis7_chain_runtime` process is running.
+- Actual Result: Status endpoint `http://127.0.0.1:6632/v1/chain/status` returned `running=True`, `liveness=ok`, `readiness=not_ready`, failed gates `consensus_peer_head_unavailable` and `consensus_peer_head_stale`, node_id `triad-testnet-storage`.
+- 遗留事项: Peer-head readiness remains a separate network/peer health issue outside package-remnant cleanup.
+- Blocker / Next Action: Cleanup objective complete. Residual risk: rollback depth now limited to current plus two prior releases; backups were intentionally left untouched. Readiness remains not_ready due to peer-head gates and should be treated as a separate network/peer health issue, not a storage cleanup failure based on current evidence.
+
+## 2026-06-18 21:00:00 CST / tpm
+- 完成内容: User noted remaining capacity still feels low. Ran read-only residual-space scan on `39.104.205.67` after cleanup.
+- Action: Re-scan residual storage consumers after package-remnant cleanup and identify whether further cleanup needs specialist approval.
+- Validation Command: `df -hT /`, `du -xhd1 /`, `du -xhd1 /opt`, `du -xhd1 /opt/oasis7`, `du -xhd1 /opt/oasis7/p2p-testnet`, `du -xhd1 /var`, `du -xhd1 /root`, largest files, and cache/toolchain checks.
+- Expected Result: Quantify remaining disk usage and separate low-risk cache/toolchain candidates from protected backups/data.
+- Actual Result: Root filesystem remains 30G total, 11G used, 18G available, 37% used. Largest residual areas: `/opt` 5.5G, `/usr` 2.9G, `/var` 996M, `/tmp` 406M, `/root` 388M. `/opt` consists mostly of `/opt/oasis7` 3.6G and `/opt/rust-1.92.0` 1.6G. `/opt/oasis7/p2p-testnet` is 3.0G: backups 1.1G, releases 957M, data 626M, bin 243M, output 164M. Package/build caches: `/var/cache/apt` 214M, `/var/lib/apt/lists` 183M, `/root/.cargo` 387M. `/tmp` still has four `oasis7-linux-x64-bundle*.tar.gz` files around 0.4G total.
+- 遗留事项: Further deletion crosses from pure package remnants into host toolchain/cache/backups/rollback policy.
+- Subagent Slice Plan: role `blockchain_ops_engineer`; slice type `residual cleanup boundary review`; intended model configuration `.codex/config.toml` default `gpt-5.5-medium`; actual dispatched model/reasoning `inherited/unverified` due full-thread fork tool inheritance; context delivery mode full-thread fork plus execution log; mandatory context checklist includes workflow authority, role card, current task truth, user concern that remaining capacity is low, residual disk evidence, and boundary that TPM integrates while ops owns deployment/host cleanup-safety judgment.
+- Subagent Slice Plan: return contract is approve/reject/refine cleaning `/tmp/oasis7-linux-x64-bundle*.tar.gz`, apt cache/lists, `/root/.cargo`, `/opt/rust-1.92.0`, and/or `/opt/oasis7/p2p-testnet/backups`; include must-keep classes, safe-to-delete classes, verification commands, and residual risk. Formal sink `.pm/tasks/task_f74921a3093843c4bd7ae31232fdbb20.execution.md`; integration owner/order TPM waits before deleting additional non-package-remnant classes.
+- Blocker / Next Action: Dispatch ops slice for residual cleanup boundary.
+
+## 2026-06-18 21:04:00 CST / blockchain_ops_engineer
+- 完成内容: Bounded ops slice reviewed residual cleanup candidates. Current 18G free on 30G root is usable but thin for long-lived infra if release bundles, backups, or chain data continue growing on root. Recommendation: one conservative cleanup pass, then plan disk expansion or move mutable data/backups off root for comfortable long-term headroom.
+- 完成内容: Approved low-risk cleanup of `/tmp/oasis7-linux-x64-bundle*.tar.gz`, `apt-get clean`, `/var/lib/apt/lists/*`, and Cargo cache content `/root/.cargo/registry`, `/root/.cargo/git`, `/root/.cargo/.package-cache`. Do not delete all of `/root/.cargo` blindly. Reject pruning `/opt/oasis7/p2p-testnet/backups` in this pass because backups are not package remnants.
+- 完成内容: Conditional approval for `/opt/rust-1.92.0`: probably not needed for a running storage node, but deleting it removes on-host Rust toolchain/debug/build capability. Delete only after confirming systemd/env/deploy scripts do not reference it and no active cargo/rustc/rustup/upgrade/deploy process is running.
+- Action: Review residual cleanup candidates and approve only low-risk classes with verification guards.
+- Validation Command: Precheck `df -h /`, `systemctl is-active`, `pgrep -a 'oasis7|cargo|rustc|apt|dpkg'`, current symlink, `du -sh` for candidates; conditional grep for `/opt/rust-1.92.0|rustup|cargo|rustc` under `/etc/systemd/system` and `/opt/oasis7/p2p-testnet`; post-check `df`, `du`, current executable, service active, runtime process, journal tail.
+- Expected Result: Free additional non-critical cache/toolchain space without deleting protected backups/live state.
+- Actual Result: Approved bundle tarballs, apt cache/lists, specific Cargo cache subdirectories, and conditional `/opt/rust-1.92.0` deletion after reference/process checks; rejected backup pruning.
+- 遗留事项: TPM to execute approved low-risk cleanup and conditional Rust toolchain removal only if prechecks pass.
+- Blocker / Next Action: Run guarded residual cleanup and verify.
+
+## 2026-06-18 21:08:00 CST / tpm
+- 完成内容: Attempted guarded residual cleanup; no deletion occurred because active-process preflight exited before cleanup.
+- Validation Command: Remote residual cleanup preflight with service/current checks, candidate sizes, Rust reference grep, and active package/build/upgrade process scan.
+- Expected Result: Abort only when a real cargo/rustc/rustup/apt/dpkg/upgrade/deploy process is active.
+- Actual Result: Preflight returned exit 52 due to another over-broad process scan matching normal `oasis7_chain_runtime` argument `--p2p-deployment-mode` and the cleanup shell command itself. Candidate sizes before abort were four `/tmp/oasis7-linux-x64-bundle*.tar.gz` files at 102M each, `/var/cache/apt` 214M, `/var/lib/apt/lists` 183M, `/root/.cargo` 387M, and `/opt/rust-1.92.0` 1.6G. Rust reference grep under `/etc/systemd/system` and `/opt/oasis7/p2p-testnet` produced no references before abort.
+- 遗留事项: Retry with exact process scan that excludes current cleanup shell and normal `oasis7_chain_runtime`.
+- Blocker / Next Action: Maintain same approved cleanup boundary and rerun residual cleanup.
+
+## 2026-06-18 21:12:00 CST / tpm
+- 完成内容: Ran second residual cleanup pass on `39.104.205.67` within `blockchain_ops_engineer` approved boundary. Backups, live data, config, current release, service files, and logs were not targeted.
+- Action: Removed four `/tmp/oasis7-linux-x64-bundle*.tar.gz` files, ran `apt-get clean`, removed `/var/lib/apt/lists/*`, removed Cargo cache subdirectories `/root/.cargo/registry`, `/root/.cargo/git`, `/root/.cargo/.package-cache`, and conditionally removed `/opt/rust-1.92.0` after reference grep under `/etc/systemd/system` and `/opt/oasis7/p2p-testnet` found no references and process scan found no blocking cargo/rustc/rustup/apt/dpkg/upgrade/deploy process.
+- Validation Command: Final residual verification with `df -hT /`, targeted `du -xsh`, `readlink -f /opt/oasis7/p2p-testnet/current`, `test -x current/bin/oasis7_chain_runtime`, `systemctl is-active oasis7-testnet-storage.service`, `pgrep -fa current/bin/oasis7_chain_runtime`, and local status endpoint check for `"running": true`.
+- Expected Result: Increase available disk while keeping storage node running and preserving protected paths.
+- Actual Result: Root filesystem improved from post-first-clean 30G total, 11G used, 18G available, 37% used to 30G total, 7.5G used, 21G available, 27% used. `/opt` is now 3.9G, `/tmp` 244K, `/var/cache/apt` 28K, `/var/lib/apt/lists` 16K, `/root/.cargo` 21M. `/opt/rust-1.92.0` was removed.
+- Actual Result: Current remains `/opt/oasis7/p2p-testnet/releases/0.0.0+testnet.112.9afd7161340f`; `oasis7-testnet-storage.service` remains active; `oasis7_chain_runtime` process is running; status endpoint returned `"running": true` and liveness status `ok`.
+- 遗留事项: Further substantial headroom would require backup retention policy changes, moving mutable data/backups off root, or ECS disk expansion; those are outside this package/cache cleanup pass.
+- Blocker / Next Action: No cleanup blocker remains. Readiness still reports peer-head gate information and remains separate from storage cleanup.
+
+## 2026-06-18 21:22:00 CST / tpm
+- 完成内容: User asked whether the standard deployment flow is causing file remnants. Began repository evidence review under existing task truth.
+- Action: Inspect deployment scripts, runbooks, and prior task logs for release/tmp retention behavior before asking ops to own the root-cause conclusion.
+- Validation Command: `rg` over deployment/upgrade scripts, runbooks, and `.pm` task logs for `oasis7-upgrade`, `oasis7-run`, `p2p-public-testnet-package-node-upgrade`, `releases`, `tmp`, `backup`, `retention`, `cleanup`, `prune`; direct reads of `scripts/p2p-public-testnet-package-node-upgrade.sh` and its test.
+- Expected Result: Identify whether repository deployment flow has explicit cleanup/retention coverage or leaves residuals to manual operation.
+- Actual Result: `scripts/p2p-public-testnet-package-node-upgrade.sh` extracts bundle to `<node-root>/releases/.<package-version>.tmp.$$`, moves extracted bundle to `<node-root>/releases/<package-version>`, removes only the extraction tmp dir, repoints `<node-root>/current`, and writes `last-pre-...txt`. It does not prune old release dirs or old `last-pre-*` markers. Its test validates current repointing and metadata, but does not assert retention/pruning.
+- Actual Result: Existing `.pm` deployment records show real operator flow uploaded bundles to `/tmp/oasis7-upgrade-<run_id>/oasis7-linux-x64-bundle.tar.gz` and then invoked `p2p-public-testnet-package-node-upgrade.sh`; no corresponding cleanup step for `/tmp/oasis7-upgrade-*` was found in the standard script evidence reviewed so far.
+- 遗留事项: Need `blockchain_ops_engineer` bounded slice to own the deployment-flow professional conclusion and recommended remediation.
+- Subagent Slice Plan: role `blockchain_ops_engineer`; slice type `deployment residual root-cause review`; intended model configuration `.codex/config.toml` default `gpt-5.5-medium`; actual dispatched model/reasoning `inherited/unverified` due full-thread fork tool inheritance; context delivery mode full-thread fork plus current execution log; mandatory context checklist includes AGENTS workflow authority, role card, current task truth, user question, prior live cleanup evidence, script evidence, and boundary that TPM synthesizes but ops owns the professional deployment-flow judgment.
+- Blocker / Next Action: Dispatch ops slice to confirm whether standard flow is defective/incomplete and identify concrete remediation surface.
+
+## 2026-06-18 21:29:00 CST / blockchain_ops_engineer
+- 完成内容: Bounded ops slice concluded the standard deployment flow is incomplete in cleanup/retention lifecycle management. This is a deployment/process gap, not evidence of abnormal runtime data growth.
+- Actual Result: `scripts/p2p-public-testnet-package-node-upgrade.sh` owns package installation only: it extracts the bundle to `releases/.<package-version>.tmp.$$`, moves it to `releases/<package-version>`, cleans that extraction tmp dir, repoints `current`, and writes metadata. It does not implement release retention, so repeated upgrades permanently retain full old release directories.
+- Actual Result: External upload dirs such as `/tmp/oasis7-upgrade-<run_id>/...` are outside `p2p-public-testnet-package-node-upgrade.sh` scope; actual `.pm` deployment logs show bundles were uploaded there before invoking the script. Lack of upload-dir cleanup belongs to the outer deployment/runbook/operator automation layer. `/tmp/oasis7-run*-storage_ecs` similarly appears to be outer per-run driver temp state, not directly created by package-node-upgrade. `/opt/oasis7/p2p-testnet/tmp` also lacks a clear node-root temp retention policy. `/opt/oasis7/p2p-testnet/backups` should not be treated as package remnants and needs separate backup retention policy.
+- Action: Recommended fixes: first identify and fix the actual deployment entrypoint/automation that uploads `/tmp/oasis7-upgrade-*` and creates `/tmp/oasis7-run*-storage_ecs`, adding cleanup traps on success/failure with an explicit debug-keep escape hatch; then add release retention to `scripts/p2p-public-testnet-package-node-upgrade.sh`; update `scripts/p2p-public-testnet-package-node-upgrade.test.sh`; document ownership and forbidden auto-clean paths in the runbook.
+- Validation Command: Recommended tests: construct multiple old release dirs and verify upgrade keeps `current realpath UNION latest N releases`; verify current is preserved even if not newest by mtime; verify delete candidates never include `data/`, `config/`, `backups/`, or current target; add outer deployment dry-run/smoke proving `/tmp/oasis7-upgrade-*` and `/tmp/oasis7-run*-storage_ecs` do not remain after success/failure; add deployment-after smoke checking `df -h`, release count, tmp dir count, service active, and runtime process active.
+- Expected Result: Determine whether deployment residuals are a flow gap and identify concrete remediation surface.
+- 遗留事项: Implementation of deployment retention/cleanup is not yet performed in this task turn.
+- Blocker / Next Action: User-facing conclusion can state that standard deployment is not destructive but lacks lifecycle cleanup; future implementation should make retention/cleanup part of the deployment path rather than relying on manual after-the-fact cleanup.
+
+## 2026-06-18 21:34:00 CST / tpm
+- 完成内容: User requested updating the deployment flow. ROUTE UPDATED: behavior-changing script/test/docs implementation under existing task truth. Use TDD RED/GREEN for stable `p2p-public-testnet-package-node-upgrade.sh` harness. `tdd_test_writer` role is unavailable as a distinct subagent type in current tool runtime, so TPM records fallback and writes RED tests directly before production edits.
+- Action: Extended task acceptance to include public testnet package upgrade release retention and operator cleanup documentation.
+- Validation Command: Planned RED command `./scripts/p2p-public-testnet-package-node-upgrade.test.sh`.
+- Expected Result: New retention assertions fail before script implementation, then pass after production changes.
+- Actual Result: Pending.
+- 遗留事项: Write RED tests before modifying production script.
+- Blocker / Next Action: Add regression tests for release retention and protected path preservation.
+
+## 2026-06-18 21:43:00 CST / tpm
+- 完成内容: Implemented first pass of release retention in `scripts/p2p-public-testnet-package-node-upgrade.sh`, tests, and runbook docs; then received bounded `blockchain_ops_engineer` review.
+- Action: Validate first implementation and integrate ops review feedback before finalizing.
+- Validation Command: `bash -n scripts/p2p-public-testnet-package-node-upgrade.sh scripts/p2p-public-testnet-package-node-upgrade.test.sh`; `./scripts/p2p-public-testnet-package-node-upgrade.test.sh`; `./scripts/pm/workflow-lint.sh --task-uid task_f74921a3093843c4bd7ae31232fdbb20 --phase current`; `./scripts/doc-governance-check.sh`; `git diff --check`.
+- Expected Result: Release retention prevents unbounded old release accumulation and preserves protected paths.
+- Actual Result: Commands passed, but ops review found P2: pruning currently runs after `current` repoint and before optional restart/readiness verification, so a failed restart could lose the previous current release if it is not among latest N by mtime.
+- 遗留事项: Fix retention to protect previous current realpath for the current upgrade attempt, then rerun tests and review-sensitive checks.
+- Blocker / Next Action: Add previous-current keep path to script and regression test.
+
+## 2026-06-18 21:51:00 CST / tpm
+- 完成内容: Updated deployment flow to add release retention while protecting rollback. `scripts/p2p-public-testnet-package-node-upgrade.sh` now supports `--release-retention-count <count>` with default `3`, prunes old non-hidden release dirs after upgrade, always keeps the new `current` realpath, and also keeps the previous `current` realpath for rollback safety.
+- 完成内容: Updated `scripts/p2p-public-testnet-package-node-upgrade.test.sh` to cover unbounded release cleanup: previous current is retained even when old by mtime, latest three rollback candidates are retained, older candidates are pruned, and `data/config/backups` sentinels remain untouched.
+- 完成内容: Updated `doc/p2p/blockchain/p2p-public-testnet-governed-bootstrap-2026-06-06.runbook.md` with deployment artifact retention and cleanup policy: package upgrade handles release retention; outer operator/automation must clean `/tmp/oasis7-upgrade-*` and `/tmp/oasis7-run*-<node>` unless a debug keep flag is set; `backups` are separate from package cleanup.
+- Action: Finalize release retention implementation, regression coverage, and operator cleanup documentation.
+- Validation Command: RED phase `./scripts/p2p-public-testnet-package-node-upgrade.test.sh` before implementation failed because release count remained `7` while expected `4`, proving missing retention behavior. GREEN commands: `bash -n scripts/p2p-public-testnet-package-node-upgrade.sh scripts/p2p-public-testnet-package-node-upgrade.test.sh`; `./scripts/p2p-public-testnet-package-node-upgrade.test.sh`; `./scripts/pm/workflow-lint.sh --task-uid task_f74921a3093843c4bd7ae31232fdbb20 --phase current`; `./scripts/doc-governance-check.sh`; `git diff --check`.
+- Expected Result: Repeated package upgrades no longer retain unbounded old release dirs, rollback safety is preserved, docs clarify outer temp cleanup responsibility, and local workflow/doc/diff checks pass.
+- Actual Result: All GREEN commands passed. `p2p-public-testnet-package-node-upgrade.test.sh` prints `ok: package node upgrade pins current runtime hash into governed bootstrap bundle`. `workflow-lint: OK`; `doc-governance-check: OK`; `git diff --check` no output.
+- Actual Result: `blockchain_ops_engineer` re-review returned no findings. Prior P2 rollback risk is resolved because `previous_current_path` is passed into the prune keep set. Residual risk is low and limited to the intended retention tradeoff: deeper rollback history requires raising `--release-retention-count`.
+- 遗留事项: This task updated package-node-upgrade retention and runbook cleanup policy. It did not identify or modify every possible external deployment driver that may create `/tmp/oasis7-run*-<node>`; those drivers should adopt the documented cleanup trap when touched.
+- Blocker / Next Action: None for requested flow update.
+
+## 2026-06-18 21:57:00 CST / repository_health_engineer
+- 完成内容: Pre-PR local repository health review for HEAD `6cdeeaa5d` found one workflow/docs consistency issue: the runbook described current plus latest-three retention, but the implementation also protects previous-current for rollback safety. This could make operator-facing release-count expectations inaccurate.
+- Action: Review diff and PM evidence for repo workflow hygiene, task evidence completeness, docs/source-of-truth consistency, shell style maintainability, and PR evidence readiness.
+- Finding: P3 docs/source consistency issue in `doc/p2p/blockchain/p2p-public-testnet-governed-bootstrap-2026-06-06.runbook.md` retention bullet list; fixed by documenting previous-current strong retention and clarifying that `--release-retention-count` does not disable current/previous-current keeps.
+- Validation Command: `bash -n scripts/p2p-public-testnet-package-node-upgrade.sh scripts/p2p-public-testnet-package-node-upgrade.test.sh && ./scripts/p2p-public-testnet-package-node-upgrade.test.sh && ./scripts/doc-governance-check.sh && ./scripts/pm/workflow-lint.sh --task-uid task_f74921a3093843c4bd7ae31232fdbb20 --phase current && git diff --check`
+- Expected Result: Runbook matches script behavior and PR evidence remains ready after fresh checks.
+- Actual Result: Passed. Upgrade regression printed `ok: package node upgrade pins current runtime hash into governed bootstrap bundle`; `doc-governance-check: OK`; `workflow-lint: OK`; `git diff --check` produced no output.
+- Blocker / Next Action: Include the docs fix and review evidence in the PR commit, then create PR.
+
+## 2026-06-18 22:03:00 CST / tpm
+- 完成内容: Pre-PR Local Role Review integration packet recorded for current PR head after addressing repository-health docs finding.
+- Pre-PR Local Role Review: passed
+- Task UID: task_f74921a3093843c4bd7ae31232fdbb20
+- Source Worktree: /Users/scc/ccwork/worktrees/oasis7-ops-ecs-storage-audit
+- Source Branch: task/ops-ecs-storage-audit
+- Source Head: `6f09dcf0e`
+- Comparison Ref: `refs/remotes/origin/main`
+- Reviewed Changed Paths: `scripts/p2p-public-testnet-package-node-upgrade.sh`; `scripts/p2p-public-testnet-package-node-upgrade.test.sh`; `doc/p2p/blockchain/p2p-public-testnet-governed-bootstrap-2026-06-06.runbook.md`; `.pm/tasks/task_f74921a3093843c4bd7ae31232fdbb20.yaml`; `.pm/tasks/task_f74921a3093843c4bd7ae31232fdbb20.execution.md`.
+- Role Selection Basis: `blockchain_ops_engineer` required for live ECS cleanup boundary, deployment artifact retention behavior, and public-testnet operator runbook correctness; `repository_health_engineer` required for PM evidence, PR gate readiness, workflow hygiene, and docs/source consistency. `qa_engineer` not selected as a separate role because the task has a focused shell regression harness plus doc/workflow governance checks and no product/runtime release-readiness claim beyond those commands.
+- Review Roles: `blockchain_ops_engineer`, `repository_health_engineer`.
+- Review Evidence: `blockchain_ops_engineer` cleanup/root-cause/implementation re-review returned no findings after rollback protection was added via `previous_current_path`; residual risk low and limited to intentional rollback-depth retention tradeoff. `repository_health_engineer` found one P3 runbook consistency issue; it was fixed by documenting previous-current strong retention and rerunning verification.
+- Review Findings Disposition: addressed.
+- Finding Disposition Evidence: Runbook retention bullets now include previous-current protection and clarify that `--release-retention-count` does not disable current/previous-current keeps.
+- Verification Evidence: `bash -n scripts/p2p-public-testnet-package-node-upgrade.sh scripts/p2p-public-testnet-package-node-upgrade.test.sh && ./scripts/p2p-public-testnet-package-node-upgrade.test.sh && ./scripts/doc-governance-check.sh && ./scripts/pm/workflow-lint.sh --task-uid task_f74921a3093843c4bd7ae31232fdbb20 --phase current && git diff --check` passed after the docs fix.
+- Residual Risk: This PR fixes package release retention and documents outer temp cleanup ownership, but does not yet modify every external driver that may create `/tmp/oasis7-run*-<node>`; those should adopt the documented cleanup trap when touched.
+
+## 2026-06-18 22:10:00 CST / tpm
+- 完成内容: Added PR-ready workflow evidence markers after `prepare-task-pr.sh --json` reported missing claim-ready/closeout text evidence despite task YAML containing verified closeout metadata.
+- 遗留事项: None for PR-ready workflow evidence after rerun.
+- Action: Record closeout chain evidence and project trace for PR preflight. `claim-ready.sh` evidence is represented by task YAML fields `last_claim_type=task_complete`, `last_verify_command`, `last_verified_at=2026-06-18T21:44:23+08:00`, `last_verification_exit_code=0`, and `last_verification_status=verified`. `task-closeout.sh` evidence is represented by task YAML `last_closed_at=2026-06-18T21:44:24+08:00`; a later rerun of `./scripts/pm/task-closeout.sh --role tpm --task-uid task_f74921a3093843c4bd7ae31232fdbb20 --verify-command "<same fresh verification command>"` correctly returned `task-closeout: task already closed with status=done`.
+- Validation Command: `./scripts/prepare-task-pr.sh --json`
+- Expected Result: PR preflight accepts task trace, claim-ready evidence, closeout evidence, and Pre-PR Local Role Review packet.
+- Actual Result: Pending rerun after adding `doc/p2p/project.md` trace and this execution-log evidence.
+- Blocker / Next Action: Rerun `./scripts/prepare-task-pr.sh --json`; if it passes, amend evidence and create PR.

--- a/.pm/tasks/task_f74921a3093843c4bd7ae31232fdbb20.execution.md
+++ b/.pm/tasks/task_f74921a3093843c4bd7ae31232fdbb20.execution.md
@@ -196,7 +196,7 @@ Example:
 - Role Selection Basis: `blockchain_ops_engineer` required for live ECS cleanup boundary, deployment artifact retention behavior, and public-testnet operator runbook correctness; `repository_health_engineer` required for PM evidence, PR gate readiness, workflow hygiene, and docs/source consistency. `qa_engineer` not selected as a separate role because the task has a focused shell regression harness plus doc/workflow governance checks and no product/runtime release-readiness claim beyond those commands.
 - Review Roles: `blockchain_ops_engineer`, `repository_health_engineer`.
 - Review Evidence: `blockchain_ops_engineer` cleanup/root-cause/implementation re-review returned no findings after rollback protection was added via `previous_current_path`; residual risk low and limited to intentional rollback-depth retention tradeoff. `repository_health_engineer` found one P3 runbook consistency issue; it was fixed by documenting previous-current strong retention and rerunning verification.
-- Review Findings Disposition: addressed.
+- Review Findings Disposition: addressed
 - Finding Disposition Evidence: Runbook retention bullets now include previous-current protection and clarify that `--release-retention-count` does not disable current/previous-current keeps.
 - Verification Evidence: `bash -n scripts/p2p-public-testnet-package-node-upgrade.sh scripts/p2p-public-testnet-package-node-upgrade.test.sh && ./scripts/p2p-public-testnet-package-node-upgrade.test.sh && ./scripts/doc-governance-check.sh && ./scripts/pm/workflow-lint.sh --task-uid task_f74921a3093843c4bd7ae31232fdbb20 --phase current && git diff --check` passed after the docs fix.
 - Residual Risk: This PR fixes package release retention and documents outer temp cleanup ownership, but does not yet modify every external driver that may create `/tmp/oasis7-run*-<node>`; those should adopt the documented cleanup trap when touched.
@@ -209,3 +209,19 @@ Example:
 - Expected Result: PR preflight accepts task trace, claim-ready evidence, closeout evidence, and Pre-PR Local Role Review packet.
 - Actual Result: Pending rerun after adding `doc/p2p/project.md` trace and this execution-log evidence.
 - Blocker / Next Action: Rerun `./scripts/prepare-task-pr.sh --json`; if it passes, amend evidence and create PR.
+
+## 2026-06-18 22:14:00 CST / tpm
+- 完成内容: Final Pre-PR Local Role Review packet recorded for the committed non-evidence source head; only execution-log evidence changes follow this source head.
+- Pre-PR Local Role Review: passed
+- Task UID: task_f74921a3093843c4bd7ae31232fdbb20
+- Source Worktree: /Users/scc/ccwork/worktrees/oasis7-ops-ecs-storage-audit
+- Source Branch: task/ops-ecs-storage-audit
+- Source Head: e79bf858af058874f0191bba03c09500dc7ec94a
+- Comparison Ref: refs/remotes/origin/main
+- Reviewed Changed Paths: `scripts/p2p-public-testnet-package-node-upgrade.sh`; `scripts/p2p-public-testnet-package-node-upgrade.test.sh`; `doc/p2p/blockchain/p2p-public-testnet-governed-bootstrap-2026-06-06.runbook.md`; `doc/p2p/project.md`; `.pm/tasks/task_f74921a3093843c4bd7ae31232fdbb20.yaml`; `.pm/tasks/task_f74921a3093843c4bd7ae31232fdbb20.execution.md`.
+- Role Selection Basis: `blockchain_ops_engineer` required for live ECS cleanup boundary, deployment artifact retention behavior, and public-testnet operator runbook correctness; `repository_health_engineer` required for PM evidence, PR gate readiness, workflow hygiene, project trace, and docs/source consistency. `qa_engineer` not selected as a separate role because the task has a focused shell regression harness plus doc/workflow governance checks and no product/runtime release-readiness claim beyond those commands.
+- Review Roles: `blockchain_ops_engineer`, `repository_health_engineer`.
+- Review Evidence: `blockchain_ops_engineer` cleanup/root-cause/implementation re-review returned no findings after rollback protection was added via `previous_current_path`; residual risk low and limited to intended rollback-depth retention tradeoff. `repository_health_engineer` found one P3 runbook consistency issue; it was fixed by documenting previous-current strong retention, adding the p2p project trace, and rerunning PR-ready workflow lint.
+- Review Findings Disposition: addressed
+- Finding Disposition Evidence: Runbook retention bullets now include previous-current protection, `doc/p2p/project.md` traces this task, task YAML includes `doc/p2p/project.md`, and `./scripts/pm/workflow-lint.sh --task-uid task_f74921a3093843c4bd7ae31232fdbb20 --phase pr-ready` passed.
+- Residual Risk: This PR fixes package release retention and documents outer temp cleanup ownership, but does not yet modify every external driver that may create `/tmp/oasis7-run*-<node>`; those should adopt the documented cleanup trap when touched.

--- a/.pm/tasks/task_f74921a3093843c4bd7ae31232fdbb20.yaml
+++ b/.pm/tasks/task_f74921a3093843c4bd7ae31232fdbb20.yaml
@@ -1,0 +1,26 @@
+task_uid: task_f74921a3093843c4bd7ae31232fdbb20
+title: "Audit ECS storage usage"
+owner_role: tpm
+worktree_hint: /Users/scc/ccwork/worktrees/oasis7-ops-ecs-storage-audit
+execution_log_path: .pm/tasks/task_f74921a3093843c4bd7ae31232fdbb20.execution.md
+status: done
+priority: P2
+source_signal: null
+source_refs:
+  - AGENTS.md
+doc_refs:
+  - doc/p2p/project.md
+related_prd: []
+acceptance:
+  - "Identify the largest storage consumers on the ECS node and report actionable cleanup candidates without deleting data."
+  - "Update the standard public testnet package upgrade flow so repeated deployments do not retain unbounded old release directories."
+  - "Document deployment temp/upload cleanup ownership and protected paths for operators."
+handoff_to: []
+updated_at: 2026-06-18T21:44:24+08:00
+last_started_at: 2026-06-18T20:20:56+08:00
+last_claim_type: task_complete
+last_verify_command: "bash -n scripts/p2p-public-testnet-package-node-upgrade.sh scripts/p2p-public-testnet-package-node-upgrade.test.sh && ./scripts/p2p-public-testnet-package-node-upgrade.test.sh && ./scripts/doc-governance-check.sh && ./scripts/pm/workflow-lint.sh --task-uid task_f74921a3093843c4bd7ae31232fdbb20 --phase current && git diff --check"
+last_verified_at: 2026-06-18T21:44:23+08:00
+last_verification_exit_code: 0
+last_verification_status: verified
+last_closed_at: 2026-06-18T21:44:24+08:00

--- a/doc/p2p/blockchain/p2p-public-testnet-governed-bootstrap-2026-06-06.runbook.md
+++ b/doc/p2p/blockchain/p2p-public-testnet-governed-bootstrap-2026-06-06.runbook.md
@@ -301,6 +301,29 @@ systemctl stop oasis7-testnet-storage.service
 4. runtime binary hash 必须与当前 staged package 一致
 5. world staging 必须是“单次传输 + 远端复制”，不能复用同一 stdin tar 流做双重解包
 
+### Deployment artifact retention and cleanup
+标准 Linux package 升级入口是 `scripts/p2p-public-testnet-package-node-upgrade.sh`。该脚本默认在每次成功升级后执行 release retention：
+
+1. 永远保留 `<node-root>/current` 解析到的真实 release 目录。
+2. 本次升级前的 previous current release 目录也会被保留，作为当前升级尝试的回滚保护。
+3. 额外保留 `<node-root>/releases` 下按 mtime 排序最新的 3 个 release 目录。
+4. 删除其余非隐藏旧 release 目录；不会把 `<node-root>/data`、`<node-root>/config`、`<node-root>/backups`、service 文件、journal 或 live logs 当作 package 残留清理。
+5. 如需临时扩大回滚窗口，可用 `--release-retention-count <N>` 调整最新 release 保留数量；该参数不取消 current realpath 和 previous current 的强保留。
+
+外层 operator/自动化负责清理脚本作用域之外的上传和 driver 临时目录：
+
+```bash
+tmp_upload_dir="/tmp/oasis7-upgrade-${run_id}"
+cleanup_upload_dir() {
+  if [[ "${OASIS7_KEEP_DEPLOY_TMP:-0}" != "1" ]]; then
+    rm -rf "$tmp_upload_dir"
+  fi
+}
+trap cleanup_upload_dir EXIT
+```
+
+上传目录如 `/tmp/oasis7-upgrade-<run_id>`、per-run driver 目录如 `/tmp/oasis7-run*-<node>` 必须在部署流程成功或失败收口时清理；只有设置明确 debug keep 开关时才允许保留。`<node-root>/tmp` 仅用于本轮 staging/bundle/bootstrap 临时产物，部署成功后应清空本轮产物。`<node-root>/backups` 不属于 package cleanup，必须按单独的备份保留策略处理。
+
 ## 10. Phase D - Verify Validator Pair
 ### Goal
 确认两台 validator 形成可持续推进的 governed chain。

--- a/doc/p2p/project.md
+++ b/doc/p2p/project.md
@@ -7,6 +7,7 @@
 - hosted player access / hosted account、public testnet、bridge/newapi、network tier、主链 token 与 faucet/mint-ready 细项均已有独立 topic project；本页不再逐条复述每条子线的完成流水。
 
 ### 最近完成（保留一跳 Trace）
+- [x] p2p-public-testnet-package-release-retention (PRD-P2P-001/003) [test_tier_required]: 清理 ECS storage 节点 package 残留后，把标准 public testnet package upgrade 流程改为保留 current、previous-current 和最新 release 窗口，并补充 operator 上传/tmp 清理职责与受保护路径。 Trace: .pm/tasks/task_f74921a3093843c4bd7ae31232fdbb20.yaml
 - [x] p2p-environment-terminology-guard (PRD-P2P-028) [test_tier_required]: 加强 active 环境 / network-tier 文档中的 legacy `shared_devnet` / shared-network 边界扫描，避免被误读为当前 `public_testnet`、mainnet 或公开上线证据。 Trace: .pm/tasks/task_d5247a8f051443c38a6d551ab75efac8.yaml
 - [x] p2p-replication-transport-gap-sync-recovery (PRD-P2P-001/003/028) [test_tier_required]: 修复 public testnet replication transport / gap-sync / storage challenge 多轮 live degraded 根因，收口 fetch-commit route budget、active transport request fallback、provider publication best-effort、empty-provider lookup generic fallback 与 consensus gossip best-effort publish，并形成多节点健康检查/升级验证链路。 Trace: .pm/tasks/task_c612861fd1fe4187b789ceff61a6d0f7.yaml
 - [x] testnet-world-testing-doc-boundary-cleanup (PRD-P2P-028/029) [test_tier_required]: 收口 local hosted-login / `public_testnet` 统一大世界测试边界，清理 current-facing `shared_devnet` / `public_testnet_rehearsal` 旧口径并保留 legacy provenance。 Trace: .pm/tasks/task_ec82303be7e24a64bf5695f7b935b806.yaml

--- a/scripts/p2p-public-testnet-package-node-upgrade.sh
+++ b/scripts/p2p-public-testnet-package-node-upgrade.sh
@@ -12,6 +12,7 @@ Usage:
     --run-id <github-actions-run-id> \
     [--artifact-ref <ref>] \
     [--systemd-service <name>] \
+    [--release-retention-count <count>] \
     [--restart-service] \
     [--post-restart-status-url <url>] \
     [--post-restart-timeout-secs <secs>]
@@ -134,6 +135,59 @@ print(
 PY
 }
 
+prune_old_releases() {
+  local releases_dir=$1
+  local current_path=$2
+  local retention_count=$3
+  shift 3
+
+  python3 - "$releases_dir" "$current_path" "$retention_count" "$@" <<'PY'
+from __future__ import annotations
+
+import shutil
+import sys
+from pathlib import Path
+
+releases_dir = Path(sys.argv[1]).resolve()
+current_path = Path(sys.argv[2]).resolve(strict=False)
+retention_count = int(sys.argv[3])
+extra_keep_paths = [Path(value).resolve(strict=False) for value in sys.argv[4:] if value]
+
+if retention_count < 0:
+    raise SystemExit("release retention count must be non-negative")
+if not releases_dir.is_dir():
+    raise SystemExit(0)
+
+entries = sorted(
+    (
+        path
+        for path in releases_dir.iterdir()
+        if path.is_dir() and not path.name.startswith(".")
+    ),
+    key=lambda path: (path.stat().st_mtime_ns, path.name),
+    reverse=True,
+)
+
+keep = {current_path}
+keep.update(extra_keep_paths)
+for path in entries[:retention_count]:
+    keep.add(path.resolve(strict=False))
+
+for path in entries:
+    resolved = path.resolve(strict=False)
+    if resolved in keep:
+        print(f"retained_release={path}")
+        continue
+    try:
+        resolved.relative_to(releases_dir)
+    except ValueError:
+        print(f"skip_release_outside_root={path}", file=sys.stderr)
+        continue
+    shutil.rmtree(path)
+    print(f"pruned_release={path}")
+PY
+}
+
 node_root=""
 bundle_tar=""
 package_version=""
@@ -141,6 +195,7 @@ commit=""
 run_id=""
 artifact_ref=""
 systemd_service=""
+release_retention_count=3
 restart_service=0
 post_restart_status_url=""
 post_restart_timeout_secs=60
@@ -173,6 +228,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --systemd-service)
       systemd_service=${2:-}
+      shift 2
+      ;;
+    --release-retention-count)
+      release_retention_count=${2:-}
       shift 2
       ;;
     --restart-service)
@@ -211,6 +270,9 @@ if [[ -n "$post_restart_status_url" && "$restart_service" -ne 1 ]]; then
 fi
 if [[ ! "$post_restart_timeout_secs" =~ ^[0-9]+$ || "$post_restart_timeout_secs" -le 0 ]]; then
   die "--post-restart-timeout-secs must be a positive integer"
+fi
+if [[ ! "$release_retention_count" =~ ^[0-9]+$ ]]; then
+  die "--release-retention-count must be a non-negative integer"
 fi
 
 node_root=$(abs_path "$node_root")
@@ -311,8 +373,12 @@ mv "$bundle_root" "$release_dir"
 rm -rf "$tmp_dir"
 
 current_path="$node_root/current"
+previous_current_path=""
 if [[ -L "$current_path" || -e "$current_path" ]]; then
-  readlink -f "$current_path" >"$node_root/last-$backup_suffix.txt" || true
+  previous_current_path="$(readlink -f "$current_path" || true)"
+  if [[ -n "$previous_current_path" ]]; then
+    printf '%s\n' "$previous_current_path" >"$node_root/last-$backup_suffix.txt"
+  fi
   if [[ -d "$current_path" && ! -L "$current_path" ]]; then
     mv "$current_path" "$node_root/current-$backup_suffix.dir"
   else
@@ -322,6 +388,7 @@ fi
 ln -s "$release_dir" "$current_path"
 
 migrate_legacy_replication_root "$node_root" "$node_id"
+prune_old_releases "$node_root/releases" "$current_path" "$release_retention_count" "$previous_current_path"
 
 if [[ "$restart_service" -eq 1 ]]; then
   systemctl daemon-reload

--- a/scripts/p2p-public-testnet-package-node-upgrade.test.sh
+++ b/scripts/p2p-public-testnet-package-node-upgrade.test.sh
@@ -11,12 +11,29 @@ package_version="0.0.0+testnet.test.abcdef123456"
 commit="abcdef1234567890abcdef1234567890abcdef12"
 run_id="12345"
 
-mkdir -p "$bundle_root/bin" "$node_root/config/doc/testing/evidence" "$node_root/releases/old/bin"
+mkdir -p \
+  "$bundle_root/bin" \
+  "$node_root/config/doc/testing/evidence" \
+  "$node_root/releases/old/bin" \
+  "$node_root/data" \
+  "$node_root/backups"
 printf 'runtime-v2\n' >"$bundle_root/bin/oasis7_chain_runtime"
 chmod +x "$bundle_root/bin/oasis7_chain_runtime"
 printf 'runtime-v1\n' >"$node_root/releases/old/bin/oasis7_chain_runtime"
 chmod +x "$node_root/releases/old/bin/oasis7_chain_runtime"
+touch -t 202001010000 "$node_root/releases/old"
 ln -s "$node_root/releases/old" "$node_root/current"
+printf 'keep-data\n' >"$node_root/data/sentinel.txt"
+printf 'keep-config\n' >"$node_root/config/sentinel.txt"
+printf 'keep-backups\n' >"$node_root/backups/sentinel.txt"
+
+for index in 1 2 3 4 5; do
+  mkdir -p "$node_root/releases/retention-candidate-$index/bin"
+  printf 'runtime-retention-%s\n' "$index" \
+    >"$node_root/releases/retention-candidate-$index/bin/oasis7_chain_runtime"
+  chmod +x "$node_root/releases/retention-candidate-$index/bin/oasis7_chain_runtime"
+  touch -t "20260601010${index}" "$node_root/releases/retention-candidate-$index"
+done
 
 cat >"$node_root/config/doc/testing/evidence/public-testnet-governed-bootstrap-bundle-2026-06-06.json" <<'EOF'
 {
@@ -32,6 +49,7 @@ cat >"$node_root/config/doc/testing/evidence/public-testnet-governed-bootstrap-b
 }
 EOF
 
+touch -t 202001010000 "$bundle_root"
 tar -czf "$TMP_DIR/oasis7-linux-x64-bundle.tar.gz" -C "$TMP_DIR/bundle" oasis7-linux-x64
 
 "$ROOT_DIR/scripts/p2p-public-testnet-package-node-upgrade.sh" \
@@ -52,6 +70,18 @@ test -f "$node_root_abs/CURRENT_VERSION"
 test -f "$node_root_abs/DEPLOYED_BUILDINFO"
 grep -q "^package_version=$package_version$" "$node_root_abs/DEPLOYED_BUILDINFO"
 grep -q "^commit=$commit$" "$node_root_abs/DEPLOYED_BUILDINFO"
+release_count=$(find "$node_root_abs/releases" -mindepth 1 -maxdepth 1 -type d ! -name '.*' | wc -l | tr -d ' ')
+test "$release_count" = "5"
+test -d "$node_root_abs/releases/$package_version"
+test -d "$node_root_abs/releases/old"
+test -d "$node_root_abs/releases/retention-candidate-3"
+test -d "$node_root_abs/releases/retention-candidate-4"
+test -d "$node_root_abs/releases/retention-candidate-5"
+test ! -e "$node_root_abs/releases/retention-candidate-1"
+test ! -e "$node_root_abs/releases/retention-candidate-2"
+test -f "$node_root_abs/data/sentinel.txt"
+test -f "$node_root_abs/config/sentinel.txt"
+test -f "$node_root_abs/backups/sentinel.txt"
 
 jq -e \
   --arg expected "$expected_sha" \


### PR DESCRIPTION
## Summary
- add release retention to the public testnet package node upgrade flow
- preserve current and previous-current release paths for rollback safety while pruning old releases
- document operator temp/upload cleanup ownership and protected paths

## Verification
- `bash -n scripts/p2p-public-testnet-package-node-upgrade.sh scripts/p2p-public-testnet-package-node-upgrade.test.sh`
- `./scripts/p2p-public-testnet-package-node-upgrade.test.sh`
- `./scripts/doc-governance-check.sh`
- `./scripts/pm/workflow-lint.sh --task-uid task_f74921a3093843c4bd7ae31232fdbb20 --phase current`
- `./scripts/pm/workflow-lint.sh --task-uid task_f74921a3093843c4bd7ae31232fdbb20 --phase pr-ready`
- `git diff --check`

Task: `task_f74921a3093843c4bd7ae31232fdbb20`
Pre-PR Local Role Review: passed