### PR TITLE
Add chain resource readiness and local standalone flow

### DIFF
--- a/.pm/tasks/task_a0e15f2d5d0547a3a13c93caab49b611.execution.md
+++ b/.pm/tasks/task_a0e15f2d5d0547a3a13c93caab49b611.execution.md
@@ -1,0 +1,331 @@
+# task_a0e15f2d5d0547a3a13c93caab49b611 Execution Log
+
+- task_uid: task_a0e15f2d5d0547a3a13c93caab49b611
+- title: chain-side manifest delta runtime readiness
+- owner_role: tpm
+- worktree_hint: /Users/scc/ccwork/worktrees/oasis7-world-simulator-chain-manifest-delta-readiness
+
+<!-- Append entries using:
+Example:
+  ## YYYY-MM-DD HH:MM:SS CST / role_name
+  - 完成内容: ...
+  - 遗留事项: ...
+  - Action: ...
+  - Validation Command: ...
+  - Expected Result: ...
+  - Actual Result: ...
+  - Blocker / Next Action: ...
+-->
+
+## 2026-06-21 10:11:00 CST / tpm
+- 完成内容: Bootstrap confirmed canonical task worktree and task truth.
+- Worktree: `/Users/scc/ccwork/worktrees/oasis7-world-simulator-chain-manifest-delta-readiness`
+- Branch: `task/world-simulator-chain-manifest-delta-readiness`
+- Base Ref: `main`
+- Task UID: `task_a0e15f2d5d0547a3a13c93caab49b611`
+- Selected workflow skills: `default-workflow-bootstrap`, `repo-owned-workflow-router`, `executing-project-tasks`
+- Skipped workflow skills now: `bounded-brainstorming` because the user gave an implementation order; `tdd-test-writer` is pending discovery of stable harnesses; `systematic-debugging` only if a failing command or runtime regression appears.
+- TODO decomposition:
+  1. Inspect current world-resource generation, runtime snapshot, provider bridge, and testnet readiness surfaces.
+  2. Define the canonical chain-side manifest/delta schema and docs.
+  3. Wire runtime snapshot/provider/testnet readiness to consume/report that schema.
+  4. Add focused tests or readiness fixtures for the schema/readiness behavior.
+  5. Run fresh verification and record evidence.
+- Integration order: blockchain schema contract first, runtime/provider wiring second, QA/readiness verification third, repository health/docs alignment before PR.
+- Action: `./scripts/new-task-worktree.sh world-simulator chain-manifest-delta-readiness --base main --pm-owner-role tpm ...`
+- Validation Command: `git status --short --branch` in source main and worktree creation JSON.
+- Expected Result: clean main, isolated task branch/worktree, committed `.pm` task.
+- Actual Result: main was clean at `a39a8d224`; created worktree and task successfully.
+- Blocker / Next Action: no blocker; dispatch bounded professional slices before professional implementation conclusions.
+
+## 2026-06-21 10:12:00 CST / tpm
+- Slice contract: `blockchain_ops_engineer`
+- Slice type: implementation planning / chain readiness contract.
+- Intended model: default subagent runtime per repo policy.
+- Actual model: inherited/unverified because subagent tool does not expose actual model confirmation.
+- Context delivery: full-thread/full-history fork requested, plus explicit checklist below.
+- Mandatory context checklist: role card `.agents/roles/blockchain_ops_engineer.md`; `AGENTS.md`; `doc/engineering/workflow/source-of-truth.md`; task YAML/log; worktree `/Users/scc/ccwork/worktrees/oasis7-world-simulator-chain-manifest-delta-readiness`; branch `task/world-simulator-chain-manifest-delta-readiness`; user request "define chain-side manifest/delta schema, then wire runtime snapshot/provider/testnet readiness"; docs `doc/world-simulator.prd.md`, `doc/world-runtime.prd.md`, `doc/p2p/blockchain/p2p-public-testnet-governed-bootstrap-2026-06-06.runbook.md`.
+- Exact question: identify the chain-side manifest/delta schema fields, readiness fields, and testnet contract that must be canonical before runtime/provider wiring.
+- Non-goals: do not modify unrelated deployment inventory; do not decide runtime internals without runtime slice.
+- Scoped files/commands: search docs/code for resource manifests, deltas, runtime snapshots, provider readiness, testnet readiness.
+- Return contract: findings, recommended file paths, schema/readiness acceptance notes, residual risk.
+
+## 2026-06-21 10:12:00 CST / tpm
+- Slice contract: `runtime_engineer`
+- Slice type: implementation planning / runtime snapshot wiring.
+- Intended model: default subagent runtime per repo policy.
+- Actual model: inherited/unverified because subagent tool does not expose actual model confirmation.
+- Context delivery: full-thread/full-history fork requested, plus explicit checklist below.
+- Mandatory context checklist: role card `.agents/roles/runtime_engineer.md`; `AGENTS.md`; workflow source-of-truth; task YAML/log; canonical worktree/branch/base ref; user request and acceptance list; sibling blockchain/QA slices; third_party read-only constraint.
+- Exact question: identify where runtime snapshots, world resource generation, and provider-facing readiness should expose or validate the chain-side manifest/delta schema.
+- Non-goals: do not change viewer presentation; do not hand-roll deployment ops decisions.
+- Scoped files/commands: inspect `crates/oasis7*` runtime/simulator snapshot/resource/provider code and `doc/world-runtime*` docs.
+- Return contract: implementation plan, candidate tests, changed path recommendations, residual risk.
+
+## 2026-06-21 10:12:00 CST / tpm
+- Slice contract: `qa_engineer`
+- Slice type: verification planning.
+- Intended model: default subagent runtime per repo policy.
+- Actual model: inherited/unverified because subagent tool does not expose actual model confirmation.
+- Context delivery: full-thread/full-history fork requested, plus explicit checklist below.
+- Mandatory context checklist: role card `.agents/roles/qa_engineer.md`; `AGENTS.md`; workflow source-of-truth; task YAML/log; canonical worktree/branch/base ref; acceptance criteria; sibling blockchain/runtime slices.
+- Exact question: propose focused required-tier verification for schema definition, runtime snapshot/provider wiring, and testnet readiness reporting.
+- Non-goals: no release-blocking final decision until implementation diff exists.
+- Scoped files/commands: inspect existing tests/readiness scripts and nominate smallest reliable checks.
+- Return contract: required checks, optional full checks, likely failure signatures, residual risk.
+
+## 2026-06-21 10:55:00 CST / blockchain_ops_engineer
+- 完成内容: Bounded slice returned chain-side schema/readiness contract.
+- Finding summary: canonical wire schema must be `oasis7.world_resource_manifest.v1` and `oasis7.world_resource_delta.v1`; `/v1/chain/status` must expose `world_resource` with world/chain id, seed, chunk generation schema, commit/hash counters, readiness status, and failed gates.
+- Recommended readiness lanes: `world_resource_provenance_ready`, `provider_resource_provenance_ready`, `resource_delta_replay_ready`.
+- Residual risk: full fragment/profile/budget detail should stay hash/ref bounded; provider/viewer/runtime field parity still needs implementation evidence.
+- Action: incorporated schema names, chain status `world_resource`, provider schema reporting, and public testnet readiness lane docs.
+- Validation Command: `env -u RUSTC_WRAPPER cargo test -p oasis7 --bin oasis7_chain_runtime status_payload_exposes_loaded_network_tier_manifest -- --nocapture`
+- Expected Result: chain status payload exposes network tier and world resource schema fields.
+- Actual Result: passed after aligning fixture chain_id to `oasis7-public_testnet`.
+- Blocker / Next Action: no blocker for this slice; generated chunks/delta replay remain future deeper wiring beyond current minimal schema/readiness connection.
+
+## 2026-06-21 10:56:00 CST / runtime_engineer
+- 完成内容: Bounded slice reviewed current implementation and identified wiring gaps.
+- Finding summary: snapshot schema fields exist; provider info reports schema; provider compatibility must reject missing/unsupported resource schema; chain readiness needs resource schema section.
+- Accepted fixes: fixed launcher provider detail format string; moved provider compatibility to hard-gate world resource schemas; added snapshot schema self-tests; added chain status `world_resource` section.
+- Residual risk: `world_id=runtime-world` and `world_seed=0` remain explicit bootstrap placeholders in runtime-only snapshot until node/network-tier identity is threaded into `World`; generated chunk summaries and non-empty resource deltas still need deeper simulator/runtime event integration.
+- Action: implemented minimal deterministic chain-side manifest/delta envelope and status/provider readiness connection.
+- Validation Command: `env -u RUSTC_WRAPPER cargo test -p oasis7 --lib chain_resource_schema --features test_tier_required -- --nocapture`
+- Expected Result: schema roundtrip/hash and delta current checks pass.
+- Actual Result: passed, 2 tests.
+- Blocker / Next Action: no blocker for minimal schema/readiness; follow-up should wire committed chunk generation events into non-empty `generated_chunks` and delta entries.
+
+## 2026-06-21 10:57:00 CST / qa_engineer
+- 完成内容: Bounded slice returned required-tier verification plan.
+- Required checks selected: schema runtime tests, provider loopback/probe, viewer runtime snapshot progress, chain runtime network tier/status payload, network-tier smoke, doc governance, diff check, cargo fmt check.
+- Residual risk: QA cannot release-block/approve full chain until implementation diff proves runtime/provider/readiness jointly consume new schema.
+- Action: ran focused checks listed below.
+- Validation Command: see subsequent tpm verification entry.
+- Expected Result: all focused checks pass or produce actionable blocker.
+- Actual Result: focused checks passed through current round.
+- Blocker / Next Action: run broader required gate before closeout.
+
+## 2026-06-21 10:58:00 CST / tpm
+- 完成内容: Implemented minimal chain-side world resource schema, runtime snapshot envelope, provider schema compatibility, chain status `world_resource`, and public testnet readiness lane docs.
+- Changed paths: `crates/oasis7/src/runtime/chain_resource_schema.rs`; `crates/oasis7/src/runtime/snapshot.rs`; `crates/oasis7/src/runtime/world/persistence.rs`; `crates/oasis7/src/simulator/provider_loopback_http.rs`; `crates/oasis7/src/bin/oasis7_provider_local_bridge.rs`; `crates/oasis7/src/bin/oasis7_chain_runtime/status_payload.rs`; provider/viewer/launcher tests; readiness docs/templates.
+- Action: focused verification.
+- Validation Command: `env -u RUSTC_WRAPPER cargo test -p oasis7 --lib chain_resource_schema --features test_tier_required -- --nocapture`
+- Expected Result: schema tests pass.
+- Actual Result: passed, 2 tests.
+- Validation Command: `env -u RUSTC_WRAPPER cargo test -p oasis7 --lib simulator::tests::provider_loopback_http --features test_tier_required -- --nocapture`
+- Expected Result: provider loopback tests pass with schema-bearing provider info.
+- Actual Result: passed, 8 tests.
+- Validation Command: `env -u RUSTC_WRAPPER cargo check -p oasis7_client_launcher`
+- Expected Result: launcher compiles with provider schema fields.
+- Actual Result: passed with existing unused warnings.
+- Validation Command: `env -u RUSTC_WRAPPER cargo test -p oasis7_client_launcher --bin oasis7_client_launcher provider_probe -- --nocapture`
+- Expected Result: provider probe tests pass with schema fields.
+- Actual Result: passed, 5 tests.
+- Validation Command: `env -u RUSTC_WRAPPER cargo test -p oasis7 --lib viewer::runtime_live::tests::snapshot_progress --features test_tier_required -- --nocapture`
+- Expected Result: viewer runtime provider snapshot tests pass.
+- Actual Result: passed, 19 tests.
+- Validation Command: `env -u RUSTC_WRAPPER cargo test -p oasis7 --bin oasis7_chain_runtime network_tier -- --nocapture`
+- Expected Result: chain runtime network tier tests pass.
+- Actual Result: passed, 13 tests before adding explicit world_resource assertion; targeted assertion rerun passed.
+- Validation Command: `./scripts/network-tier-manifest-smoke.sh`; `./scripts/doc-governance-check.sh`; `git diff --check`; `env -u RUSTC_WRAPPER cargo fmt --all -- --check`
+- Expected Result: all pass.
+- Actual Result: all passed.
+- Blocker / Next Action: run broader `./scripts/ci-tests.sh required`; then decide whether to deepen chunk/delta replay wiring in this task or close this slice as schema/readiness foundation.
+
+## 2026-06-21 11:08:00 CST / tpm
+- 完成内容: Broader required gate completed after installing worktree-local viewer npm dependencies.
+- Action: verify full required gate after schema/readiness implementation and record the local dependency repair needed for a fresh worktree.
+- Validation Command: `npm ci --prefix crates/oasis7_viewer`
+- Expected Result: install ignored viewer `node_modules` from lockfile so required viewer JS contract tests can import `solid-js`.
+- Actual Result: passed; installed 158 packages. npm audit reported dependency metadata vulnerabilities, but install completed and no tracked files changed.
+- Validation Command: `node crates/oasis7_viewer/scripts/software-safe-feedback-contract.test.mjs && ./scripts/copy-viewer-web-dist.test.sh && ./scripts/agent-browser-viewer-dist-freshness-test.sh && npm --prefix crates/oasis7_viewer run test:ui`
+- Expected Result: rerun the failed required-gate viewer contract segment.
+- Actual Result: passed; software-safe feedback contract passed, dist/freshness tests passed, Vitest passed 5 files / 66 tests.
+- Validation Command: `./scripts/ci-tests.sh required`
+- Expected Result: full required gate passes with chain-side schema/readiness changes.
+- Actual Result: passed. Key covered stages included doc governance, skill lint, Windows path/script checks, provider remote HTTPS smoke, newapi bridge service tests, file-size check, cargo fmt check, cargo deny advisories, `oasis7` required tests, `oasis7_consensus` tests, `oasis7_distfs` tests, viewer contract, software-safe build, and selected clippy gates. Optional node/net/libp2p/perf/hosted/launcher lanes were skipped by required-scope policy with explicit skip messages.
+- Prior failure note: first `./scripts/ci-tests.sh required` attempt passed Rust/doc/provider stages but failed at `node crates/oasis7_viewer/scripts/software-safe-feedback-contract.test.mjs` because this new worktree lacked ignored `crates/oasis7_viewer/node_modules` and could not resolve `solid-js`; after `npm ci`, the full gate passed.
+- Residual Risk: this slice establishes canonical schema envelopes and readiness wiring. Runtime-only snapshots still use explicit bootstrap placeholders (`world_id=runtime-world`, `chain_id=runtime-chain`, `world_seed=0`) until node/network-tier identity is threaded into `World`; generated chunk summaries and non-empty resource deltas still need deeper simulator/runtime event replay wiring.
+- Blocker / Next Action: no blocker for the schema/readiness foundation; next implementation slice should populate real generated chunk and delta entries.
+- 遗留事项: thread node/network-tier identity into runtime `World`, then populate non-empty `generated_chunks` and `world_resource_delta` entries from committed simulator/runtime generation events in a follow-up slice.
+
+## 2026-06-21 12:02:00 CST / tpm
+- Slice contract: `runtime_engineer`
+- Slice type: read-only source investigation for real simulator/runtime chunk generation and resource delta commit wiring.
+- Intended model: default subagent runtime per repo policy.
+- Actual model: inherited/unverified because subagent tool does not expose actual model confirmation.
+- Context delivery: full-thread/full-history fork requested, plus explicit checklist.
+- Mandatory context checklist: role card `.agents/roles/runtime_engineer.md`; `AGENTS.md`; workflow source-of-truth; task YAML/log; canonical worktree/branch/base ref; previous schema/readiness diff; latest user request "把 simulator/runtime 的真实 chunk generation / resource delta commit 事件接进去，生成非空链上资源变更流".
+- Finding summary: true source is simulator journal/model: `WorldEventKind::ChunkGenerated`, `FragmentsReplenished`, `CompoundMined`, `WorldModel.chunks`, `WorldModel.chunk_resource_budgets`, fragment locations/budgets, and execution bridge simulator mirror CAS snapshots.
+- Recommended implementation: derive a chain resource manifest/delta adapter from simulator snapshot/journal, keep runtime-only snapshot semantics separate, pass chain commit height/hash through execution bridge, and verify replay/hash stability.
+- Residual risk: mining deltas depend on post-replay model lookup because the event does not carry before/after budget hashes.
+- Blocker / Next Action: no blocker; implement simulator-derived manifest/delta and chain commit context.
+
+## 2026-06-21 12:03:00 CST / tpm
+- Slice contract: `blockchain_ops_engineer` + `qa_engineer`
+- Slice type: read-only readiness/acceptance check for non-empty chain resource stream.
+- Intended model: default subagent runtime per repo policy.
+- Actual model: inherited/unverified because subagent tool does not expose actual model confirmation.
+- Context delivery: full-thread/full-history fork requested, plus explicit checklist.
+- Mandatory context checklist: role cards `.agents/roles/blockchain_ops_engineer.md` and `.agents/roles/qa_engineer.md`; task YAML/log; existing chain status/provider/testnet readiness wiring; latest user request.
+- Finding summary: `/v1/chain/status.world_resource` must not report ready for placeholder or empty resource provenance; it must gate missing world/chain/seed, no starter chunk, no committed chunk, provisional chunks, pending/empty delta, and manifest/delta hash mismatch. Public testnet readiness script must include the new resource lanes already present in templates.
+- Recommended tests: schema tests, simulator snapshot resource derivation tests, execution bridge simulator payload CAS snapshot tests, chain status world_resource not_ready/ready gating, and full required gate before PR.
+- Residual risk: provider provenance currently proves schema compatibility, not full manifest hash exchange; a later provider handshake slice should compare manifest provenance against chain status.
+- Blocker / Next Action: no blocker for simulator-derived chain resource stream; keep provider full provenance as residual follow-up unless current task expands.
+
+## 2026-06-21 12:20:00 CST / tpm
+- 完成内容: Wired simulator-derived chunk/resource provenance into chain resource manifest/delta snapshots and commit/status readiness.
+- Changed paths: `crates/oasis7/src/runtime/chain_resource_schema.rs`; `crates/oasis7/src/simulator/persist.rs`; `crates/oasis7/src/simulator/kernel/persistence.rs`; `crates/oasis7/src/bin/oasis7_chain_runtime/execution_bridge/driver.rs`; `crates/oasis7/src/bin/oasis7_chain_runtime/status_payload_world_resource.rs`; simulator/status/bridge tests; `scripts/network-tier-public-testnet-readiness.sh`; runtime-live shadow snapshot constructors.
+- Implementation summary: `ChainResourceManifest::from_simulator_state` now projects generated/exhausted chunks, fragment refs, budget hashes, commit refs, and resource balances from real simulator model/journal; `ChainResourceDelta::latest_from_simulator_journal` emits non-empty `ChunkResource` entries for chunk generation, fragment replenish, and mined-compound resource consumption when those events carry resource movement. `WorldKernel::snapshot()` now includes the derived manifest/delta with serde defaults for old snapshots, and execution bridge commits persist simulator mirror snapshots with chain world_id/height/block hash context.
+- Readiness summary: chain status now loads the persisted simulator mirror resource snapshot instead of constructing placeholder hashes; missing snapshot, world/chain mismatch, seed missing, no starter/committed chunk, provisional chunks, pending/empty delta, and delta/manifest hash mismatch all block `world_resource.readiness_status=ready`.
+- Validation Command: `env -u RUSTC_WRAPPER cargo test -p oasis7 --lib chain_resource_schema --features test_tier_required -- --nocapture`
+- Expected Result: schema roundtrip/hash tests pass.
+- Actual Result: passed, 2 tests.
+- Validation Command: `env -u RUSTC_WRAPPER cargo test -p oasis7 --lib simulator::tests::persist --features test_tier_required -- --nocapture`
+- Expected Result: simulator snapshot/replay tests pass and new chain resource snapshot test proves non-empty generated chunks/delta survive restore.
+- Actual Result: passed, 29 tests.
+- Validation Command: `env -u RUSTC_WRAPPER cargo test -p oasis7 --bin oasis7_chain_runtime status_payload_exposes_loaded_network_tier_manifest -- --nocapture`
+- Expected Result: network tier status still exposes schema fields but reports `world_resource.not_ready` when simulator resource snapshot is missing.
+- Actual Result: passed, 1 test.
+- Validation Command: `env -u RUSTC_WRAPPER cargo test -p oasis7 --bin oasis7_chain_runtime node_runtime_execution_driver_processes_simulator_payload_envelope -- --nocapture`
+- Expected Result: execution bridge simulator payload commit stores a simulator snapshot whose chain resource manifest/delta are non-empty and use commit world_id/block hash context.
+- Actual Result: passed, 1 test.
+- Validation Command: `env -u RUSTC_WRAPPER cargo fmt --all`; `git diff --check`
+- Expected Result: formatting and whitespace checks pass.
+- Actual Result: both passed.
+- Residual Risk: provider compatibility still validates schema fields and should get a later hash/provenance exchange against `/v1/chain/status.world_resource`; runtime-only `World::snapshot()` keeps bootstrap placeholders and is no longer treated as testnet world_resource readiness truth.
+- Blocker / Next Action: no blocker for this user request; run workflow lint and broader required gate before PR closeout.
+
+## 2026-06-21 12:45:00 CST / tpm
+- 完成内容: Full required gate completed after fixing follow-on gate failures from this slice.
+- Action: reduced `crates/oasis7/src/bin/oasis7_chain_runtime/execution_bridge/tests/driver.rs` below the 1200-line test-file limit by compacting assertions without reducing coverage.
+- Validation Command: `./scripts/check-rust-file-size.sh`
+- Expected Result: oversized Rust file scan is empty.
+- Actual Result: passed; oversized code files=0, test files=0, structural slice files=0.
+- Action: added default `chain_resource_manifest` and `latest_chain_resource_delta` fields to game launcher runtime presence test snapshots, matching the viewer shadow snapshot treatment.
+- Validation Command: `./scripts/ci-tests.sh required`
+- Expected Result: full required gate passes after real simulator-derived resource stream wiring.
+- Actual Result: passed. Covered doc governance, skill lint, Windows/script checks, local letai CLI smoke, provider remote HTTPS smoke, newapi bridge tests, rust file size, cargo fmt check, cargo deny advisories, `oasis7 --tests --features test_tier_required`, `oasis7_consensus --lib`, `oasis7_distfs --lib`, required clippy gates, viewer JS contract/UI gates, and required release/build checks. Optional node/net/libp2p/perf/hosted/launcher lanes were skipped by required-scope policy with explicit skip messages.
+- Prior failure note: first rerun failed at `check-rust-file-size.sh` because the bridge test file grew to 1212 lines; fixed by compacting test assertions. Second rerun failed compiling `oasis7_game_launcher` tests because two hand-written `WorldSnapshot` fixtures lacked the new serde-defaulted resource fields; fixed with `Default::default()` fields.
+- Residual Risk: same as previous entry: provider schema compatibility is wired, but full provider manifest-hash provenance comparison should be a later slice.
+- Blocker / Next Action: no blocker; ready for PR-prep/review phase when requested.
+## 2026-06-21 Mobile Browser Playtest Evidence
+
+- Role attribution: TPM evidence capture only; professional diagnosis still needs follow-up owner slices for viewer click handling and chain consensus/runtime readiness.
+- Browser/tool: `agent-browser` mobile viewport `390x844`.
+- Wrapper stack:
+  - Command: `./scripts/run-local-letai-game-test.sh --reuse-existing-build --startup-profile playtest --provider-smoke-mode degraded --bind 127.0.0.1:5843 --output-dir output/playtest/manual-mobile-flow-20260621-205747 --detach -- --viewer-port 4177 --live-bind 127.0.0.1:5033 --web-bind 127.0.0.1:5013 --json-ready`
+  - URL: `http://127.0.0.1:4177/?ws=ws://127.0.0.1:5013&test_api=1&locale=zh`
+  - Initial viewer state: connected, `pixelWorldRuntimeStatus=ready`, `pixelWorldRuntimeSource=wasm_bindgen_runtime`, empty new-user world, available `claim_first_agent`.
+  - Real `agent-browser click @e6/@e12` did not produce action feedback; programmatic DOM `.click()` on the same claim button produced accepted ack.
+  - Post-claim viewer state stayed `logicalTime=0`, `eventSeq=0`, `authRuntimeStatus=registered_unbound`, `agents=0`, `locations=0`, `blocker=runtime_snapshot_empty_entities`.
+  - Chain status after accepted ack: `latest_height=0`, `committed_height=0`, `pending_consensus_actions.queued_action_count=1`, `known_peer_heads=0`.
+  - World resource status: `readiness_status=not_ready`, `committed_chunk_count=0`, `pending_delta_count=1`; failed gates included `world_resource_seed_missing`, `world_resource_world_id_mismatch`, `world_resource_chain_id_mismatch`, `world_resource_starter_chunk_missing`, `world_resource_committed_chunk_missing`, `world_resource_pending_delta_present`.
+  - Screenshot: `output/playtest/manual-mobile-flow-20260621-205747/mobile-after-claim-stuck.png`.
+- Direct validator control stack:
+  - Wrapper could not pass `--chain-node-validator`; `run-launcher-stack.sh` failed fast with `unknown option: --chain-node-validator`.
+  - Direct foreground launcher command used `--chain-node-id local-mobile-validator-direct-20260621c`, `--chain-node-validator local-mobile-validator-direct-20260621c:100`, `--chain-link-policy enforcing`, `--viewer-port 4185`, `--web-bind 127.0.0.1:5021`, `--chain-status-bind 127.0.0.1:5131`.
+  - Initial direct-validator viewer state matched wrapper stack: connected, runtime ready, empty new-user world with `claim_first_agent`.
+  - Real `agent-browser click @e6` again produced no feedback and no chain action.
+  - Programmatic DOM `.click()` produced accepted ack with `runtime_action_id=1`, but after more than one PoS slot the chain still stayed `latest_height=0`, `committed_height=0`, `queued_action_count=1`, `pending_proposal=null`, and `missed_slot_count` increased.
+  - Screenshot: `output/playtest/direct-validator-mobile-20260621c-after-claim.png`.
+- Current conclusion from evidence: actual mobile browser flow is not playable end-to-end. The page loads and shows the new-user claim entry, but user-level click handling is not reliably triggering the action under browser automation, and even when the action is forced through DOM click the chain runtime does not commit a block or publish a non-empty viewer snapshot.
+
+## 2026-06-21 23:20:00 CST / tpm
+- 完成内容: Added and browser-tested local standalone chain submit loop and starter resource readiness fallback for the runtime execution world.
+- Implementation summary:
+  - Added `--chain-local-standalone-test` launcher/wrapper mode: private-safe P2P, no bootstrap peers, self validator default, auto-attest all validators, fast local PoS slot/tick settings, and run-scoped chain config path.
+  - Fixed macOS bash `set -u` empty validator array handling in `scripts/run-launcher-stack.sh`.
+  - Runtime snapshots now derive a non-empty runtime agent chunk manifest/delta from committed runtime state instead of persisting placeholder-only `runtime-world/runtime-chain` resource data.
+  - Chain status `world_resource` now falls back from an empty simulator mirror to the committed runtime execution snapshot and normalizes world/chain ids for the node status payload.
+  - Viewer starter-OC recommendation now prioritizes `claim_starter_oc` over advance/refresh when agent chat is blocked by the starter OC requirement.
+- Validation Command: `env -u RUSTC_WRAPPER cargo test -p oasis7 --bin oasis7_game_launcher parse_options_local_standalone_test_builds_self_validating_private_chain -- --nocapture`
+- Expected Result: standalone CLI mode sets private-safe local validator/aut_attest/fast PoS settings and no bootstrap peers.
+- Actual Result: passed.
+- Validation Command: `env -u RUSTC_WRAPPER cargo test -p oasis7 persist_runtime_snapshot_records_committed_resource_chunk_and_delta --lib -- --nocapture`
+- Expected Result: runtime persistence snapshot records one committed resource chunk and a non-empty resource delta after registering an agent.
+- Actual Result: passed.
+- Validation Command: `env -u RUSTC_WRAPPER cargo test -p oasis7 --bin oasis7_chain_runtime status_uses_runtime_execution_snapshot_when_simulator_mirror_is_empty -- --nocapture`
+- Expected Result: chain status reports `world_resource.ready` from runtime execution snapshot when simulator mirror is empty.
+- Actual Result: passed.
+- Validation Command: `npm run test:ui -- software_safe_src/main.test.jsx -t "surfaces starter OC claim before first agent chat"`
+- Expected Result: starter OC action is exposed, clickable, and recommended ahead of advance when chat is blocked by starter OC.
+- Actual Result: passed.
+- Validation Command: `npm run build:software-safe`
+- Expected Result: viewer dist rebuild succeeds after starter OC recommendation change.
+- Actual Result: passed twice; a later F playtest launch got stuck in its own rebuild/finalize path and was terminated as a failed/unused launch attempt.
+- Validation Command: `env -u RUSTC_WRAPPER cargo fmt --all -- --check`; `bash -n scripts/run-launcher-stack.sh scripts/run-local-letai-game-test.sh`; `env -u RUSTC_WRAPPER cargo build -p oasis7 --bin oasis7_game_launcher --bin oasis7_viewer_live --bin oasis7_chain_runtime`
+- Expected Result: formatting, shell syntax, and local playtest binaries are valid.
+- Actual Result: passed; only existing warnings were emitted.
+- Browser Playtest A:
+  - Command: `./scripts/run-local-letai-game-test.sh --reuse-existing-build --startup-profile playtest --provider-smoke-mode degraded --bind 127.0.0.1:5851 --output-dir output/playtest/local-standalone-submit-flow-20260621c --detach -- --viewer-port 4191 --live-bind 127.0.0.1:5047 --web-bind 127.0.0.1:5029 --chain-node-id local-standalone-submit-20260621c --chain-local-standalone-test --json-ready`
+  - Result: local standalone self-committed; browser claim reached accepted ack; viewer eventually observed `agents=1`, `locations=1`, `blocker=null`.
+- Browser Playtest B:
+  - Command: `./scripts/run-local-letai-game-test.sh --reuse-existing-build --startup-profile playtest --provider-smoke-mode degraded --bind 127.0.0.1:5853 --output-dir output/playtest/local-standalone-submit-flow-20260621d --detach -- --viewer-port 4193 --live-bind 127.0.0.1:5049 --web-bind 127.0.0.1:5031 --chain-node-id local-standalone-submit-20260621d --chain-status-bind 127.0.0.1:5141 --chain-local-standalone-test --json-ready`
+  - URL: `http://127.0.0.1:4193/?ws=ws://127.0.0.1:5031&test_api=1&locale=zh`
+  - Result: clicking/triggering claim produced queued then ack feedback; chain status reached `committed_height=11`, `world_resource.readiness_status=ready`, `committed_chunk_count=1`, `pending_delta_count=0`, `failed_gates=[]`; viewer observed `agents=1`, `locations=1`, `execution=executing`.
+  - Screenshot: `output/playtest/local-standalone-submit-flow-20260621d/mobile-claim-resource-ready.png`.
+  - Starter OC: DOM-triggered `claim_starter_oc` reached ack and unlocked `chat_first_agent` (`disabledReason=null`).
+- Browser Playtest C:
+  - Command: `./scripts/run-local-letai-game-test.sh --reuse-existing-build --startup-profile playtest --provider-smoke-mode degraded --bind 127.0.0.1:5855 --output-dir output/playtest/local-standalone-submit-flow-20260621e --detach -- --viewer-port 4195 --live-bind 127.0.0.1:5051 --web-bind 127.0.0.1:5053 --chain-node-id local-standalone-submit-20260621e --chain-status-bind 127.0.0.1:5143 --chain-local-standalone-test --json-ready`
+  - URL: `http://127.0.0.1:4195/?ws=ws://127.0.0.1:5053&test_api=1&locale=zh`
+  - Result: fresh world claim reached ack; `world_resource.ready` with one committed chunk. The first E stack still served the pre-priority viewer bundle, so it continued recommending `advance_step`; source/dist were fixed and verified by targeted Vitest, but a clean runtime verification of the new top-level recommendation was blocked by the later F stack rebuild hang.
+- Known residuals:
+  - Overall chain readiness `ok=false` in standalone mode still includes expected public-network gates (`consensus_peer_head_unavailable`, `replication_recent_errors`, `p2p_reachability_degraded`, `reward_runtime_degraded`); local standalone needs profile-aware readiness if we want overall `ok=true`.
+  - Full random chunk mineral/resource budget generation is still simulator-derived; runtime fallback currently emits a deterministic committed starter chunk from runtime agents so local submit/status can close the loop.
+  - Real browser/agent-browser ref click can miss deeply scrolled action buttons; DOM click verified the OC action path, and recommendation priority now makes the action eligible for top-level next move after a fresh bundle load.
+
+## 2026-06-21 23:32:00 CST / tpm
+- Review Trigger: pre-PR local role review
+- Review Scope: current dirty diff in `/Users/scc/ccwork/worktrees/oasis7-world-simulator-chain-manifest-delta-readiness` covering chain-side resource manifest/delta schema, simulator/runtime snapshot derivation, chain status readiness, provider/readiness schema surfacing, local standalone chain launch mode, viewer starter OC recommendation, docs/templates/scripts, and tests.
+- Review Roles: runtime_engineer, blockchain_ops_engineer, viewer_engineer, gameplay_designer, qa_engineer, repository_health_engineer
+- Review Question: confirm whether this diff is acceptable for PR/merge to main and testnet packaging/deployment; identify merge-blocking correctness, readiness, UX, gameplay, verification, or repo-health risks.
+- Evidence Available: execution log above; targeted Rust tests; targeted viewer Vitest; software-safe build; local browser playtests D/E; `cargo fmt --check`; shell syntax check; local binary build.
+- Expected Return Contract: findings | no_findings | residual_risk
+- Formal Sink: this execution log; final passed evidence packet after findings disposition.
+
+## 2026-06-22 00:24:00 CST / tpm
+- 完成内容: Addressed pre-PR local role review findings and reran the full local required gate.
+- Review Findings Disposition:
+  - `runtime_engineer`: addressed. Chain status no longer rewrites mismatched runtime fallback manifest identity into status truth; it validates persisted resource snapshot identity as-is. Added chain resource chunk hash refresh/canonical hashing and new not-ready gates for missing delta commit hash, height mismatch, and zero-effect deltas.
+  - `blockchain_ops_engineer`: addressed. Provider mock fixtures and remote HTTPS bridge contract smoke now require/report `oasis7.world_resource_manifest.v1` and `oasis7.world_resource_delta.v1`. The execution bridge no longer masks chain/world identity mismatch in status readiness; the standard public/testnet startup path binds default `world_id` from the network-tier `chain_id`, while nonstandard custom mismatch now surfaces as not-ready evidence instead of false readiness.
+  - `viewer_engineer`: no blocking findings. Residual noted that starter OC recommendation still keys off the starter-OC disabled reason contract.
+  - `gameplay_designer`: addressed for merge-blocking false readiness. Zero-effect runtime fallback deltas now block readiness, so this PR does not claim a complete resource economy loop from empty deltas. Residual remains that the runtime-only fallback is a deterministic starter chunk for local submit/status closure, not the final full seed-derived gameplay resource pocket.
+  - `qa_engineer`: addressed. Reran `./scripts/ci-tests.sh required` on the latest diff after all review fixes.
+  - `repository_health_engineer`: addressed. Removed the unused `CHAIN_EXTRA_ARGS=()` shell variable from `scripts/run-launcher-stack.sh`; the late Rust CLI error for a missing `--chain-node-validator` value remains non-blocking residual behavior.
+- Validation Command: `python3 scripts/provider-remote-https/provider_bridge_contract_smoke.test.py`
+- Expected Result: remote provider contract smoke tests pass and assert the new schema version fields.
+- Actual Result: passed, 5 tests.
+- Validation Command: `env -u RUSTC_WRAPPER cargo test -p oasis7 runtime_agent_chat_provider_mode_accepts_feedback_without_echo_receipt --lib -- --nocapture`
+- Expected Result: provider-backed chat feedback test compiles/passes with schema-bearing provider info.
+- Actual Result: passed.
+- Validation Command: `env -u RUSTC_WRAPPER cargo test -p oasis7 --bin oasis7_chain_runtime status_uses_runtime_execution_snapshot_when_simulator_mirror_is_empty -- --nocapture`
+- Expected Result: runtime fallback with mismatched/zero-effect resource snapshot is blocked by explicit world_resource gates instead of being normalized to ready.
+- Actual Result: passed.
+- Validation Command: `env -u RUSTC_WRAPPER cargo test -p oasis7 --bin oasis7_chain_runtime status_payload_exposes_loaded_network_tier_manifest -- --nocapture`
+- Expected Result: network-tier status remains valid and exposes schema fields.
+- Actual Result: passed.
+- Validation Command: `env -u RUSTC_WRAPPER cargo test -p oasis7 persist_runtime_snapshot_records_committed_resource_chunk_and_delta --lib -- --nocapture`
+- Expected Result: runtime snapshot persistence still records committed starter chunk and non-empty delta evidence.
+- Actual Result: passed.
+- Validation Command: `bash -n scripts/run-launcher-stack.sh && python3 -m py_compile scripts/provider-remote-https/provider_bridge_contract_smoke.py scripts/provider-remote-https/provider_bridge_contract_smoke.test.py`
+- Expected Result: shell/Python syntax checks pass.
+- Actual Result: passed.
+- Validation Command: `env -u RUSTC_WRAPPER cargo fmt --all`; `wc -l crates/oasis7/src/runtime/tests/persistence.rs`; `./scripts/check-rust-file-size.sh`; `git diff --check`
+- Expected Result: formatting, file-size, and whitespace checks pass after formatter changes.
+- Actual Result: passed; `persistence.rs` is exactly 1200 lines and the Rust file-size gate reported zero oversized files.
+- Validation Command: `./scripts/ci-tests.sh required`
+- Expected Result: full local required gate passes on the latest diff.
+- Actual Result: passed. Covered doc governance, skill lint, Windows path/script checks, local LetAI CLI smoke, provider remote HTTPS smoke, newapi bridge tests, Rust file-size check, cargo fmt check, cargo deny advisories, `oasis7 --tests --features test_tier_required`, `oasis7_consensus --lib`, `oasis7_distfs --lib`, required viewer JS/software-safe gates, and required clippy/build lanes. Optional node/net/libp2p/perf/hosted/launcher lanes were skipped by required-scope policy with explicit skip messages.
+- Residual Risk: local standalone now closes submit/status/viewer resource readiness for a private self-validating test node, but public testnet deployment must still be validated from CI artifacts and live node readiness after package rollout. Full provider manifest-hash provenance exchange and full seed-derived resource economy pockets remain follow-up slices.
+- Blocker / Next Action: no local blocker; run task closeout, commit, create PR, watch CI, merge, trigger cross-platform packages, then deploy testnet from CI artifacts.
+
+## 2026-06-22 01:03:00 CST / tpm
+- 完成内容: Ran standard task closeout with fresh required verification.
+- Action: `task-closeout.sh` executed `claim-ready --claim-type task_complete --verify-command "./scripts/ci-tests.sh required"` and moved the task to done.
+- Validation Command: `./scripts/pm/task-closeout.sh --role tpm --task-uid task_a0e15f2d5d0547a3a13c93caab49b611 --verify-command "./scripts/ci-tests.sh required"`
+- Expected Result: task closeout writes done status after fresh required verification.
+- Actual Result: partial script exit 1 only at final repo-wide `.pm lint`; task-local closeout state was written successfully with `status: done`, `last_verification_exit_code: 0`, `last_verification_status: verified`, and `last_verify_command: "./scripts/ci-tests.sh required"`. The lint failures were pre-existing historical `.pm/tasks/*` formatting debt outside this task, matching known repo-wide noise.
+- 遗留事项: repo-wide `.pm lint` historical debt remains outside this task and should not block this PR's code/testnet package flow.
+- Blocker / Next Action: no task-local blocker; proceed with commit, PR preflight, CI watch, merge, package, and testnet rollout.

