### PR TITLE
Sync engineering inventory status

### DIFF
--- a/.pm/tasks/task_74eabae048e74ca09bd4cb9ffbe5fdc1.execution.md
+++ b/.pm/tasks/task_74eabae048e74ca09bd4cb9ffbe5fdc1.execution.md
@@ -1,0 +1,59 @@
+# task_74eabae048e74ca09bd4cb9ffbe5fdc1 Execution Log
+
+- task_uid: task_74eabae048e74ca09bd4cb9ffbe5fdc1
+- title: Run next repository health inspection slice
+- owner_role: tpm
+- worktree_hint: /Users/scc/ccwork/worktrees/oasis7-engineering-repository-health-inspection-20260623c
+
+<!-- Append entries using:
+Example:
+  ## YYYY-MM-DD HH:MM:SS CST / role_name
+  - 完成内容: ...
+  - 遗留事项: ...
+  - Action: ...
+  - Validation Command: ...
+  - Expected Result: ...
+  - Actual Result: ...
+  - Blocker / Next Action: ...
+-->
+
+## 2026-06-23 13:23:20 CST / tpm
+- 完成内容: WORKFLOW BOOTSTRAP DECIDED. Created a dedicated task worktree and bound `.pm` task for the next repository-health governance inspection.
+- 遗留事项: Dispatch repository_health_engineer bounded slice before any professional governance conclusion.
+- Action: Repository State Impact: likely repository-changing if a valid governance issue is found; user intent is to continue finding the next governance issue. Isolation Decision: source worktree `/Users/scc/ccwork/oasis7` was clean on `main...origin/main`; created `/Users/scc/ccwork/worktrees/oasis7-engineering-repository-health-inspection-20260623c` on branch `task/engineering-repository-health-inspection-20260623c` from `origin/main`. Task Truth: owner role `tpm`; task UID `task_74eabae048e74ca09bd4cb9ffbe5fdc1`; source ref `doc/engineering/project.md`; acceptance requires repository_health_engineer inspection and focused fix/PR path if valid. Routed Next Phase: repo-owned-workflow-router selected read-only professional repository-health inspection followed by execution if a valid finding is returned. TPM remains workflow coordinator/integrator only.
+- Slice Contract: role=repository_health_engineer; slice type=bounded repository governance inspection; intended model configuration=workflow source-of-truth Default subagent runtime; actual dispatched model/reasoning=inherited/unverified because current subagent tool does not report actual model; context delivery mode=full-thread/full-history fork by default plus this explicit checklist; mandatory context checklist/packet=AGENTS.md workflow contract, `doc/engineering/workflow/source-of-truth.md` authority, task UID `task_74eabae048e74ca09bd4cb9ffbe5fdc1`, worktree `/Users/scc/ccwork/worktrees/oasis7-engineering-repository-health-inspection-20260623c`, user intent "继续找下一个待治理问题", engineering project current completed governance trail, prior adjacent recent closures include prepare-task-pr support shard coverage and runtime CI flake stabilization in PR #572; write scope=analysis only unless explicitly returning a focused proposed changed-path set; return contract=findings/no_findings with severity, evidence paths, why non-duplicate, proposed minimal fix, verification commands, residual risk; formal sink=`.pm/tasks/task_74eabae048e74ca09bd4cb9ffbe5fdc1.execution.md`; integration owner=tpm; integration order=record finding, apply focused patch if valid, verify, local role review, PR watch/merge path.
+- Validation Command: git status --short --branch; sed -n '1,220p' .pm/tasks/task_74eabae048e74ca09bd4cb9ffbe5fdc1.yaml; sed -n '1,180p' doc/engineering/project.md
+- Expected Result: Task/worktree truth exists and next step is a repository_health_engineer bounded inspection slice.
+- Actual Result: Worktree created, task YAML committed with owner `tpm`, execution log initialized, engineering project page available.
+- Blocker / Next Action: No blocker. Dispatch repository_health_engineer subagent for the next governance inspection.
+
+## 2026-06-23 13:37:10 CST / tpm
+- 完成内容: Added a narrowed fallback inspection slice because the broad repository_health_engineer inspection had not returned yet.
+- 遗留事项: Integrate the first returned repository_health_engineer conclusion, de-duplicate if both slices return, and only then patch.
+- Action: TPM gathered objective evidence while waiting: `bash scripts/doc-inventory-report.sh` reports `Near-Limit Active Docs: _none_`, while `doc/engineering/project.md` status still says the next task should prioritize near-limit active project docs and first look at `doc/world-simulator/project.md` / `doc/readme/project.md`; those files are currently 78 and 37 lines. `doc-hotspot-path-aftercare` for `doc/world-simulator/launcher` and `doc/game/gameplay` is already completed, so residual hotspot density is not automatically an unexecuted task. A narrower repository_health_engineer slice will verify whether this stale next-task/status text is a valid focused governance drift.
+- Slice Contract: role=repository_health_engineer; slice type=narrowed repository governance drift validation; intended model configuration=workflow source-of-truth Default subagent runtime; actual dispatched model/reasoning=inherited/unverified; context delivery mode=full-thread/full-history fork plus explicit objective evidence; mandatory context checklist/packet=task UID `task_74eabae048e74ca09bd4cb9ffbe5fdc1`, worktree path, inventory report output, engineering project status lines, `doc/engineering/prd.md` PRD-ENGINEERING-033 already completed via `doc-hotspot-path-aftercare`; write scope=analysis only; return contract=findings/no_findings, severity, exact stale lines if valid, proposed minimal patch and verification; formal sink=this execution log; integration owner=tpm; integration order=use first valid professional finding, avoid duplicate implementation.
+- Validation Command: bash scripts/doc-inventory-report.sh; wc -l doc/world-simulator/project.md doc/readme/project.md; rg -n "PRD-ENGINEERING-033|doc-hotspot-path-aftercare|下一任务|Near-Limit Active Docs" doc/engineering/prd.md doc/engineering/project.md
+- Expected Result: Narrow slice decides whether stale engineering project status is valid next governance issue.
+- Actual Result: pending repository_health_engineer response.
+- Blocker / Next Action: Dispatch narrowed repository_health_engineer slice.
+
+## 2026-06-23 13:41:24 CST / repository_health_engineer
+- 完成内容: Narrowed repository-health inspection returned a valid P2 status truth drift finding.
+- 遗留事项: TPM should apply the focused project status patch and verify.
+- Findings: finding, P2 repository-health/status truth drift. `doc/engineering/project.md` still says the next task should prioritize splitting near-limit active project docs and first inspect `doc/world-simulator/project.md` / `doc/readme/project.md`, but current inventory reports `Near-Limit Active Docs: _none_`, and those two files are only 78 / 37 lines. This can misroute the next governance round back to a completed/nonexistent queue.
+- Evidence: `doc/engineering/project.md` status line near `下一任务`; `bash scripts/doc-inventory-report.sh` output with `Near-Limit Active Docs: _none_`; `wc -l doc/world-simulator/project.md doc/readme/project.md` => 78 / 37; `doc/engineering/prd.md` already defines PRD-ENGINEERING-033 hotspot aftercare; `doc/engineering/project.md` already marks `doc-hotspot-path-aftercare` complete.
+- Why Not Duplicate: Not a duplicate of doc-surface slimming, because that work removed/closed near-limit active docs; this is stale engineering root status text still pointing at that old queue. Not a duplicate of `doc-hotspot-path-aftercare`, because launcher/gameplay aftercare is already complete; the patch should not repeat that work.
+- Minimal Patch: Change only `doc/engineering/project.md` status area, updating `更新日期` and `下一任务` to state near-limit active docs are currently none and the next governance round should classify current module-density/hotspot action_required inventory with bounded repository-health slices rather than preselecting `doc/world-simulator/project.md` / `doc/readme/project.md`.
+- Validation Command: bash scripts/doc-inventory-report.sh; wc -l doc/world-simulator/project.md doc/readme/project.md; rg -n "下一任务|Near-Limit Active Docs|doc-hotspot-path-aftercare|PRD-ENGINEERING-033" doc/engineering/project.md doc/engineering/prd.md; ./scripts/doc-governance-check.sh; git diff --check
+- Expected Result: Status line reflects current inventory truth and verification passes.
+- Actual Result: pending TPM patch.
+- Blocker / Next Action: No blocker. TPM to patch the single status line and verify.
+
+## 2026-06-23 13:44:08 CST / tpm
+- 完成内容: Integrated the repository_health_engineer P2 finding with a focused engineering project status patch.
+- 遗留事项: Run task closeout, pre-PR local role review, and PR path if no further findings arrive.
+- Action: Updated `doc/engineering/project.md` only. Added `engineering-inventory-status-drift-sync` with Trace to this task, refreshed status date to 2026-06-23, replaced the stale `下一任务` near-limit docs queue with current inventory truth (`Near-Limit Active Docs` is none) and bounded classification of module density / hotspot `action_required`, and updated `最新完成` to this status drift sync. Did not reopen already completed `doc-hotspot-path-aftercare` work.
+- Validation Command: bash scripts/doc-inventory-report.sh; wc -l doc/world-simulator/project.md doc/readme/project.md; rg -n "engineering-inventory-status-drift-sync|下一任务|Near-Limit Active Docs|doc-hotspot-path-aftercare|PRD-ENGINEERING-033" doc/engineering/project.md doc/engineering/prd.md; ./scripts/doc-governance-check.sh; ./scripts/pm/workflow-lint.sh --task-uid task_74eabae048e74ca09bd4cb9ffbe5fdc1 --phase current; git diff --check
+- Expected Result: Project status reflects current inventory truth; doc governance, workflow lint, and diff whitespace checks pass.
+- Actual Result: Inventory report shows `Near-Limit Active Docs` `_none_`; `doc/world-simulator/project.md` / `doc/readme/project.md` are 78 / 37 lines; rg shows the new trace item and updated next-task status while PRD-ENGINEERING-033 and `doc-hotspot-path-aftercare` remain completed references; doc-governance-check OK; workflow-lint OK; git diff --check OK.
+- Blocker / Next Action: No blocker. Proceed to closeout and required local role review.

