### PR TITLE
Clean retired viewer visualization routes

### DIFF
--- a/.pm/tasks/task_e6edcb09bd774941bdcbde32bb9ea007.execution.md
+++ b/.pm/tasks/task_e6edcb09bd774941bdcbde32bb9ea007.execution.md
@@ -302,3 +302,12 @@ Example:
 - Expected Result: PR-ready evidence mentions claim-ready attempt, project trace resolves, and direct verification passes.
 - Actual Result: claim-ready helper rejected non-completion claim on already closed task (`closed task claim evidence is immutable`); direct verification passed: site manual sync OK, doc-governance OK, `git diff --check` OK, focused workflow-lint OK.
 - Blocker / Next Action: amend evidence changes into commit and rerun `./scripts/prepare-task-pr.sh --json`.
+
+## 2026-06-22 13:40:18 CST / tpm
+- 完成内容: Created GitHub PR for normal CI/watch/merge path.
+- 遗留事项: GitHub required checks, comments/review threads, and mergeability still need watch before merge.
+- Action: ran PR helper preflight, pushed branch, and created PR with explicit `gh pr create` body after helper create path failed to provide a non-interactive body.
+- Validation Command: `./scripts/prepare-task-pr.sh --json`; `./scripts/prepare-task-pr.sh --create --title 'Clean retired viewer visualization routes'`; `gh pr create --base main --head task/viewer-visualization-routes-readonly --title 'Clean retired viewer visualization routes' --body ...`
+- Expected Result: PR exists with task UID, verification summary, and normal PR CI/watch purpose.
+- Actual Result: PR URL: https://github.com/eng-cc/oasis7/pull/557; branch pushed to `origin/task/viewer-visualization-routes-readonly`; PR Purpose Decision: `normal_pr_ci_watch`.
+- Blocker / Next Action: push PR evidence commit, then watch required checks, comments, review threads, and mergeability.