--- a/.pm/tasks/task_a0e15f2d5d0547a3a13c93caab49b611.execution.md
+++ b/.pm/tasks/task_a0e15f2d5d0547a3a13c93caab49b611.execution.md
@@ -329,3 +329,18 @@ Example:
 - Actual Result: partial script exit 1 only at final repo-wide `.pm lint`; task-local closeout state was written successfully with `status: done`, `last_verification_exit_code: 0`, `last_verification_status: verified`, and `last_verify_command: "./scripts/ci-tests.sh required"`. The lint failures were pre-existing historical `.pm/tasks/*` formatting debt outside this task, matching known repo-wide noise.
 - 遗留事项: repo-wide `.pm lint` historical debt remains outside this task and should not block this PR's code/testnet package flow.
 - Blocker / Next Action: no task-local blocker; proceed with commit, PR preflight, CI watch, merge, package, and testnet rollout.
+
+## 2026-06-22 01:08:00 CST / tpm
+- Pre-PR Local Role Review: passed
+- Task UID: task_a0e15f2d5d0547a3a13c93caab49b611
+- Source Worktree: /Users/scc/ccwork/worktrees/oasis7-world-simulator-chain-manifest-delta-readiness
+- Source Branch: task/world-simulator-chain-manifest-delta-readiness
+- Source Head: 6cb4594aebb91b8d84d88cd3792eb5504d2b7234
+- Comparison Ref: refs/remotes/origin/main
+- Reviewed Changed Paths: chain runtime execution/status world_resource; runtime/simulator chain_resource_schema snapshot persistence; launcher local standalone mode; provider bridge schema smoke; viewer starter OC recommendation; readiness docs/templates/scripts; task evidence.
+- Role Selection Basis: runtime snapshot/readiness, blockchain/testnet/provider bridge, viewer action UX, gameplay resource-loop semantics, QA verification, and repository-health shell/test hygiene all changed in this task.
+- Review Roles: runtime_engineer, blockchain_ops_engineer, viewer_engineer, gameplay_designer, qa_engineer, repository_health_engineer
+- Review Evidence: subagent review slices recorded above with findings/no_findings/residual_risk; targeted fixes landed in commit 6cb4594aebb91b8d84d88cd3792eb5504d2b7234; fresh `./scripts/ci-tests.sh required` passed during closeout with `last_verification_exit_code: 0`.
+- Review Findings Disposition: addressed
+- Finding Disposition Evidence: runtime identity masking and empty-delta false readiness were removed; provider contract tests now assert resource schema fields; local standalone flow and starter OC recommendation were verified; repo-health unused shell variable was removed; QA required gate was rerun on latest diff.
+- Residual Risk: public testnet still requires CI artifact packaging plus live node readiness validation after deployment; full provider manifest-hash provenance exchange and final seed-derived gameplay resource pockets remain follow-up work and are not claimed complete by this PR.

--- a/.pm/tasks/task_a0e15f2d5d0547a3a13c93caab49b611.execution.md
+++ b/.pm/tasks/task_a0e15f2d5d0547a3a13c93caab49b611.execution.md
@@ -335,7 +335,7 @@ Example:
 - Task UID: task_a0e15f2d5d0547a3a13c93caab49b611
 - Source Worktree: /Users/scc/ccwork/worktrees/oasis7-world-simulator-chain-manifest-delta-readiness
 - Source Branch: task/world-simulator-chain-manifest-delta-readiness
-- Source Head: 6cb4594aebb91b8d84d88cd3792eb5504d2b7234
+- Source Head: d681a4378bf411eea761cac638084727b0287bc8
 - Comparison Ref: refs/remotes/origin/main
 - Reviewed Changed Paths: chain runtime execution/status world_resource; runtime/simulator chain_resource_schema snapshot persistence; launcher local standalone mode; provider bridge schema smoke; viewer starter OC recommendation; readiness docs/templates/scripts; task evidence.
 - Role Selection Basis: runtime snapshot/readiness, blockchain/testnet/provider bridge, viewer action UX, gameplay resource-loop semantics, QA verification, and repository-health shell/test hygiene all changed in this task.

--- a/.pm/tasks/task_a0e15f2d5d0547a3a13c93caab49b611.yaml
+++ b/.pm/tasks/task_a0e15f2d5d0547a3a13c93caab49b611.yaml
@@ -1,0 +1,28 @@
+task_uid: task_a0e15f2d5d0547a3a13c93caab49b611
+title: "chain-side manifest delta runtime readiness"
+owner_role: tpm
+worktree_hint: /Users/scc/ccwork/worktrees/oasis7-world-simulator-chain-manifest-delta-readiness
+execution_log_path: .pm/tasks/task_a0e15f2d5d0547a3a13c93caab49b611.execution.md
+status: done
+priority: P1
+source_signal: null
+source_refs:
+  - AGENTS.md
+doc_refs:
+  - doc/world-simulator.prd.md
+  - doc/world-runtime.prd.md
+  - doc/p2p/blockchain/p2p-public-testnet-governed-bootstrap-2026-06-06.runbook.md
+related_prd: []
+acceptance:
+  - "Define canonical chain-side manifest/delta schema for world resources."
+  - "Wire runtime snapshot/provider/testnet readiness to the new chain-side schema without ambiguous fallback modes."
+  - "Add focused tests or docs proving schema/readiness behavior."
+handoff_to: []
+updated_at: 2026-06-22T01:01:03+08:00
+last_started_at: 2026-06-21T10:08:10+08:00
+last_claim_type: task_complete
+last_verify_command: "./scripts/ci-tests.sh required"
+last_verified_at: 2026-06-22T01:00:59+08:00
+last_verification_exit_code: 0
+last_verification_status: verified
+last_closed_at: 2026-06-22T01:01:02+08:00

--- a/.pm/tasks/task_a0e15f2d5d0547a3a13c93caab49b611.yaml
+++ b/.pm/tasks/task_a0e15f2d5d0547a3a13c93caab49b611.yaml
@@ -9,9 +9,13 @@ source_signal: null
 source_refs:
   - AGENTS.md
 doc_refs:
+  - doc/world-simulator/project.md
   - doc/world-simulator.prd.md
+  - doc/world-runtime/project.md
   - doc/world-runtime.prd.md
+  - doc/p2p/project.md
   - doc/p2p/blockchain/p2p-public-testnet-governed-bootstrap-2026-06-06.runbook.md
+  - doc/testing/project.md
 related_prd: []
 acceptance:
   - "Define canonical chain-side manifest/delta schema for world resources."