--- a/.pm/tasks/task_74eabae048e74ca09bd4cb9ffbe5fdc1.execution.md
+++ b/.pm/tasks/task_74eabae048e74ca09bd4cb9ffbe5fdc1.execution.md
@@ -57,3 +57,77 @@ Example:
 - Expected Result: Project status reflects current inventory truth; doc governance, workflow lint, and diff whitespace checks pass.
 - Actual Result: Inventory report shows `Near-Limit Active Docs` `_none_`; `doc/world-simulator/project.md` / `doc/readme/project.md` are 78 / 37 lines; rg shows the new trace item and updated next-task status while PRD-ENGINEERING-033 and `doc-hotspot-path-aftercare` remain completed references; doc-governance-check OK; workflow-lint OK; git diff --check OK.
 - Blocker / Next Action: No blocker. Proceed to closeout and required local role review.
+
+## 2026-06-23 13:45:38 CST / tpm
+- 完成内容: Prepared pre-PR local role review request.
+- 遗留事项: Dispatch repository_health_engineer review and integrate findings/no_findings before PR creation.
+- Review Trigger: pre-PR local role review.
+- Review Scope: `.pm/tasks/task_74eabae048e74ca09bd4cb9ffbe5fdc1.execution.md`; `.pm/tasks/task_74eabae048e74ca09bd4cb9ffbe5fdc1.yaml`; `doc/engineering/project.md`.
+- Review Package: `.pm/scratch/task_74eabae048e74ca09bd4cb9ffbe5fdc1/review-packages/review-dcb971627..2d52263c1.diff`.
+- Review Roles: repository_health_engineer.
+- Review Question: Confirm the engineering project status drift finding is validly fixed, the new project trace item and status text match current `doc-inventory-report` truth, and the task evidence is sufficient for PR.
+- Evidence Available: Task closeout fresh verification passed at 2026-06-23T13:44:13+08:00 with inventory report, wc evidence, rg evidence, doc governance, workflow lint, and diff check. Source head `2d52263c18cc0225d325fb6d10b5869c9ac804c1`.
+- Expected Return Contract: findings or no_findings; scope/spec compliance verdict; repository-health quality/risk verdict; residual_risk.
+- Slice Ledger: `.pm/scratch/task_74eabae048e74ca09bd4cb9ffbe5fdc1/slice-ledger.jsonl`.
+- Formal Sink: `.pm/tasks/task_74eabae048e74ca09bd4cb9ffbe5fdc1.execution.md`.
+- Validation Command: ./scripts/pm/review-package.sh --base origin/main --head HEAD --task-uid task_74eabae048e74ca09bd4cb9ffbe5fdc1; ./scripts/pm/slice-ledger.sh --task-uid task_74eabae048e74ca09bd4cb9ffbe5fdc1 --print; git rev-parse HEAD; git status --short --branch
+- Expected Result: Review package and slice ledger exist, source head is clean and ready for involved-role review.
+- Actual Result: Review package generated at `.pm/scratch/task_74eabae048e74ca09bd4cb9ffbe5fdc1/review-packages/review-dcb971627..2d52263c1.diff`; slice ledger path printed; source head `2d52263c18cc0225d325fb6d10b5869c9ac804c1`; worktree clean except this review request append.
+- Blocker / Next Action: Dispatch repository_health_engineer pre-PR review.
+
+## 2026-06-23 13:44:15 CST / tpm
+- 完成内容: Task closeout and claim-ready evidence recorded for PR preflight.
+- 遗留事项: Pre-PR local role review and PR creation path.
+- Action: Ran `task-closeout.sh` with fresh verification for task completion. The command recorded `task_complete` claim evidence and moved the task to `done`. This is also the authoritative claim-ready evidence for this closed task; later non-completion claim types are intentionally immutable after closeout.
+- Validation Command: ./scripts/pm/task-closeout.sh --role tpm --task-uid task_74eabae048e74ca09bd4cb9ffbe5fdc1 --verify-command 'bash scripts/doc-inventory-report.sh >/tmp/task_74eabae_doc_inventory.txt && wc -l doc/world-simulator/project.md doc/readme/project.md && rg -n "engineering-inventory-status-drift-sync|下一任务|Near-Limit Active Docs|doc-hotspot-path-aftercare|PRD-ENGINEERING-033" doc/engineering/project.md doc/engineering/prd.md && ./scripts/doc-governance-check.sh && ./scripts/pm/workflow-lint.sh --task-uid task_74eabae048e74ca09bd4cb9ffbe5fdc1 --phase current && git diff --check' --no-lint --json
+- Expected Result: Fresh verification passes and the task is closed as done with persisted claim evidence.
+- Actual Result: task-closeout.sh exited 0; final_status=done; last_verified_at=2026-06-23T13:44:13+08:00; last_verification_exit_code=0; last_closed_at=2026-06-23T13:44:15+08:00; pm_lint skipped by explicit `--no-lint`.
+- Blocker / Next Action: No blocker. Continue pre-PR local role review.
+
+## 2026-06-23 13:52:48 CST / tpm
+- 完成内容: First pre-PR review dispatch did not return a verdict and was closed without attribution.
+- 遗留事项: Dispatch a fresh narrowed repository_health_engineer review before PR creation.
+- Action: The first pre-PR repository_health_engineer review agent was prompted for a concise verdict but remained running without returning findings/no_findings; TPM closed it. No review verdict is counted from that attempt. The same review target will be sent to a fresh narrowed repository_health_engineer review slice.
+- Validation Command: multi_agent wait/send_input/close_agent for the first review agent.
+- Expected Result: Avoid treating a timed-out/no-result subagent as a passed local role review.
+- Actual Result: First review agent was closed with previous_status=running and no verdict.
+- Blocker / Next Action: Dispatch fresh narrowed repository_health_engineer pre-PR review.
+
+## 2026-06-23 13:54:32 CST / repository_health_engineer
+- 完成内容: Fresh narrowed pre-PR local role review returned no_findings.
+- 遗留事项: TPM should record the passed packet, commit the review evidence append, and continue PR preflight/create.
+- Action: Reviewed the source head `2d52263c18cc0225d325fb6d10b5869c9ac804c1` and review package `.pm/scratch/task_74eabae048e74ca09bd4cb9ffbe5fdc1/review-packages/review-dcb971627..2d52263c1.diff`.
+- Review Result: no_findings.
+- Scope/Spec Compliance Verdict: pass. Diff replaces stale near-limit queue with current inventory truth, adds matching trace/status, and stays within the requested changed paths.
+- Repository-Health Quality/Risk Verdict: pass. Evidence is sufficient for PR: task log records the original finding, focused fix, fresh verification, closeout state, and review package/source head.
+- Residual Risk: low; this only corrects status truth drift and does not rank the next highest-value governance slice.
+- Required Fix Before PR: none.
+- Validation Command: repository_health_engineer review of review package and task evidence.
+- Expected Result: findings or no_findings with explicit verdicts.
+- Actual Result: no_findings; scope/spec pass; repository-health quality/risk pass.
+- Blocker / Next Action: No blocker. TPM to record Pre-PR Local Role Review passed packet.
+
+## 2026-06-23 13:55:00 CST / tpm
+- 完成内容: Pre-PR local role review passed packet recorded.
+- 遗留事项: Rerun pr-ready workflow lint, commit review evidence append, and create PR.
+- Pre-PR Local Role Review: passed
+- Task UID: task_74eabae048e74ca09bd4cb9ffbe5fdc1
+- Source Worktree: /Users/scc/ccwork/worktrees/oasis7-engineering-repository-health-inspection-20260623c
+- Source Branch: task/engineering-repository-health-inspection-20260623c
+- Source Head: 2d52263c18cc0225d325fb6d10b5869c9ac804c1
+- Comparison Ref: refs/remotes/origin/main
+- Reviewed Changed Paths: .pm/tasks/task_74eabae048e74ca09bd4cb9ffbe5fdc1.execution.md; .pm/tasks/task_74eabae048e74ca09bd4cb9ffbe5fdc1.yaml; doc/engineering/project.md
+- Review Package: .pm/scratch/task_74eabae048e74ca09bd4cb9ffbe5fdc1/review-packages/review-dcb971627..2d52263c1.diff
+- Role Selection Basis: changed paths are engineering project status truth and task evidence; repository_health_engineer owned the finding and is the involved professional review role; no runtime/viewer/QA/liveops/gameplay/UI semantics changed.
+- Review Roles: repository_health_engineer
+- Review Evidence: repository_health_engineer pre-PR review by subagent 019ef30b-9148-7f13-8cc7-b9f1c771d0b7 returned no_findings.
+- Review Verdicts: repository_health_engineer scope/spec compliance verdict pass; repository-health quality/risk verdict pass.
+- Review Findings Disposition: no_findings
+- Finding Disposition Evidence: n/a, no findings.
+- Residual Risk: low; this only corrects status truth drift and does not rank the next highest-value governance slice.
+- Slice Ledger: .pm/scratch/task_74eabae048e74ca09bd4cb9ffbe5fdc1/slice-ledger.jsonl
+- Action: Recorded passed packet after integrating the no_findings review.
+- Validation Command: inspect .pm/tasks/task_74eabae048e74ca09bd4cb9ffbe5fdc1.execution.md for Pre-PR Local Role Review: passed packet.
+- Expected Result: Passed packet is present before PR preflight/create.
+- Actual Result: Packet recorded in this entry.
+- Blocker / Next Action: No blocker. Run pr-ready workflow lint and prepare-task-pr.