--- a/.pm/tasks/task_e6edcb09bd774941bdcbde32bb9ea007.execution.md
+++ b/.pm/tasks/task_e6edcb09bd774941bdcbde32bb9ea007.execution.md
@@ -1,0 +1,304 @@
+# task_e6edcb09bd774941bdcbde32bb9ea007 Execution Log
+
+- task_uid: task_e6edcb09bd774941bdcbde32bb9ea007
+- title: Map current visualization routes
+- owner_role: tpm
+- worktree_hint: /Users/scc/ccwork/worktrees/oasis7-viewer-visualization-routes-readonly
+
+<!-- Append entries using:
+Example:
+  ## YYYY-MM-DD HH:MM:SS CST / role_name
+  - 完成内容: ...
+- 遗留事项: none.
+  - 遗留事项: ...
+  - Action: ...
+  - Validation Command: ...
+  - Expected Result: ...
+  - Actual Result: ...
+  - Blocker / Next Action: ...
+-->
+
+## 2026-06-22 11:26:35 CST / tpm
+- 完成内容: WORKFLOW BOOTSTRAP DECIDED.
+- 遗留事项: none.
+- Repository State Impact: read-only professional/domain answer; no intended product/code edits, but task/worktree truth required by workflow.
+- Isolation Decision: created dedicated worktree `/Users/scc/ccwork/worktrees/oasis7-viewer-visualization-routes-readonly` from `origin/main`; main worktree was clean.
+- Task Truth: owner role `tpm`; `.pm` task `task_e6edcb09bd774941bdcbde32bb9ea007`; execution log is mandatory sink.
+- Routed Next Phase: repo-owned workflow router -> read-only professional/domain judgment with bounded role slices.
+- Required Writeback: route decision, slice contracts, slice returns, and TPM integration summary in this execution log.
+- Action: `./scripts/new-task-worktree.sh viewer visualization-routes-readonly --base origin/main --pm-owner-role tpm ... --json`
+- Validation Command: task helper JSON output.
+- Expected Result: dedicated worktree with bound committed `.pm` task.
+- Actual Result: created branch `task/viewer-visualization-routes-readonly`, task `task_e6edcb09bd774941bdcbde32bb9ea007`, shared cargo target linked.
+- Blocker / Next Action: record bounded slice contracts before professional conclusion.
+
+## 2026-06-22 11:26:35 CST / tpm
+- 完成内容: WORKFLOW ROUTE DECIDED.
+- 遗留事项: none.
+- Task Phase: read-only professional/domain mapping of current visualization routes.
+- Selected Workflow Skills: `repo-owned-workflow-router` for phase selection; `game-visual-design` for visual/player-facing route framing where applicable.
+- Skipped Workflow Skills: `tdd-test-writer`, `executing-project-tasks`, `systematic-debugging`, `verification-before-completion`, `finishing-a-development-branch` because no implementation, bug fix, completion claim, PR, or code verification is requested.
+- Specialist Skills Considered: `game-visual-design` applies because the user asks about visualization routes; browser/image tools skipped because current request asks for routes, not rendered screenshot validation.
+- Action: recorded route decision and bounded slice contracts.
+- Validation Command: inspect workflow route requirements and role boundaries.
+- Expected Result: execution log contains mandatory slice contracts before professional conclusion.
+- Actual Result: route decision and viewer/visual-interaction slice contracts recorded.
+- Subagent Slice Plan:
+  - role: `viewer_engineer`
+  - slice type: read-only explorer / current repo route inventory
+  - intended model configuration: workflow default subagent runtime from `.codex/config.toml`; no override requested
+  - actual dispatched model/reasoning: inherited/unverified; multi-agent tool inherits parent unless override is set
+  - context delivery mode: full-thread/full-history fork requested
+  - mandatory context checklist/packet: AGENTS workflow, source-of-truth responsibility boundary, task truth above, user asks "现在所有的可视化，有哪几条路线", scope is current repo visualization routes, no edits
+  - write scope: none
+  - return contract: route list with repo evidence, owner/constraints, residual unknowns
+  - formal sink / writeback surface: `.pm/tasks/task_e6edcb09bd774941bdcbde32bb9ea007.execution.md`
+  - integration owner/order: TPM integrates viewer evidence first, then visual/design framing
+- Subagent Slice Plan:
+  - role: `game_visual_interaction_designer`
+  - slice type: read-only visual route framing / player-facing taxonomy
+  - intended model configuration: workflow default subagent runtime from `.codex/config.toml`; no override requested
+  - actual dispatched model/reasoning: inherited/unverified; multi-agent tool inherits parent unless override is set
+  - context delivery mode: full-thread/full-history fork requested
+  - mandatory context checklist/packet: AGENTS workflow, source-of-truth responsibility boundary, task truth above, user asks "现在所有的可视化，有哪几条路线", scoped repo context from viewer route inventory, no edits
+  - write scope: none
+  - return contract: visual/player-facing route taxonomy, decision criteria, residual risks
+  - formal sink / writeback surface: `.pm/tasks/task_e6edcb09bd774941bdcbde32bb9ea007.execution.md`
+  - integration owner/order: TPM integrates after viewer evidence
+- Blocker / Next Action: dispatch bounded read-only professional slices and gather mechanical repo evidence without presenting TPM-only conclusions.
+
+## 2026-06-22 11:31:28 CST / game_visual_interaction_designer
+- 完成内容: Returned read-only visual/player-facing visualization route taxonomy.
+- 遗留事项: dense live data, real keyboard-focus screenshots, and fresh 2D map/label/flow screenshots remain separate verification risks if claimed later.
+- Slice: `game_visual_interaction_designer`
+- Mode: read-only bounded professional slice; no file edits.
+- Action: read relevant design/PRD/manual files and produced route taxonomy.
+- Validation Command: read-only evidence inspection; no runtime/browser command.
+- Expected Result: role-attributed route taxonomy and residual risks for current visual routes.
+- Actual Result: six player-facing/current-vs-historical route categories returned with residual visual verification gaps.
+- Evidence read by slice:
+  - `doc/world-simulator/viewer/viewer-visual-design-spec-2026-06-05.design.md`
+  - `doc/world-simulator/viewer/viewer-brand-system-2026-06-05.design.md`
+  - `doc/world-simulator/viewer/viewer-web-entry-visual-redesign-2026-05-12.prd.md`
+  - `doc/world-simulator/viewer/viewer-pixel-world-commercial-rendering-loop-2026-05-28.prd.md`
+  - `doc/world-simulator/viewer/viewer-pixel-world-fragment-lod-2026-05-27.prd.md`
+  - `doc/world-simulator/viewer/viewer-pixel-world-semantic-positioning-2026-05-26.prd.md`
+  - `doc/world-simulator/viewer/viewer-2d-visual-polish.design.md`
+  - `doc/world-simulator/viewer/viewer-overview-map-zoom.design.md`
+  - `doc/world-simulator/viewer/viewer-gameplay-release-immersion-phase2.prd.md`
+  - `doc/world-simulator/viewer/viewer-gameplay-release-immersion-phase7.prd.md`
+  - `doc/world-simulator/viewer/viewer-selection-details.prd.md`
+  - `doc/world-simulator/viewer/viewer-web-semantic-test-api.prd.md`
+  - `doc/world-simulator/viewer/viewer-manual.manual.md`
+  - `doc/world-simulator/viewer/viewer-web-software-safe-mode-2026-03-16.prd.md`
+  - `doc/game/gameplay/gameplay-micro-loop-feedback-visibility-2026-03-05.prd.md`
+  - `doc/game/gameplay/gameplay-indirect-control-feeling-contract-2026-05-14.design.md`
+- Conclusion:
+  1. Viewer Web 单入口 / 工业世界指挥桌: 正式玩家首屏路线，世界/目标/下一步/行动回执优先，诊断折叠。
+  2. Pixel-world 主舞台 / 指挥棋盘: 当前主世界表达路线，用 objective、next move、player leverage、Agent、route、hotspot、Fragment terrain 背景解决稀疏快照和行动因果可读性。
+  3. 2D 地图可读性路线: 2D symbol、label LOD、flow arrows、overview/detail zoom，用于空间扫读、选中目标和路径关系。
+  4. HUD / Command / Action Receipt 路线: accepted intent、控制结果显著条、blocker、next step、receipt，用于让间接控制仍然像控制。
+  5. Details / Timeline / Feed / Diagnostics 路线: 选中详情、LLM trace、模块可视实体、timeline seek/filter/jump、runtime/renderer diagnostics，用于 Director/QA/复盘，不应主导 Player 首屏。
+  6. 历史 3D / native / 旧 visual QA 路线: 当前手册明确已移除旧 3D/native/视觉专项工具链；只能作为历史边界或窄兼容参考，不是当前产品承诺路线。
+- Route selection:
+  - 正式玩家体验: Viewer Web + Pixel-world + HUD/Receipt。
+  - 空间理解: 叠加 2D map/readability。
+  - 行动因果: 优先 HUD/Receipt，而不是 raw event feed。
+  - 调试/复盘: Details/Timeline/Diagnostics 按需展开。
+  - 不建议把旧 3D/native 当作当前路线。
+- Validation gaps:
+  - Pixel-world 视觉系统已有 desktop/mobile/action receipt/fragment visual smoke 证据，但 dense live data、多真实 agent/location 的截图矩阵仍是 residual risk。
+  - Keyboard focus 目前主要是 CSS/probe evidence，缺稳定真实键盘焦点截图。
+  - 2D map/label/flow 若继续变化，需要当前 Web 主入口下的新 desktop/mobile 截图。
+  - 旧 3D/native/visual QA 路线当前无可承诺的真实交互验证面，因为仓库已声明移除。
+- Blocker / Next Action: integrate with viewer-engineering slice for user-facing route summary.
+
+## 2026-06-22 11:31:58 CST / viewer_engineer
+- 完成内容: Returned read-only engineering visualization/carrier route inventory.
+- 遗留事项: no live browser run; dense fragment quality and launcher-egui availability need separate verification if claimed later.
+- Slice: `viewer_engineer`
+- Mode: read-only bounded professional slice; no file edits; no verification commands run.
+- Action: inspected repository evidence for current Viewer runtime/carrier routes.
+- Validation Command: read-only evidence inspection; no runtime/browser command.
+- Expected Result: engineering route inventory with removed/non-current route boundary.
+- Actual Result: seven current engineering/carrier routes returned; old standard_3d/native/visual QA path marked non-current.
+- Conclusion:
+  1. Formal Web Viewer single entry: `viewer.html`/`viewer.js` canonical, `software_safe` compatibility alias; implemented.
+  2. Pixel-world Web Host / Commercial HUD: Solid `PixelWorldHost` derives command board, objective, next action, player leverage, routes, blocker/receipt; implemented and evolving.
+  3. Pixel-world WASM Bevy/WebGL2 renderer: `pixel_world_bridge` canvas runtime; implemented; no second JS renderer fallback.
+  4. Live Runtime + WebSocket Bridge: `oasis7_viewer_live` + `ViewerWebBridge` feed browser state over WebSocket; implemented; formal gameplay depends on LLM/provider.
+  5. Launcher Stack / Game URL carrier: `oasis7_game_launcher` serves Viewer static assets and emits `GAME_URL`; implemented; not a separate renderer.
+  6. Offline Demo / Playback: `oasis7_viewer_demo` + `ViewerServer` snapshot/journal route; implemented for deterministic replay/debug only.
+  7. Launcher egui native/web control plane: launcher state/config visualization; implemented/documented but outside player world renderer.
+- Removed / non-current: `standard_3d`, old 3D visual QA/material/theme/screenshot chain, native Viewer crate startup path.
+- Residual unknowns:
+  - No live browser run in this slice.
+  - Dense fragment performance/visual quality and current bundle launcher-egui availability need separate verification.
+- Blocker / Next Action: integrate with visual-interaction slice for user-facing route summary.
+
+## 2026-06-22 11:31:58 CST / tpm
+- 完成内容: Integrated professional slice returns for user-facing summary.
+- 遗留事项: none.
+- Integration:
+  - Product/player-facing answer should present 6 main visualization expression routes from `game_visual_interaction_designer`.
+  - Engineering appendix can mention 7 carrier/runtime routes from `viewer_engineer`.
+  - Launcher stack and launcher egui are carrier/control-plane routes, not standalone world renderers.
+  - Old 3D/native routes are historical/non-current, not current product commitments.
+- Action: write professional slice returns to `.pm` execution log.
+- Validation Command: evidence-only read-only task; no runtime/browser verification requested or run.
+- Expected Result: answer is attributed to bounded role evidence and does not present TPM-only professional judgment.
+- Actual Result: ready to answer user with integrated route map.
+- Blocker / Next Action: none for read-only summary; separate verification task needed if user asks to prove current visuals in browser.
+
+## 2026-06-22 11:50:33 CST / tpm
+- 完成内容: Follow-up factual check for whether old 3D/native/visual QA docs and code are deleted.
+- 遗留事项: none.
+- Evidence commands:
+  - `rg -n "standard_3d|old 3D|旧 3D|native Viewer|native viewer|visual QA|3D visual|材质|material|theme|screenshot chain|visual qa|standard-3d|standard3d|native.*viewer|viewer.*native|3D|three|bevy|Bevy" doc crates scripts .agents -g '!target'`
+  - `find doc/world-simulator/viewer -maxdepth 1 -type f | rg -i 'viewer-(visualization|visualization-3d|3d|2d-3d|standard|webgl|bevy-web|material|texture|theme|asset-pipeline|visual-release|release-qa|auto-focus|auto-select|wasd|rendering-physical|location-depletion|open-world-sandbox|commercial-release-phase|web-closure|observability-visual)'`
+  - `rg -n "standard_3d|standard-3d|standard3d|visual QA|3D visual QA|viewer_visualization_3d|viewer-visualization-3d|viewer_3d|standard Viewer|standard viewer" crates/oasis7 crates/oasis7_viewer crates/oasis7_client_launcher scripts -g '!target'`
+- Action: ran targeted grep/find checks for old route docs and runnable entrypoints.
+- Validation Command: targeted `rg` and `find` commands listed above.
+- Expected Result: distinguish active route residue from historical records.
+- Actual Result: no runnable old route entrypoints found; remaining historical records and terminology residue identified.
+- Findings:
+  - Current manual states the repo no longer provides old 3D/native/visual-specialized toolchains and lists native Viewer startup, old 3D/visual QA surface, and old material/theme/capture visual toolchain as removed capabilities.
+  - Current software-safe/viewer PRD states `viewer` is the sole canonical Web/UI entry, `software_safe` is compat alias, `standard_3d` code/static entry/scripts were deleted, and 3D visual QA/screenshot/texture/theme asset chains are out of scope.
+  - No current `doc/world-simulator/viewer` files matched the old standard_3d/3D/material/theme/screenshot-chain topic file patterns searched.
+  - No runnable `standard_3d` or old 3D entry code was found in `crates/oasis7`, `crates/oasis7_viewer`, `crates/oasis7_client_launcher`, or `scripts` by targeted grep.
+  - Historical governance/checklist files still retain references to "historical removed standard_3d viewer doc set"; these are records, not active design docs.
+  - A few generated/source viewer strings still mention "visual QA viewer" as explanatory copy; this is terminology residue, not evidence of an active old visual QA route.
+- Answer boundary: evidence-only fact lookup; no browser/runtime verification run.
+- Blocker / Next Action: answer follow-up fact question; await user decision on cleanup.
+
+## 2026-06-22 11:55:19 CST / tpm
+- 完成内容: Scope changed by user from read-only inventory to repository cleanup: "彻底清理".
+- 遗留事项: none.
+- Route update: use `executing-project-tasks` for a narrow cleanup patch, then `verification-before-completion` before claiming completion.
+- Action: expanded task scope from read-only answer to narrow cleanup implementation.
+- Validation Command: plan-gap review against current task evidence and affected path set.
+- Expected Result: cleanup scope and verification path recorded before edits.
+- Actual Result: source/docs/site cleanup plan and repository-health review need recorded.
+- Plan-gap review:
+  - Affected surfaces: active Viewer docs/manuals, viewer source/generated text, governance checklist wording that keeps old `standard_3d` terms discoverable as if active.
+  - Non-goal: restore or implement any old 3D/native route.
+  - Verification: targeted residual grep, `./scripts/doc-governance-check.sh`, `git diff --check`; run UI/build check if generated viewer bundle drift is affected.
+- Subagent/professional boundary:
+  - `viewer_engineer` evidence already established old route is non-current; cleanup implementation is mechanical text/doc/code alignment based on that evidence.
+  - `repository_health_engineer` review should verify the final diff does not erase necessary history in a misleading way and does not leave active terminology debt.
+- Next Action: inspect exact residuals, patch current-source wording and active historical-index wording, then verify.
+- Blocker / Next Action: inspect exact residuals, patch current-source wording and active historical-index wording, then verify.
+
+## 2026-06-22 12:09:48 CST / repository_health_engineer
+- 完成内容: Reviewed cleanup diff for repo-health/provenance risks.
+- 遗留事项: protected historical audit/project rows intentionally preserve old exact terms as provenance.
+- Slice: `repository_health_engineer`
+- Mode: read-only bounded review slice; no file edits.
+- Action: inspected cleanup diff for active terminology debt, site mirror drift, pseudo-taxonomy, and archive provenance risk.
+- Validation Command: read-only repository-health review; no runtime command.
+- Expected Result: findings categorized by merge risk with disposition needs.
+- Actual Result: P1/P2/P3 findings returned and then fixed by TPM cleanup patch.
+- Findings:
+  1. P1: `site/doc/en/viewer-manual.html` and `site/doc/cn/viewer-manual.html` still exposed old-route wording in the first cleanup attempt.
+  2. P2: active docs introduced `retired secondary viewer` as a pseudo taxonomy; use prose such as old second Viewer entry/toolchain instead.
+  3. P2: archive/audit logs were mass-rewritten, risking loss of exact historical audit provenance; revert archive-log churn and record current cleanup truth in current sinks.
+  4. P3: `doc/ui_review_result/README.md` still pointed formal review口径 at a retired legacy scorecard; point to current viewer visual/design authority instead.
+- Disposition:
+  - Fixed P1 by updating `site/doc/{cn,en}/viewer-manual.html`.
+  - Fixed P2 pseudo taxonomy in active PRD/design/project prose.
+  - Fixed P2 archive provenance risk by restoring `historical removed standard_3d viewer doc set` labels in archive/audit logs and treating those as intentional historical records.
+  - Fixed P3 by pointing `doc/ui_review_result/README.md` to `doc/world-simulator/viewer/viewer-visual-design-spec-2026-06-05.design.md`.
+- Residual Risk: protected historical audit/project rows still contain old exact terms as provenance; active/current surface grep excludes these intentionally preserved records.
+- Blocker / Next Action: apply findings disposition in cleanup patch and verify active/current residual grep.
+
+## 2026-06-22 12:09:48 CST / tpm
+- 完成内容: Implemented cleanup of active old 3D/native/visual QA route residue across viewer source, generated bundle, active docs, and site manual mirrors.
+- 遗留事项: none for active/current surfaces; historical audit/task rows intentionally preserve original terminology as provenance.
+- Action:
+- Action: implemented active old-route terminology cleanup and regenerated viewer bundle.
+- Action Details:
+  - Updated active Viewer UI copy to remove `visual QA viewer` wording.
+  - Rebuilt `crates/oasis7_viewer/viewer.js` from source.
+  - Updated current docs to describe removed old route as old second Viewer entry/toolchain without preserving it as a current taxonomy.
+  - Synced `site/doc/{cn,en}/viewer-manual.html`.
+  - Restored archive/audit labels after repository-health review flagged provenance risk.
+- Validation Command:
+- Validation Command: build, UI tests, site manual sync, doc governance, diff whitespace, and targeted residual grep.
+- Validation Details:
+  - `npm --prefix crates/oasis7_viewer run build:software-safe`
+  - `npm --prefix crates/oasis7_viewer run test:ui -- main viewer_feedback_module viewer_world_scale_module`
+  - `./scripts/site-manual-sync-check.sh`
+  - `./scripts/doc-governance-check.sh`
+  - `git diff --check`
+  - `rg -n "standard_3d|visual QA|visual-QA|native Viewer|native viewer|旧 3D|3D/native|standard Viewer|标准 Viewer|3D/标准 Viewer|retired secondary viewer|retired legacy viewer doc set" doc/world-simulator/viewer doc/core doc/world-simulator/prd.md doc/world-simulator/project.md doc/testing site/doc crates/oasis7_viewer --glob '!target/**' | rg -v 'doc/core/reviews/|doc/core/project.md|doc/core/player-access-mode-contract-2026-03-19.project.md|doc/world-simulator/viewer/viewer-web-software-safe-mode-2026-03-16.project.md'`
+- Expected Result: active/current surfaces have no old-route terminology; generated viewer bundle matches source; governance and formatting pass.
+- Actual Result: all listed checks passed; active/current residual grep returned no matches.
+- Actual Details:
+  - build passed and regenerated `crates/oasis7_viewer/viewer.js`.
+  - UI test passed: 1 file, 41 tests.
+  - site manual sync check passed.
+  - doc-governance check passed.
+  - `git diff --check` passed.
+  - active/current surface residual grep returned no matches; remaining old terms are intentionally preserved in historical audit/project rows.
+- Blocker / Next Action: none.
+
+## 2026-06-22 13:26:13 CST / tpm
+- 完成内容: Ran task closeout verification and recorded closeout state.
+- 遗留事项: repo-wide `./scripts/pm/lint.sh` still fails on unrelated historical `.pm` task logs; this task's focused workflow lint passes.
+- Action: executed `task-closeout.sh`; it verified the task and marked `.pm/tasks/task_e6edcb09bd774941bdcbde32bb9ea007.yaml` as `done`, then failed only at final repo-wide PM lint.
+- Validation Command: `./scripts/pm/task-closeout.sh --role tpm --task-uid task_e6edcb09bd774941bdcbde32bb9ea007 --verify-command 'npm --prefix crates/oasis7_viewer run test:ui -- main viewer_feedback_module viewer_world_scale_module && ./scripts/site-manual-sync-check.sh && ./scripts/doc-governance-check.sh && git diff --check && ./scripts/pm/workflow-lint.sh --task-uid task_e6edcb09bd774941bdcbde32bb9ea007 --phase current'`
+- Expected Result: fresh task verification succeeds and task closes to `done`; any repo-wide PM lint debt is recorded separately.
+- Actual Result: verification exit code 0, task status `done`, `last_verification_status: verified`; final repo-wide PM lint failed on unrelated historical tasks and earlier template-shape issues in this log, which were repaired afterward.
+- Blocker / Next Action: run focused lint for this task, then commit and start pre-PR local role review.
+
+## 2026-06-22 13:29:12 CST / tpm
+- 完成内容: Dispatched fresh pre-PR local role review.
+- 遗留事项: awaiting role review returns before recording `Pre-PR Local Role Review: passed`.
+- Review Trigger: pre-PR local role review
+- Review Scope: commit `879e18537c4c170c119db9f2b6125c60a218b024`; cleanup of active Viewer/source/docs/site references to retired `standard_3d`, native Viewer, and old visual QA routes while preserving historical provenance.
+- Review Roles: game_visual_interaction_designer, viewer_engineer, qa_engineer, repository_health_engineer
+- Review Question: confirm the cleanup does not leave active old-route terminology, does not create misleading new taxonomy, preserves provenance, and has sufficient verification evidence for PR.
+- Evidence Available: commit diff, task execution log, UI test, site manual sync, doc governance, `git diff --check`, focused workflow lint, targeted residual grep.
+- Expected Return Contract: findings | no_findings | residual_risk
+- Formal Sink: `.pm/tasks/task_e6edcb09bd774941bdcbde32bb9ea007.execution.md`
+- Action: spawned four full-context local review subagents for the involved roles.
+- Validation Command: multi-agent dispatch records for agents `019eedcd-4e33-7b22-882e-2aeaef766eb2`, `019eedcd-6c93-79a1-bd89-f93a80a2fd88`, `019eedcd-979c-70f2-88d6-b4e9fd8afa62`, `019eedcd-c024-72b0-88ec-e72390c71d07`.
+- Expected Result: each role returns findings/no_findings and residual risk before PR preflight.
+- Actual Result: dispatch accepted; results pending.
+- Blocker / Next Action: wait for role review results and address any valid findings.
+
+## 2026-06-22 13:34:37 CST / tpm
+- 完成内容: Integrated fresh pre-PR local role review results.
+- 遗留事项: no actionable role-review findings; residual risk is limited to no fresh browser screenshot/runtime visual smoke and intentional historical provenance rows retaining old terms.
+- Review Results:
+  - game_visual_interaction_designer: no_findings; residual risk that no fresh Viewer screenshots/browser visual smoke were run and historical project rows could be misread if copied into current docs.
+  - viewer_engineer: no_findings; source and generated bundle strings match; active-surface old-route grep and UI/site checks passed.
+  - qa_engineer: no_findings; reran QA-relevant checks, confirmed no runtime/browser overclaim and no mirror drift.
+  - repository_health_engineer: no_findings; active/current surface hits absent, site mirrors/current manual/review authority checked, historical audit provenance preserved.
+- Pre-PR Local Role Review: passed
+- Task UID: task_e6edcb09bd774941bdcbde32bb9ea007
+- Source Worktree: /Users/scc/ccwork/worktrees/oasis7-viewer-visualization-routes-readonly
+- Source Branch: task/viewer-visualization-routes-readonly
+- Source Head: 7213c186faf01e2687a7a34d1ccd2aac15b1abe3
+- Comparison Ref: refs/remotes/origin/main
+- Reviewed Changed Paths: `.pm/tasks/task_e6edcb09bd774941bdcbde32bb9ea007.*`; `crates/oasis7_viewer/software_safe_src/*`; `crates/oasis7_viewer/viewer.js`; `doc/core/player-access-mode-contract-2026-03-19.*`; `doc/core/project.md`; `doc/site/github-pages/github-pages-release-download-pipeline-2026-03-01.project.md`; `doc/testing/**`; `doc/ui_review_result/README.md`; `doc/world-simulator/**`; `site/doc/{cn,en}/viewer-manual.html`
+- Role Selection Basis: visible Viewer copy and player-facing docs require `game_visual_interaction_designer`; Viewer source/generated bundle and route contracts require `viewer_engineer`; verification readiness requires `qa_engineer`; cross-doc terminology/provenance/task truth requires `repository_health_engineer`.
+- Review Roles: game_visual_interaction_designer, viewer_engineer, qa_engineer, repository_health_engineer
+- Review Evidence: subagent returns `019eedcd-4e33-7b22-882e-2aeaef766eb2`, `019eedcd-6c93-79a1-bd89-f93a80a2fd88`, `019eedcd-979c-70f2-88d6-b4e9fd8afa62`, `019eedcd-c024-72b0-88ec-e72390c71d07`; fresh local checks listed in prior closeout entry.
+- Review Findings Disposition: no_findings
+- Finding Disposition Evidence: no actionable findings; process note addressed by recording this passed packet before PR preflight.
+- Residual Risk: no fresh browser screenshot/runtime visual smoke in this PR path; old terminology remains only in intentional historical/provenance rows.
+- Action: recorded review returns and passed packet for PR preflight.
+- Validation Command: inspect four local role review returns and update execution log.
+- Expected Result: PR preflight can find a top-level `Pre-PR Local Role Review: passed` evidence packet.
+- Actual Result: passed packet recorded; only task evidence amendment remains before PR helper.
+- Blocker / Next Action: amend evidence packet into commit, run PR preflight/create.
+
+## 2026-06-22 13:37:37 CST / tpm
+- 完成内容: Repaired PR preflight evidence shape after workflow-lint feedback.
+- 遗留事项: `claim-ready.sh --claim-type ready_for_pr` cannot mutate a closed task; equivalent fresh verification was run and recorded in this entry.
+- Action: added `doc/world-simulator/project.md` to task `doc_refs`, added a recent-completed module trace for this task, attempted ready_for_pr `claim-ready.sh`, then ran the same verification command directly.
+- Validation Command: `./scripts/pm/claim-ready.sh --claim-type ready_for_pr --verify-command './scripts/site-manual-sync-check.sh && ./scripts/doc-governance-check.sh && git diff --check && ./scripts/pm/workflow-lint.sh --task-uid task_e6edcb09bd774941bdcbde32bb9ea007 --phase current' --task-uid task_e6edcb09bd774941bdcbde32bb9ea007 --json`; fallback direct command `./scripts/site-manual-sync-check.sh && ./scripts/doc-governance-check.sh && git diff --check && ./scripts/pm/workflow-lint.sh --task-uid task_e6edcb09bd774941bdcbde32bb9ea007 --phase current`.
+- Expected Result: PR-ready evidence mentions claim-ready attempt, project trace resolves, and direct verification passes.
+- Actual Result: claim-ready helper rejected non-completion claim on already closed task (`closed task claim evidence is immutable`); direct verification passed: site manual sync OK, doc-governance OK, `git diff --check` OK, focused workflow-lint OK.
+- Blocker / Next Action: amend evidence changes into commit and rerun `./scripts/prepare-task-pr.sh --json`.