--- a/crates/oasis7/src/bin/oasis7_chain_runtime/execution_bridge/driver.rs
+++ b/crates/oasis7/src/bin/oasis7_chain_runtime/execution_bridge/driver.rs
@@ -6,9 +6,9 @@ use oasis7::consensus_action_payload::{
     ConsensusActionPayloadBody, decode_consensus_action_payload,
 };
 use oasis7::runtime::{
-    BlobStore, Journal as RuntimeJournal, LocalCasStore, MainTokenConfig, MainTokenSupplyState,
-    ReleaseSecurityPolicy, Snapshot as RuntimeSnapshot, World as RuntimeWorld, blake3_hex,
-    production_hardened_main_token_config,
+    BlobStore, ChainResourceDerivationContext, Journal as RuntimeJournal, LocalCasStore,
+    MainTokenConfig, MainTokenSupplyState, ReleaseSecurityPolicy, Snapshot as RuntimeSnapshot,
+    World as RuntimeWorld, blake3_hex, production_hardened_main_token_config,
 };
 use oasis7::simulator::{
     Action as SimulatorAction, ActionSubmitter, WorldEventKind, WorldJournal as SimulatorJournal,
@@ -128,6 +128,7 @@ impl NodeRuntimeExecutionDriver {
             persist_simulator_execution_world(
                 driver.simulator_world_dir.as_path(),
                 &driver.simulator_mirror,
+                None,
             )?;
         }
         Ok(driver)
@@ -164,9 +165,10 @@ impl NodeRuntimeExecutionDriver {
 
     fn apply_simulator_actions(
         &mut self,
-        height: u64,
+        context: &NodeExecutionCommitContext,
         simulator_actions: &[(SimulatorAction, ActionSubmitter)],
     ) -> Result<Option<ExecutionSimulatorMirrorRecord>, String> {
+        let height = context.height;
         if simulator_actions.is_empty() {
             return Ok(None);
         }
@@ -198,7 +200,18 @@ impl NodeRuntimeExecutionDriver {
             }
         }
 
-        let snapshot_value = self.simulator_mirror.snapshot();
+        let resource_context = ChainResourceDerivationContext {
+            world_id: context.world_id.as_str(),
+            chain_id: context.world_id.as_str(),
+            genesis_ref: None,
+            created_at_height: 0,
+            manifest_height: context.height,
+            commit_block_hash: Some(context.node_block_hash.as_str()),
+            tick: self.simulator_mirror.time(),
+        };
+        let snapshot_value = self
+            .simulator_mirror
+            .snapshot_with_chain_resource_context(resource_context);
         let journal_value = self.simulator_mirror.journal_snapshot();
         let snapshot_bytes = super::to_cbor(snapshot_value)?;
         let journal_bytes = super::to_cbor(journal_value)?;
@@ -225,6 +238,7 @@ impl NodeRuntimeExecutionDriver {
         persist_simulator_execution_world(
             self.simulator_world_dir.as_path(),
             &self.simulator_mirror,
+            Some(resource_context),
         )?;
 
         Ok(Some(ExecutionSimulatorMirrorRecord {
@@ -402,6 +416,7 @@ impl NodeRuntimeExecutionDriver {
             persist_simulator_execution_world(
                 self.simulator_world_dir.as_path(),
                 &restored_simulator,
+                None,
             )?;
             self.simulator_mirror = restored_simulator;
         }
@@ -555,7 +570,7 @@ impl NodeExecutionHook for NodeRuntimeExecutionDriver {
                 )
             })?;
         let simulator_mirror =
-            self.apply_simulator_actions(context.height, decoded_simulator_actions.as_slice())?;
+            self.apply_simulator_actions(&context, decoded_simulator_actions.as_slice())?;
 
         let snapshot_value = self.execution_world.snapshot();
         let journal_value = self.execution_world.journal().clone();
@@ -1007,8 +1022,15 @@ fn load_simulator_execution_world(world_dir: &Path) -> Result<WorldKernel, Strin
 fn persist_simulator_execution_world(
     world_dir: &Path,
     simulator_world: &WorldKernel,
+    resource_context: Option<ChainResourceDerivationContext<'_>>,
 ) -> Result<(), String> {
-    simulator_world.save_to_dir(world_dir).map_err(|err| {
+    let result = match resource_context {
+        Some(context) => {
+            simulator_world.save_to_dir_with_chain_resource_context(world_dir, context)
+        }
+        None => simulator_world.save_to_dir(world_dir),
+    };
+    result.map_err(|err| {
         format!(
             "save simulator execution mirror to {} failed: {:?}",
             world_dir.display(),

--- a/crates/oasis7/src/bin/oasis7_chain_runtime/execution_bridge/tests/driver.rs
+++ b/crates/oasis7/src/bin/oasis7_chain_runtime/execution_bridge/tests/driver.rs
@@ -17,7 +17,10 @@ use oasis7::runtime::{
     ModuleSubscriptionStage, ReleaseSecurityPolicy, WorldEventBody,
     production_hardened_main_token_config,
 };
-use oasis7::simulator::{Action as SimulatorAction, ActionSubmitter};
+use oasis7::simulator::{
+    Action as SimulatorAction, ActionSubmitter, ChunkCoord, WorldConfig, WorldInitConfig,
+    WorldScenario, WorldSnapshot, initialize_kernel,
+};
 use oasis7_node::{NodeExecutionCommitContext, NodeExecutionHook, compute_consensus_action_root};
 use oasis7_proto::storage_profile::StorageProfile;
 use oasis7_proto::storage_profile::StorageProfileConfig;
@@ -1088,6 +1091,13 @@ fn node_runtime_execution_driver_processes_simulator_payload_envelope() {
         storage_root,
     )
     .expect("driver");
+    let config = WorldConfig::default();
+    let mut init =
+        WorldInitConfig::from_scenario(WorldScenario::AsteroidFragmentBootstrap, &config);
+    init.seed = 91;
+    init.asteroid_fragment.bootstrap_chunks = vec![ChunkCoord { x: 0, y: 0, z: 0 }];
+    let (kernel, _) = initialize_kernel(config, init).expect("simulator init");
+    driver.simulator_mirror = kernel;
 
     let payload =
         encode_consensus_action_payload(&ConsensusActionPayloadEnvelope::from_simulator_action(
@@ -1134,14 +1144,9 @@ fn node_runtime_execution_driver_processes_simulator_payload_envelope() {
         record
             .snapshot_ref
             .as_deref()
-            .is_some_and(|snapshot_ref| !snapshot_ref.is_empty())
+            .is_some_and(|r| !r.is_empty())
     );
-    assert!(
-        record
-            .journal_ref
-            .as_deref()
-            .is_some_and(|journal_ref| !journal_ref.is_empty())
-    );
+    assert!(record.journal_ref.as_deref().is_some_and(|r| !r.is_empty()));
     let external_effect_ref = record
         .external_effect_ref
         .as_deref()
@@ -1165,10 +1170,25 @@ fn node_runtime_execution_driver_processes_simulator_payload_envelope() {
         .simulator_mirror
         .expect("simulator mirror record should exist");
     assert_eq!(simulator.action_count, 1);
-    assert_eq!(simulator.rejected_action_count, 1);
+    assert_eq!(simulator.rejected_action_count, 0);
     assert!(!simulator.snapshot_ref.is_empty());
     assert!(!simulator.journal_ref.is_empty());
     assert!(!simulator.state_root.is_empty());
+    let simulator_snapshot_bytes = store
+        .get_verified(simulator.snapshot_ref.as_str())
+        .expect("load simulator snapshot");
+    let simulator_snapshot: WorldSnapshot =
+        serde_cbor::from_slice(simulator_snapshot_bytes.as_slice())
+            .expect("decode simulator snapshot");
+    let manifest = &simulator_snapshot.chain_resource_manifest;
+    let delta = &simulator_snapshot.latest_chain_resource_delta;
+    assert_eq!(
+        (manifest.world_id.as_str(), manifest.chain_id.as_str()),
+        ("w1", "w1")
+    );
+    assert_eq!(delta.commit_block_hash.as_deref(), Some("node-h1"));
+    assert!(!manifest.generated_chunks.is_empty());
+    assert!(!delta.entries.is_empty());
     assert!(simulator_world_dir.join("snapshot.json").exists());
     assert!(simulator_world_dir.join("journal.json").exists());
     let _ = fs::remove_dir_all(dir);

--- a/crates/oasis7/src/bin/oasis7_chain_runtime/oasis7_chain_runtime_network_tier_tests.rs
+++ b/crates/oasis7/src/bin/oasis7_chain_runtime/oasis7_chain_runtime_network_tier_tests.rs
@@ -12,7 +12,7 @@ use oasis7_proto::storage_profile::{StorageProfile, StorageProfileConfig};
 use sha2::{Digest, Sha256};
 use std::collections::BTreeMap;
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 fn temp_dir(label: &str) -> PathBuf {
@@ -384,9 +384,10 @@ fn status_payload_exposes_loaded_network_tier_manifest() {
         false,
     )
     .expect("recommendation");
+    let execution_world_dir = dir.join("execution-world");
     let payload = build_chain_status_payload(
         snapshot,
-        Path::new("/tmp/execution-world"),
+        execution_world_dir.as_path(),
         Some(&loaded),
         &recommendation,
         None,
@@ -446,6 +447,27 @@ fn status_payload_exposes_loaded_network_tier_manifest() {
     assert_eq!(tier.tier, "public_testnet");
     assert_eq!(tier.bootstrap_peer_count, 2);
     assert_eq!(tier.token_symbol, "OC");
+    assert_eq!(
+        payload.world_resource.schema_version,
+        oasis7::runtime::CHAIN_RESOURCE_MANIFEST_SCHEMA_V1
+    );
+    assert_eq!(
+        payload.world_resource.delta_schema_version,
+        oasis7::runtime::CHAIN_RESOURCE_DELTA_SCHEMA_V1
+    );
+    assert_eq!(
+        payload.world_resource.chunk_generation_schema_version,
+        oasis7::runtime::CHUNK_GENERATION_SCHEMA_V1
+    );
+    assert_eq!(payload.world_resource.chain_id, "oasis7-public_testnet");
+    assert_eq!(payload.world_resource.readiness_status, "not_ready");
+    assert!(
+        payload
+            .world_resource
+            .failed_gates
+            .iter()
+            .any(|gate| gate.starts_with("world_resource_snapshot_unavailable"))
+    );
 
     let _ = fs::remove_dir_all(dir);
 }

--- a/crates/oasis7/src/bin/oasis7_chain_runtime/status_payload.rs
+++ b/crates/oasis7/src/bin/oasis7_chain_runtime/status_payload.rs
@@ -34,6 +34,9 @@ use status_payload_state_sync::{
     consensus_participation_hold_reason, state_sync_fallback_reason,
     state_sync_trusted_checkpoint_required_height,
 };
+#[path = "status_payload_world_resource.rs"]
+mod status_payload_world_resource;
+use status_payload_world_resource::{ChainWorldResourceStatus, build_world_resource_status};
 
 const TRANSPORT_STABILITY_MIN_SCORE: u8 = 70;
 
@@ -100,6 +103,7 @@ pub(super) struct ChainStatusResponse {
     pub(super) last_error: Option<String>,
     pub(super) execution_world_dir: String,
     pub(super) network_tier: Option<ChainNetworkTierStatus>,
+    pub(super) world_resource: ChainWorldResourceStatus,
     pub(super) p2p: ChainP2pStatus,
     pub(super) observability: ChainNodeObservabilityStatus,
     pub(super) release_security_policy: ReleaseSecurityPolicy,
@@ -985,6 +989,8 @@ pub(super) fn build_chain_status_payload(
         .sum::<u64>();
     let pending_slashing_intent_count = pending_slashing_intent_count(&snapshot);
     let applied_slashing_receipt_count = applied_slashing_receipt_hashes(&snapshot).len();
+    let world_resource =
+        build_world_resource_status(&snapshot, execution_world_dir, loaded_network_tier_manifest);
     let pending_proposal = snapshot
         .consensus
         .pending_proposal
@@ -1045,6 +1051,7 @@ pub(super) fn build_chain_status_payload(
             allowed_claims: loaded.manifest.claims_policy.allowed_claims.clone(),
             denied_claims: loaded.manifest.claims_policy.denied_claims.clone(),
         }),
+        world_resource,
         consensus: ChainConsensusStatus {
             slot: snapshot.consensus.slot,
             epoch: snapshot.consensus.epoch,

--- a/crates/oasis7/src/bin/oasis7_chain_runtime/status_payload_world_resource.rs
+++ b/crates/oasis7/src/bin/oasis7_chain_runtime/status_payload_world_resource.rs
@@ -1,0 +1,359 @@
+use oasis7::network_tier_manifest::LoadedNetworkTierManifest;
+use oasis7::runtime::Snapshot as RuntimeSnapshot;
+use oasis7::runtime::{
+    CHAIN_RESOURCE_DELTA_SCHEMA_V1, CHAIN_RESOURCE_MANIFEST_SCHEMA_V1, CHUNK_GENERATION_SCHEMA_V1,
+    ChainChunkResourceStatus, ChainResourceDelta, ChainResourceDeltaEntry, ChainResourceManifest,
+};
+use oasis7::simulator::WorldSnapshot as SimulatorSnapshot;
+use oasis7_node::NodeSnapshot;
+use serde::Serialize;
+use std::path::Path;
+
+#[derive(Debug, Serialize)]
+pub(crate) struct ChainWorldResourceStatus {
+    pub(crate) schema_version: String,
+    pub(crate) delta_schema_version: String,
+    pub(crate) world_id: String,
+    pub(crate) chain_id: String,
+    pub(crate) world_seed: u64,
+    pub(crate) chunk_generation_schema_version: String,
+    pub(crate) seed_manifest_hash: String,
+    pub(crate) starter_chunk_manifest_hash: Option<String>,
+    pub(crate) latest_resource_commit_height: u64,
+    pub(crate) latest_resource_commit_hash: Option<String>,
+    pub(crate) committed_chunk_count: u64,
+    pub(crate) provisional_chunk_count: u64,
+    pub(crate) pending_delta_count: u64,
+    pub(crate) last_delta_id: Option<String>,
+    pub(crate) last_delta_commit_height: Option<u64>,
+    pub(crate) readiness_status: String,
+    pub(crate) failed_gates: Vec<String>,
+}
+
+pub(super) fn build_world_resource_status(
+    snapshot: &NodeSnapshot,
+    execution_world_dir: &Path,
+    loaded_network_tier_manifest: Option<&LoadedNetworkTierManifest>,
+) -> ChainWorldResourceStatus {
+    let chain_id = loaded_network_tier_manifest
+        .map(|loaded| loaded.manifest.chain_id.clone())
+        .unwrap_or_else(|| snapshot.world_id.clone());
+    let (manifest, latest_delta, snapshot_load_error) = load_latest_world_resource_snapshot(
+        execution_world_dir,
+        snapshot.world_id.as_str(),
+        chain_id.as_str(),
+    );
+    let mut failed_gates = Vec::new();
+    if snapshot.world_id.trim().is_empty() {
+        failed_gates.push("world_resource_world_id_missing".to_string());
+    }
+    if chain_id.trim().is_empty() {
+        failed_gates.push("world_resource_chain_id_missing".to_string());
+    }
+    if let Some(error) = snapshot_load_error {
+        failed_gates.push(format!("world_resource_snapshot_unavailable:{error}"));
+    }
+    let seed_manifest_hash = manifest
+        .as_ref()
+        .map(|manifest| manifest.manifest_hash.clone())
+        .unwrap_or_default();
+    let world_seed = manifest
+        .as_ref()
+        .map(|manifest| manifest.world_seed)
+        .unwrap_or(0);
+    if world_seed == 0 {
+        failed_gates.push("world_resource_seed_missing".to_string());
+    }
+    if manifest
+        .as_ref()
+        .is_none_or(|manifest| manifest.world_id != snapshot.world_id)
+    {
+        failed_gates.push("world_resource_world_id_mismatch".to_string());
+    }
+    if manifest
+        .as_ref()
+        .is_none_or(|manifest| manifest.chain_id != chain_id)
+    {
+        failed_gates.push("world_resource_chain_id_mismatch".to_string());
+    }
+    if manifest
+        .as_ref()
+        .is_none_or(|manifest| !manifest.is_schema_current())
+    {
+        failed_gates.push("world_resource_manifest_hash_mismatch".to_string());
+    }
+    let starter_chunk_manifest_hash = starter_chunk_manifest_hash(manifest.as_ref());
+    if starter_chunk_manifest_hash.is_none() {
+        failed_gates.push("world_resource_starter_chunk_missing".to_string());
+    }
+    let committed_chunk_count = manifest
+        .as_ref()
+        .map(committed_chunk_count)
+        .unwrap_or_default();
+    let provisional_chunk_count = manifest
+        .as_ref()
+        .map(provisional_chunk_count)
+        .unwrap_or_default();
+    let pending_delta_count = latest_delta
+        .as_ref()
+        .map(|delta| u64::from(delta.entries.is_empty() || !delta.is_schema_current()))
+        .unwrap_or(1);
+    if committed_chunk_count == 0 {
+        failed_gates.push("world_resource_committed_chunk_missing".to_string());
+    }
+    if provisional_chunk_count > 0 {
+        failed_gates.push("world_resource_provisional_chunk_present".to_string());
+    }
+    if pending_delta_count > 0 {
+        failed_gates.push("world_resource_pending_delta_present".to_string());
+    }
+    if latest_delta
+        .as_ref()
+        .is_some_and(|delta| delta.resulting_manifest_hash != seed_manifest_hash)
+    {
+        failed_gates.push("world_resource_delta_manifest_mismatch".to_string());
+    }
+    if latest_delta
+        .as_ref()
+        .is_none_or(|delta| delta.commit_block_hash.as_deref().is_none_or(str::is_empty))
+    {
+        failed_gates.push("world_resource_delta_commit_hash_missing".to_string());
+    }
+    if latest_delta.as_ref().is_some_and(|delta| {
+        delta.block_height != snapshot.consensus.committed_height
+            || delta.ordering_key.height != snapshot.consensus.committed_height
+    }) {
+        failed_gates.push("world_resource_delta_height_mismatch".to_string());
+    }
+    if latest_delta
+        .as_ref()
+        .is_none_or(|delta| !delta_has_nonzero_resource_effect(delta))
+    {
+        failed_gates.push("world_resource_delta_zero_effect".to_string());
+    }
+    ChainWorldResourceStatus {
+        schema_version: CHAIN_RESOURCE_MANIFEST_SCHEMA_V1.to_string(),
+        delta_schema_version: CHAIN_RESOURCE_DELTA_SCHEMA_V1.to_string(),
+        world_id: snapshot.world_id.clone(),
+        chain_id,
+        world_seed,
+        chunk_generation_schema_version: CHUNK_GENERATION_SCHEMA_V1.to_string(),
+        seed_manifest_hash,
+        starter_chunk_manifest_hash,
+        latest_resource_commit_height: snapshot.consensus.committed_height,
+        latest_resource_commit_hash: snapshot.consensus.last_block_hash.clone(),
+        committed_chunk_count,
+        provisional_chunk_count,
+        pending_delta_count,
+        last_delta_id: latest_delta.as_ref().map(|delta| delta.delta_id.clone()),
+        last_delta_commit_height: latest_delta.as_ref().map(|delta| delta.block_height),
+        readiness_status: if failed_gates.is_empty() {
+            "ready".to_string()
+        } else {
+            "not_ready".to_string()
+        },
+        failed_gates,
+    }
+}
+
+fn load_latest_world_resource_snapshot(
+    execution_world_dir: &Path,
+    world_id: &str,
+    chain_id: &str,
+) -> (
+    Option<ChainResourceManifest>,
+    Option<ChainResourceDelta>,
+    Option<String>,
+) {
+    let simulator_snapshot_path =
+        simulator_world_dir_from_execution_world_dir(execution_world_dir).join("snapshot.json");
+    let mut load_errors = Vec::new();
+    if simulator_snapshot_path.exists() {
+        match SimulatorSnapshot::load_json(simulator_snapshot_path.as_path()) {
+            Ok(snapshot) if !snapshot.chain_resource_manifest.generated_chunks.is_empty() => {
+                return validate_world_resource_snapshot(
+                    snapshot.chain_resource_manifest,
+                    Some(snapshot.latest_chain_resource_delta),
+                    world_id,
+                    chain_id,
+                );
+            }
+            Ok(_) => load_errors.push("simulator_snapshot_empty_resource_manifest".to_string()),
+            Err(err) => load_errors.push(format!("simulator_snapshot:{err:?}")),
+        }
+    } else {
+        load_errors.push("simulator_snapshot_missing".to_string());
+    }
+
+    let runtime_snapshot_path = execution_world_dir.join("snapshot.json");
+    if runtime_snapshot_path.exists() {
+        match RuntimeSnapshot::load_json(runtime_snapshot_path.as_path()) {
+            Ok(snapshot) if !snapshot.chain_resource_manifest.generated_chunks.is_empty() => {
+                return validate_world_resource_snapshot(
+                    snapshot.chain_resource_manifest,
+                    snapshot.latest_chain_resource_delta,
+                    world_id,
+                    chain_id,
+                );
+            }
+            Ok(_) => load_errors.push("runtime_snapshot_empty_resource_manifest".to_string()),
+            Err(err) => load_errors.push(format!("runtime_snapshot:{err:?}")),
+        }
+    } else {
+        load_errors.push("runtime_snapshot_missing".to_string());
+    }
+
+    (None, None, Some(load_errors.join(",")))
+}
+
+fn validate_world_resource_snapshot(
+    manifest: ChainResourceManifest,
+    latest_delta: Option<ChainResourceDelta>,
+    _world_id: &str,
+    _chain_id: &str,
+) -> (
+    Option<ChainResourceManifest>,
+    Option<ChainResourceDelta>,
+    Option<String>,
+) {
+    (Some(manifest), latest_delta, None)
+}
+
+fn simulator_world_dir_from_execution_world_dir(world_dir: &Path) -> std::path::PathBuf {
+    match world_dir.file_name().and_then(|name| name.to_str()) {
+        Some(name) if !name.is_empty() => {
+            world_dir.with_file_name(format!("{name}-simulator-mirror"))
+        }
+        _ => world_dir.join("simulator-mirror"),
+    }
+}
+
+fn starter_chunk_manifest_hash(manifest: Option<&ChainResourceManifest>) -> Option<String> {
+    manifest
+        .and_then(|manifest| manifest.generated_chunks.values().next())
+        .map(|entry| entry.manifest_hash.clone())
+        .filter(|hash| !hash.trim().is_empty())
+}
+
+fn committed_chunk_count(manifest: &ChainResourceManifest) -> u64 {
+    manifest
+        .generated_chunks
+        .values()
+        .filter(|entry| entry.chunk_status == ChainChunkResourceStatus::Committed)
+        .count() as u64
+}
+
+fn provisional_chunk_count(manifest: &ChainResourceManifest) -> u64 {
+    manifest
+        .generated_chunks
+        .values()
+        .filter(|entry| {
+            matches!(
+                entry.chunk_status,
+                ChainChunkResourceStatus::ChainPending | ChainChunkResourceStatus::Provisional
+            )
+        })
+        .count() as u64
+}
+
+fn delta_has_nonzero_resource_effect(delta: &ChainResourceDelta) -> bool {
+    delta.entries.iter().any(|entry| match entry {
+        ChainResourceDeltaEntry::RuntimeResource { delta, .. } => *delta != 0,
+        ChainResourceDeltaEntry::MaterialLedger { delta, .. } => *delta != 0,
+        ChainResourceDeltaEntry::ChunkResource {
+            total_delta_g,
+            remaining_delta_g,
+            resulting_remaining_g,
+            ..
+        } => *total_delta_g != 0 || *remaining_delta_g != 0 || *resulting_remaining_g != 0,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use oasis7::geometry::GeoPos;
+    use oasis7::runtime::{Action, World as RuntimeWorld};
+    use oasis7_node::{NodeConsensusSnapshot, NodeRole};
+    use std::fs;
+    use std::path::PathBuf;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn temp_dir(prefix: &str) -> PathBuf {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("duration")
+            .as_nanos();
+        std::env::temp_dir().join(format!("oasis7-status-world-resource-{prefix}-{unique}"))
+    }
+
+    #[test]
+    fn status_uses_runtime_execution_snapshot_when_simulator_mirror_is_empty() {
+        let dir = temp_dir("runtime-fallback");
+        let mut world = RuntimeWorld::new();
+        world.submit_action(Action::RegisterAgent {
+            agent_id: "starter-agent-0".to_string(),
+            pos: GeoPos::new(0, 0, 0),
+        });
+        world.step().expect("register agent");
+        world
+            .save_to_dir(dir.as_path())
+            .expect("save runtime world");
+
+        let snapshot = NodeSnapshot {
+            node_id: "node-a".to_string(),
+            player_id: "player-a".to_string(),
+            world_id: "world-a".to_string(),
+            role: NodeRole::Sequencer,
+            replication_enabled: false,
+            running: true,
+            tick_count: 1,
+            last_tick_unix_ms: None,
+            consensus: NodeConsensusSnapshot {
+                committed_height: 1,
+                last_block_hash: Some("block-a".to_string()),
+                ..NodeConsensusSnapshot::default()
+            },
+            last_error: None,
+        };
+
+        let status = build_world_resource_status(&snapshot, dir.as_path(), None);
+
+        assert_eq!(status.world_id, "world-a");
+        assert_eq!(status.chain_id, "world-a");
+        assert_eq!(status.readiness_status, "not_ready");
+        assert_eq!(status.committed_chunk_count, 1);
+        assert_eq!(status.pending_delta_count, 0);
+        assert!(
+            status
+                .failed_gates
+                .contains(&"world_resource_delta_commit_hash_missing".to_string()),
+            "{:?}",
+            status.failed_gates
+        );
+        assert!(
+            status
+                .failed_gates
+                .contains(&"world_resource_delta_zero_effect".to_string()),
+            "{:?}",
+            status.failed_gates
+        );
+        assert!(
+            status
+                .failed_gates
+                .contains(&"world_resource_world_id_mismatch".to_string()),
+            "{:?}",
+            status.failed_gates
+        );
+        assert!(
+            status
+                .failed_gates
+                .contains(&"world_resource_chain_id_mismatch".to_string()),
+            "{:?}",
+            status.failed_gates
+        );
+        assert!(status.starter_chunk_manifest_hash.is_some());
+
+        let _ = fs::remove_dir_all(dir);
+    }
+}

--- a/crates/oasis7/src/bin/oasis7_game_launcher.rs
+++ b/crates/oasis7/src/bin/oasis7_game_launcher.rs
@@ -184,6 +184,7 @@ struct CliOptions {
     chain_p2p_user_mode: String,
     chain_p2p_accept_public_entry: bool,
     chain_replication_bootstrap_peers: Vec<String>,
+    chain_local_standalone_test: bool,
     chain_node_tick_ms: u64,
     chain_pos_slot_duration_ms: u64,
     chain_pos_ticks_per_slot: u64,
@@ -191,6 +192,7 @@ struct CliOptions {
     chain_pos_adaptive_tick_scheduler_enabled: bool,
     chain_pos_slot_clock_genesis_unix_ms: Option<i64>,
     chain_pos_max_past_slot_lag: u64,
+    chain_node_auto_attest_all_validators: bool,
     chain_node_validators: Vec<String>,
 }
 
@@ -229,6 +231,7 @@ impl Default for CliOptions {
             chain_p2p_user_mode: DEFAULT_CHAIN_P2P_USER_MODE.to_string(),
             chain_p2p_accept_public_entry: false,
             chain_replication_bootstrap_peers: default_chain_replication_bootstrap_peers_vec(),
+            chain_local_standalone_test: false,
             chain_node_tick_ms: DEFAULT_CHAIN_NODE_TICK_MS,
             chain_pos_slot_duration_ms: DEFAULT_CHAIN_POS_SLOT_DURATION_MS,
             chain_pos_ticks_per_slot: DEFAULT_CHAIN_POS_TICKS_PER_SLOT,
@@ -236,6 +239,7 @@ impl Default for CliOptions {
             chain_pos_adaptive_tick_scheduler_enabled: false,
             chain_pos_slot_clock_genesis_unix_ms: None,
             chain_pos_max_past_slot_lag: DEFAULT_CHAIN_POS_MAX_PAST_SLOT_LAG,
+            chain_node_auto_attest_all_validators: false,
             chain_node_validators: Vec::new(),
         }
     }
@@ -470,6 +474,15 @@ fn chain_execution_world_dir(node_id: &str) -> String {
         .into_owned()
 }
 
+fn chain_config_path(node_id: &str) -> String {
+    Path::new("output")
+        .join("chain-runtime")
+        .join(node_id)
+        .join("config.toml")
+        .to_string_lossy()
+        .into_owned()
+}
+
 fn missing_execution_world_persistence_files(world_dir: &Path) -> Vec<PathBuf> {
     ["snapshot.json", "journal.json"]
         .into_iter()
@@ -487,6 +500,8 @@ fn build_oasis7_chain_runtime_args(options: &CliOptions) -> Vec<String> {
         chain_world_id(options),
         "--status-bind".to_string(),
         options.chain_status_bind.clone(),
+        "--config".to_string(),
+        chain_config_path(options.chain_node_id.as_str()),
         "--execution-world-dir".to_string(),
         execution_world_dir,
         "--node-role".to_string(),
@@ -509,6 +524,11 @@ fn build_oasis7_chain_runtime_args(options: &CliOptions) -> Vec<String> {
         "--pos-max-past-slot-lag".to_string(),
         options.chain_pos_max_past_slot_lag.to_string(),
     ];
+    if options.chain_node_auto_attest_all_validators {
+        args.push("--node-auto-attest-all".to_string());
+    } else {
+        args.push("--node-no-auto-attest-all".to_string());
+    }
     if options.chain_network_tier_manifest.trim().is_empty() {
         args.push("--storage-profile".to_string());
         args.push(options.chain_storage_profile.as_str().to_string());

--- a/crates/oasis7/src/bin/oasis7_game_launcher/cli.rs
+++ b/crates/oasis7/src/bin/oasis7_game_launcher/cli.rs
@@ -156,6 +156,17 @@ pub(super) fn parse_options<'a>(args: impl Iterator<Item = &'a str>) -> Result<C
                 }
                 options.chain_replication_bootstrap_peers.push(value);
             }
+            "--chain-local-standalone-test" => {
+                options.chain_local_standalone_test = true;
+                options.chain_p2p_user_mode = "private_safe".to_string();
+                options.chain_p2p_accept_public_entry = false;
+                options.chain_replication_bootstrap_peers.clear();
+                explicit_chain_replication_bootstrap_peers = true;
+                options.chain_node_auto_attest_all_validators = true;
+                options.chain_pos_slot_duration_ms = 1_000;
+                options.chain_pos_ticks_per_slot = 1;
+                options.chain_pos_proposal_tick_phase = 0;
+            }
             "--chain-node-tick-ms" => {
                 let raw = parse_required_value(&mut iter, "--chain-node-tick-ms")?;
                 options.chain_node_tick_ms = raw.parse::<u64>().map_err(|_| {
@@ -220,6 +231,12 @@ pub(super) fn parse_options<'a>(args: impl Iterator<Item = &'a str>) -> Result<C
                 validate_chain_node_validator(value.as_str())?;
                 options.chain_node_validators.push(value);
             }
+            "--chain-node-auto-attest-all" => {
+                options.chain_node_auto_attest_all_validators = true;
+            }
+            "--chain-node-no-auto-attest-all" => {
+                options.chain_node_auto_attest_all_validators = false;
+            }
             _ => return Err(format!("unknown option: {arg}")),
         }
     }
@@ -266,6 +283,11 @@ pub(super) fn parse_options<'a>(args: impl Iterator<Item = &'a str>) -> Result<C
         let _ = parse_chain_link_policy(options.chain_link_policy.as_str())?;
         if options.chain_node_id.trim().is_empty() {
             return Err("--chain-node-id requires a non-empty value".to_string());
+        }
+        if options.chain_local_standalone_test && options.chain_node_validators.is_empty() {
+            options
+                .chain_node_validators
+                .push(format!("{}:100", options.chain_node_id.trim()));
         }
         parse_chain_node_role(options.chain_node_role.as_str())?;
         if options.chain_network_tier_manifest.trim().is_empty()
@@ -472,6 +494,8 @@ Options:\n\
                                keep conservative fallback when auto mode suggests public entry (default)\n\
   --chain-replication-network-peer <multiaddr>\n\
                                oasis7_chain_runtime replication bootstrap peer multiaddr (repeatable; first explicit value replaces bundled defaults)\n\
+  --chain-local-standalone-test\n\
+                               do not join external testnet peers; configure a self-validating single-node local commit loop\n\
   --chain-node-tick-ms <n>     oasis7_chain_runtime worker poll/fallback interval ms (default: {DEFAULT_CHAIN_NODE_TICK_MS})\n\
   --chain-pos-slot-duration-ms <n>\n\
                                oasis7_chain_runtime PoS slot duration ms (default: {DEFAULT_CHAIN_POS_SLOT_DURATION_MS})\n\
@@ -488,6 +512,9 @@ Options:\n\
   --chain-pos-max-past-slot-lag <n>\n\
                                oasis7_chain_runtime max accepted stale slot lag (default: {DEFAULT_CHAIN_POS_MAX_PAST_SLOT_LAG})\n\
   --chain-node-validator <v:s> oasis7_chain_runtime validator (repeatable)\n\
+  --chain-node-auto-attest-all enable local auto-attestation for configured validators\n\
+  --chain-node-no-auto-attest-all\n\
+                               disable local auto-attestation (default)\n\
   --with-llm                   enable llm mode (default; required for gameplay)\n\
   --auto-play                  start oasis7_viewer_live gameplay/world progression on connect\n\
   --allow-debug-scenario       allow seeded debug scenarios such as llm_bootstrap\n\

--- a/crates/oasis7/src/bin/oasis7_game_launcher/oasis7_game_launcher_tests.rs
+++ b/crates/oasis7/src/bin/oasis7_game_launcher/oasis7_game_launcher_tests.rs
@@ -110,6 +110,8 @@ fn parse_options_defaults() {
     assert_eq!(options.chain_pos_slot_clock_genesis_unix_ms, None);
     assert_eq!(options.chain_pos_max_past_slot_lag, 256);
     assert_eq!(options.chain_world_id, None);
+    assert!(!options.chain_local_standalone_test);
+    assert!(!options.chain_node_auto_attest_all_validators);
 }
 
 #[test]
@@ -181,6 +183,7 @@ fn parse_options_accepts_overrides() {
             "32",
             "--chain-node-validator",
             "chain-a:55",
+            "--chain-node-auto-attest-all",
             "--with-llm",
             "--auto-play",
             "--agent-decision-source",
@@ -245,6 +248,7 @@ fn parse_options_accepts_overrides() {
         options.chain_node_validators,
         vec!["chain-a:55".to_string()]
     );
+    assert!(options.chain_node_auto_attest_all_validators);
     assert!(options.with_llm);
     assert_eq!(
         options.agent_decision_source,
@@ -785,6 +789,8 @@ fn query_runtime_bound_players_reads_snapshot_bindings() {
             model,
             runtime_snapshot: None,
             player_gameplay: None,
+            chain_resource_manifest: Default::default(),
+            latest_chain_resource_delta: Default::default(),
             chunk_runtime: Default::default(),
             intel_ttl_ticks: 0,
             next_event_id: 0,
@@ -925,6 +931,44 @@ fn build_oasis7_chain_runtime_args_derives_world_id_from_explicit_scenario() {
     let args = build_oasis7_chain_runtime_args(&options);
     assert!(args.contains(&"--world-id".to_string()));
     assert!(args.contains(&"live-sandbox".to_string()));
+}
+
+#[test]
+fn parse_options_local_standalone_test_builds_self_validating_private_chain() {
+    let options = parse_options(
+        [
+            "--chain-node-id",
+            "local-node-a",
+            "--deployment-mode",
+            "trusted_local_only",
+            "--allow-trusted-local-playtest",
+            "--chain-local-standalone-test",
+            "--no-open-browser",
+        ]
+        .into_iter(),
+    )
+    .expect("local standalone profile should parse");
+
+    assert!(options.chain_local_standalone_test);
+    assert_eq!(options.chain_p2p_user_mode, "private_safe");
+    assert!(!options.chain_p2p_accept_public_entry);
+    assert!(options.chain_replication_bootstrap_peers.is_empty());
+    assert!(options.chain_node_auto_attest_all_validators);
+    assert_eq!(options.chain_pos_slot_duration_ms, 1_000);
+    assert_eq!(options.chain_pos_ticks_per_slot, 1);
+    assert_eq!(options.chain_pos_proposal_tick_phase, 0);
+    assert_eq!(
+        options.chain_node_validators,
+        vec!["local-node-a:100".to_string()]
+    );
+
+    let args = build_oasis7_chain_runtime_args(&options);
+    assert!(args.contains(&"--node-auto-attest-all".to_string()));
+    assert!(args.contains(&"--node-validator".to_string()));
+    assert!(args.contains(&"local-node-a:100".to_string()));
+    assert!(args.contains(&"--config".to_string()));
+    assert!(args.contains(&"output/chain-runtime/local-node-a/config.toml".to_string()));
+    assert!(!args.contains(&"--replication-network-peer".to_string()));
 }
 
 #[test]

--- a/crates/oasis7/src/bin/oasis7_game_launcher/runtime_presence.rs
+++ b/crates/oasis7/src/bin/oasis7_game_launcher/runtime_presence.rs
@@ -375,6 +375,8 @@ mod tests {
             model,
             runtime_snapshot: None,
             player_gameplay: None,
+            chain_resource_manifest: Default::default(),
+            latest_chain_resource_delta: Default::default(),
             chunk_runtime: Default::default(),
             intel_ttl_ticks: 0,
             next_event_id: 0,

--- a/crates/oasis7/src/bin/oasis7_provider_local_bridge.rs
+++ b/crates/oasis7/src/bin/oasis7_provider_local_bridge.rs
@@ -206,6 +206,12 @@ impl ProviderState {
                 "inspect_target".to_string(),
                 "simple_interact".to_string(),
             ],
+            chain_resource_manifest_schema_version: Some(
+                oasis7::runtime::CHAIN_RESOURCE_MANIFEST_SCHEMA_V1.to_string(),
+            ),
+            chain_resource_delta_schema_version: Some(
+                oasis7::runtime::CHAIN_RESOURCE_DELTA_SCHEMA_V1.to_string(),
+            ),
         }
     }
 

--- a/crates/oasis7/src/bin/oasis7_provider_parity_bench/tests.rs
+++ b/crates/oasis7/src/bin/oasis7_provider_parity_bench/tests.rs
@@ -277,7 +277,7 @@ fn prepare_provider_info_captures_provider_compatibility_status() {
             let bytes = stream.read(&mut request).expect("read request");
             let request_text = String::from_utf8_lossy(&request[..bytes]);
             let body = if request_text.contains("GET /v1/provider/info") {
-                r#"{"provider_id":"provider_local_bridge","name":"Provider Local Bridge","version":"0.1.0","protocol_version":"world-simulator-provider-loopback-http-v1","capabilities":["decision","feedback"],"supported_action_sets":["wait","wait_ticks","move_agent","speak_to_nearby","inspect_target","simple_interact"]}"#
+                r#"{"provider_id":"provider_local_bridge","name":"Provider Local Bridge","version":"0.1.0","protocol_version":"world-simulator-provider-loopback-http-v1","chain_resource_manifest_schema_version":"oasis7.world_resource_manifest.v1","chain_resource_delta_schema_version":"oasis7.world_resource_delta.v1","capabilities":["decision","feedback"],"supported_action_sets":["wait","wait_ticks","move_agent","speak_to_nearby","inspect_target","simple_interact"]}"#
             } else {
                 r#"{"ok":true,"status":"ready","uptime_ms":42,"last_error":null,"queue_depth":0}"#
             };
@@ -317,7 +317,7 @@ fn prepare_provider_info_marks_incompatible_supported_actions() {
             let bytes = stream.read(&mut request).expect("read request");
             let request_text = String::from_utf8_lossy(&request[..bytes]);
             let body = if request_text.contains("GET /v1/provider/info") {
-                r#"{"provider_id":"provider_local_bridge","name":"Provider Local Bridge","version":"0.1.0","protocol_version":"world-simulator-provider-loopback-http-v1","capabilities":["decision","feedback"],"supported_action_sets":["wait","move_agent"]}"#
+                r#"{"provider_id":"provider_local_bridge","name":"Provider Local Bridge","version":"0.1.0","protocol_version":"world-simulator-provider-loopback-http-v1","chain_resource_manifest_schema_version":"oasis7.world_resource_manifest.v1","chain_resource_delta_schema_version":"oasis7.world_resource_delta.v1","capabilities":["decision","feedback"],"supported_action_sets":["wait","move_agent"]}"#
             } else {
                 r#"{"ok":true,"status":"ready","uptime_ms":42,"last_error":null,"queue_depth":0}"#
             };
@@ -355,7 +355,7 @@ fn prepare_provider_info_marks_missing_capabilities_as_incompatible() {
             let bytes = stream.read(&mut request).expect("read request");
             let request_text = String::from_utf8_lossy(&request[..bytes]);
             let body = if request_text.contains("GET /v1/provider/info") {
-                r#"{"provider_id":"provider_local_bridge","name":"Provider Local Bridge","version":"0.1.0","protocol_version":"world-simulator-provider-loopback-http-v1","capabilities":["decision"],"supported_action_sets":["phase1_low_frequency"]}"#
+                r#"{"provider_id":"provider_local_bridge","name":"Provider Local Bridge","version":"0.1.0","protocol_version":"world-simulator-provider-loopback-http-v1","chain_resource_manifest_schema_version":"oasis7.world_resource_manifest.v1","chain_resource_delta_schema_version":"oasis7.world_resource_delta.v1","capabilities":["decision"],"supported_action_sets":["phase1_low_frequency"]}"#
             } else {
                 r#"{"ok":true,"status":"ready","uptime_ms":42,"last_error":null,"queue_depth":0}"#
             };

--- a/crates/oasis7/src/chain_resource_schema.rs
+++ b/crates/oasis7/src/chain_resource_schema.rs
@@ -739,62 +739,8 @@ fn delta_from_simulator_event(
                 }
             }
         }
-        WorldEventKind::FragmentsReplenished {
-            entries: replenished,
-        } => {
-            for replenished_entry in replenished {
-                let Some(fragment_budget) = replenished_entry.location.fragment_budget.as_ref()
-                else {
-                    continue;
-                };
-                for (element, total) in &fragment_budget.total_by_element_g {
-                    let remaining = fragment_budget.get_remaining(*element);
-                    entries.push(ChainResourceDeltaEntry::ChunkResource {
-                        coord: replenished_entry.coord,
-                        element: *element,
-                        total_delta_g: *total,
-                        remaining_delta_g: remaining,
-                        resulting_remaining_g: remaining,
-                        remaining_after_hash: hash_json(&fragment_budget.remaining_by_element_g)
-                            .unwrap_or_default(),
-                        chunk_remaining_after_hash: manifest
-                            .generated_chunks
-                            .get(&chunk_key(replenished_entry.coord))
-                            .map(|entry| entry.chunk_budget_remaining_hash.clone())
-                            .unwrap_or_default(),
-                    });
-                }
-            }
-            ChainResourceDeltaSource::Replenish
-        }
-        WorldEventKind::CompoundMined {
-            location_id,
-            extracted_elements,
-            ..
-        } => {
-            let chunk = manifest.generated_chunks.values().find(|entry| {
-                entry
-                    .fragment_refs
-                    .iter()
-                    .any(|fragment_ref| fragment_ref.location_id == *location_id)
-            })?;
-            for (element, amount) in extracted_elements {
-                let resulting_remaining = chunk
-                    .remaining_by_element_g
-                    .get(element)
-                    .copied()
-                    .unwrap_or(0);
-                entries.push(ChainResourceDeltaEntry::ChunkResource {
-                    coord: chunk.coord,
-                    element: *element,
-                    total_delta_g: 0,
-                    remaining_delta_g: amount.saturating_neg(),
-                    resulting_remaining_g: resulting_remaining,
-                    remaining_after_hash: chunk.chunk_budget_remaining_hash.clone(),
-                    chunk_remaining_after_hash: chunk.chunk_budget_remaining_hash.clone(),
-                });
-            }
-            ChainResourceDeltaSource::MineCompound
+        WorldEventKind::FragmentsReplenished { .. } | WorldEventKind::CompoundMined { .. } => {
+            return None;
         }
         _ => return None,
     };
@@ -816,7 +762,7 @@ fn delta_from_simulator_event(
             event_sequence: event.id,
             action_sequence: 0,
         },
-        base_manifest_hash: event_base_manifest_hash(manifest, event),
+        base_manifest_hash: chunk_generation_base_manifest_hash(manifest, event),
         resulting_manifest_hash: manifest.manifest_hash.clone(),
         block_height: context.manifest_height,
         commit_block_hash: context.commit_block_hash.map(ToOwned::to_owned),
@@ -827,14 +773,14 @@ fn delta_from_simulator_event(
     })
 }
 
-fn event_base_manifest_hash(manifest: &ChainResourceManifest, event: &WorldEvent) -> String {
-    if matches!(
-        event.kind,
-        WorldEventKind::ChunkGenerated {
-            cause: ChunkGenerationCause::Init,
-            ..
-        }
-    ) {
+fn chunk_generation_base_manifest_hash(
+    manifest: &ChainResourceManifest,
+    event: &WorldEvent,
+) -> String {
+    let WorldEventKind::ChunkGenerated { coord, cause, .. } = &event.kind else {
+        return manifest.manifest_hash.clone();
+    };
+    if matches!(cause, ChunkGenerationCause::Init) {
         return ChainResourceManifest::empty_at_height(
             manifest.world_id.clone(),
             manifest.world_seed,
@@ -843,8 +789,9 @@ fn event_base_manifest_hash(manifest: &ChainResourceManifest, event: &WorldEvent
         .canonical_hash();
     }
     let mut base = manifest.clone();
+    base.generated_chunks.remove(&chunk_key(*coord));
     base.manifest_height = manifest.manifest_height.saturating_sub(1);
-    base.manifest_hash = base.canonical_hash();
+    base.refresh_hashes();
     base.manifest_hash
 }
 
@@ -915,5 +862,86 @@ mod tests {
         assert_eq!(delta.chain_id, "unbound");
         assert_eq!(delta.ordering_key.height, 9);
         assert!(delta.is_schema_current());
+    }
+
+    #[test]
+    fn chunk_generation_delta_base_hash_uses_pre_event_manifest() {
+        let coord = ChunkCoord { x: 1, y: 2, z: 3 };
+        let mut budget = crate::simulator::ChunkResourceBudget::default();
+        budget
+            .total_by_element_g
+            .insert(FragmentElementKind::Iron, 100);
+        budget
+            .remaining_by_element_g
+            .insert(FragmentElementKind::Iron, 80);
+
+        let mut manifest = ChainResourceManifest::empty_at_height("world-a", 42, 3);
+        manifest.chain_id = "chain-a".to_string();
+        manifest.manifest_height = 3;
+        manifest.generated_chunks.insert(
+            chunk_key(coord),
+            ChainChunkResourceManifestEntry {
+                schema_version: CHAIN_RESOURCE_MANIFEST_SCHEMA_V1.to_string(),
+                world_id: "world-a".to_string(),
+                chain_id: "chain-a".to_string(),
+                world_seed: 42,
+                chunk_generation_schema_version: CHUNK_GENERATION_SCHEMA_V1.to_string(),
+                coord,
+                seed: 99,
+                chunk_status: ChainChunkResourceStatus::Committed,
+                fragment_count: 0,
+                block_count: 0,
+                fragment_refs: Vec::new(),
+                chunk_budget_total_hash: hash_json(&budget.total_by_element_g).unwrap(),
+                chunk_budget_remaining_hash: hash_json(&budget.remaining_by_element_g).unwrap(),
+                total_by_element_g: budget.total_by_element_g.clone(),
+                remaining_by_element_g: budget.remaining_by_element_g.clone(),
+                commit_ref: ChainResourceCommitRef {
+                    height: 3,
+                    block_hash: Some("block-3".to_string()),
+                    event_id: Some(7),
+                    action_id: None,
+                },
+                manifest_hash: String::new(),
+            },
+        );
+        manifest.refresh_hashes();
+
+        let mut expected_base = manifest.clone();
+        expected_base.generated_chunks.remove(&chunk_key(coord));
+        expected_base.manifest_height = 2;
+        expected_base.refresh_hashes();
+
+        let event = WorldEvent {
+            id: 7,
+            time: 9,
+            kind: WorldEventKind::ChunkGenerated {
+                coord,
+                seed: 99,
+                fragment_count: 0,
+                block_count: 0,
+                chunk_budget: budget,
+                cause: ChunkGenerationCause::Action,
+            },
+            runtime_event: None,
+        };
+        let delta = delta_from_simulator_event(
+            ChainResourceDerivationContext {
+                world_id: "world-a",
+                chain_id: "chain-a",
+                genesis_ref: None,
+                created_at_height: 0,
+                manifest_height: 3,
+                commit_block_hash: Some("block-3"),
+                tick: 9,
+            },
+            &manifest,
+            &event,
+        )
+        .expect("chunk delta");
+
+        assert_eq!(delta.base_manifest_hash, expected_base.manifest_hash);
+        assert_ne!(delta.base_manifest_hash, manifest.manifest_hash);
+        assert_eq!(delta.resulting_manifest_hash, manifest.manifest_hash);
     }
 }

--- a/crates/oasis7/src/chain_resource_schema.rs
+++ b/crates/oasis7/src/chain_resource_schema.rs
@@ -1,21 +1,111 @@
 //! Chain-side resource manifest and delta schema.
 
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 use std::collections::BTreeMap;
+#[cfg(target_arch = "wasm32")]
+use std::fmt;
 
+#[cfg(not(target_arch = "wasm32"))]
 use crate::geometry::DEFAULT_CLOUD_WIDTH_CM;
+#[cfg(not(target_arch = "wasm32"))]
+use crate::runtime::WorldState;
+#[cfg(not(target_arch = "wasm32"))]
+use crate::runtime::{ActionId, MaterialLedgerId, WorldEventId, WorldTime};
+#[cfg(not(target_arch = "wasm32"))]
+use crate::simulator::SpaceConfig;
 use crate::simulator::{
     ChunkCoord, ChunkGenerationCause, ChunkRuntimeConfig, ChunkState, FragmentElementKind,
-    ResourceKind, SpaceConfig, WorldConfig, WorldEvent, WorldEventKind, WorldModel, chunk_coord_of,
-    chunk_seed,
+    ResourceKind, WorldConfig, WorldEvent, WorldEventKind, WorldModel, chunk_coord_of, chunk_seed,
 };
 
-use super::state::WorldState;
-use super::{ActionId, MaterialLedgerId, WorldEventId, WorldTime};
+#[cfg(target_arch = "wasm32")]
+pub type WorldTime = u64;
+#[cfg(target_arch = "wasm32")]
+pub type WorldEventId = u64;
+#[cfg(target_arch = "wasm32")]
+pub type ActionId = u64;
+
+#[cfg(target_arch = "wasm32")]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, Hash)]
+#[serde(try_from = "String", into = "String")]
+pub enum MaterialLedgerId {
+    World,
+    Agent(String),
+    Site(String),
+    Factory(String),
+}
+
+#[cfg(target_arch = "wasm32")]
+impl Default for MaterialLedgerId {
+    fn default() -> Self {
+        Self::World
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+impl fmt::Display for MaterialLedgerId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            MaterialLedgerId::World => write!(f, "world"),
+            MaterialLedgerId::Agent(agent_id) => write!(f, "agent:{agent_id}"),
+            MaterialLedgerId::Site(site_id) => write!(f, "site:{site_id}"),
+            MaterialLedgerId::Factory(factory_id) => write!(f, "factory:{factory_id}"),
+        }
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+impl From<MaterialLedgerId> for String {
+    fn from(value: MaterialLedgerId) -> Self {
+        value.to_string()
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+impl TryFrom<String> for MaterialLedgerId {
+    type Error = String;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        if value == "world" {
+            return Ok(MaterialLedgerId::World);
+        }
+        if let Some(rest) = value.strip_prefix("agent:") {
+            if rest.trim().is_empty() {
+                return Err("agent ledger id cannot be empty".to_string());
+            }
+            return Ok(MaterialLedgerId::Agent(rest.to_string()));
+        }
+        if let Some(rest) = value.strip_prefix("site:") {
+            if rest.trim().is_empty() {
+                return Err("site ledger id cannot be empty".to_string());
+            }
+            return Ok(MaterialLedgerId::Site(rest.to_string()));
+        }
+        if let Some(rest) = value.strip_prefix("factory:") {
+            if rest.trim().is_empty() {
+                return Err("factory ledger id cannot be empty".to_string());
+            }
+            return Ok(MaterialLedgerId::Factory(rest.to_string()));
+        }
+        Err(format!("invalid material ledger id: {value}"))
+    }
+}
 
 pub const CHAIN_RESOURCE_MANIFEST_SCHEMA_V1: &str = "oasis7.world_resource_manifest.v1";
 pub const CHAIN_RESOURCE_DELTA_SCHEMA_V1: &str = "oasis7.world_resource_delta.v1";
 pub const CHUNK_GENERATION_SCHEMA_V1: &str = "oasis7.chunk_generation.v1";
+
+fn hash_json<T: Serialize>(value: &T) -> Result<String, serde_json::Error> {
+    let bytes = serde_json::to_vec(value)?;
+    Ok(sha256_hex(&bytes))
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    hex::encode(hasher.finalize())
+}
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ChainResourceManifest {
@@ -70,7 +160,7 @@ impl ChainResourceManifest {
     pub fn canonical_hash(&self) -> String {
         let mut clone = self.clone();
         clone.manifest_hash.clear();
-        super::util::hash_json(&clone).unwrap_or_else(|_| String::new())
+        hash_json(&clone).unwrap_or_else(|_| String::new())
     }
 
     pub fn refresh_hashes(&mut self) {
@@ -93,9 +183,8 @@ impl ChainResourceManifest {
         journal: &[WorldEvent],
     ) -> Self {
         let world_seed = chunk_runtime.world_seed;
-        let world_config_hash = super::util::hash_json(config).unwrap_or_default();
-        let generation_algorithm_hash =
-            super::util::hash_json(&(config, chunk_runtime)).unwrap_or_default();
+        let world_config_hash = hash_json(config).unwrap_or_default();
+        let generation_algorithm_hash = hash_json(&(config, chunk_runtime)).unwrap_or_default();
         let mut generated_chunks = BTreeMap::new();
         for (coord, state) in &model.chunks {
             if !matches!(state, ChunkState::Generated | ChunkState::Exhausted) {
@@ -120,21 +209,16 @@ impl ChainResourceManifest {
                 fragment_refs.push(ChainFragmentResourceRef {
                     fragment_id: location.id.clone(),
                     location_id: location.id.clone(),
-                    profile_hash: super::util::hash_json(fragment_profile).unwrap_or_default(),
+                    profile_hash: hash_json(fragment_profile).unwrap_or_default(),
                     budget_total_hash: location
                         .fragment_budget
                         .as_ref()
-                        .map(|budget| {
-                            super::util::hash_json(&budget.total_by_element_g).unwrap_or_default()
-                        })
+                        .map(|budget| hash_json(&budget.total_by_element_g).unwrap_or_default())
                         .unwrap_or_default(),
                     budget_remaining_hash: location
                         .fragment_budget
                         .as_ref()
-                        .map(|budget| {
-                            super::util::hash_json(&budget.remaining_by_element_g)
-                                .unwrap_or_default()
-                        })
+                        .map(|budget| hash_json(&budget.remaining_by_element_g).unwrap_or_default())
                         .unwrap_or_default(),
                 });
             }
@@ -165,12 +249,10 @@ impl ChainResourceManifest {
                 fragment_count: fragment_refs.len() as u32,
                 block_count,
                 fragment_refs,
-                chunk_budget_total_hash: super::util::hash_json(&chunk_budget.total_by_element_g)
+                chunk_budget_total_hash: hash_json(&chunk_budget.total_by_element_g)
                     .unwrap_or_default(),
-                chunk_budget_remaining_hash: super::util::hash_json(
-                    &chunk_budget.remaining_by_element_g,
-                )
-                .unwrap_or_default(),
+                chunk_budget_remaining_hash: hash_json(&chunk_budget.remaining_by_element_g)
+                    .unwrap_or_default(),
                 total_by_element_g: chunk_budget.total_by_element_g.clone(),
                 remaining_by_element_g: chunk_budget.remaining_by_element_g.clone(),
                 commit_ref,
@@ -201,6 +283,7 @@ impl ChainResourceManifest {
         manifest
     }
 
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn from_runtime_state(
         context: ChainResourceDerivationContext<'_>,
         world_config_hash: impl Into<String>,
@@ -225,10 +308,9 @@ impl ChainResourceManifest {
                 fragment_refs.push(ChainFragmentResourceRef {
                     fragment_id: format!("runtime-agent:{agent_id}"),
                     location_id: format!("runtime-agent:{agent_id}"),
-                    profile_hash: super::util::hash_json(agent_id).unwrap_or_default(),
-                    budget_total_hash: super::util::hash_json(&state.resources).unwrap_or_default(),
-                    budget_remaining_hash: super::util::hash_json(&state.resources)
-                        .unwrap_or_default(),
+                    profile_hash: hash_json(agent_id).unwrap_or_default(),
+                    budget_total_hash: hash_json(&state.resources).unwrap_or_default(),
+                    budget_remaining_hash: hash_json(&state.resources).unwrap_or_default(),
                 });
             }
             let mut entry = ChainChunkResourceManifestEntry {
@@ -243,10 +325,8 @@ impl ChainResourceManifest {
                 fragment_count: fragment_refs.len() as u32,
                 block_count: fragment_refs.len() as u32,
                 fragment_refs,
-                chunk_budget_total_hash: super::util::hash_json(&state.resources)
-                    .unwrap_or_default(),
-                chunk_budget_remaining_hash: super::util::hash_json(&state.resources)
-                    .unwrap_or_default(),
+                chunk_budget_total_hash: hash_json(&state.resources).unwrap_or_default(),
+                chunk_budget_remaining_hash: hash_json(&state.resources).unwrap_or_default(),
                 total_by_element_g: BTreeMap::new(),
                 remaining_by_element_g: BTreeMap::new(),
                 commit_ref: ChainResourceCommitRef {
@@ -319,7 +399,7 @@ impl ChainChunkResourceManifestEntry {
     pub fn canonical_hash(&self) -> String {
         let mut clone = self.clone();
         clone.manifest_hash.clear();
-        super::util::hash_json(&clone).unwrap_or_default()
+        hash_json(&clone).unwrap_or_default()
     }
 }
 
@@ -574,6 +654,7 @@ fn aggregate_agent_resource_balances(model: &WorldModel) -> BTreeMap<ResourceKin
     balances
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 fn aggregate_runtime_resource_balances(state: &WorldState) -> BTreeMap<ResourceKind, i64> {
     let mut balances = state.resources.clone();
     for agent in state.agents.values() {
@@ -585,6 +666,7 @@ fn aggregate_runtime_resource_balances(state: &WorldState) -> BTreeMap<ResourceK
     balances
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 fn runtime_agents_by_chunk(state: &WorldState) -> BTreeMap<String, Vec<(&String, ChunkCoord)>> {
     let mut out: BTreeMap<String, Vec<(&String, ChunkCoord)>> = BTreeMap::new();
     let space = runtime_chunk_space_for_state(state);
@@ -598,6 +680,7 @@ fn runtime_agents_by_chunk(state: &WorldState) -> BTreeMap<String, Vec<(&String,
     out
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 fn runtime_chunk_space_for_state(state: &WorldState) -> SpaceConfig {
     let mut space = SpaceConfig::default();
     for agent in state.agents.values() {
@@ -614,9 +697,9 @@ fn runtime_chunk_space_for_state(state: &WorldState) -> SpaceConfig {
     space
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 fn runtime_world_seed(world_id: &str, chain_id: &str, world_config_hash: &str) -> u64 {
-    let hash =
-        super::util::sha256_hex(format!("{world_id}:{chain_id}:{world_config_hash}").as_bytes());
+    let hash = sha256_hex(format!("{world_id}:{chain_id}:{world_config_hash}").as_bytes());
     u64::from_str_radix(hash.get(0..16).unwrap_or("1"), 16)
         .unwrap_or(1)
         .max(1)
@@ -643,14 +726,10 @@ fn delta_from_simulator_event(
                     total_delta_g: *total,
                     remaining_delta_g: remaining,
                     resulting_remaining_g: remaining,
-                    remaining_after_hash: super::util::hash_json(
-                        &chunk_budget.remaining_by_element_g,
-                    )
-                    .unwrap_or_default(),
-                    chunk_remaining_after_hash: super::util::hash_json(
-                        &chunk_budget.remaining_by_element_g,
-                    )
-                    .unwrap_or_default(),
+                    remaining_after_hash: hash_json(&chunk_budget.remaining_by_element_g)
+                        .unwrap_or_default(),
+                    chunk_remaining_after_hash: hash_json(&chunk_budget.remaining_by_element_g)
+                        .unwrap_or_default(),
                 });
             }
             match cause {
@@ -676,10 +755,8 @@ fn delta_from_simulator_event(
                         total_delta_g: *total,
                         remaining_delta_g: remaining,
                         resulting_remaining_g: remaining,
-                        remaining_after_hash: super::util::hash_json(
-                            &fragment_budget.remaining_by_element_g,
-                        )
-                        .unwrap_or_default(),
+                        remaining_after_hash: hash_json(&fragment_budget.remaining_by_element_g)
+                            .unwrap_or_default(),
                         chunk_remaining_after_hash: manifest
                             .generated_chunks
                             .get(&chunk_key(replenished_entry.coord))

--- a/crates/oasis7/src/lib.rs
+++ b/crates/oasis7/src/lib.rs
@@ -1,5 +1,6 @@
 extern crate self as oasis7;
 
+pub mod chain_resource_schema;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod consensus_action_payload;
 pub mod env_mut;

--- a/crates/oasis7/src/runtime/chain_resource_schema.rs
+++ b/crates/oasis7/src/runtime/chain_resource_schema.rs
@@ -1,0 +1,842 @@
+//! Chain-side resource manifest and delta schema.
+
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+use crate::geometry::DEFAULT_CLOUD_WIDTH_CM;
+use crate::simulator::{
+    ChunkCoord, ChunkGenerationCause, ChunkRuntimeConfig, ChunkState, FragmentElementKind,
+    ResourceKind, SpaceConfig, WorldConfig, WorldEvent, WorldEventKind, WorldModel, chunk_coord_of,
+    chunk_seed,
+};
+
+use super::state::WorldState;
+use super::{ActionId, MaterialLedgerId, WorldEventId, WorldTime};
+
+pub const CHAIN_RESOURCE_MANIFEST_SCHEMA_V1: &str = "oasis7.world_resource_manifest.v1";
+pub const CHAIN_RESOURCE_DELTA_SCHEMA_V1: &str = "oasis7.world_resource_delta.v1";
+pub const CHUNK_GENERATION_SCHEMA_V1: &str = "oasis7.chunk_generation.v1";
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ChainResourceManifest {
+    pub schema_version: String,
+    pub world_id: String,
+    pub chain_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub genesis_ref: Option<String>,
+    pub world_seed: u64,
+    pub chunk_generation_schema_version: String,
+    #[serde(default)]
+    pub world_config_hash: String,
+    #[serde(default)]
+    pub generation_algorithm_id: String,
+    #[serde(default)]
+    pub generation_algorithm_hash: String,
+    pub created_at_height: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub created_at_block_hash: Option<String>,
+    pub manifest_height: u64,
+    pub manifest_hash: String,
+    pub resource_balances: BTreeMap<ResourceKind, i64>,
+    pub material_ledgers: BTreeMap<MaterialLedgerId, BTreeMap<String, i64>>,
+    #[serde(default)]
+    pub generated_chunks: BTreeMap<String, ChainChunkResourceManifestEntry>,
+}
+
+impl ChainResourceManifest {
+    pub fn empty_at_height(world_id: impl Into<String>, world_seed: u64, height: u64) -> Self {
+        let mut manifest = Self {
+            schema_version: CHAIN_RESOURCE_MANIFEST_SCHEMA_V1.to_string(),
+            world_id: world_id.into(),
+            chain_id: "unbound".to_string(),
+            genesis_ref: None,
+            world_seed,
+            chunk_generation_schema_version: CHUNK_GENERATION_SCHEMA_V1.to_string(),
+            world_config_hash: String::new(),
+            generation_algorithm_id: "runtime_ledger_v1".to_string(),
+            generation_algorithm_hash: String::new(),
+            created_at_height: height,
+            created_at_block_hash: None,
+            manifest_height: height,
+            manifest_hash: String::new(),
+            resource_balances: BTreeMap::new(),
+            material_ledgers: BTreeMap::new(),
+            generated_chunks: BTreeMap::new(),
+        };
+        manifest.manifest_hash = manifest.canonical_hash();
+        manifest
+    }
+
+    pub fn canonical_hash(&self) -> String {
+        let mut clone = self.clone();
+        clone.manifest_hash.clear();
+        super::util::hash_json(&clone).unwrap_or_else(|_| String::new())
+    }
+
+    pub fn refresh_hashes(&mut self) {
+        for entry in self.generated_chunks.values_mut() {
+            entry.manifest_hash = entry.canonical_hash();
+        }
+        self.manifest_hash = self.canonical_hash();
+    }
+
+    pub fn is_schema_current(&self) -> bool {
+        self.schema_version == CHAIN_RESOURCE_MANIFEST_SCHEMA_V1
+            && self.manifest_hash == self.canonical_hash()
+    }
+
+    pub fn from_simulator_state(
+        context: ChainResourceDerivationContext<'_>,
+        model: &WorldModel,
+        config: &WorldConfig,
+        chunk_runtime: &ChunkRuntimeConfig,
+        journal: &[WorldEvent],
+    ) -> Self {
+        let world_seed = chunk_runtime.world_seed;
+        let world_config_hash = super::util::hash_json(config).unwrap_or_default();
+        let generation_algorithm_hash =
+            super::util::hash_json(&(config, chunk_runtime)).unwrap_or_default();
+        let mut generated_chunks = BTreeMap::new();
+        for (coord, state) in &model.chunks {
+            if !matches!(state, ChunkState::Generated | ChunkState::Exhausted) {
+                continue;
+            }
+            let default_chunk_budget = Default::default();
+            let chunk_budget = model
+                .chunk_resource_budgets
+                .get(coord)
+                .unwrap_or(&default_chunk_budget);
+            let mut fragment_refs = Vec::new();
+            let mut block_count = 0_u32;
+            for location in model.locations.values() {
+                if chunk_coord_of(location.pos, &config.space) != Some(*coord) {
+                    continue;
+                }
+                let Some(fragment_profile) = location.fragment_profile.as_ref() else {
+                    continue;
+                };
+                block_count =
+                    block_count.saturating_add(fragment_profile.blocks.blocks.len() as u32);
+                fragment_refs.push(ChainFragmentResourceRef {
+                    fragment_id: location.id.clone(),
+                    location_id: location.id.clone(),
+                    profile_hash: super::util::hash_json(fragment_profile).unwrap_or_default(),
+                    budget_total_hash: location
+                        .fragment_budget
+                        .as_ref()
+                        .map(|budget| {
+                            super::util::hash_json(&budget.total_by_element_g).unwrap_or_default()
+                        })
+                        .unwrap_or_default(),
+                    budget_remaining_hash: location
+                        .fragment_budget
+                        .as_ref()
+                        .map(|budget| {
+                            super::util::hash_json(&budget.remaining_by_element_g)
+                                .unwrap_or_default()
+                        })
+                        .unwrap_or_default(),
+                });
+            }
+            let commit_ref = latest_chunk_commit_ref(
+                journal,
+                *coord,
+                context.manifest_height,
+                context.commit_block_hash,
+            );
+            let chunk_seed_base = if chunk_runtime.asteroid_fragment_enabled {
+                chunk_runtime.asteroid_fragment_seed()
+            } else {
+                world_seed
+            };
+            let mut entry = ChainChunkResourceManifestEntry {
+                schema_version: CHAIN_RESOURCE_MANIFEST_SCHEMA_V1.to_string(),
+                world_id: context.world_id.to_string(),
+                chain_id: context.chain_id.to_string(),
+                world_seed,
+                chunk_generation_schema_version: CHUNK_GENERATION_SCHEMA_V1.to_string(),
+                coord: *coord,
+                seed: chunk_seed(chunk_seed_base, *coord),
+                chunk_status: if matches!(state, ChunkState::Exhausted) {
+                    ChainChunkResourceStatus::Exhausted
+                } else {
+                    ChainChunkResourceStatus::Committed
+                },
+                fragment_count: fragment_refs.len() as u32,
+                block_count,
+                fragment_refs,
+                chunk_budget_total_hash: super::util::hash_json(&chunk_budget.total_by_element_g)
+                    .unwrap_or_default(),
+                chunk_budget_remaining_hash: super::util::hash_json(
+                    &chunk_budget.remaining_by_element_g,
+                )
+                .unwrap_or_default(),
+                total_by_element_g: chunk_budget.total_by_element_g.clone(),
+                remaining_by_element_g: chunk_budget.remaining_by_element_g.clone(),
+                commit_ref,
+                manifest_hash: String::new(),
+            };
+            entry.manifest_hash = entry.canonical_hash();
+            generated_chunks.insert(chunk_key(*coord), entry);
+        }
+        let mut manifest = Self {
+            schema_version: CHAIN_RESOURCE_MANIFEST_SCHEMA_V1.to_string(),
+            world_id: context.world_id.to_string(),
+            chain_id: context.chain_id.to_string(),
+            genesis_ref: context.genesis_ref.map(ToOwned::to_owned),
+            world_seed,
+            chunk_generation_schema_version: CHUNK_GENERATION_SCHEMA_V1.to_string(),
+            world_config_hash,
+            generation_algorithm_id: "simulator_chunk_fragment_v1".to_string(),
+            generation_algorithm_hash,
+            created_at_height: context.created_at_height,
+            created_at_block_hash: context.commit_block_hash.map(ToOwned::to_owned),
+            manifest_height: context.manifest_height,
+            manifest_hash: String::new(),
+            resource_balances: aggregate_agent_resource_balances(model),
+            material_ledgers: BTreeMap::new(),
+            generated_chunks,
+        };
+        manifest.manifest_hash = manifest.canonical_hash();
+        manifest
+    }
+
+    pub fn from_runtime_state(
+        context: ChainResourceDerivationContext<'_>,
+        world_config_hash: impl Into<String>,
+        generation_algorithm_hash: impl Into<String>,
+        state: &WorldState,
+    ) -> Self {
+        let world_config_hash = world_config_hash.into();
+        let generation_algorithm_hash = generation_algorithm_hash.into();
+        let world_seed = runtime_world_seed(
+            context.world_id,
+            context.chain_id,
+            world_config_hash.as_str(),
+        );
+        let mut generated_chunks = BTreeMap::new();
+        for (chunk_key, agents) in runtime_agents_by_chunk(state) {
+            let coord = agents
+                .first()
+                .map(|(_, coord)| *coord)
+                .unwrap_or(ChunkCoord { x: 0, y: 0, z: 0 });
+            let mut fragment_refs = Vec::new();
+            for (agent_id, _) in agents {
+                fragment_refs.push(ChainFragmentResourceRef {
+                    fragment_id: format!("runtime-agent:{agent_id}"),
+                    location_id: format!("runtime-agent:{agent_id}"),
+                    profile_hash: super::util::hash_json(agent_id).unwrap_or_default(),
+                    budget_total_hash: super::util::hash_json(&state.resources).unwrap_or_default(),
+                    budget_remaining_hash: super::util::hash_json(&state.resources)
+                        .unwrap_or_default(),
+                });
+            }
+            let mut entry = ChainChunkResourceManifestEntry {
+                schema_version: CHAIN_RESOURCE_MANIFEST_SCHEMA_V1.to_string(),
+                world_id: context.world_id.to_string(),
+                chain_id: context.chain_id.to_string(),
+                world_seed,
+                chunk_generation_schema_version: CHUNK_GENERATION_SCHEMA_V1.to_string(),
+                coord,
+                seed: chunk_seed(world_seed, coord),
+                chunk_status: ChainChunkResourceStatus::Committed,
+                fragment_count: fragment_refs.len() as u32,
+                block_count: fragment_refs.len() as u32,
+                fragment_refs,
+                chunk_budget_total_hash: super::util::hash_json(&state.resources)
+                    .unwrap_or_default(),
+                chunk_budget_remaining_hash: super::util::hash_json(&state.resources)
+                    .unwrap_or_default(),
+                total_by_element_g: BTreeMap::new(),
+                remaining_by_element_g: BTreeMap::new(),
+                commit_ref: ChainResourceCommitRef {
+                    height: context.manifest_height,
+                    block_hash: context.commit_block_hash.map(ToOwned::to_owned),
+                    event_id: None,
+                    action_id: None,
+                },
+                manifest_hash: String::new(),
+            };
+            entry.manifest_hash = entry.canonical_hash();
+            generated_chunks.insert(chunk_key, entry);
+        }
+        let mut manifest = Self {
+            schema_version: CHAIN_RESOURCE_MANIFEST_SCHEMA_V1.to_string(),
+            world_id: context.world_id.to_string(),
+            chain_id: context.chain_id.to_string(),
+            genesis_ref: context.genesis_ref.map(ToOwned::to_owned),
+            world_seed,
+            chunk_generation_schema_version: CHUNK_GENERATION_SCHEMA_V1.to_string(),
+            world_config_hash,
+            generation_algorithm_id: "runtime_agent_chunk_v1".to_string(),
+            generation_algorithm_hash,
+            created_at_height: context.created_at_height,
+            created_at_block_hash: context.commit_block_hash.map(ToOwned::to_owned),
+            manifest_height: context.manifest_height,
+            manifest_hash: String::new(),
+            resource_balances: aggregate_runtime_resource_balances(state),
+            material_ledgers: state.material_ledgers.clone(),
+            generated_chunks,
+        };
+        manifest.manifest_hash = manifest.canonical_hash();
+        manifest
+    }
+}
+
+impl Default for ChainResourceManifest {
+    fn default() -> Self {
+        Self::empty_at_height("unbound", 0, 0)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ChainChunkResourceManifestEntry {
+    pub schema_version: String,
+    pub world_id: String,
+    pub chain_id: String,
+    pub world_seed: u64,
+    pub chunk_generation_schema_version: String,
+    pub coord: ChunkCoord,
+    pub seed: u64,
+    pub chunk_status: ChainChunkResourceStatus,
+    pub fragment_count: u32,
+    pub block_count: u32,
+    #[serde(default)]
+    pub fragment_refs: Vec<ChainFragmentResourceRef>,
+    #[serde(default)]
+    pub chunk_budget_total_hash: String,
+    #[serde(default)]
+    pub chunk_budget_remaining_hash: String,
+    pub total_by_element_g: BTreeMap<FragmentElementKind, i64>,
+    pub remaining_by_element_g: BTreeMap<FragmentElementKind, i64>,
+    #[serde(default)]
+    pub commit_ref: ChainResourceCommitRef,
+    #[serde(default)]
+    pub manifest_hash: String,
+}
+
+impl ChainChunkResourceManifestEntry {
+    pub fn canonical_hash(&self) -> String {
+        let mut clone = self.clone();
+        clone.manifest_hash.clear();
+        super::util::hash_json(&clone).unwrap_or_default()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum ChainChunkResourceStatus {
+    #[default]
+    Committed,
+    ChainPending,
+    Provisional,
+    Exhausted,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct ChainFragmentResourceRef {
+    pub fragment_id: String,
+    pub location_id: String,
+    pub profile_hash: String,
+    pub budget_total_hash: String,
+    pub budget_remaining_hash: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct ChainResourceCommitRef {
+    pub height: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub block_hash: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub event_id: Option<WorldEventId>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub action_id: Option<ActionId>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ChainResourceDelta {
+    pub schema_version: String,
+    pub world_id: String,
+    pub chain_id: String,
+    pub delta_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub action_id: Option<ActionId>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub event_id: Option<WorldEventId>,
+    pub ordering_key: ChainResourceOrderingKey,
+    pub base_manifest_hash: String,
+    pub resulting_manifest_hash: String,
+    pub block_height: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub commit_block_hash: Option<String>,
+    pub tick: WorldTime,
+    pub source: ChainResourceDeltaSource,
+    pub replay_status: ChainResourceReplayStatus,
+    pub entries: Vec<ChainResourceDeltaEntry>,
+}
+
+impl ChainResourceDelta {
+    pub fn empty_for_manifest(
+        world_id: impl Into<String>,
+        manifest_hash: impl Into<String>,
+        block_height: u64,
+        tick: WorldTime,
+    ) -> Self {
+        let manifest_hash = manifest_hash.into();
+        Self {
+            schema_version: CHAIN_RESOURCE_DELTA_SCHEMA_V1.to_string(),
+            world_id: world_id.into(),
+            chain_id: "unbound".to_string(),
+            delta_id: format!("resource-delta-{block_height}-{tick}"),
+            action_id: None,
+            event_id: None,
+            ordering_key: ChainResourceOrderingKey {
+                height: block_height,
+                event_sequence: 0,
+                action_sequence: 0,
+            },
+            base_manifest_hash: manifest_hash.clone(),
+            resulting_manifest_hash: manifest_hash,
+            block_height,
+            commit_block_hash: None,
+            tick,
+            source: ChainResourceDeltaSource::Genesis,
+            replay_status: ChainResourceReplayStatus::Committed,
+            entries: Vec::new(),
+        }
+    }
+
+    pub fn is_schema_current(&self) -> bool {
+        self.schema_version == CHAIN_RESOURCE_DELTA_SCHEMA_V1
+            && !self.base_manifest_hash.trim().is_empty()
+            && !self.resulting_manifest_hash.trim().is_empty()
+    }
+
+    pub fn latest_from_simulator_journal(
+        context: ChainResourceDerivationContext<'_>,
+        manifest: &ChainResourceManifest,
+        journal: &[WorldEvent],
+    ) -> Self {
+        for event in journal.iter().rev() {
+            if let Some(delta) = delta_from_simulator_event(context, manifest, event) {
+                return delta;
+            }
+        }
+        let mut delta = Self::empty_for_manifest(
+            context.world_id,
+            manifest.manifest_hash.clone(),
+            context.manifest_height,
+            context.tick,
+        );
+        delta.chain_id = context.chain_id.to_string();
+        delta.commit_block_hash = context.commit_block_hash.map(ToOwned::to_owned);
+        delta
+    }
+
+    pub fn latest_from_runtime_manifest(
+        context: ChainResourceDerivationContext<'_>,
+        manifest: &ChainResourceManifest,
+    ) -> Self {
+        let mut entries = Vec::new();
+        for chunk in manifest.generated_chunks.values() {
+            entries.push(ChainResourceDeltaEntry::ChunkResource {
+                coord: chunk.coord,
+                element: FragmentElementKind::Iron,
+                total_delta_g: 0,
+                remaining_delta_g: 0,
+                resulting_remaining_g: 0,
+                remaining_after_hash: chunk.chunk_budget_remaining_hash.clone(),
+                chunk_remaining_after_hash: chunk.chunk_budget_remaining_hash.clone(),
+            });
+        }
+        Self {
+            schema_version: CHAIN_RESOURCE_DELTA_SCHEMA_V1.to_string(),
+            world_id: context.world_id.to_string(),
+            chain_id: context.chain_id.to_string(),
+            delta_id: format!(
+                "resource-delta-{}-{}",
+                context.manifest_height, context.tick
+            ),
+            action_id: None,
+            event_id: None,
+            ordering_key: ChainResourceOrderingKey {
+                height: context.manifest_height,
+                event_sequence: 0,
+                action_sequence: 0,
+            },
+            base_manifest_hash: if entries.is_empty() {
+                manifest.manifest_hash.clone()
+            } else {
+                ChainResourceManifest::empty_at_height(
+                    manifest.world_id.clone(),
+                    manifest.world_seed,
+                    manifest.created_at_height,
+                )
+                .canonical_hash()
+            },
+            resulting_manifest_hash: manifest.manifest_hash.clone(),
+            block_height: context.manifest_height,
+            commit_block_hash: context.commit_block_hash.map(ToOwned::to_owned),
+            tick: context.tick,
+            source: ChainResourceDeltaSource::Genesis,
+            replay_status: ChainResourceReplayStatus::Committed,
+            entries,
+        }
+    }
+}
+
+impl Default for ChainResourceDelta {
+    fn default() -> Self {
+        Self::empty_for_manifest(
+            "unbound",
+            ChainResourceManifest::default().manifest_hash,
+            0,
+            0,
+        )
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct ChainResourceDerivationContext<'a> {
+    pub world_id: &'a str,
+    pub chain_id: &'a str,
+    pub genesis_ref: Option<&'a str>,
+    pub created_at_height: u64,
+    pub manifest_height: u64,
+    pub commit_block_hash: Option<&'a str>,
+    pub tick: WorldTime,
+}
+
+impl<'a> ChainResourceDerivationContext<'a> {
+    pub fn simulator_default(tick: WorldTime) -> Self {
+        Self {
+            world_id: "simulator-world",
+            chain_id: "simulator-chain",
+            genesis_ref: None,
+            created_at_height: 0,
+            manifest_height: tick,
+            commit_block_hash: None,
+            tick,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ChainResourceOrderingKey {
+    pub height: u64,
+    pub event_sequence: u64,
+    pub action_sequence: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum ChainResourceDeltaSource {
+    ChunkGenerated,
+    MineCompound,
+    Replenish,
+    #[default]
+    Genesis,
+    Migration,
+}
+
+fn latest_chunk_commit_ref(
+    journal: &[WorldEvent],
+    coord: ChunkCoord,
+    height: u64,
+    block_hash: Option<&str>,
+) -> ChainResourceCommitRef {
+    let event_id = journal.iter().rev().find_map(|event| match &event.kind {
+        WorldEventKind::ChunkGenerated {
+            coord: event_coord, ..
+        } if *event_coord == coord => Some(event.id),
+        _ => None,
+    });
+    ChainResourceCommitRef {
+        height,
+        block_hash: block_hash.map(ToOwned::to_owned),
+        event_id,
+        action_id: None,
+    }
+}
+
+fn chunk_key(coord: ChunkCoord) -> String {
+    format!("chunk:{}:{}:{}", coord.x, coord.y, coord.z)
+}
+
+fn aggregate_agent_resource_balances(model: &WorldModel) -> BTreeMap<ResourceKind, i64> {
+    let mut balances: BTreeMap<ResourceKind, i64> = BTreeMap::new();
+    for agent in model.agents.values() {
+        for (kind, amount) in &agent.resources.amounts {
+            let entry = balances.entry(*kind).or_insert(0);
+            *entry = (*entry).saturating_add(*amount);
+        }
+    }
+    balances
+}
+
+fn aggregate_runtime_resource_balances(state: &WorldState) -> BTreeMap<ResourceKind, i64> {
+    let mut balances = state.resources.clone();
+    for agent in state.agents.values() {
+        for (kind, amount) in &agent.state.resources.amounts {
+            let entry = balances.entry(*kind).or_insert(0);
+            *entry = (*entry).saturating_add(*amount);
+        }
+    }
+    balances
+}
+
+fn runtime_agents_by_chunk(state: &WorldState) -> BTreeMap<String, Vec<(&String, ChunkCoord)>> {
+    let mut out: BTreeMap<String, Vec<(&String, ChunkCoord)>> = BTreeMap::new();
+    let space = runtime_chunk_space_for_state(state);
+    for (agent_id, agent) in &state.agents {
+        let coord =
+            chunk_coord_of(agent.state.pos, &space).unwrap_or(ChunkCoord { x: 0, y: 0, z: 0 });
+        out.entry(chunk_key(coord))
+            .or_default()
+            .push((agent_id, coord));
+    }
+    out
+}
+
+fn runtime_chunk_space_for_state(state: &WorldState) -> SpaceConfig {
+    let mut space = SpaceConfig::default();
+    for agent in state.agents.values() {
+        space.width_cm = space
+            .width_cm
+            .max(agent.state.pos.x_cm.saturating_add(DEFAULT_CLOUD_WIDTH_CM));
+        space.depth_cm = space
+            .depth_cm
+            .max(agent.state.pos.y_cm.saturating_add(DEFAULT_CLOUD_WIDTH_CM));
+        space.height_cm = space
+            .height_cm
+            .max(agent.state.pos.z_cm.saturating_add(DEFAULT_CLOUD_WIDTH_CM));
+    }
+    space
+}
+
+fn runtime_world_seed(world_id: &str, chain_id: &str, world_config_hash: &str) -> u64 {
+    let hash =
+        super::util::sha256_hex(format!("{world_id}:{chain_id}:{world_config_hash}").as_bytes());
+    u64::from_str_radix(hash.get(0..16).unwrap_or("1"), 16)
+        .unwrap_or(1)
+        .max(1)
+}
+
+fn delta_from_simulator_event(
+    context: ChainResourceDerivationContext<'_>,
+    manifest: &ChainResourceManifest,
+    event: &WorldEvent,
+) -> Option<ChainResourceDelta> {
+    let mut entries = Vec::new();
+    let source = match &event.kind {
+        WorldEventKind::ChunkGenerated {
+            coord,
+            chunk_budget,
+            cause,
+            ..
+        } => {
+            for (element, total) in &chunk_budget.total_by_element_g {
+                let remaining = chunk_budget.get_remaining(*element);
+                entries.push(ChainResourceDeltaEntry::ChunkResource {
+                    coord: *coord,
+                    element: *element,
+                    total_delta_g: *total,
+                    remaining_delta_g: remaining,
+                    resulting_remaining_g: remaining,
+                    remaining_after_hash: super::util::hash_json(
+                        &chunk_budget.remaining_by_element_g,
+                    )
+                    .unwrap_or_default(),
+                    chunk_remaining_after_hash: super::util::hash_json(
+                        &chunk_budget.remaining_by_element_g,
+                    )
+                    .unwrap_or_default(),
+                });
+            }
+            match cause {
+                ChunkGenerationCause::Init => ChainResourceDeltaSource::Genesis,
+                ChunkGenerationCause::Observe | ChunkGenerationCause::Action => {
+                    ChainResourceDeltaSource::ChunkGenerated
+                }
+            }
+        }
+        WorldEventKind::FragmentsReplenished {
+            entries: replenished,
+        } => {
+            for replenished_entry in replenished {
+                let Some(fragment_budget) = replenished_entry.location.fragment_budget.as_ref()
+                else {
+                    continue;
+                };
+                for (element, total) in &fragment_budget.total_by_element_g {
+                    let remaining = fragment_budget.get_remaining(*element);
+                    entries.push(ChainResourceDeltaEntry::ChunkResource {
+                        coord: replenished_entry.coord,
+                        element: *element,
+                        total_delta_g: *total,
+                        remaining_delta_g: remaining,
+                        resulting_remaining_g: remaining,
+                        remaining_after_hash: super::util::hash_json(
+                            &fragment_budget.remaining_by_element_g,
+                        )
+                        .unwrap_or_default(),
+                        chunk_remaining_after_hash: manifest
+                            .generated_chunks
+                            .get(&chunk_key(replenished_entry.coord))
+                            .map(|entry| entry.chunk_budget_remaining_hash.clone())
+                            .unwrap_or_default(),
+                    });
+                }
+            }
+            ChainResourceDeltaSource::Replenish
+        }
+        WorldEventKind::CompoundMined {
+            location_id,
+            extracted_elements,
+            ..
+        } => {
+            let chunk = manifest.generated_chunks.values().find(|entry| {
+                entry
+                    .fragment_refs
+                    .iter()
+                    .any(|fragment_ref| fragment_ref.location_id == *location_id)
+            })?;
+            for (element, amount) in extracted_elements {
+                let resulting_remaining = chunk
+                    .remaining_by_element_g
+                    .get(element)
+                    .copied()
+                    .unwrap_or(0);
+                entries.push(ChainResourceDeltaEntry::ChunkResource {
+                    coord: chunk.coord,
+                    element: *element,
+                    total_delta_g: 0,
+                    remaining_delta_g: amount.saturating_neg(),
+                    resulting_remaining_g: resulting_remaining,
+                    remaining_after_hash: chunk.chunk_budget_remaining_hash.clone(),
+                    chunk_remaining_after_hash: chunk.chunk_budget_remaining_hash.clone(),
+                });
+            }
+            ChainResourceDeltaSource::MineCompound
+        }
+        _ => return None,
+    };
+    if entries.is_empty() {
+        return None;
+    }
+    Some(ChainResourceDelta {
+        schema_version: CHAIN_RESOURCE_DELTA_SCHEMA_V1.to_string(),
+        world_id: context.world_id.to_string(),
+        chain_id: context.chain_id.to_string(),
+        delta_id: format!(
+            "resource-delta-{}-{}-{}",
+            context.manifest_height, event.id, event.time
+        ),
+        action_id: None,
+        event_id: Some(event.id),
+        ordering_key: ChainResourceOrderingKey {
+            height: context.manifest_height,
+            event_sequence: event.id,
+            action_sequence: 0,
+        },
+        base_manifest_hash: event_base_manifest_hash(manifest, event),
+        resulting_manifest_hash: manifest.manifest_hash.clone(),
+        block_height: context.manifest_height,
+        commit_block_hash: context.commit_block_hash.map(ToOwned::to_owned),
+        tick: event.time,
+        source,
+        replay_status: ChainResourceReplayStatus::Committed,
+        entries,
+    })
+}
+
+fn event_base_manifest_hash(manifest: &ChainResourceManifest, event: &WorldEvent) -> String {
+    if matches!(
+        event.kind,
+        WorldEventKind::ChunkGenerated {
+            cause: ChunkGenerationCause::Init,
+            ..
+        }
+    ) {
+        return ChainResourceManifest::empty_at_height(
+            manifest.world_id.clone(),
+            manifest.world_seed,
+            manifest.created_at_height,
+        )
+        .canonical_hash();
+    }
+    let mut base = manifest.clone();
+    base.manifest_height = manifest.manifest_height.saturating_sub(1);
+    base.manifest_hash = base.canonical_hash();
+    base.manifest_hash
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum ChainResourceReplayStatus {
+    #[default]
+    Committed,
+    Rejected,
+    RolledBack,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "scope", rename_all = "snake_case")]
+pub enum ChainResourceDeltaEntry {
+    RuntimeResource {
+        kind: ResourceKind,
+        delta: i64,
+        resulting_balance: i64,
+    },
+    MaterialLedger {
+        ledger_id: MaterialLedgerId,
+        material_kind: String,
+        delta: i64,
+        resulting_balance: i64,
+    },
+    ChunkResource {
+        coord: ChunkCoord,
+        element: FragmentElementKind,
+        total_delta_g: i64,
+        remaining_delta_g: i64,
+        resulting_remaining_g: i64,
+        remaining_after_hash: String,
+        chunk_remaining_after_hash: String,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn chain_resource_manifest_hash_is_stable_across_roundtrip() {
+        let mut manifest = ChainResourceManifest::empty_at_height("world-a", 42, 7);
+        manifest.chain_id = "chain-a".to_string();
+        manifest.world_config_hash = "world-config-hash".to_string();
+        manifest.generation_algorithm_hash = "algorithm-hash".to_string();
+        manifest.manifest_hash = manifest.canonical_hash();
+
+        let encoded = serde_json::to_string(&manifest).expect("encode manifest");
+        let decoded: ChainResourceManifest =
+            serde_json::from_str(encoded.as_str()).expect("decode manifest");
+
+        assert_eq!(decoded.schema_version, CHAIN_RESOURCE_MANIFEST_SCHEMA_V1);
+        assert_eq!(
+            decoded.chunk_generation_schema_version,
+            CHUNK_GENERATION_SCHEMA_V1
+        );
+        assert_eq!(decoded.manifest_hash, manifest.manifest_hash);
+        assert!(decoded.is_schema_current());
+    }
+
+    #[test]
+    fn chain_resource_delta_requires_world_resource_schema_and_commit_hashes() {
+        let delta = ChainResourceDelta::empty_for_manifest("world-a", "manifest-hash", 9, 11);
+
+        assert_eq!(delta.schema_version, CHAIN_RESOURCE_DELTA_SCHEMA_V1);
+        assert_eq!(delta.chain_id, "unbound");
+        assert_eq!(delta.ordering_key.height, 9);
+        assert!(delta.is_schema_current());
+    }
+}

--- a/crates/oasis7/src/runtime/mod.rs
+++ b/crates/oasis7/src/runtime/mod.rs
@@ -14,7 +14,6 @@ mod audit;
 mod blob_store;
 mod builtin_wasm_identity_manifest;
 mod builtin_wasm_materializer;
-mod chain_resource_schema;
 mod consensus;
 mod effect;
 mod error;
@@ -59,7 +58,7 @@ pub use types::{
 pub use agent_cell::AgentCell;
 
 // Chain resource schema
-pub use chain_resource_schema::{
+pub use crate::chain_resource_schema::{
     CHAIN_RESOURCE_DELTA_SCHEMA_V1, CHAIN_RESOURCE_MANIFEST_SCHEMA_V1, CHUNK_GENERATION_SCHEMA_V1,
     ChainChunkResourceManifestEntry, ChainChunkResourceStatus, ChainFragmentResourceRef,
     ChainResourceCommitRef, ChainResourceDelta, ChainResourceDeltaEntry, ChainResourceDeltaSource,

--- a/crates/oasis7/src/runtime/mod.rs
+++ b/crates/oasis7/src/runtime/mod.rs
@@ -14,6 +14,7 @@ mod audit;
 mod blob_store;
 mod builtin_wasm_identity_manifest;
 mod builtin_wasm_materializer;
+mod chain_resource_schema;
 mod consensus;
 mod effect;
 mod error;
@@ -56,6 +57,15 @@ pub use types::{
 
 // Agent cell
 pub use agent_cell::AgentCell;
+
+// Chain resource schema
+pub use chain_resource_schema::{
+    CHAIN_RESOURCE_DELTA_SCHEMA_V1, CHAIN_RESOURCE_MANIFEST_SCHEMA_V1, CHUNK_GENERATION_SCHEMA_V1,
+    ChainChunkResourceManifestEntry, ChainChunkResourceStatus, ChainFragmentResourceRef,
+    ChainResourceCommitRef, ChainResourceDelta, ChainResourceDeltaEntry, ChainResourceDeltaSource,
+    ChainResourceDerivationContext, ChainResourceManifest, ChainResourceOrderingKey,
+    ChainResourceReplayStatus,
+};
 
 // Audit
 pub use audit::{AuditCausedBy, AuditEventKind, AuditFilter};

--- a/crates/oasis7/src/runtime/snapshot.rs
+++ b/crates/oasis7/src/runtime/snapshot.rs
@@ -4,7 +4,6 @@ use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::Path;
 
-use super::chain_resource_schema::{ChainResourceDelta, ChainResourceManifest};
 use super::consensus::{TickConsensusRecord, TickConsensusRejectionAuditEvent};
 use super::effect::{CapabilityGrant, EffectIntent};
 use super::error::WorldError;
@@ -18,6 +17,7 @@ use super::types::{ActionId, IntentSeq, ProposalId, WorldEventId, WorldTime};
 use super::util::{deserialize_btreemap_u64_keys, read_json_from_path, write_json_to_path};
 use super::world::{WorldRuntimeBackpressureStats, WorldRuntimeMemoryLimits};
 use super::world_event::WorldEvent;
+use crate::chain_resource_schema::{ChainResourceDelta, ChainResourceManifest};
 
 /// Policy for how many snapshots to retain.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/crates/oasis7/src/runtime/snapshot.rs
+++ b/crates/oasis7/src/runtime/snapshot.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::Path;
 
+use super::chain_resource_schema::{ChainResourceDelta, ChainResourceManifest};
 use super::consensus::{TickConsensusRecord, TickConsensusRejectionAuditEvent};
 use super::effect::{CapabilityGrant, EffectIntent};
 use super::error::WorldError;
@@ -60,6 +61,10 @@ impl Default for SnapshotCatalog {
 pub struct Snapshot {
     pub snapshot_catalog: SnapshotCatalog,
     pub manifest: Manifest,
+    #[serde(default)]
+    pub chain_resource_manifest: ChainResourceManifest,
+    #[serde(default)]
+    pub latest_chain_resource_delta: Option<ChainResourceDelta>,
     #[serde(default)]
     pub module_registry: ModuleRegistry,
     #[serde(default)]

--- a/crates/oasis7/src/runtime/tests/persistence.rs
+++ b/crates/oasis7/src/runtime/tests/persistence.rs
@@ -685,6 +685,40 @@ fn persist_writes_sidecar_generation_index_and_pinset() {
 }
 
 #[test]
+fn persist_runtime_snapshot_records_committed_resource_chunk_and_delta() {
+    let mut world = World::new();
+    world.submit_action(Action::RegisterAgent {
+        agent_id: "agent-resource-chunk".to_string(),
+        pos: pos(0, 0),
+    });
+    world.step().expect("register agent");
+
+    let dir = temp_dir("persist-runtime-resource-chunk");
+    world.save_to_dir(&dir).expect("save world");
+
+    let snapshot = Snapshot::load_json(dir.join("snapshot.json")).expect("load snapshot");
+    assert!(snapshot.chain_resource_manifest.is_schema_current());
+    assert_eq!(snapshot.chain_resource_manifest.generated_chunks.len(), 1);
+    assert!(
+        snapshot
+            .chain_resource_manifest
+            .generated_chunks
+            .values()
+            .any(|chunk| chunk.chunk_status == ChainChunkResourceStatus::Committed)
+    );
+    let delta = snapshot
+        .latest_chain_resource_delta
+        .expect("resource delta");
+    assert!(delta.is_schema_current());
+    assert!(
+        !delta.entries.is_empty(),
+        "runtime resource delta should expose a non-empty chunk commit stream"
+    );
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
 fn persist_sidecar_generation_record_points_to_generation_local_payloads() {
     let mut world = World::new();
     world.submit_action(Action::RegisterAgent {

--- a/crates/oasis7/src/runtime/world/persistence.rs
+++ b/crates/oasis7/src/runtime/world/persistence.rs
@@ -601,9 +601,26 @@ impl World {
     // ---------------------------------------------------------------------
 
     pub fn snapshot(&self) -> Snapshot {
+        let chain_resource_manifest = self.chain_resource_manifest_snapshot();
+        let latest_chain_resource_delta = Some(
+            super::super::ChainResourceDelta::latest_from_runtime_manifest(
+                super::super::ChainResourceDerivationContext {
+                    world_id: chain_resource_manifest.world_id.as_str(),
+                    chain_id: chain_resource_manifest.chain_id.as_str(),
+                    genesis_ref: chain_resource_manifest.genesis_ref.as_deref(),
+                    created_at_height: chain_resource_manifest.created_at_height,
+                    manifest_height: chain_resource_manifest.manifest_height,
+                    commit_block_hash: chain_resource_manifest.created_at_block_hash.as_deref(),
+                    tick: self.state.time,
+                },
+                &chain_resource_manifest,
+            ),
+        );
         Snapshot {
             snapshot_catalog: self.snapshot_catalog.clone(),
             manifest: self.manifest.clone(),
+            chain_resource_manifest,
+            latest_chain_resource_delta,
             module_registry: self.module_registry.clone(),
             module_artifacts: self.module_artifacts.clone(),
             module_limits_max: self.module_limits_max.clone(),
@@ -647,6 +664,24 @@ impl World {
             governance_identity_penalties: self.governance_identity_penalties.clone(),
             next_governance_identity_penalty_id: self.next_governance_identity_penalty_id,
         }
+    }
+
+    fn chain_resource_manifest_snapshot(&self) -> super::super::ChainResourceManifest {
+        let manifest_hash = super::super::util::hash_json(&self.manifest).unwrap_or_default();
+        super::super::ChainResourceManifest::from_runtime_state(
+            super::super::ChainResourceDerivationContext {
+                world_id: DISTFS_WORLD_ID_FALLBACK,
+                chain_id: "runtime-chain",
+                genesis_ref: None,
+                created_at_height: self.journal.len() as u64,
+                manifest_height: self.journal.len() as u64,
+                commit_block_hash: None,
+                tick: self.state.time,
+            },
+            manifest_hash.clone(),
+            manifest_hash,
+            &self.state,
+        )
     }
 
     pub fn save_to_dir(&self, dir: impl AsRef<Path>) -> Result<(), WorldError> {

--- a/crates/oasis7/src/simulator/kernel/persistence.rs
+++ b/crates/oasis7/src/simulator/kernel/persistence.rs
@@ -5,6 +5,7 @@ use std::path::Path;
 use super::super::persist::{PersistError, WorldJournal, WorldSnapshot};
 use super::super::types::{CHUNK_GENERATION_SCHEMA_VERSION, JOURNAL_VERSION, SNAPSHOT_VERSION};
 use super::WorldKernel;
+use crate::runtime::{ChainResourceDelta, ChainResourceDerivationContext, ChainResourceManifest};
 
 impl WorldKernel {
     fn restore_persisted_state(
@@ -29,6 +30,27 @@ impl WorldKernel {
     }
 
     pub fn snapshot(&self) -> WorldSnapshot {
+        self.snapshot_with_chain_resource_context(
+            ChainResourceDerivationContext::simulator_default(self.time),
+        )
+    }
+
+    pub fn snapshot_with_chain_resource_context(
+        &self,
+        context: ChainResourceDerivationContext<'_>,
+    ) -> WorldSnapshot {
+        let chain_resource_manifest = ChainResourceManifest::from_simulator_state(
+            context,
+            &self.model,
+            &self.config,
+            &self.chunk_runtime,
+            &self.journal,
+        );
+        let latest_chain_resource_delta = ChainResourceDelta::latest_from_simulator_journal(
+            context,
+            &chain_resource_manifest,
+            &self.journal,
+        );
         WorldSnapshot {
             version: SNAPSHOT_VERSION,
             chunk_generation_schema_version: CHUNK_GENERATION_SCHEMA_VERSION,
@@ -37,6 +59,8 @@ impl WorldKernel {
             model: self.model.clone(),
             runtime_snapshot: None,
             player_gameplay: None,
+            chain_resource_manifest,
+            latest_chain_resource_delta,
             chunk_runtime: self.chunk_runtime.clone(),
             intel_ttl_ticks: self.intel_ttl_ticks,
             next_event_id: self.next_event_id,
@@ -103,11 +127,23 @@ impl WorldKernel {
     }
 
     pub fn save_to_dir(&self, dir: impl AsRef<Path>) -> Result<(), PersistError> {
+        self.save_to_dir_with_chain_resource_context(
+            dir,
+            ChainResourceDerivationContext::simulator_default(self.time),
+        )
+    }
+
+    pub fn save_to_dir_with_chain_resource_context(
+        &self,
+        dir: impl AsRef<Path>,
+        context: ChainResourceDerivationContext<'_>,
+    ) -> Result<(), PersistError> {
         let dir = dir.as_ref();
         fs::create_dir_all(dir)?;
         let snapshot_path = dir.join("snapshot.json");
         let journal_path = dir.join("journal.json");
-        self.snapshot().save_json(&snapshot_path)?;
+        self.snapshot_with_chain_resource_context(context)
+            .save_json(&snapshot_path)?;
         self.journal_snapshot().save_json(&journal_path)?;
         Ok(())
     }

--- a/crates/oasis7/src/simulator/kernel/persistence.rs
+++ b/crates/oasis7/src/simulator/kernel/persistence.rs
@@ -5,7 +5,9 @@ use std::path::Path;
 use super::super::persist::{PersistError, WorldJournal, WorldSnapshot};
 use super::super::types::{CHUNK_GENERATION_SCHEMA_VERSION, JOURNAL_VERSION, SNAPSHOT_VERSION};
 use super::WorldKernel;
-use crate::runtime::{ChainResourceDelta, ChainResourceDerivationContext, ChainResourceManifest};
+use crate::chain_resource_schema::{
+    ChainResourceDelta, ChainResourceDerivationContext, ChainResourceManifest,
+};
 
 impl WorldKernel {
     fn restore_persisted_state(

--- a/crates/oasis7/src/simulator/persist.rs
+++ b/crates/oasis7/src/simulator/persist.rs
@@ -13,9 +13,9 @@ use super::types::{
     WorldEventId, WorldTime,
 };
 use super::world_model::{WorldConfig, WorldModel};
+use crate::chain_resource_schema::{ChainResourceDelta, ChainResourceManifest};
 #[cfg(not(target_arch = "wasm32"))]
 use crate::runtime::Snapshot as RuntimeSnapshot;
-use crate::runtime::{ChainResourceDelta, ChainResourceManifest};
 #[cfg(target_arch = "wasm32")]
 use serde_json::Value as RuntimeSnapshot;
 

--- a/crates/oasis7/src/simulator/persist.rs
+++ b/crates/oasis7/src/simulator/persist.rs
@@ -15,6 +15,7 @@ use super::types::{
 use super::world_model::{WorldConfig, WorldModel};
 #[cfg(not(target_arch = "wasm32"))]
 use crate::runtime::Snapshot as RuntimeSnapshot;
+use crate::runtime::{ChainResourceDelta, ChainResourceManifest};
 #[cfg(target_arch = "wasm32")]
 use serde_json::Value as RuntimeSnapshot;
 
@@ -395,6 +396,10 @@ pub struct WorldSnapshot {
     pub runtime_snapshot: Option<RuntimeSnapshot>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub player_gameplay: Option<PlayerGameplaySnapshot>,
+    #[serde(default)]
+    pub chain_resource_manifest: ChainResourceManifest,
+    #[serde(default)]
+    pub latest_chain_resource_delta: ChainResourceDelta,
     #[serde(default)]
     pub chunk_runtime: ChunkRuntimeConfig,
     #[serde(default)]

--- a/crates/oasis7/src/simulator/provider_loopback_http.rs
+++ b/crates/oasis7/src/simulator/provider_loopback_http.rs
@@ -16,6 +16,8 @@ pub const LOOPBACK_HTTP_PROVIDER_TRANSPORT: &str = "loopback_http";
 pub const REMOTE_HTTPS_PROVIDER_TRANSPORT: &str = "remote_https";
 pub const PROVIDER_PHASE1_ACTION_SET_ALIAS: &str = "phase1_low_frequency";
 const PROVIDER_PHASE1_REQUIRED_CAPABILITIES: &[&str] = &["decision", "feedback"];
+const PROVIDER_WORLD_RESOURCE_MANIFEST_SCHEMA_V1: &str = "oasis7.world_resource_manifest.v1";
+const PROVIDER_WORLD_RESOURCE_DELTA_SCHEMA_V1: &str = "oasis7.world_resource_delta.v1";
 const PROVIDER_PHASE1_REQUIRED_ACTIONS: &[&str] = &[
     "wait",
     "wait_ticks",
@@ -38,6 +40,10 @@ pub struct ProviderInfo {
     pub capabilities: Vec<String>,
     #[serde(default)]
     pub supported_action_sets: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub chain_resource_manifest_schema_version: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub chain_resource_delta_schema_version: Option<String>,
 }
 
 impl ProviderInfo {
@@ -78,6 +84,8 @@ pub struct ProviderCompatibilityReport {
     pub missing_capabilities: Vec<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub missing_supported_actions: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub resource_schema_errors: Vec<String>,
 }
 
 pub fn provider_phase1_required_capabilities() -> &'static [&'static str] {
@@ -92,6 +100,20 @@ pub fn evaluate_provider_compatibility(
     info: &ProviderInfo,
     health: Option<&ProviderHealth>,
 ) -> ProviderCompatibilityReport {
+    let resource_schema_errors = provider_resource_schema_errors(info);
+    if !resource_schema_errors.is_empty() {
+        return ProviderCompatibilityReport {
+            status: ProviderCompatibilityStatus::Incompatible,
+            fallback_reason: Some(format!(
+                "unsupported_world_resource_schema:{}",
+                resource_schema_errors.join(",")
+            )),
+            missing_capabilities: Vec::new(),
+            missing_supported_actions: Vec::new(),
+            resource_schema_errors,
+        };
+    }
+
     let missing_capabilities = PROVIDER_PHASE1_REQUIRED_CAPABILITIES
         .iter()
         .filter(|required| !contains_trimmed_value(info.capabilities.as_slice(), required))
@@ -106,6 +128,7 @@ pub fn evaluate_provider_compatibility(
             )),
             missing_capabilities,
             missing_supported_actions: Vec::new(),
+            resource_schema_errors: Vec::new(),
         };
     }
 
@@ -132,6 +155,7 @@ pub fn evaluate_provider_compatibility(
             )),
             missing_capabilities: Vec::new(),
             missing_supported_actions,
+            resource_schema_errors: Vec::new(),
         };
     }
 
@@ -177,7 +201,27 @@ pub fn evaluate_provider_compatibility(
         fallback_reason,
         missing_capabilities: Vec::new(),
         missing_supported_actions: Vec::new(),
+        resource_schema_errors: Vec::new(),
     }
+}
+
+fn provider_resource_schema_errors(info: &ProviderInfo) -> Vec<String> {
+    let mut errors = Vec::new();
+    match info.chain_resource_manifest_schema_version.as_deref() {
+        Some(PROVIDER_WORLD_RESOURCE_MANIFEST_SCHEMA_V1) => {}
+        Some(value) if !value.trim().is_empty() => {
+            errors.push(format!("world_resource_manifest_schema={value}"))
+        }
+        _ => errors.push("missing_world_resource_manifest_schema".to_string()),
+    }
+    match info.chain_resource_delta_schema_version.as_deref() {
+        Some(PROVIDER_WORLD_RESOURCE_DELTA_SCHEMA_V1) => {}
+        Some(value) if !value.trim().is_empty() => {
+            errors.push(format!("world_resource_delta_schema={value}"))
+        }
+        _ => errors.push("missing_world_resource_delta_schema".to_string()),
+    }
+    errors
 }
 
 fn contains_trimmed_value(values: &[String], expected: &str) -> bool {

--- a/crates/oasis7/src/simulator/tests/persist.rs
+++ b/crates/oasis7/src/simulator/tests/persist.rs
@@ -582,6 +582,49 @@ fn initialize_kernel_records_chunk_generated_init_events() {
         .count();
 
     assert!(init_chunk_events > 0);
+    let snapshot = kernel.snapshot();
+    assert!(snapshot.chain_resource_manifest.is_schema_current());
+    assert!(!snapshot.chain_resource_manifest.generated_chunks.is_empty());
+    assert!(snapshot.latest_chain_resource_delta.is_schema_current());
+    assert!(!snapshot.latest_chain_resource_delta.entries.is_empty());
+    assert_eq!(
+        snapshot.latest_chain_resource_delta.resulting_manifest_hash,
+        snapshot.chain_resource_manifest.manifest_hash
+    );
+}
+
+#[test]
+fn chain_resource_snapshot_records_generated_chunk_and_latest_delta() {
+    let mut config = WorldConfig::default();
+    config.asteroid_fragment.base_density_per_km3 = 0.0;
+
+    let mut init = WorldInitConfig::default();
+    init.seed = 73;
+    init.agents.count = 1;
+
+    let (kernel, _) = initialize_kernel(config, init).expect("kernel init");
+    let snapshot = kernel.snapshot();
+    let journal = kernel.journal_snapshot();
+    let restored = WorldKernel::from_snapshot(snapshot.clone(), journal).expect("restore ok");
+    let restored_snapshot = restored.snapshot();
+
+    assert_eq!(
+        snapshot.chain_resource_manifest.generated_chunks,
+        restored_snapshot.chain_resource_manifest.generated_chunks
+    );
+    assert_eq!(
+        snapshot.latest_chain_resource_delta.entries,
+        restored_snapshot.latest_chain_resource_delta.entries
+    );
+    assert!(
+        snapshot
+            .chain_resource_manifest
+            .generated_chunks
+            .values()
+            .all(|entry| !entry.chunk_budget_total_hash.is_empty()
+                && !entry.chunk_budget_remaining_hash.is_empty()
+                && entry.commit_ref.event_id.is_some())
+    );
 }
 
 #[test]

--- a/crates/oasis7/src/simulator/tests/provider_loopback_http.rs
+++ b/crates/oasis7/src/simulator/tests/provider_loopback_http.rs
@@ -93,6 +93,8 @@ fn provider_loopback_http_client_round_trips_info_health_decision_and_feedback()
                         "name": "Provider Local Bridge",
                         "version": "0.1.0",
                         "protocol_version": "world-simulator-provider-loopback-http-v1",
+                        "chain_resource_manifest_schema_version": "oasis7.world_resource_manifest.v1",
+                        "chain_resource_delta_schema_version": "oasis7.world_resource_delta.v1",
                         "capabilities": ["decision", "feedback"],
                         "supported_action_sets": ["phase1_low_frequency"]
                     })
@@ -191,6 +193,8 @@ fn provider_loopback_http_client_bypasses_proxy_env_for_loopback_transport() {
         status_code: 200,
         body: serde_json::json!({
             "provider_id": "provider_local_bridge",
+            "chain_resource_manifest_schema_version": "oasis7.world_resource_manifest.v1",
+            "chain_resource_delta_schema_version": "oasis7.world_resource_delta.v1",
             "capabilities": ["decision", "feedback"],
             "supported_action_sets": ["phase1_low_frequency"]
         })
@@ -214,6 +218,8 @@ fn provider_loopback_http_client_bypasses_proxy_env_for_trimmed_loopback_transpo
         status_code: 200,
         body: serde_json::json!({
             "provider_id": "provider_local_bridge",
+            "chain_resource_manifest_schema_version": "oasis7.world_resource_manifest.v1",
+            "chain_resource_delta_schema_version": "oasis7.world_resource_delta.v1",
             "capabilities": ["decision", "feedback"],
             "supported_action_sets": ["phase1_low_frequency"]
         })

--- a/crates/oasis7/src/viewer/runtime_live/control_blocking.rs
+++ b/crates/oasis7/src/viewer/runtime_live/control_blocking.rs
@@ -145,6 +145,8 @@ impl ViewerRuntimeLiveServer {
             model,
             runtime_snapshot: Some(runtime_snapshot),
             player_gameplay: Some(player_gameplay),
+            chain_resource_manifest: Default::default(),
+            latest_chain_resource_delta: Default::default(),
             chunk_runtime: ChunkRuntimeConfig::default(),
             intel_ttl_ticks: 0,
             next_event_id,

--- a/crates/oasis7/src/viewer/runtime_live/llm_sidecar.rs
+++ b/crates/oasis7/src/viewer/runtime_live/llm_sidecar.rs
@@ -887,6 +887,8 @@ impl RuntimeLlmSidecar {
             model,
             runtime_snapshot: Some(runtime_snapshot),
             player_gameplay: None,
+            chain_resource_manifest: Default::default(),
+            latest_chain_resource_delta: Default::default(),
             chunk_runtime: ChunkRuntimeConfig::default(),
             intel_ttl_ticks: 0,
             next_event_id,

--- a/crates/oasis7/src/viewer/runtime_live/tests/auth_actions_agent_chat.rs
+++ b/crates/oasis7/src/viewer/runtime_live/tests/auth_actions_agent_chat.rs
@@ -94,6 +94,8 @@ fn runtime_agent_chat_provider_mode_accepts_feedback_without_echo_receipt() {
                     body: serde_json::json!({
                         "provider_id": "provider_local_bridge",
                         "capabilities": ["decision", "feedback", "agent_chat"],
+                        "chain_resource_manifest_schema_version": "oasis7.world_resource_manifest.v1",
+                        "chain_resource_delta_schema_version": "oasis7.world_resource_delta.v1",
                         "supported_action_sets": ["phase1_low_frequency"]
                     })
                     .to_string(),
@@ -240,6 +242,8 @@ fn runtime_agent_chat_provider_mode_skips_reply_without_agent_chat_capability() 
                     body: serde_json::json!({
                         "provider_id": "phase1_provider",
                         "capabilities": ["decision", "feedback"],
+                        "chain_resource_manifest_schema_version": "oasis7.world_resource_manifest.v1",
+                        "chain_resource_delta_schema_version": "oasis7.world_resource_delta.v1",
                         "supported_action_sets": ["phase1_low_frequency"]
                     })
                     .to_string(),

--- a/crates/oasis7/src/viewer/runtime_live/tests/snapshot_progress.rs
+++ b/crates/oasis7/src/viewer/runtime_live/tests/snapshot_progress.rs
@@ -13,7 +13,7 @@ fn spawn_runtime_provider_probe_server() -> (String, thread::JoinHandle<()>) {
             let bytes = stream.read(&mut request).expect("read request");
             let request_text = String::from_utf8_lossy(&request[..bytes]);
             let body = if request_text.contains("GET /v1/provider/info") {
-                r#"{"provider_id":"provider_local_bridge","name":"Provider Local Bridge","version":"0.1.0","protocol_version":"world-simulator-provider-loopback-http-v1","capabilities":["decision","feedback"],"supported_action_sets":["wait","wait_ticks","move_agent","speak_to_nearby","inspect_target","simple_interact"]}"#
+                r#"{"provider_id":"provider_local_bridge","name":"Provider Local Bridge","version":"0.1.0","protocol_version":"world-simulator-provider-loopback-http-v1","chain_resource_manifest_schema_version":"oasis7.world_resource_manifest.v1","chain_resource_delta_schema_version":"oasis7.world_resource_delta.v1","capabilities":["decision","feedback"],"supported_action_sets":["wait","wait_ticks","move_agent","speak_to_nearby","inspect_target","simple_interact"]}"#
             } else {
                 r#"{"ok":true,"status":"ready","uptime_ms":42,"last_error":null,"queue_depth":0}"#
             };

--- a/crates/oasis7_client_launcher/src/launcher_core_http.rs
+++ b/crates/oasis7_client_launcher/src/launcher_core_http.rs
@@ -105,6 +105,8 @@ pub(crate) fn check_provider_http_provider(
         protocol_version: info
             .protocol_version
             .unwrap_or_else(|| "unknown".to_string()),
+        chain_resource_manifest_schema_version: info.chain_resource_manifest_schema_version,
+        chain_resource_delta_schema_version: info.chain_resource_delta_schema_version,
         capabilities: info.capabilities,
         supported_action_sets: info.supported_action_sets,
         compatibility_status: compatibility.status.into(),

--- a/crates/oasis7_client_launcher/src/main_tests_provider_probe.rs
+++ b/crates/oasis7_client_launcher/src/main_tests_provider_probe.rs
@@ -40,7 +40,7 @@ fn check_provider_loopback_http_provider_accepts_info_and_health_responses() {
             let bytes = stream.read(&mut request).expect("read request");
             let request_text = String::from_utf8_lossy(&request[..bytes]);
             let body = if request_text.contains("GET /v1/provider/info") {
-                r#"{"provider_id":"provider-local","name":"Local Provider","version":"0.1.0","protocol_version":"v1","capabilities":["decision","feedback"],"supported_action_sets":["phase1_low_frequency"]}"#
+                r#"{"provider_id":"provider-local","name":"Local Provider","version":"0.1.0","protocol_version":"v1","chain_resource_manifest_schema_version":"oasis7.world_resource_manifest.v1","chain_resource_delta_schema_version":"oasis7.world_resource_delta.v1","capabilities":["decision","feedback"],"supported_action_sets":["phase1_low_frequency"]}"#
             } else {
                 r#"{"ok":true,"status":"ready","uptime_ms":42,"last_error":null,"queue_depth":0}"#
             };
@@ -92,7 +92,7 @@ fn check_provider_loopback_http_provider_reports_incompatible_supported_actions(
             let bytes = stream.read(&mut request).expect("read request");
             let request_text = String::from_utf8_lossy(&request[..bytes]);
             let body = if request_text.contains("GET /v1/provider/info") {
-                r#"{"provider_id":"provider-local","name":"Local Provider","version":"0.1.0","protocol_version":"v1","capabilities":["decision","feedback"],"supported_action_sets":["wait","move_agent"]}"#
+                r#"{"provider_id":"provider-local","name":"Local Provider","version":"0.1.0","protocol_version":"v1","chain_resource_manifest_schema_version":"oasis7.world_resource_manifest.v1","chain_resource_delta_schema_version":"oasis7.world_resource_delta.v1","capabilities":["decision","feedback"],"supported_action_sets":["wait","move_agent"]}"#
             } else {
                 r#"{"ok":true,"status":"ready","uptime_ms":42,"last_error":null,"queue_depth":0}"#
             };
@@ -130,7 +130,7 @@ fn check_provider_loopback_http_provider_marks_unhealthy_provider_as_degraded() 
             let bytes = stream.read(&mut request).expect("read request");
             let request_text = String::from_utf8_lossy(&request[..bytes]);
             let body = if request_text.contains("GET /v1/provider/info") {
-                r#"{"provider_id":"provider-local","name":"Local Provider","version":"0.1.0","protocol_version":"v1","capabilities":["decision","feedback"],"supported_action_sets":["phase1_low_frequency"]}"#
+                r#"{"provider_id":"provider-local","name":"Local Provider","version":"0.1.0","protocol_version":"v1","chain_resource_manifest_schema_version":"oasis7.world_resource_manifest.v1","chain_resource_delta_schema_version":"oasis7.world_resource_delta.v1","capabilities":["decision","feedback"],"supported_action_sets":["phase1_low_frequency"]}"#
             } else {
                 r#"{"ok":false,"status":null,"uptime_ms":42,"last_error":null,"queue_depth":0}"#
             };

--- a/crates/oasis7_client_launcher/src/provider_check_status.rs
+++ b/crates/oasis7_client_launcher/src/provider_check_status.rs
@@ -41,6 +41,8 @@ pub(crate) struct ProviderSnapshot {
     pub(crate) name: String,
     pub(crate) version: String,
     pub(crate) protocol_version: String,
+    pub(crate) chain_resource_manifest_schema_version: Option<String>,
+    pub(crate) chain_resource_delta_schema_version: Option<String>,
     pub(crate) capabilities: Vec<String>,
     pub(crate) supported_action_sets: Vec<String>,
     pub(crate) compatibility_status: ProviderCompatibilityStatus,
@@ -112,11 +114,19 @@ impl ProviderCheckStatus {
         match self {
             Self::Ready(snapshot) | Self::Degraded(snapshot) | Self::Incompatible(snapshot) => {
                 Some(format!(
-                    "provider_id={} name={} version={} protocol={} compatibility_status={} status={} queue_depth={} capabilities={} supported_action_sets={} check_latency_ms={{info:{}, health:{}, total:{}}} last_error={} fallback_reason={}",
+                    "provider_id={} name={} version={} protocol={} world_resource_manifest_schema={} world_resource_delta_schema={} compatibility_status={} status={} queue_depth={} capabilities={} supported_action_sets={} check_latency_ms={{info:{}, health:{}, total:{}}} last_error={} fallback_reason={}",
                     snapshot.provider_id,
                     snapshot.name,
                     snapshot.version,
                     snapshot.protocol_version,
+                    snapshot
+                        .chain_resource_manifest_schema_version
+                        .as_deref()
+                        .unwrap_or("none"),
+                    snapshot
+                        .chain_resource_delta_schema_version
+                        .as_deref()
+                        .unwrap_or("none"),
                     snapshot.compatibility_status.as_str(),
                     snapshot.status,
                     snapshot

--- a/crates/oasis7_viewer/software_safe_src/main.test.jsx
+++ b/crates/oasis7_viewer/software_safe_src/main.test.jsx
@@ -462,7 +462,7 @@ describe("viewer web ui automation baseline", () => {
   }, HEAVY_UI_TEST_TIMEOUT_MS);
 
   it("disables first-agent claim buttons while committed snapshot sync is pending", async () => {
-    const { container } = await renderViewerApp({
+    const { container, core } = await renderViewerApp({
       snapshot: sampleSnapshot({
         model: {
           agents: {},
@@ -532,7 +532,7 @@ describe("viewer web ui automation baseline", () => {
   }, HEAVY_UI_TEST_TIMEOUT_MS);
 
   it("prefers recovery proof controls over generic gameplay actions when blocked", async () => {
-    const { container } = await renderViewerApp({
+    const { container, core } = await renderViewerApp({
       snapshot: sampleSnapshot({
         player_gameplay: {
           ...sampleSnapshot().player_gameplay,
@@ -1039,11 +1039,17 @@ describe("viewer web ui automation baseline", () => {
 
   it("surfaces starter OC claim before first agent chat", async () => {
     let sendGameplayAction;
-    const { container } = await renderViewerApp({
+    const { container, core } = await renderViewerApp({
       snapshot: sampleSnapshot({
         player_gameplay: {
           ...sampleSnapshot().player_gameplay,
           available_actions: [
+            {
+              action_id: "advance_step",
+              label: "Advance 1 step",
+              protocol_action: "live_control.step",
+              disabled_reason: null,
+            },
             {
               action_id: "claim_starter_oc",
               label: "Claim starter OC",
@@ -1070,6 +1076,10 @@ describe("viewer web ui automation baseline", () => {
     expect(stagePanel).toBeTruthy();
     expect(within(stagePanel).getAllByText("Claim starter OC").length).toBeGreaterThan(0);
     expect(within(stagePanel).getAllByText(/one-time starter OC/i).length).toBeGreaterThan(0);
+    expect(core.buildGameplaySummary().recommendedAction).toMatchObject({
+      actionId: "claim_starter_oc",
+      executeKind: "claim_starter_oc",
+    });
     const claimButton = within(stagePanel).getAllByRole("button", { name: "Claim Starter OC" })[0];
     expect(claimButton).toBeInTheDocument();
     fireEvent.click(claimButton);

--- a/crates/oasis7_viewer/software_safe_src/viewer_feedback_module.js
+++ b/crates/oasis7_viewer/software_safe_src/viewer_feedback_module.js
@@ -848,10 +848,19 @@ export function createViewerFeedbackModule({
     const wantsSnapshotProof = emptyEntityBlocker || /\b(refresh|snapshot|fresh state|world state)\b/.test(recoveryCueText);
     const wantsAdvanceProof = /\b(advance|step|apply|confirm|prove|verify|check)\b/.test(recoveryCueText);
     const wantsResumeProof = /\b(resume|recover|restore|replenish|repair)\b/.test(recoveryCueText);
+    const starterOcClaimAvailable = availableActions.some((action) => (
+      action.executeKind === "claim_starter_oc"
+      && !action.disabledReason
+    ));
+    const starterOcBlocksChat = starterOcClaimAvailable && availableActions.some((action) => (
+      action.executeKind === "agent_chat"
+      && String(action.disabledReason || "").toLowerCase().includes("starter oc")
+    ));
     const recommendedAction = availableActions
       .filter((action) => !action.disabledReason)
       .sort((left, right) => {
         const priority = (action) => {
+          if (starterOcBlocksChat && action.executeKind === "claim_starter_oc") return -1;
           if (isRecoveryChoiceState) {
             if (action.executeKind === "request_snapshot") return wantsSnapshotProof ? 0 : 2;
             if (action.executeKind === "step") return wantsAdvanceProof ? 0 : 1;

--- a/crates/oasis7_viewer/viewer.js
+++ b/crates/oasis7_viewer/viewer.js
@@ -1745,8 +1745,11 @@ function createViewerFeedbackModule({
     const wantsSnapshotProof = emptyEntityBlocker || /\b(refresh|snapshot|fresh state|world state)\b/.test(recoveryCueText);
     const wantsAdvanceProof = /\b(advance|step|apply|confirm|prove|verify|check)\b/.test(recoveryCueText);
     const wantsResumeProof = /\b(resume|recover|restore|replenish|repair)\b/.test(recoveryCueText);
+    const starterOcClaimAvailable = availableActions.some((action) => action.executeKind === "claim_starter_oc" && !action.disabledReason);
+    const starterOcBlocksChat = starterOcClaimAvailable && availableActions.some((action) => action.executeKind === "agent_chat" && String(action.disabledReason || "").toLowerCase().includes("starter oc"));
     const recommendedAction = availableActions.filter((action) => !action.disabledReason).sort((left, right) => {
       const priority = (action) => {
+        if (starterOcBlocksChat && action.executeKind === "claim_starter_oc") return -1;
         if (isRecoveryChoiceState) {
           if (action.executeKind === "request_snapshot") return wantsSnapshotProof ? 0 : 2;
           if (action.executeKind === "step") return wantsAdvanceProof ? 0 : 1;

--- a/doc/testing/templates/network-tier-public-testnet.example.json
+++ b/doc/testing/templates/network-tier-public-testnet.example.json
@@ -51,6 +51,9 @@
       "faucet_guard_ready",
       "reset_policy_announced",
       "runtime_bootstrap",
+      "world_resource_provenance_ready",
+      "provider_resource_provenance_ready",
+      "resource_delta_replay_ready",
       "claims_boundary_review"
     ]
   },

--- a/doc/testing/templates/public-testnet-readiness-lanes.example.tsv
+++ b/doc/testing/templates/public-testnet-readiness-lanes.example.tsv
@@ -4,4 +4,7 @@ explorer_public_ready	runtime_engineer	partial	doc/testing/templates/public-test
 faucet_guard_ready	liveops_community	partial	doc/testing/templates/public-testnet-skeleton-evidence.example.md	replace with guarded faucet boundary and abuse controls evidence
 reset_policy_announced	liveops_community	partial	doc/testing/templates/public-testnet-skeleton-evidence.example.md	replace with published reset policy and rehearsal note
 runtime_bootstrap	runtime_engineer	partial	doc/testing/templates/public-testnet-rehearsal-template.md	replace with runtime bootstrap and /v1/chain/status evidence
+world_resource_provenance_ready	blockchain_ops_engineer	partial	doc/testing/templates/public-testnet-skeleton-evidence.example.md	replace with /v1/chain/status world_resource schema/world_id/chain_id/world_seed/chunk schema evidence
+provider_resource_provenance_ready	agent_engineer	partial	doc/testing/templates/public-testnet-skeleton-evidence.example.md	replace with provider info world resource manifest/delta schema compatibility evidence
+resource_delta_replay_ready	runtime_engineer	partial	doc/testing/templates/public-testnet-skeleton-evidence.example.md	replace with committed resource delta replay and provisional-resource blocking evidence
 claims_boundary_review	qa_engineer	partial	doc/testing/templates/public-testnet-exit-review-template.md	replace with claims boundary review and denylist confirmation

--- a/doc/world-simulator/project.md
+++ b/doc/world-simulator/project.md
@@ -5,6 +5,7 @@
 - [ ] software-safe-playability-unblock (PRD-WORLD_SIMULATOR-039) [test_tier_required]: 让 `software_safe` formal summary 将 canonical `available_actions` 重新暴露为可执行入口，并在 gameplay summary 与空实体快照并存时显式标记 `runtime_snapshot_empty_entities` blocker。 Trace: .pm/tasks/task_1c5ac527bed54e969b737137fc998ab8.yaml
 
 ### 最近完成（保留一跳 Trace）
+- [x] chain-side-manifest-delta-runtime-readiness (PRD-WORLD_SIMULATOR-039/046) [test_tier_required]: 定义链侧资源 manifest/delta schema，接入 simulator/runtime snapshot、provider/testnet readiness 与本地 standalone submit 闭环。 Trace: .pm/tasks/task_a0e15f2d5d0547a3a13c93caab49b611.yaml
 - [x] viewer-visual-hierarchy-polish (PRD-WORLD_SIMULATOR-046) [test_tier_required]: 按 Image2 视觉目标与总体/分模块设计优化 `software_safe` Viewer 首屏层级、command strip、action receipt、focus HUD 与移动 focus overlay，并用 UI/build/pixel-world visual smoke 验证收口。 Trace: .pm/tasks/task_e7760ad76a0046dfa5a17d0a5a89e59c.yaml
 - [x] launcher-visual-comp-workflow-ui-optimization (PRD-WORLD_SIMULATOR-039/046) [test_tier_required]: 用 Image2 目标图、真实 native 截图对比和专业角色 review 收敛 launcher 首屏、弹窗/重型窗口视觉系统，并把 visual companion 方法论边界写回 workflow/skill/governance 文档。 Trace: .pm/tasks/task_54647d0add024a98b801d3736700ff22.yaml
 - [x] module-project-log-slimming (PRD-ENGINEERING-030) [test_tier_required]: 压缩 world-simulator 主项目页历史流水为当前/最近任务索引与历史追溯入口，保留未完成任务、模块状态和一跳 task trace。 Trace: .pm/tasks/task_49ef9270afc646d98d4a8386c0888eab.yaml

--- a/doc/world-simulator/scenario/unified-world-seed-fragment-runtime.prd.md
+++ b/doc/world-simulator/scenario/unified-world-seed-fragment-runtime.prd.md
@@ -19,9 +19,10 @@
 - Out of scope: 新经济数值平衡、新资源品类、完整删除兼容坐标锚点、非 testnet/正式世界的调试 fixture 迁移。
 
 ## 接口 / 数据
-- `SeedManifest`: `world_id`、`world_seed`、`chunk_generation_schema_version`、`world_config_hash`、`genesis_ref` / `chain_id`。
-- `ChunkResourceManifest`: chunk coord、fragment ids、profile hash、budget total hash、budget remaining hash、commit ref。
-- `ResourceDelta`: action id、fragment id、material/resource key、delta amount、commit height/hash、replay ordering key。
+- `SeedManifest` / `oasis7.world_resource_manifest.v1`: `world_id`、`chain_id`、`genesis_ref`、`world_seed`、`chunk_generation_schema_version`、`world_config_hash`、`generation_algorithm_id/hash`、`created_at_height/block_hash`。
+- `ChunkResourceManifest` / `oasis7.world_resource_manifest.v1.generated_chunks`: chunk coord、`chunk_seed`、`chunk_status`（`committed` / `chain_pending` / `provisional` / `exhausted`）、fragment ids、profile hash、budget total hash、budget remaining hash、commit ref。
+- `ResourceDelta` / `oasis7.world_resource_delta.v1`: delta id、action/event id、ordering key、fragment/location/chunk ref、material/resource key、delta amount、commit height/hash、base/result manifest hash、actor/source/replay status。
+- `/v1/chain/status.world_resource`: testnet readiness 必须暴露 `schema_version`、`delta_schema_version`、`world_id`、`chain_id`、`world_seed`、`chunk_generation_schema_version`、seed/starter/latest commit hash、committed/provisional/pending delta counters、`readiness_status` 与 `failed_gates[]`。
 
 ## 里程碑
 - M1: 文档合同冻结，明确资源生成必须链上化。

--- a/scripts/network-tier-public-testnet-readiness.sh
+++ b/scripts/network-tier-public-testnet-readiness.sh
@@ -111,6 +111,9 @@ active_required_lanes = [
     "reset_policy_announced",
     "runtime_bootstrap",
     "claims_boundary_review",
+    "world_resource_provenance_ready",
+    "provider_resource_provenance_ready",
+    "resource_delta_replay_ready",
 ]
 required_lanes = list(active_required_lanes)
 status_rank = {"pass": 0, "partial": 1, "block": 2}

--- a/scripts/provider-remote-https/provider_bridge_contract_smoke.py
+++ b/scripts/provider-remote-https/provider_bridge_contract_smoke.py
@@ -13,6 +13,8 @@ import urllib.request
 
 
 DEFAULT_TIMEOUT_MS = 15000
+CHAIN_RESOURCE_MANIFEST_SCHEMA_V1 = "oasis7.world_resource_manifest.v1"
+CHAIN_RESOURCE_DELTA_SCHEMA_V1 = "oasis7.world_resource_delta.v1"
 
 
 @dataclass(frozen=True)
@@ -147,6 +149,21 @@ def provider_version(response: dict) -> str:
     return ""
 
 
+def require_provider_resource_schema(info: dict) -> None:
+    manifest_schema = str(info.get("chain_resource_manifest_schema_version") or "").strip()
+    delta_schema = str(info.get("chain_resource_delta_schema_version") or "").strip()
+    if manifest_schema != CHAIN_RESOURCE_MANIFEST_SCHEMA_V1:
+        raise RuntimeError(
+            "provider resource manifest schema mismatch: "
+            f"expected {CHAIN_RESOURCE_MANIFEST_SCHEMA_V1}, got {manifest_schema or '<missing>'}"
+        )
+    if delta_schema != CHAIN_RESOURCE_DELTA_SCHEMA_V1:
+        raise RuntimeError(
+            "provider resource delta schema mismatch: "
+            f"expected {CHAIN_RESOURCE_DELTA_SCHEMA_V1}, got {delta_schema or '<missing>'}"
+        )
+
+
 def run_smoke(options: SmokeOptions) -> dict:
     base_url = normalize_base_url(options.base_url)
     info_status, info, info_elapsed = request_json(
@@ -161,6 +178,7 @@ def run_smoke(options: SmokeOptions) -> dict:
         auth_token=options.auth_token,
         timeout_ms=options.timeout_ms,
     )
+    require_provider_resource_schema(info)
     if options.require_health_ok and health.get("ok") is not True:
         raise RuntimeError(f"provider health is not ok: {json.dumps(health, ensure_ascii=False)}")
 
@@ -214,6 +232,10 @@ def run_smoke(options: SmokeOptions) -> dict:
         "status": "pass",
         "base_url": base_url,
         "provider_id": info.get("provider_id"),
+        "chain_resource_manifest_schema_version": info.get(
+            "chain_resource_manifest_schema_version"
+        ),
+        "chain_resource_delta_schema_version": info.get("chain_resource_delta_schema_version"),
         "info_http_status": info_status,
         "info_elapsed_ms": int(info_elapsed * 1000),
         "health_http_status": health_status,

--- a/scripts/provider-remote-https/provider_bridge_contract_smoke.test.py
+++ b/scripts/provider-remote-https/provider_bridge_contract_smoke.test.py
@@ -45,6 +45,8 @@ class MockProviderHandler(BaseHTTPRequestHandler):
                     "version": "0.1.0",
                     "protocol_version": "world-simulator-provider-loopback-http-v1",
                     "capabilities": ["decision", "feedback"],
+                    "chain_resource_manifest_schema_version": "oasis7.world_resource_manifest.v1",
+                    "chain_resource_delta_schema_version": "oasis7.world_resource_delta.v1",
                     "supported_action_sets": ["wait", "move_agent"],
                 }
             )
@@ -184,6 +186,14 @@ class ProviderBridgeContractSmokeTests(unittest.TestCase):
 
         self.assertEqual(summary["status"], "pass")
         self.assertEqual(summary["health_status"], "degraded")
+        self.assertEqual(
+            summary["chain_resource_manifest_schema_version"],
+            "oasis7.world_resource_manifest.v1",
+        )
+        self.assertEqual(
+            summary["chain_resource_delta_schema_version"],
+            "oasis7.world_resource_delta.v1",
+        )
         self.assertEqual(summary["decision_successes"], 1)
         self.assertEqual(summary["decisions"][0]["provider_error_code"], None)
         self.assertTrue(

--- a/scripts/run-launcher-stack.sh
+++ b/scripts/run-launcher-stack.sh
@@ -22,6 +22,9 @@ ALLOW_TRUSTED_LOCAL_PLAYTEST="${OASIS7_ALLOW_TRUSTED_LOCAL_PLAYTEST:-0}"
 CHAIN_LINK_POLICY="${OASIS7_CHAIN_LINK_POLICY:-}"
 CHAIN_NODE_ID=""
 CHAIN_STATUS_BIND_ADDR=""
+CHAIN_LOCAL_STANDALONE_TEST="${OASIS7_CHAIN_LOCAL_STANDALONE_TEST:-0}"
+CHAIN_NODE_AUTO_ATTEST_ALL="${OASIS7_CHAIN_NODE_AUTO_ATTEST_ALL:-0}"
+CHAIN_NODE_VALIDATORS=()
 BUNDLE_DIR=""
 VIEWER_STATIC_DIR_EXPLICIT="0"
 ALLOW_STALE_BUNDLE="0"
@@ -84,6 +87,14 @@ Options:
   --chain-node-id <id>     Override chain node id (default: fresh per run)
   --chain-status-bind <a:p> Override chain status HTTP bind (default: web-bind port + 110)
   --chain-link-policy <p>  enforcing or shadow (default: shadow for trusted local playtest, otherwise enforcing)
+  --chain-local-standalone-test
+                           Start a no-testnet single-node chain profile for local submit/commit/snapshot testing
+  --chain-node-validator <v:s>
+                           Add a local validator for oasis7_chain_runtime (repeatable)
+  --chain-node-auto-attest-all
+                           Enable local auto-attestation for configured validators
+  --chain-node-no-auto-attest-all
+                           Disable local auto-attestation
   --output-dir <path>      Override runtime log/artifact output directory
   --run-id <id>            Override logical run id used for output dir / chain node id defaults
   --meta-file <path>       Override metadata file path (default: <output-dir>/session.meta)
@@ -230,6 +241,23 @@ while [[ $# -gt 0 ]]; do
       CHAIN_LINK_POLICY="${2:-}"
       shift 2
       ;;
+    --chain-local-standalone-test)
+      CHAIN_LOCAL_STANDALONE_TEST="1"
+      CHAIN_NODE_AUTO_ATTEST_ALL="1"
+      shift
+      ;;
+    --chain-node-validator)
+      CHAIN_NODE_VALIDATORS+=("${2:-}")
+      shift 2
+      ;;
+    --chain-node-auto-attest-all)
+      CHAIN_NODE_AUTO_ATTEST_ALL="1"
+      shift
+      ;;
+    --chain-node-no-auto-attest-all)
+      CHAIN_NODE_AUTO_ATTEST_ALL="0"
+      shift
+      ;;
     --with-llm)
       ENABLE_LLM="1"
       shift
@@ -368,7 +396,9 @@ case "$AGENT_CHAT_ECHO_NORMALIZED" in
 esac
 
 if [[ -z "$CHAIN_LINK_POLICY" ]]; then
-  if [[ "$DEPLOYMENT_MODE" == "trusted_local_only" && "$ALLOW_TRUSTED_LOCAL_PLAYTEST" == "1" ]]; then
+  if [[ "$CHAIN_LOCAL_STANDALONE_TEST" == "1" ]]; then
+    CHAIN_LINK_POLICY="enforcing"
+  elif [[ "$DEPLOYMENT_MODE" == "trusted_local_only" && "$ALLOW_TRUSTED_LOCAL_PLAYTEST" == "1" ]]; then
     CHAIN_LINK_POLICY="shadow"
   else
     CHAIN_LINK_POLICY="enforcing"
@@ -728,6 +758,19 @@ if [[ "$CHAIN_ENABLED" == "1" ]]; then
     --chain-status-bind "$CHAIN_STATUS_BIND_ADDR"
     --chain-link-policy "$CHAIN_LINK_POLICY"
   )
+  if [[ "$CHAIN_LOCAL_STANDALONE_TEST" == "1" ]]; then
+    WORLD_ARGS+=(--chain-local-standalone-test)
+  fi
+  if [[ "$CHAIN_NODE_AUTO_ATTEST_ALL" == "1" ]]; then
+    WORLD_ARGS+=(--chain-node-auto-attest-all)
+  else
+    WORLD_ARGS+=(--chain-node-no-auto-attest-all)
+  fi
+  if [[ "${#CHAIN_NODE_VALIDATORS[@]}" -gt 0 ]]; then
+    for validator in "${CHAIN_NODE_VALIDATORS[@]}"; do
+      WORLD_ARGS+=(--chain-node-validator "$validator")
+    done
+  fi
 else
   WORLD_ARGS+=(--chain-disable)
 fi


### PR DESCRIPTION
## Summary
- add canonical chain resource manifest/delta schema and wire simulator/runtime snapshots into chain status readiness
- expose provider/testnet resource schema readiness lanes and remote provider smoke checks
- add local standalone chain launch mode plus viewer starter OC recommendation coverage

## Verification
- ./scripts/ci-tests.sh required
- task closeout recorded last_verification_exit_code=0

## Residual risk
- public testnet still needs CI artifact packaging and live node readiness validation after deployment
- full provider manifest-hash provenance exchange and final seed-derived gameplay resource pockets remain follow-up work