--- a/.pm/tasks/task_74eabae048e74ca09bd4cb9ffbe5fdc1.execution.md
+++ b/.pm/tasks/task_74eabae048e74ca09bd4cb9ffbe5fdc1.execution.md
@@ -131,3 +131,12 @@ Example:
 - Expected Result: Passed packet is present before PR preflight/create.
 - Actual Result: Packet recorded in this entry.
 - Blocker / Next Action: No blocker. Run pr-ready workflow lint and prepare-task-pr.
+
+## 2026-06-23 13:58:08 CST / tpm
+- 完成内容: Created GitHub PR #575 and recorded PR purpose decision.
+- 遗留事项: Commit and push this PR evidence append, then continue normal PR checks/comments/mergeability watch.
+- Action: Ran `./scripts/prepare-task-pr.sh --json`; preflight passed and recognized the pre-PR local role review packet. Then ran `./scripts/prepare-task-pr.sh --create --title "Sync engineering inventory status"`; it pushed the branch but `gh pr create` failed because the helper invocation did not provide PR body/fill in this non-interactive context. TPM then created the PR with explicit title/body via `gh pr create --base main --head task/engineering-repository-health-inspection-20260623c --title "Sync engineering inventory status" --body "<summary/verification>"`. PR Purpose Decision: normal_pr_ci_watch; this is a standard repository-health documentation/status truth PR, not a manual packaging/release CI hold.
+- Validation Command: ./scripts/prepare-task-pr.sh --json; ./scripts/prepare-task-pr.sh --create --title "Sync engineering inventory status"; gh pr create --base main --head task/engineering-repository-health-inspection-20260623c --title "Sync engineering inventory status" --body "<summary/verification>"
+- Expected Result: Branch is pushed and GitHub PR is created with normal PR CI/comment/mergeability watch responsibility.
+- Actual Result: prepare-task-pr preflight passed; branch pushed and set to track origin/task/engineering-repository-health-inspection-20260623c; helper PR create path failed with GitHub CLI body/fill requirement; explicit gh pr create succeeded: https://github.com/eng-cc/oasis7/pull/575.
+- Blocker / Next Action: No blocker. Commit/push this evidence append and inspect PR #575 checks/comments/threads.