--- a/.pm/tasks/task_e6edcb09bd774941bdcbde32bb9ea007.execution.md
+++ b/.pm/tasks/task_e6edcb09bd774941bdcbde32bb9ea007.execution.md
@@ -279,7 +279,7 @@ Example:
 - Task UID: task_e6edcb09bd774941bdcbde32bb9ea007
 - Source Worktree: /Users/scc/ccwork/worktrees/oasis7-viewer-visualization-routes-readonly
 - Source Branch: task/viewer-visualization-routes-readonly
-- Source Head: 7213c186faf01e2687a7a34d1ccd2aac15b1abe3
+- Source Head: 41bf8bd0167312272303c59c15f455f9c03755e0
 - Comparison Ref: refs/remotes/origin/main
 - Reviewed Changed Paths: `.pm/tasks/task_e6edcb09bd774941bdcbde32bb9ea007.*`; `crates/oasis7_viewer/software_safe_src/*`; `crates/oasis7_viewer/viewer.js`; `doc/core/player-access-mode-contract-2026-03-19.*`; `doc/core/project.md`; `doc/site/github-pages/github-pages-release-download-pipeline-2026-03-01.project.md`; `doc/testing/**`; `doc/ui_review_result/README.md`; `doc/world-simulator/**`; `site/doc/{cn,en}/viewer-manual.html`
 - Role Selection Basis: visible Viewer copy and player-facing docs require `game_visual_interaction_designer`; Viewer source/generated bundle and route contracts require `viewer_engineer`; verification readiness requires `qa_engineer`; cross-doc terminology/provenance/task truth requires `repository_health_engineer`.

