### PR TITLE
Keep starter OC state root compatible

### DIFF
--- a/.pm/tasks/task_a0e15f2d5d0547a3a13c93caab49b611.execution.md
+++ b/.pm/tasks/task_a0e15f2d5d0547a3a13c93caab49b611.execution.md
@@ -344,3 +344,25 @@ Example:
 - Review Findings Disposition: addressed
 - Finding Disposition Evidence: runtime identity masking and empty-delta false readiness were removed; provider contract tests now assert resource schema fields; local standalone flow and starter OC recommendation were verified; repo-health unused shell variable was removed; QA required gate was rerun on latest diff.
 - Residual Risk: public testnet still requires CI artifact packaging plus live node readiness validation after deployment; full provider manifest-hash provenance exchange and final seed-derived gameplay resource pockets remain follow-up work and are not claimed complete by this PR.
+
+## 2026-06-22 02:55:00 CST / tpm
+- 完成内容: PR #554 merged and CI Testnet Packages run `27912954283` produced linux/windows/macos packages for `0.0.0+testnet.115.03220c2871bb`; deployment attempted on ECS storage node `39.104.205.67`.
+- Deployment Blocker:
+  - Storage node package upgrade replaced `current` with `0.0.0+testnet.115.03220c2871bb`, updated governed bootstrap runtime hash, and restarted `oasis7-testnet-storage.service`.
+  - New runtime failed while loading existing `/opt/oasis7/p2p-testnet/data/execution-world`: `DistributedValidationFailed { reason: "latest state root mismatch tick=22152 expected=cfcc9f6a2bd5361a5f57b6294d1adcd7f715df3a9d0f2064152619be41139df9 found=928ce02e1aaf6b7425d3af435d60ff9c98644edb699f7119f568d94351945390" }`.
+  - Sequencer node `39.104.204.172` was not upgraded after the storage failure.
+- Recovery:
+  - Rolled storage node back to `0.0.0+testnet.114.e9ffac0edf18`, repointed `/opt/oasis7/p2p-testnet/current`, restored governed bootstrap runtime hash to the prior runtime binary, and restarted `oasis7-testnet-storage.service`.
+  - Post-rollback status: `running=true`, `last_error=null`, `height=22152`, `network_height=22152`, `pending=null`.
+- Root Cause:
+  - `WorldState` gained `starter_oc_claims` with `#[serde(default)]` only. Old snapshots deserialize this as an empty map, but canonical state JSON then includes the new empty field during `current_state_root_hash()`, changing old consensus state roots.
+- Hotfix:
+  - Changed `starter_oc_claims` to `#[serde(default, skip_serializing_if = "BTreeMap::is_empty")]` so legacy worlds with no starter OC claims keep the same canonical state projection; once a claim exists, the field is non-empty and participates in future roots.
+  - Added runtime serialization tests for empty-field omission and legacy missing-field decode.
+- Validation Command: `env -u RUSTC_WRAPPER cargo test -p oasis7 --lib starter_oc_claims --features test_tier_required -- --nocapture`
+- Actual Result: passed, 2 tests.
+- Validation Command: `env -u RUSTC_WRAPPER cargo test -p oasis7 --lib chain_resource_schema --features test_tier_required -- --nocapture`
+- Actual Result: passed, 3 tests.
+- Validation Command: `env -u RUSTC_WRAPPER cargo fmt --all -- --check`
+- Actual Result: passed after formatting.
+- Blocker / Next Action: package `0.0.0+testnet.115` is not deployable to existing testnet state. Land the hotfix, rebuild CI packages, then retry storage->sequencer package rollout.

--- a/crates/oasis7/src/runtime/state.rs
+++ b/crates/oasis7/src/runtime/state.rs
@@ -424,7 +424,7 @@ pub struct WorldState {
     pub economic_contracts: BTreeMap<String, EconomicContractState>,
     #[serde(default)]
     pub agent_claims: BTreeMap<String, AgentClaimState>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub starter_oc_claims: BTreeMap<String, StarterOcClaimState>,
     #[serde(default)]
     pub agent_claim_last_processed_epoch: u64,

--- a/crates/oasis7/src/runtime/tests/mod.rs
+++ b/crates/oasis7/src/runtime/tests/mod.rs
@@ -96,5 +96,6 @@ mod power_bootstrap_release_manifest_full;
 mod reward_asset;
 mod reward_asset_settlement_action;
 mod rules;
+mod state_serialization;
 mod storage_cold_index;
 mod storage_footprint_fixture;

--- a/crates/oasis7/src/runtime/tests/state_serialization.rs
+++ b/crates/oasis7/src/runtime/tests/state_serialization.rs
@@ -1,0 +1,26 @@
+use crate::runtime::WorldState;
+
+#[test]
+fn empty_starter_oc_claims_do_not_change_legacy_state_projection_json() {
+    let state = WorldState::default();
+    let value = serde_json::to_value(&state).expect("serialize world state");
+    let object = value.as_object().expect("world state serializes as object");
+
+    assert!(
+        !object.contains_key("starter_oc_claims"),
+        "empty starter OC claims must stay out of canonical state JSON so old state roots remain stable"
+    );
+}
+
+#[test]
+fn legacy_world_state_json_defaults_empty_starter_oc_claims() {
+    let mut value = serde_json::to_value(WorldState::default()).expect("serialize world state");
+    let object = value
+        .as_object_mut()
+        .expect("world state serializes as object");
+    object.remove("starter_oc_claims");
+
+    let decoded: WorldState = serde_json::from_value(value).expect("decode legacy world state");
+
+    assert!(decoded.starter_oc_claims.is_empty());
+}


### PR DESCRIPTION
## Summary\n- Keep empty starter OC claim state out of canonical WorldState JSON so existing testnet state roots remain stable.\n- Add legacy serialization coverage for missing/empty starter OC claims.\n- Record the package rollout blocker and rollback evidence in the task log.\n\n## Verification\n- env -u RUSTC_WRAPPER cargo test -p oasis7 --lib starter_oc_claims --features test_tier_required -- --nocapture\n- env -u RUSTC_WRAPPER cargo test -p oasis7 --lib chain_resource_schema --features test_tier_required -- --nocapture\n- env -u RUSTC_WRAPPER cargo fmt --all -- --check\n- git diff --check