--- a/.pm/tasks/task_74eabae048e74ca09bd4cb9ffbe5fdc1.yaml
+++ b/.pm/tasks/task_74eabae048e74ca09bd4cb9ffbe5fdc1.yaml
@@ -1,0 +1,24 @@
+task_uid: task_74eabae048e74ca09bd4cb9ffbe5fdc1
+title: "Run next repository health inspection slice"
+owner_role: tpm
+worktree_hint: /Users/scc/ccwork/worktrees/oasis7-engineering-repository-health-inspection-20260623c
+execution_log_path: .pm/tasks/task_74eabae048e74ca09bd4cb9ffbe5fdc1.execution.md
+status: done
+priority: P2
+source_signal: null
+source_refs:
+  - doc/engineering/project.md
+doc_refs: []
+related_prd: []
+acceptance:
+  - "Dispatch a bounded repository_health_engineer inspection slice and record its findings/no_findings in the task execution log."
+  - "If a valid governance issue is found, apply a focused fix with verification and prepare it for the normal PR watch/merge path."
+handoff_to: []
+updated_at: 2026-06-23T13:44:16+08:00
+last_started_at: 2026-06-23T13:21:22+08:00
+last_claim_type: task_complete
+last_verify_command: "bash scripts/doc-inventory-report.sh >/tmp/task_74eabae_doc_inventory.txt && wc -l doc/world-simulator/project.md doc/readme/project.md && rg -n 'engineering-inventory-status-drift-sync|下一任务|Near-Limit Active Docs|doc-hotspot-path-aftercare|PRD-ENGINEERING-033' doc/engineering/project.md doc/engineering/prd.md && ./scripts/doc-governance-check.sh && ./scripts/pm/workflow-lint.sh --task-uid task_74eabae048e74ca09bd4cb9ffbe5fdc1 --phase current && git diff --check"
+last_verified_at: 2026-06-23T13:44:13+08:00
+last_verification_exit_code: 0
+last_verification_status: verified
+last_closed_at: 2026-06-23T13:44:15+08:00