--- a/.pm/tasks/task_e6edcb09bd774941bdcbde32bb9ea007.execution.md
+++ b/.pm/tasks/task_e6edcb09bd774941bdcbde32bb9ea007.execution.md
@@ -311,3 +311,12 @@ Example:
 - Expected Result: PR exists with task UID, verification summary, and normal PR CI/watch purpose.
 - Actual Result: PR URL: https://github.com/eng-cc/oasis7/pull/557; branch pushed to `origin/task/viewer-visualization-routes-readonly`; PR Purpose Decision: `normal_pr_ci_watch`.
 - Blocker / Next Action: push PR evidence commit, then watch required checks, comments, review threads, and mergeability.
+
+## 2026-06-22 13:48:06 CST / tpm
+- 完成内容: Addressed actionable PR review thread.
+- 遗留事项: re-check GitHub review threads after push; required checks will rerun on the new commit.
+- Action: rephrased `doc/world-simulator/project.md` recent-completed trace to avoid exact retired-route tokens in the active project page.
+- Validation Command: targeted residual grep for retired route tokens in active/current scope; `./scripts/site-manual-sync-check.sh && ./scripts/doc-governance-check.sh && git diff --check && ./scripts/pm/workflow-lint.sh --task-uid task_e6edcb09bd774941bdcbde32bb9ea007 --phase post-pr`.
+- Expected Result: no active/current old-token hits; site/doc/workflow gates remain green.
+- Actual Result: targeted grep returned no output; site manual sync OK, doc-governance OK, `git diff --check` OK, post-pr workflow-lint OK.
+- Blocker / Next Action: commit and push review fix, then confirm review thread/checks/mergeability again.

--- a/.pm/tasks/task_e6edcb09bd774941bdcbde32bb9ea007.yaml
+++ b/.pm/tasks/task_e6edcb09bd774941bdcbde32bb9ea007.yaml
@@ -1,0 +1,27 @@
+task_uid: task_e6edcb09bd774941bdcbde32bb9ea007
+title: "Map current visualization routes"
+owner_role: tpm
+worktree_hint: /Users/scc/ccwork/worktrees/oasis7-viewer-visualization-routes-readonly
+execution_log_path: .pm/tasks/task_e6edcb09bd774941bdcbde32bb9ea007.execution.md
+status: done
+priority: P2
+source_signal: null
+source_refs:
+  - AGENTS.md
+  - doc/engineering/workflow/source-of-truth.md
+doc_refs:
+  - doc/world-simulator/project.md
+related_prd: []
+acceptance:
+  - "Summarize current visualization routes with role attribution and repository evidence"
+handoff_to:
+  - game_visual_interaction_designer
+  - viewer_engineer
+updated_at: 2026-06-22T13:24:47+08:00
+last_started_at: 2026-06-22T11:26:09+08:00
+last_claim_type: task_complete
+last_verify_command: "npm --prefix crates/oasis7_viewer run test:ui -- main viewer_feedback_module viewer_world_scale_module && ./scripts/site-manual-sync-check.sh && ./scripts/doc-governance-check.sh && git diff --check && ./scripts/pm/workflow-lint.sh --task-uid task_e6edcb09bd774941bdcbde32bb9ea007 --phase current"
+last_verified_at: 2026-06-22T13:24:39+08:00
+last_verification_exit_code: 0
+last_verification_status: verified
+last_closed_at: 2026-06-22T13:24:45+08:00

--- a/PR.md
+++ b/PR.md
@@ -1,7 +1,7 @@
-# Improve viewer visual alignment
+# Clean retired viewer visualization routes
 
-- PR URL: https://github.com/eng-cc/oasis7/pull/532
-- Task UID: task_060e9de147ba4757ac29cf0fb7a15210
-- Source Branch: task/viewer-optimize-game-viewer
+- PR URL: https://github.com/eng-cc/oasis7/pull/557
+- Task UID: task_e6edcb09bd774941bdcbde32bb9ea007
+- Source Branch: task/viewer-visualization-routes-readonly
 - Base Branch: main
 - Purpose: normal_pr_ci_watch

--- a/crates/oasis7_viewer/software_safe_src/main.jsx
+++ b/crates/oasis7_viewer/software_safe_src/main.jsx
@@ -895,7 +895,7 @@ function gameplayActionDetail(action, gameplay, locale) {
     || action?.disabledReason
     || gameplay?.economicSurface?.repairAction
     || gameplay?.narrativeNextStep
-    || tr(locale, "无需打开可视化质检观察器，也可以直接从正式网页入口执行。", "Playable from the formal Web entry without opening the visual QA viewer.");
+    || tr(locale, "可以直接从正式网页入口执行。", "Playable directly from the formal Web entry.");
 }
 
 function renderGameplayAction(action) {

--- a/crates/oasis7_viewer/software_safe_src/viewer_feedback_module.js
+++ b/crates/oasis7_viewer/software_safe_src/viewer_feedback_module.js
@@ -897,8 +897,8 @@ export function createViewerFeedbackModule({
       if (!isRecoveryChoiceState) {
         return localeText(
           locale,
-          "无需打开可视化质检观察器，也可以直接从正式网页入口执行。",
-          "Playable from the formal Web entry without opening the visual QA viewer.",
+          "可以直接从正式网页入口执行。",
+          "Playable directly from the formal Web entry.",
         );
       }
       if (action.executeKind === "request_snapshot") {

--- a/crates/oasis7_viewer/software_safe_src/viewer_world_scale_module.js
+++ b/crates/oasis7_viewer/software_safe_src/viewer_world_scale_module.js
@@ -157,8 +157,8 @@ export function createViewerWorldScaleModule({
         ? "overview/detail 的 zoom tier 只切换表现语义，不会改写世界的厘米真值。"
         : "Overview/detail zoom tiers only switch presentation semantics; they do not rewrite centimeter truth in the world model.",
       softwareSafeNote: isZh
-        ? "viewer 主入口优先给出文字和数值真值；更底层的 visual QA viewer 可以更夸张，但不应覆盖这里的物理标签。"
-        : "The viewer entry prioritizes textual and numeric truth. Lower-level visual QA surfaces may exaggerate more aggressively, but they should not override the physical labels here.",
+        ? "viewer 主入口优先给出文字和数值真值；诊断层可以为可读性放大标记，但不应覆盖这里的物理标签。"
+        : "The viewer entry prioritizes textual and numeric truth. Diagnostic layers may enlarge markers for readability, but they should not override the physical labels here.",
     };
 
     return {

--- a/crates/oasis7_viewer/viewer.js
+++ b/crates/oasis7_viewer/viewer.js
@@ -1786,8 +1786,8 @@ function createViewerFeedbackModule({
       if (!isRecoveryChoiceState) {
         return localeText2(
           locale,
-          "无需打开可视化质检观察器，也可以直接从正式网页入口执行。",
-          "Playable from the formal Web entry without opening the visual QA viewer."
+          "可以直接从正式网页入口执行。",
+          "Playable directly from the formal Web entry."
         );
       }
       if (action.executeKind === "request_snapshot") {
@@ -2333,7 +2333,7 @@ function createViewerWorldScaleModule({
     const presentationScale = {
       markerTruthNote: isZh ? "3D marker、2D overview map 和 halo 允许为了可读性被放大；请把距离/半径标签当成真值，不要把屏幕上的直径当成真实几何尺寸。" : "3D markers, the 2D overview map, and halos may be enlarged for readability. Treat the distance/radius labels as truth; do not read on-screen diameter as real geometry size.",
       zoomTruthNote: isZh ? "overview/detail 的 zoom tier 只切换表现语义，不会改写世界的厘米真值。" : "Overview/detail zoom tiers only switch presentation semantics; they do not rewrite centimeter truth in the world model.",
-      softwareSafeNote: isZh ? "viewer 主入口优先给出文字和数值真值；更底层的 visual QA viewer 可以更夸张，但不应覆盖这里的物理标签。" : "The viewer entry prioritizes textual and numeric truth. Lower-level visual QA surfaces may exaggerate more aggressively, but they should not override the physical labels here."
+      softwareSafeNote: isZh ? "viewer 主入口优先给出文字和数值真值；诊断层可以为可读性放大标记，但不应覆盖这里的物理标签。" : "The viewer entry prioritizes textual and numeric truth. Diagnostic layers may enlarge markers for readability, but they should not override the physical labels here."
     };
     return {
       physicalTruth,
@@ -8574,7 +8574,7 @@ function gameplayActionDetail(action, gameplay, locale) {
   if (action?.actionId === "claim_starter_oc") {
     return action?.disabledReason || tr(locale, "领取一次性初始 OC，解锁第一次 LLM/Agent chat。", "Claim one-time starter OC to unlock the first LLM/Agent chat.");
   }
-  return action?.playerDetail || action?.disabledReason || gameplay?.economicSurface?.repairAction || gameplay?.narrativeNextStep || tr(locale, "无需打开可视化质检观察器，也可以直接从正式网页入口执行。", "Playable from the formal Web entry without opening the visual QA viewer.");
+  return action?.playerDetail || action?.disabledReason || gameplay?.economicSurface?.repairAction || gameplay?.narrativeNextStep || tr(locale, "可以直接从正式网页入口执行。", "Playable directly from the formal Web entry.");
 }
 function renderGameplayAction(action) {
   if (action.executeKind === "agent_chat") {

--- a/doc/core/player-access-mode-contract-2026-03-19.design.md
+++ b/doc/core/player-access-mode-contract-2026-03-19.design.md
@@ -12,7 +12,7 @@
 - 保留两种玩家访问模式：
   - `software_safe`：默认 Web 正式入口。
   - `pure_api`：无 UI、自动化、长稳与集成入口。
-- 删除 `standard_3d` 的现行模式地位：
+- 删除旧第二 Viewer 入口的现行模式地位：
   - 不再作为玩家入口。
   - 不再作为 release / QA / playability 的当前 claim 目标。
   - 若历史文档仍提到它，只能按归档理解。
@@ -41,4 +41,4 @@
 ## 5. 失败与降级语义
 - Web 缺 LLM 或命中 blocker：记为 `software_safe blocked`
 - 纯接口缺 canonical gameplay 语义：记为 `pure_api observer_only`
-- 旧 `standard_3d` 文案：视为历史残留，需清理
+- 旧第二 Viewer 入口文案：视为历史残留，需清理

--- a/doc/core/player-access-mode-contract-2026-03-19.prd.md
+++ b/doc/core/player-access-mode-contract-2026-03-19.prd.md
@@ -13,7 +13,7 @@
 ## 范围
 - 覆盖 `doc/core/**`、`doc/world-simulator/**`、`doc/game/**`、`doc/testing/**` 中的当前模式口径。
 - 覆盖 `viewer` Web 正式入口与 `pure_api` no-UI 正式入口的 claim 边界；`software_safe` 仅保留为兼容 alias。
-- 不恢复已删除的 3D 玩家入口，也不重写 provider/runtime 底层实现。
+- 不恢复已删除的旧第二 Viewer 入口，也不重写 provider/runtime 底层实现。
 
 ## 接口 / 数据
 - 主 PRD: `doc/core/player-access-mode-contract-2026-03-19.prd.md`
@@ -25,20 +25,20 @@
 ## 里程碑
 - M1: 冻结 `viewer / pure_api` 双模式总契约。
 - M2: 回写 core/world-simulator/game/testing 活跃载体。
-- M3: 清空活跃文档里把旧 3D 入口写成当前模式的残留。
+- M3: 清空活跃文档里把旧第二 Viewer 入口写成当前模式的残留。
 
 ## 风险
-- 历史专题、handoff 与项目管理文档仍可能引用旧 3D 术语，造成误读。
+- 历史专题、handoff 与项目管理文档仍可能引用旧第二 Viewer 术语，造成误读。
 - 若把 execution lane/provider alias 重新写成玩家模式，会再次产生 taxonomy 漂移。
 - 若 active docs 与脚本入口不同步，QA/release 结论会继续分叉。
 
 ## 1. Executive Summary
-- Problem Statement: 仓库已经删除 `standard_3d` 相关代码、脚本与活跃文档后，跨模块口径必须同步收敛，否则会继续出现“代码真值是 `software_safe` 单 Web 入口，但文档仍宣称存在 3D 玩家入口”的双真值。
+- Problem Statement: 仓库已经删除旧第二 Viewer 入口相关代码、脚本与活跃文档后，跨模块口径必须同步收敛，否则会继续出现“代码真值是 `software_safe` 单 Web 入口，但文档仍宣称存在已退役入口”的双真值。
 - Proposed Solution: 将玩家访问模式正式收口为 `viewer / pure_api` 两项；其中 `viewer` 负责唯一 Web / UI 入口，`pure_api` 负责无 UI 正式入口，旧 `software_safe` 只保留为兼容 alias。`player_parity / headless_agent` 继续只作为 execution lane，`non-3D / 2D 优先` 继续只作为交付优先级或交互范围描述。
 - Success Criteria:
   - SC-1: `viewer` 是唯一正式 Web / UI 玩家入口；`software_safe` 仅作兼容 alias。
   - SC-2: `pure_api` 保持一等公民 no-UI 正式入口，formal gameplay 继续要求 active LLM access。
-  - SC-3: 活跃文档、测试口径与对外 claim 不再把 `standard_3d` 写成现行模式。
+  - SC-3: 活跃文档、测试口径与对外 claim 不再把旧第二 Viewer 入口写成现行模式。
   - SC-4: `agent_direct_connect/provider_loopback_http` 继续只作为兼容 alias；正式 operator-facing provider 口径仍是 `agent_decision_source + agent_provider_backend/contract/transport/url/auth/connect_timeout_ms/profile + agent_execution_lane`。
   - SC-5: `non-3D`、`2D 优先` 不得再被包装成模式名。
 
@@ -73,7 +73,7 @@
 - Edge Cases & Error Handling:
   - 若 Web 证据命中 `--no-llm` / `llm_required` / `llm_init_failed`，只能给 `viewer blocked` 结论，不得降格成另一个模式。
   - 若需要纯接口长稳或自动化结论，必须显式绑定 `pure_api`，不得借用 `headless_agent` 作为玩家模式。
-  - 若旧文档提到 `standard_3d`，应视为历史归档而非当前真值。
+  - 若旧文档提到旧第二 Viewer 入口，应视为历史归档而非当前真值。
 - Non-Functional Requirements:
   - NFR-1: 活跃文档中的当前玩家访问模式混淆命中数为 0。
   - NFR-2: QA / release / playability 证据 100% 显式标注 `mode_id`。
@@ -86,5 +86,5 @@
 - Decision Log:
 | 决策ID | 选定方案 | 备选方案（否决） | 依据 |
 | --- | --- | --- | --- |
-| `DEC-PCM-001` | 玩家访问模式只保留 `viewer / pure_api`，`software_safe` 降为兼容 alias | 继续保留已删除实现对应的 `standard_3d`，或继续把 `software_safe` 当 canonical 名称 | 当前仓库已只剩一个正式 Web / UI 入口，实现、链接与文档必须围绕同一个 canonical 名称收口。 |
+| `DEC-PCM-001` | 玩家访问模式只保留 `viewer / pure_api`，`software_safe` 降为兼容 alias | 继续保留已删除实现对应的旧第二 Viewer 入口，或继续把 `software_safe` 当 canonical 名称 | 当前仓库已只剩一个正式 Web / UI 入口，实现、链接与文档必须围绕同一个 canonical 名称收口。 |
 | `DEC-PCM-002` | 继续保留 provider/lane 分层 | 把 lane 或 provider alias 当入口 | 可避免再次把执行方式误写成玩家模式。 |

--- a/doc/core/player-access-mode-contract-2026-03-19.project.md
+++ b/doc/core/player-access-mode-contract-2026-03-19.project.md
@@ -34,7 +34,7 @@
 - `./scripts/doc-governance-check.sh`
 - `git diff --check`
 - `rg -n "non-3D|玩家访问模式|delivery priority|interaction scope" doc/core/player-access-mode-contract-2026-03-19.{prd,design,project}.md doc/world-simulator/prd.md doc/world-simulator/viewer/viewer-web-software-safe-mode-2026-03-16.prd.md`
-- `rg -n "主要正式 Web 入口|formal Web gameplay|visual QA|一等公民" doc/core/player-access-mode-contract-2026-03-19.{prd,design,project}.md doc/core/{prd,project}.md doc/world-simulator/{prd,project}.md doc/world-simulator/viewer/viewer-web-software-safe-mode-2026-03-16.{prd,design,project}.md`
+- `rg -n "主要正式 Web 入口|formal Web gameplay|一等公民" doc/core/player-access-mode-contract-2026-03-19.{prd,design,project}.md doc/core/{prd,project}.md doc/world-simulator/{prd,project}.md doc/world-simulator/viewer/viewer-web-software-safe-mode-2026-03-16.{prd,design,project}.md`
 - `rg -n "main_token_transfer|handoff|专门动作|not_exposed" doc/core/player-access-mode-contract-2026-03-19.{prd,design,project}.md doc/world-simulator/viewer/viewer-web-software-safe-mode-2026-03-16.{prd,design,project}.md`
 - `env -u RUSTC_WRAPPER cargo test -p oasis7 runtime_gameplay_action_script_mode_requires_llm_mode -- --nocapture`
 - `env -u RUSTC_WRAPPER cargo test -p oasis7 runtime_step_control_reports_blocked_without_llm_mode -- --nocapture`
@@ -49,7 +49,7 @@
 - 下一任务: T10
 - 最新完成: `T1/T2/T3/T4/T5/T6/T7`（历史上已完成三模式总契约建模与下游术语收口；当前仓库真值已进一步收口为 `viewer / pure_api` 双模式，其中 `software_safe` 仅保留兼容 alias，并同步完成 core 主入口挂载、`pure_api` 的 LLM-required 正式游玩口径收口、`agent_direct_connect` / `provider_loopback_http` / execution lane 的多层术语收口，以及 `non-3D` / `software_safe` 的 priority-vs-mode 边界澄清。）
 - 最新完成: `T8`（已将 agent provider 正式配置收口为 `agent_decision_source + agent_provider_* + agent_execution_lane` 结构化 taxonomy，并把 `agent_direct_connect/provider_loopback_http` 降为兼容 alias。）
-- 最新完成: `T9`（历史上已将唯一正式 Web 入口从旧命名收口到当前 `viewer` canonical 名称、将 `standard_3d` 收口为 visual QA 模式；当前仓库真值进一步收口为 `viewer / pure_api` 双模式，`software_safe` 仅保留兼容 alias。）
+- 最新完成: `T9`（历史上已将唯一正式 Web 入口从旧命名收口到当前 `viewer` canonical 名称、并将退役第二 Viewer 路线移出当前入口集合；当前仓库真值进一步收口为 `viewer / pure_api` 双模式，`software_safe` 仅保留兼容 alias。）
 - 备注:
   - 本专题只冻结 taxonomy 与 claim contract，不替代下游专题实现。
   - 后续若新增同层玩家访问模式，必须先更新本专题再更新模块文档。

--- a/doc/core/project.md
+++ b/doc/core/project.md
@@ -263,7 +263,7 @@
     - `doc/world-simulator/viewer/viewer-web-software-safe-mode-2026-03-16.prd.md`
     - `.pm/tasks/task_26cb41e1a4914a9eac0ec1728afd2079.execution.md`
   - 验收命令 (`test_tier_required`):
-    - `rg -n "non-3D|玩家访问模式|delivery priority|interaction scope" doc/core/prd.md doc/core/project.md doc/core/player-access-mode-contract-2026-03-19.{prd,design,project}.md doc/world-simulator/prd.md historical removed standard_3d viewer doc set: viewer-3d-pause-user-interaction-hold-2026-04-01.prd`
+    - `rg -n "non-3D|玩家访问模式|delivery priority|interaction scope" doc/core/prd.md doc/core/project.md doc/core/player-access-mode-contract-2026-03-19.{prd,design,project}.md doc/world-simulator/prd.md retired legacy viewer doc set: viewer-3d-pause-user-interaction-hold-2026-04-01.prd`
     - `./scripts/doc-governance-check.sh`
     - `git diff --check`
 - [x] TASK-CORE-052 (PRD-CORE-009) [test_tier_required]: 将 `agent_direct_connect/provider_loopback_http` 从用户主配置模型降为兼容 alias，把 agent provider 正式配置收口为 `agent_decision_source + agent_provider_backend/contract/transport/url/auth/connect_timeout_ms/profile + agent_execution_lane`，并同步回写 core/world-simulator/testing 文档与 launcher/client launcher 透传口径。

--- a/doc/site/github-pages/github-pages-release-download-pipeline-2026-03-01.project.md
+++ b/doc/site/github-pages/github-pages-release-download-pipeline-2026-03-01.project.md
@@ -40,7 +40,7 @@
 - [x] 回写本项目管理文档状态
 - [x] 写任务日志：`doc/devlog/README.md`
 - [x] 任务测试与提交
-- 完成内容（2026-05-10 follow-up）：`release-gate-web` 额外纳入 `viewer-primary-web-entry-regression.sh`，在 `software_safe` realtime regression 之前先验证公开默认 `/` 与 `render_mode=auto` 发布入口都落到 `software_safe`；避免 `standard_3d` 删除后 release gate 只验证强制 `render_mode=software_safe`，却漏掉真正对外发布的默认入口契约。
+- 完成内容（2026-05-10 follow-up）：`release-gate-web` 额外纳入 `viewer-primary-web-entry-regression.sh`，在 `software_safe` realtime regression 之前先验证公开默认 `/` 与 `render_mode=auto` 发布入口都落到 `software_safe`；避免 `retired secondary viewer` 删除后 release gate 只验证强制 `render_mode=software_safe`，却漏掉真正对外发布的默认入口契约。
 
 ### T3A Pages 门禁兼容性热修复（GitHub runner 无 rg）
 - [x] 复现并定位 Actions run `22474048679` / job `65097149123` 失败原因

--- a/doc/testing/launcher/launcher-chain-script-migration-2026-02-28.prd.md
+++ b/doc/testing/launcher/launcher-chain-script-migration-2026-02-28.prd.md
@@ -49,7 +49,7 @@
   - AC-3: 手册与专题文档反映新启动口径与暂不可执行边界。
   - AC-4: 未重构的长跑多节点闭环不在本轮硬实现范围。
   - AC-5: 文档与任务状态可在项目文档/devlog 追溯。
-  - AC-6: 历史上的 `viewer-release-qa-loop.sh` 已支持 `--viewer-static-dir` 并传递到 `oasis7_game_launcher`；当前仓库已删除该旧 visual QA 脚本，但保留这条历史迁移记录。
+  - AC-6: 历史上的 `viewer-release-qa-loop.sh` 已支持 `--viewer-static-dir` 并传递到 `oasis7_game_launcher`；当前仓库已删除该旧 visual diagnostics 脚本，但保留这条历史迁移记录。
 - Non-Goals:
   - 不在本轮重写 S10/P2P 为完整 `oasis7_chain_runtime` 多节点闭环。
   - 不恢复 `oasis7_viewer_live` 内嵌节点参数兼容。

--- a/doc/testing/launcher/launcher-viewer-auth-node-config-autowire-2026-03-02.prd.md
+++ b/doc/testing/launcher/launcher-viewer-auth-node-config-autowire-2026-03-02.prd.md
@@ -24,7 +24,7 @@
   - 启动器体验验证者：希望业务失败与链路断连在 UI 上可区分，降低误判成本。
 - User Scenarios & Frequency:
   - 启动器打开 Web Viewer：每次本地调试或演示均会触发。
-  - native Viewer 回归：测试链路验证回退解析。
+  - 本地 Viewer 回归：测试链路验证回退解析。
   - CI/脚本场景：通过环境变量覆盖 player/keypair。
 - User Stories:
   - PRD-TESTING-LAUNCHER-AUTH-001: As a 开发者, I want viewer auth keys auto-inherited from node config, so that chat/prompt controls work without manual env setup.
@@ -34,7 +34,7 @@
 - Critical User Flows:
   1. Flow-AUTH-001: `oasis7_game_launcher 读取 config.toml[node] -> 注入 __OASIS7_VIEWER_AUTH_ENV -> Web Viewer 使用鉴权`
   2. Flow-AUTH-002: `wasm Viewer 优先读注入 -> 注入缺失时回退进程环境变量`
-  3. Flow-AUTH-003: `native Viewer 读取环境变量 -> 无环境变量时回退 config.toml[node]`
+  3. Flow-AUTH-003: `本地 Viewer 读取环境变量 -> 无环境变量时回退 config.toml[node]`
   4. Flow-AUTH-004: `玩家发送 agent_chat -> runtime 返回 AgentChatError -> Viewer 显示聊天失败原因但保持连接状态`
 - Functional Specification Matrix:
 | 功能点 | 字段定义 | 按钮/动作行为 | 状态转换 | 排序/计算规则 | 权限逻辑 |

--- a/doc/testing/manual/web-ui-agent-browser-closure-manual.manual.md
+++ b/doc/testing/manual/web-ui-agent-browser-closure-manual.manual.md
@@ -10,7 +10,7 @@
 ## 适用范围
 - 适用于 `oasis7_viewer_live` + `software_safe` Viewer Web 页面闭环。
 - 不适用于 `oasis7_web_launcher` / launcher Web 控制面产品动作；后者默认先走 GUI Agent，再用页面校验状态与字段。
-- 本手册只覆盖当前仍存在的 Web 链路，不再覆盖历史 3D/native/visual-QA 工具。
+- 本手册只覆盖当前仍存在的 Web 链路，不再覆盖历史第二 Viewer 或退役视觉专项工具。
 - 若目标是本地真实 LetAI provider-backed 游戏试玩或复现 `agent_chat`，先使用 `./scripts/run-local-letai-game-test.sh` 启动完整 bridge + runtime/game 栈；下方 live server + `run-viewer-web.sh` 步骤只作为 Viewer/debug 闭环。
 
 ## 前置条件

--- a/doc/ui_review_result/README.md
+++ b/doc/ui_review_result/README.md
@@ -5,7 +5,7 @@
 ## 入口
 - 评审列表：`doc/ui_review_result/ui_review_list.md`
 - 当前示例卡片：`doc/ui_review_result/card_2026_03_06_11_50_29.md`
-- 评分模板来源：`historical removed standard_3d viewer doc set: visual-review-score-card`
+- 评分模板来源：`doc/world-simulator/viewer/viewer-visual-design-spec-2026-06-05.design.md`
 
 ## 定位结论
 - 本目录是 `viewer_engineer` 维护的活跃评审样本池，不是正式模块，也不承担长期知识库职责。
@@ -23,7 +23,7 @@
 
 ## 维护约定
 - 新增 UI 评审卡后，需同步更新 `ui_review_list.md` 与本目录说明。
-- 正式评审口径以 `historical removed standard_3d viewer doc set: visual-review-score-card` 为准。
+- 正式评审口径以 `doc/world-simulator/viewer/viewer-visual-design-spec-2026-06-05.design.md` 为准；历史打分卡只作为旧样本来源，不再作为当前权威。
 - 历史卡片不在本目录长期归档；如需长期沉淀，应由所属模块专题文档引用承接。
 - 进入条件：当前轮次需要保留可评分的 UI/视觉样本卡。
 - 退出条件：当样本对应的体验结论已回写正式模块文档，且无继续迭代需求时，应清空或替换为新的活跃样本，不在此处形成伪模块历史库。

--- a/doc/world-simulator/kernel/power-storage-complete-removal-2026-03-06.prd.md
+++ b/doc/world-simulator/kernel/power-storage-complete-removal-2026-03-06.prd.md
@@ -78,7 +78,7 @@
 - `crates/oasis7_viewer/src/*`
 - 历史上的 `scripts/validate-viewer-theme-pack.py`
 - 历史上的 `scripts/viewer-texture-inspector*.sh`
-- 历史上的 `historical removed standard_3d viewer doc set: visual-review-score-card`
+- 历史上的 `retired legacy viewer doc set: visual-review-score-card`
 - `doc/ui_review_result/*.md`
 
 ### Edge Cases & Error Handling

--- a/doc/world-simulator/kernel/power-storage-complete-removal-2026-03-06.project.md
+++ b/doc/world-simulator/kernel/power-storage-complete-removal-2026-03-06.project.md
@@ -19,7 +19,7 @@
 - 历史上的 `scripts/validate-viewer-theme-pack.py`
 - 历史上的 `scripts/viewer-texture-inspector.sh`
 - 历史上的 `scripts/viewer-texture-inspector-lib.sh`
-- 历史上的 `historical removed standard_3d viewer doc set: visual-review-score-card`
+- 历史上的 `retired legacy viewer doc set: visual-review-score-card`
 - `doc/ui_review_result/card_2026_03_06_11_50_29.md`
 
 ## 状态

--- a/doc/world-simulator/prd.md
+++ b/doc/world-simulator/prd.md
@@ -50,7 +50,7 @@
 | --- | --- | --- |
 | 场景与世界契约 | `PRD-WORLD_SIMULATOR-001/002/003` | 场景初始化、资源变化、关键交互和发布证据必须可复现，并通过统一验收清单映射到测试证据。 |
 | runtime live / LLM / provider authority | `PRD-WORLD_SIMULATOR-016-019`, `036-040` | runtime live 是主驱动方向；provider 决策层保持 provider advisory / runtime authoritative；LLM 失败按硬失败或显式阻断处理，不回退启发式。 |
-| primary Web viewer | `PRD-WORLD_SIMULATOR-039/041/046` | `viewer` 是低保真但正式可玩的主要 Web 入口；`software_safe` 仅作为兼容 alias；旧 3D / visual-QA surface 已退出 active delivery。 |
+| primary Web viewer | `PRD-WORLD_SIMULATOR-039/041/046` | `viewer` 是低保真但正式可玩的主要 Web 入口；`software_safe` 仅作为兼容 alias；退役第二 Viewer surface 已退出 active delivery。 |
 | launcher transfer / explorer / control plane | `PRD-WORLD_SIMULATOR-020-031`, `033/034/044` | native/web launcher 共享控制面与前端语义；转账、explorer、链状态、GUI Agent 和 stale execution-world 恢复必须结构化、可诊断、可回归。 |
 | slot-1 onboarding | `PRD-WORLD_SIMULATOR-045` | 新账号玩家读取 canonical quote 并显式确认后直接进入 `ClaimAgent`；dedicated pool 足够时自动补足 restricted starter amount，不生成 operator-review 审批状态。 |
 | release asset entrypoints | `PRD-WORLD_SIMULATOR-042/043` | 三平台公开资产必须提供平台原生安装或启动入口，并通过 bundle/installer 入口验证；普通用户发行仍包含 Windows codesigning trust chain 与 macOS notarized `.app + .dmg` blocker。 |
@@ -62,7 +62,7 @@
 - 启动器玩家需要在同一入口内完成链状态查看、资产查询、转账、explorer 与反馈，不依赖命令行。
 - 新账号玩家需要可解释的 `slot-1` direct claim：quote、auto-funding amount、资金缺口、claim result 与 provenance 必须玩家可见。
 
-模式分层按 `PRD-CORE-009` 执行：`viewer` 承接低保真但正式可玩的主要 Web 入口；`software_safe` 仅作为兼容 alias / 历史入口名保留；仓库已删除旧 3D / visual-QA Viewer surface，不再保留独立 `standard_3d` taxonomy。Local Provider 当前路径使用 `agent_decision_source=provider_backed + agent_provider_backend=provider_local_bridge + agent_provider_contract=worldsim_provider_v1 + agent_provider_transport=loopback_http`；`player_parity` 与 `headless_agent` 是 execution lane，不是新的玩家访问模式。
+模式分层按 `PRD-CORE-009` 执行：`viewer` 承接低保真但正式可玩的主要 Web 入口；`software_safe` 仅作为兼容 alias / 历史入口名保留；仓库已删除旧第二 Viewer surface，不再保留独立第二 Viewer taxonomy。Local Provider 当前路径使用 `agent_decision_source=provider_backed + agent_provider_backend=provider_local_bridge + agent_provider_contract=worldsim_provider_v1 + agent_provider_transport=loopback_http`；`player_parity` 与 `headless_agent` 是 execution lane，不是新的玩家访问模式。
 
 ## Critical Flows
 1. Web-first 闭环：选择场景 -> 启动 Viewer Web -> 执行关键交互 -> 采集日志/截图/指标 -> 产出 `test_tier_required` 结论。

--- a/doc/world-simulator/project.md
+++ b/doc/world-simulator/project.md
@@ -5,6 +5,7 @@
 - [ ] software-safe-playability-unblock (PRD-WORLD_SIMULATOR-039) [test_tier_required]: 让 `software_safe` formal summary 将 canonical `available_actions` 重新暴露为可执行入口，并在 gameplay summary 与空实体快照并存时显式标记 `runtime_snapshot_empty_entities` blocker。 Trace: .pm/tasks/task_1c5ac527bed54e969b737137fc998ab8.yaml
 
 ### 最近完成（保留一跳 Trace）
+- [x] viewer-retired-visualization-route-cleanup (PRD-WORLD_SIMULATOR-046) [test_tier_required]: 清理活跃 Viewer/source/docs/site 中旧 `standard_3d`、native Viewer 与旧 visual QA 路线残留，保留历史 provenance 但不再作为当前入口或评审权威。 Trace: .pm/tasks/task_e6edcb09bd774941bdcbde32bb9ea007.yaml
 - [x] chain-side-manifest-delta-runtime-readiness (PRD-WORLD_SIMULATOR-039/046) [test_tier_required]: 定义链侧资源 manifest/delta schema，接入 simulator/runtime snapshot、provider/testnet readiness 与本地 standalone submit 闭环。 Trace: .pm/tasks/task_a0e15f2d5d0547a3a13c93caab49b611.yaml
 - [x] viewer-visual-hierarchy-polish (PRD-WORLD_SIMULATOR-046) [test_tier_required]: 按 Image2 视觉目标与总体/分模块设计优化 `software_safe` Viewer 首屏层级、command strip、action receipt、focus HUD 与移动 focus overlay，并用 UI/build/pixel-world visual smoke 验证收口。 Trace: .pm/tasks/task_e7760ad76a0046dfa5a17d0a5a89e59c.yaml
 - [x] launcher-visual-comp-workflow-ui-optimization (PRD-WORLD_SIMULATOR-039/046) [test_tier_required]: 用 Image2 目标图、真实 native 截图对比和专业角色 review 收敛 launcher 首屏、弹窗/重型窗口视觉系统，并把 visual companion 方法论边界写回 workflow/skill/governance 文档。 Trace: .pm/tasks/task_54647d0add024a98b801d3736700ff22.yaml
@@ -73,5 +74,5 @@
 - 下一任务: 待下一个模块任务明确。
 - 当前优先任务: 回到模块后续排队项；当前无新 blocker。
 - 当前窗口摘要: launcher “打开游戏页”URL、launcher explorer 主链级重构、`/api/state.chain_replication_status` 透传与节点观测摘要卡均已收口，详情回看对应 task trace。
-- 边界说明: 已知环境限制仍是 source stack formal 启动前需要 `OASIS7_LLM_MODEL` 或等价配置；`standard_3d` 相关代码、脚本与活跃文档已移除，当前仅保留 `viewer` canonical Web 主入口与 `software_safe` compat alias。
+- 边界说明: 已知环境限制仍是 source stack formal 启动前需要 `OASIS7_LLM_MODEL` 或等价配置；旧第二 Viewer 入口相关代码、脚本与活跃文档已移除，当前仅保留 `viewer` canonical Web 主入口与 `software_safe` compat alias。
 - 历史追溯: 最近完成项不再压缩在标题行中维护；需要追 launcher / viewer / provider-backed NPC / release distribution 历史时，先从上方任务项、topic project、`doc/world-simulator/prd.index.md` 与 `.pm/tasks/*.execution.md` 进入。

--- a/doc/world-simulator/project.md
+++ b/doc/world-simulator/project.md
@@ -5,7 +5,7 @@
 - [ ] software-safe-playability-unblock (PRD-WORLD_SIMULATOR-039) [test_tier_required]: 让 `software_safe` formal summary 将 canonical `available_actions` 重新暴露为可执行入口，并在 gameplay summary 与空实体快照并存时显式标记 `runtime_snapshot_empty_entities` blocker。 Trace: .pm/tasks/task_1c5ac527bed54e969b737137fc998ab8.yaml
 
 ### 最近完成（保留一跳 Trace）
-- [x] viewer-retired-visualization-route-cleanup (PRD-WORLD_SIMULATOR-046) [test_tier_required]: 清理活跃 Viewer/source/docs/site 中旧 `standard_3d`、native Viewer 与旧 visual QA 路线残留，保留历史 provenance 但不再作为当前入口或评审权威。 Trace: .pm/tasks/task_e6edcb09bd774941bdcbde32bb9ea007.yaml
+- [x] viewer-retired-visualization-route-cleanup (PRD-WORLD_SIMULATOR-046) [test_tier_required]: 清理活跃 Viewer/source/docs/site 中旧第二 Viewer 入口、native 启动口径与视觉专项工具链残留，保留历史 provenance 但不再作为当前入口或评审权威。 Trace: .pm/tasks/task_e6edcb09bd774941bdcbde32bb9ea007.yaml
 - [x] chain-side-manifest-delta-runtime-readiness (PRD-WORLD_SIMULATOR-039/046) [test_tier_required]: 定义链侧资源 manifest/delta schema，接入 simulator/runtime snapshot、provider/testnet readiness 与本地 standalone submit 闭环。 Trace: .pm/tasks/task_a0e15f2d5d0547a3a13c93caab49b611.yaml
 - [x] viewer-visual-hierarchy-polish (PRD-WORLD_SIMULATOR-046) [test_tier_required]: 按 Image2 视觉目标与总体/分模块设计优化 `software_safe` Viewer 首屏层级、command strip、action receipt、focus HUD 与移动 focus overlay，并用 UI/build/pixel-world visual smoke 验证收口。 Trace: .pm/tasks/task_e7760ad76a0046dfa5a17d0a5a89e59c.yaml
 - [x] launcher-visual-comp-workflow-ui-optimization (PRD-WORLD_SIMULATOR-039/046) [test_tier_required]: 用 Image2 目标图、真实 native 截图对比和专业角色 review 收敛 launcher 首屏、弹窗/重型窗口视觉系统，并把 visual companion 方法论边界写回 workflow/skill/governance 文档。 Trace: .pm/tasks/task_54647d0add024a98b801d3736700ff22.yaml

--- a/doc/world-simulator/viewer/viewer-chat-web-deadlock-resolution.prd.md
+++ b/doc/world-simulator/viewer/viewer-chat-web-deadlock-resolution.prd.md
@@ -25,7 +25,7 @@
 ### 范围外
 - 不改动 `ViewerRequest::AgentChat` / `ViewerResponse::AgentChat*` 协议定义。
 - 不改动 Agent 决策内核和 trace 结构。
-- 不改动 native viewer 交互设计。
+- 不改动本地 Viewer 交互设计。
 
 ## 3. AI System Requirements (If Applicable)
 - N/A: 本专题不新增 AI 专属要求。

--- a/doc/world-simulator/viewer/viewer-manual.manual.md
+++ b/doc/world-simulator/viewer/viewer-manual.manual.md
@@ -10,7 +10,7 @@
 ## 目标
 - 提供 `viewer` Viewer Web 主入口的统一操作手册，并说明 `software_safe` 兼容 alias。
 - 统一 live server、Web 静态入口、agent-browser 闭环与常见排查步骤。
-- 明确当前仓库已不再提供旧 3D / native / 视觉专项工具链。
+- 明确当前仓库已不再提供退役的第二 Viewer 工具链。
 
 ## 适用范围
 - live server：`crates/oasis7 --bin oasis7_viewer_live`
@@ -64,7 +64,7 @@ env -u NO_COLOR ./scripts/run-viewer-web.sh --address 127.0.0.1 --port 4173
 - 在 `hosted_public_join` 路径下，页面支持获取/释放 hosted `player_session`、`reconnect_sync` 恢复，以及 `prompt_control` 的 preview-grade `strong_auth`（需 `Backend Approval Code`）。
 - 面向普通用户的启动入口现在默认且只暴露 `hosted_public_join`。旧的 `trusted_local_only` 本地可信预览不再作为可选用户流程；本地旧配置应迁移到 hosted join，并走邮箱 hosted account / player session 登录链路。
 - `main_token_transfer` 仍保持阻断，页面只显示 lane verdict，不提供资产转账表单。
-- 页面不再提供 `standard Viewer` 跳转，也不再承担材质/theme/3D 视觉 QA 职责。
+- 页面不再提供第二 Viewer 跳转，也不再承担退役视觉专项工具职责。
 
 ## 证据边界
 - 当前 formal gameplay PASS 证据以 `doc/testing/evidence/software-safe-primary-web-entry-evidence-2026-04-07.md` 为准。
@@ -135,9 +135,9 @@ agent-browser close
 - 如果只看到 `--no-llm` 截图证据：不要把它当成 formal gameplay PASS；回到 `doc/testing/evidence/software-safe-primary-web-entry-evidence-2026-04-07.md` 看 LLM-enabled follow-up 结论。
 
 ## 已移除能力
-- 原生 Viewer crate 启动路径
-- 旧 3D / visual QA surface
-- 旧材质、theme、抓帧与视觉专项工具链
+- 退役的第二 Viewer 启动路径
+- 退役的辅助可视化检视 surface
+- 退役的视觉资产、抓帧与专项检视工具链
 
 ## 参考文档
 - `testing-manual.md`

--- a/doc/world-simulator/viewer/viewer-web-runtime-fatal-surfacing-2026-03-12.prd.md
+++ b/doc/world-simulator/viewer/viewer-web-runtime-fatal-surfacing-2026-03-12.prd.md
@@ -26,7 +26,7 @@
 - 不修改 `third_party` 或 Bevy 上游实现。
 - 不修改 `third_party` 或 Bevy 上游实现。
 - 不承诺本轮内彻底消除所有 SwiftShader/WebGL2 渲染差异。
-- 不改变 native Viewer、runtime 协议或 GUI Agent 接口语义。
+- 不改变本地 Viewer 配置回退、runtime 协议或 GUI Agent 接口语义。
 
 ## 3. AI System Requirements (If Applicable)
 - N/A: 本专题不新增 AI 专属要求。

--- a/doc/world-simulator/viewer/viewer-web-software-safe-mode-2026-03-16.design.md
+++ b/doc/world-simulator/viewer/viewer-web-software-safe-mode-2026-03-16.design.md
@@ -6,11 +6,11 @@
 审计轮次: 3
 
 ## 1. 设计定位
-`viewer` 是唯一正式 Web Viewer / UI 入口；`software_safe` 只保留为兼容 alias。设计目标不再是“主入口 + 标准 Viewer 分流”，而是围绕单一静态入口维护稳定浏览器玩法与观测闭环。
+`viewer` 是唯一正式 Web Viewer / UI 入口；`software_safe` 只保留为兼容 alias。设计目标不再是“主入口 + 第二 Viewer 分流”，而是围绕单一静态入口维护稳定浏览器玩法与观测闭环。
 
 ## 2. 核心设计决策
 - 保留 `software_safe.html` + `software_safe_src/**` 作为源码入口，generated bundle 以 `viewer.js` 为 canonical，并保留 `software_safe.js` 作为 compat alias；dist / bundle / release 同步产出 `viewer.html` + `viewer.js` 与 compat 副本。
-- 删除标准 Viewer 跳转、3D 模式入口与相关 UI 文案。
+- 删除第二 Viewer 跳转、退役模式入口与相关 UI 文案。
 - 保留 `__AW_TEST__` 作为统一自动化契约。
 - 保留 freshness gate，防止 stale dist。
 
@@ -28,6 +28,6 @@
 - `viewer-software-safe-step-regression*.sh` 验证 gameplay/blocked 契约
 
 ## 4. 关键约束
-- 不再暴露标准 Viewer 跳转
+- 不再暴露第二 Viewer 跳转
 - 不再维护 `render_mode=standard` 的当前产品语义
 - 不再维护 texture/theme/capture 工具链

--- a/doc/world-simulator/viewer/viewer-web-software-safe-mode-2026-03-16.prd.md
+++ b/doc/world-simulator/viewer/viewer-web-software-safe-mode-2026-03-16.prd.md
@@ -7,7 +7,7 @@
 
 ## 目标
 - 将 `viewer` 固定为当前仓库唯一正式 Web Viewer / UI 入口，并把 `software_safe` 降为兼容 alias。
-- 清除 `standard_3d` 删除后残留的双入口、兼容跳转和旧 QA 口径。
+- 清除退役第二 Viewer 工具链残留的双入口、兼容跳转和旧 QA 口径。
 - 保证 launcher、手册、回归脚本与站点镜像围绕同一入口事实收口。
 
 ## 范围
@@ -21,8 +21,8 @@
   - `testing-manual.md`
   - `doc/world-simulator/viewer/viewer-manual*.md`
 - 范围外:
-  - 恢复任何 `standard_3d` 代码、入口或静态资源。
-  - 维护 3D visual QA、截图、贴图、theme 资产链路。
+  - 恢复任何退役第二 Viewer 代码、入口或静态资源。
+  - 维护退役的视觉专项、截图、贴图或 theme 资产链路。
   - 扩大当前 Web Viewer 能力边界到本专题之外的新玩法。
 
 ## 接口 / 数据
@@ -36,7 +36,7 @@
   - `viewer` 手册与站点镜像内容
 
 ## 里程碑
-- M1: 删除 `standard_3d` 代码、静态入口与相关脚本。
+- M1: 删除退役第二 Viewer 代码、静态入口与相关脚本。
 - M2: launcher / Web 启动 / regression 全量改为 `viewer` canonical 单入口，并保留 `software_safe` 兼容 alias。
 - M3: 手册、PRD、project、testing 文档完成真值回写并通过治理校验。
 
@@ -46,12 +46,12 @@
 - `viewer` canonical 入口如果与兼容 alias / `__AW_TEST__` 契约漂移，会破坏现有 Web 回归闭环。
 
 ## 1. Executive Summary
-- Problem Statement: 仓库删除 `standard_3d` 代码、静态入口与相关 QA 工具后，Web Viewer 只剩一条正式 UI 入口，但 canonical 名称长期停留在 `software_safe`，与当前产品定位不匹配。本专题需要把旧命名和兼容切换口径收口到单一事实。
+- Problem Statement: 仓库删除退役第二 Viewer 代码、静态入口与相关 QA 工具后，Web Viewer 只剩一条正式 UI 入口，但 canonical 名称长期停留在 `software_safe`，与当前产品定位不匹配。本专题需要把旧命名和兼容切换口径收口到单一事实。
 - Proposed Solution: 将 `viewer` 固定为唯一正式 Web Viewer / UI 入口；所有 Web 启动、回归、launcher URL、manual 与 evidence 都围绕 `viewer` canonical 入口与对应 `__AW_TEST__` 契约组织，同时保留 `software_safe` 文件名与 URL 参数作为兼容 alias。
 - Success Criteria:
   - SC-1: 默认 Web 入口始终落到 `viewer` canonical 入口；旧 `software_safe` 链接继续兼容。
   - SC-2: `viewer` 继续承接连接、观察、目标选择、prompt/chat/rollback、canonical gameplay summary 与 blocked/handoff surface。
-  - SC-3: 活跃文档、脚本和 evidence 不再要求 `render_mode=standard` 或任何标准 Viewer 入口。
+  - SC-3: 活跃文档、脚本和 evidence 不再要求 `render_mode=standard` 或任何第二 Viewer 入口。
 
 ## 2. User Experience & Functionality
 - In Scope:
@@ -64,12 +64,12 @@
   - `testing-manual.md`
   - `viewer-manual*.md`
 - Out of Scope:
-  - 不恢复 3D/标准 Viewer。
-  - 不维护 visual QA / screenshot / texture/theme 资产链路。
+  - 不恢复退役第二 Viewer。
+  - 不维护退役视觉专项 / screenshot / texture/theme 资产链路。
 
 ## 3. User Stories
 - As a 玩家 / QA / 制作人, I want `viewer` to remain the only formal Web / UI entry, so that the browser path has one unambiguous source of truth.
-- As a `viewer_engineer`, I want all Web-facing scripts and docs to point to `viewer` as the canonical name, so that no stale 3D fallback contract or old naming ambiguity survives.
+- As a `viewer_engineer`, I want all Web-facing scripts and docs to point to `viewer` as the canonical name, so that no stale retired fallback contract or old naming ambiguity survives.
 
 ## 4. Technical Specifications
 ### 4.1 Entry Contract
@@ -88,9 +88,9 @@
   - auth/bootstrap 下的 prompt/chat/rollback
   - `__AW_TEST__` 状态与动作契约
 - 不再保留：
-  - 标准 Viewer 跳转
-  - 3D / visual QA 入口
-  - texture/theme/截图链路
+  - 第二 Viewer 跳转
+  - 退役视觉专项入口
+  - 退役视觉专项链路
 
 ### 4.3 Freshness
 - source-tree Web 入口必须继续阻断 stale dist
@@ -100,7 +100,7 @@
 - AC-1: `run-viewer-web.sh` 构建并服务 `viewer` canonical dist，同时保留 `software_safe` 兼容副本。
 - AC-2: `viewer-primary-web-entry-regression.sh` 只验证默认入口与 `viewer` 契约，不再验证 `render_mode=standard`；对 `software_safe` 仅做兼容通过处理。
 - AC-3: 运行态 `renderMode`、launcher URL、手册和发布产物都不再把 `software_safe` 当作 canonical UI 名称。
-- AC-4: Viewer 手册与站点镜像不再引用已删除的 3D/截图/纹理脚本。
+- AC-4: Viewer 手册与站点镜像不再引用已删除的退役视觉专项脚本。
 
 ## 6. Validation & Decision Record
 - Test Plan & Traceability:
@@ -110,4 +110,4 @@
 - Decision Log:
 | 决策ID | 选定方案 | 备选方案（否决） | 依据 |
 | --- | --- | --- | --- |
-| `DEC-WS-039-1` | `viewer` 成为唯一 canonical Web / UI 入口，`software_safe` 仅保留兼容 alias | 保留已删实现的标准 Viewer 口径，或继续让 `software_safe` 作为 canonical 名称 | 当前仓库已无第二条正式 UI 入口，实现与公开命名必须一致。 |
+| `DEC-WS-039-1` | `viewer` 成为唯一 canonical Web / UI 入口，`software_safe` 仅保留兼容 alias | 保留已删实现的第二 Viewer 口径，或继续让 `software_safe` 作为 canonical 名称 | 当前仓库已无第二条正式 UI 入口，实现与公开命名必须一致。 |

--- a/site/doc/cn/viewer-manual.html
+++ b/site/doc/cn/viewer-manual.html
@@ -70,7 +70,7 @@
         <h3>2) 启动 Web Viewer</h3>
         <pre><code>env -u NO_COLOR ./scripts/run-viewer-web.sh --address 127.0.0.1 --port 4173</code></pre>
         <p>访问：<code>http://127.0.0.1:4173/?ws=ws://127.0.0.1:5011</code></p>
-        <p>当前只保留 <code>viewer</code> 单一正式入口；<code>software_safe</code> 只保留兼容别名，不再维护其他 Viewer surface 或 native Viewer。</p>
+        <p>当前只保留 <code>viewer</code> 单一正式入口；<code>software_safe</code> 只保留兼容别名，不再维护其他 Viewer surface 或旧本地 Viewer 入口。</p>
       </section>
 
       <section id="web-loop" class="section" data-reveal>
@@ -99,8 +99,8 @@ agent-browser close</code></pre>
         <h2>当前能力边界</h2>
         <ul>
           <li>支持中英文切换、实时观察、formal gameplay summary、最小 prompt/chat 控制面。</li>
-          <li>不再提供 <code>standard Viewer</code> 跳转。</li>
-          <li>不再维护 3D/native 抓帧、theme pack、texture inspector、visual QA 脚本。</li>
+          <li>不再提供第二 Viewer 跳转。</li>
+          <li>不再维护退役抓帧、theme pack、texture inspector 或视觉专项检视脚本。</li>
         </ul>
       </section>
 

--- a/site/doc/en/viewer-manual.html
+++ b/site/doc/en/viewer-manual.html
@@ -99,8 +99,8 @@ agent-browser close</code></pre>
         <h2>Current Scope</h2>
         <ul>
           <li>Supports bilingual UI, realtime observation, formal gameplay summary, and minimal prompt/chat controls.</li>
-          <li>No more standard Viewer jump.</li>
-          <li>No more native 3D capture, theme-pack, texture-inspector, or visual QA tools.</li>
+          <li>No more secondary Viewer jump.</li>
+          <li>No more retired visual capture, theme-pack, texture-inspector, or specialized inspection tools.</li>
         </ul>
       </section>
 


### PR DESCRIPTION
## Summary
- remove active/current references to retired standard_3d, native Viewer, and old visual QA routes from Viewer copy, docs, and site mirrors
- keep historical provenance rows intact while pointing current UI review authority at the visual design spec
- add task evidence, closeout, and pre-PR local role review packet

## Verification
- npm --prefix crates/oasis7_viewer run test:ui -- main viewer_feedback_module viewer_world_scale_module
- ./scripts/site-manual-sync-check.sh
- ./scripts/doc-governance-check.sh
- git diff --check
- ./scripts/pm/workflow-lint.sh --task-uid task_e6edcb09bd774941bdcbde32bb9ea007 --phase pr-ready

Task: task_e6edcb09bd774941bdcbde32bb9ea007