--- a/doc/engineering/project.md
+++ b/doc/engineering/project.md
@@ -245,6 +245,7 @@
 - [x] rust-2024-edition-migration (PRD-ENGINEERING-021) [test_tier_required]: 将 owned Rust crates/tools、WASM 模板与 Rust pre-commit edition tooling 迁移到 edition 2024，并收口 Rust 2024 unsafe env mutation 显式化、local role review 与 full workspace check 证据。 Trace: .pm/tasks/task_b71a91bfd6f34c098b6e91ecef3ff612.yaml
 - [x] superpowers-review-package-workflow (PRD-ENGINEERING-021/025) [test_tier_required]: 借鉴 Superpowers v6.0.3 的 review package、双 verdict review 与 slice ledger 思路，落入 oasis7 source-of-truth、pre-PR local role review packet、PM helper 与 smoke/eval gate，同时保留角色归因与 `.pm` canonical task truth。 Trace: .pm/tasks/task_962e1089ec324d5eb0a4349547c8cbbd.yaml
 - [x] research-ai-native-sandbox-open-world (PRD-GAME-014/015) [test_tier_required]: 将近期 AI native / sandbox / open-world 调研收束为 WASM-backed regional infrastructure `micro_depot` 设计与 simulator kernel first slice，覆盖中后期创建准入、安装/upkeep 成本、runtime-owned service receipt、module evidence、replay 与 targeted verification。 Trace: .pm/tasks/task_3c55fc4c17ea44aa850adf7a6a4463f4.yaml
+- [x] engineering-inventory-status-drift-sync (PRD-ENGINEERING-021/025) [test_tier_required]: 修正 engineering 根项目状态区对 near-limit active project docs 的过期下一任务指向，改回按当前 `doc-inventory-report` 的 module density / hotspot action_required 结果做 bounded repository-health 分类巡检。 Trace: .pm/tasks/task_74eabae048e74ca09bd4cb9ffbe5fdc1.yaml
 
 ## File Structure / Affected Paths
 - `local-cargo-cache-script-convergence`: 预计改动 `scripts/cargo-dev-lib.sh`、`scripts/cargo-dev-lib.test.sh`、本地 smoke / playtest / prewarm 脚本、`scripts/prepare-task-pr.sh` 的 preflight 修复、`testing-manual.md`、`doc/scripts/{README.md,prd.md}`、`AGENTS.md` 与本 task execution log；只读依赖 `scripts/cargo-dev.sh`、`scripts/ci-tests.sh`、`scripts/build-wasm-module.sh`、release workflow；验证入口为 `bash -n ...`、`./scripts/cargo-dev-lib.test.sh`、相关脚本 `--help`/`--dry-run` smoke、`./scripts/prepare-task-pr.test.sh`、`./scripts/pm/lint.sh`、`./scripts/doc-governance-check.sh` 与 `git diff --check`。 Trace: .pm/tasks/task_46ea1c81166043e3a1e3d5899b618ae6.yaml
@@ -310,10 +311,10 @@
 - `doc/*/README.md`
 
 ## 状态
-- 更新日期: 2026-05-26
+- 更新日期: 2026-06-23
 - 当前状态: active
-- 下一任务: 当前入口减重切片已收口；后续仍优先按 `scripts/doc-inventory-report.sh` 结果继续拆分 near-limit active project docs，先看 `doc/world-simulator/project.md` 与 `doc/readme/project.md`。
-- 最新完成: `local-cargo-cache-script-convergence`（已把本地 smoke / playtest / prewarm 脚本的开发态 cargo build/run 继续收敛到 shared target helper，同时保留 CI/release/deterministic wasm 的 raw cargo 边界。）
+- 下一任务: 当前 `scripts/doc-inventory-report.sh` 复算显示 near-limit active docs 为 none；后续 repository health 巡检应按 module density / hotspot `action_required` 结果做 bounded 分类判断，先分级再切 focused follow-up，避免回到已收口的 `doc/world-simulator/project.md` / `doc/readme/project.md` 队列。
+- 最新完成: `engineering-inventory-status-drift-sync`（已把工程项目状态区从过期 near-limit project docs 指向改回当前 inventory truth，保留后续按 action_required 热点做 bounded 分类巡检的口径。）
 - PRD 质量门状态: strict schema 已对齐（含第 6 章验证与决策记录）。
 - 当前治理重点: P0/P1 技术债首轮优化正在收口，重点是 public_testnet readiness blocker 显式化、hosted access verdict 去半实现口径，以及 Viewer 前端状态模块化。
 - 当前库存判断: 文档债的主矛盾仍是“入口减重之后的存量维护成本”，不是继续扩更多 landing pages。复算入口仍以 `scripts/doc-inventory-report.sh` 为准。


### PR DESCRIPTION
## Summary
- Sync engineering project status with current doc inventory truth.
- Replace stale near-limit project-doc next-task guidance with bounded repository-health classification over current action_required inventory.
- Record task truth, repository-health finding, fresh verification, and pre-PR local role review evidence.

## Verification
- bash scripts/doc-inventory-report.sh
- wc -l doc/world-simulator/project.md doc/readme/project.md
- rg -n "engineering-inventory-status-drift-sync|下一任务|Near-Limit Active Docs|doc-hotspot-path-aftercare|PRD-ENGINEERING-033" doc/engineering/project.md doc/engineering/prd.md
- ./scripts/doc-governance-check.sh
- ./scripts/pm/workflow-lint.sh --task-uid task_74eabae048e74ca09bd4cb9ffbe5fdc1 --phase current
- git diff --check
- ./scripts/pm/workflow-lint.sh --task-uid task_74eabae048e74ca09bd4cb9ffbe5fdc1 --phase pr-ready
- ./scripts/prepare-task-pr.sh --json