### PR TITLE
Sync world-runtime inventory snapshots

### DIFF
--- a/.pm/tasks/task_5da43be9aa8f4bb39b6635d4b147d54f.execution.md
+++ b/.pm/tasks/task_5da43be9aa8f4bb39b6635d4b147d54f.execution.md
@@ -80,7 +80,7 @@ Example:
 - Review Trigger: pre-PR local role review
 - Review Scope: uncommitted live diff for `.pm/roles/tpm/backlog/committed.yaml`, `.pm/tasks/task_5da43be9aa8f4bb39b6635d4b147d54f.yaml`, `.pm/tasks/task_5da43be9aa8f4bb39b6635d4b147d54f.execution.md`, `doc/engineering/project.md`, `doc/world-runtime/README.md`, and `doc/world-runtime/prd.index.md`.
 - Review Package: n/a; generated review package only covered committed `HEAD` and this review target is the current uncommitted live diff.
-- Review Roles: repository_health_engineer, qa_engineer, runtime_engineer, wasm_platform_engineer
+- Review Roles: repository_health_engineer, qa_engineer, runtime_engineer, wasm_platform_engineer, producer_system_designer
 - Review Question: confirm or challenge that the patch is a narrow inventory metadata sync, matches current direct counts, preserves world-runtime/WASM/runtime semantics, and has sufficient verification for PR readiness.
 - Evidence Available: direct counts 124/57/7/25/16/5/2/1; targeted `rg` evidence; `doc-governance-check: OK`; `workflow-lint: OK`; `git diff --check` passed.
 - Expected Return Contract: `findings` or `no_findings`; scope/spec compliance verdict; role quality/risk verdict; residual_risk.
@@ -95,13 +95,13 @@ Example:
 - Comparison Ref: refs/remotes/origin/main
 - Reviewed Changed Paths: `.pm/roles/tpm/backlog/committed.yaml`; `.pm/tasks/task_5da43be9aa8f4bb39b6635d4b147d54f.yaml`; `.pm/tasks/task_5da43be9aa8f4bb39b6635d4b147d54f.execution.md`; `doc/engineering/project.md`; `doc/world-runtime/README.md`; `doc/world-runtime/prd.index.md`
 - Review Package: n/a; review was performed against the uncommitted live diff that was committed as `5ba70a4ca46991f01a8a567a490e14d0e852c1ec`.
-- Role Selection Basis: repository_health_engineer owns the inventory drift finding and doc/code contract alignment; qa_engineer owns verification sufficiency; runtime_engineer and wasm_platform_engineer were included because the changed world-runtime entrypoints contain runtime and WASM routing semantics even though the intended patch is metadata-only.
-- Review Roles: repository_health_engineer, qa_engineer, runtime_engineer, wasm_platform_engineer
-- Review Evidence: James repository_health_engineer returned `no_findings`; Planck qa_engineer returned `no_findings`; Hubble runtime_engineer returned `no_findings`; Bacon wasm_platform_engineer returned `no_findings`.
-- Review Verdicts: repository_health_engineer scope/spec pass and quality/risk pass; qa_engineer scope/spec pass and quality/risk pass; runtime_engineer scope/spec pass and quality/risk pass; wasm_platform_engineer scope/spec pass and quality/risk pass.
+- Role Selection Basis: repository_health_engineer owns the inventory drift finding and doc/code contract alignment; qa_engineer owns verification sufficiency; runtime_engineer and wasm_platform_engineer were included because the changed world-runtime entrypoints contain runtime and WASM routing semantics even though the intended patch is metadata-only; producer_system_designer was included after `prepare-task-pr` changed-path inference required product/system semantic coverage for `doc/engineering/project.md` and world-runtime entrypoints.
+- Review Roles: repository_health_engineer, qa_engineer, runtime_engineer, wasm_platform_engineer, producer_system_designer
+- Review Evidence: James repository_health_engineer returned `no_findings`; Planck qa_engineer returned `no_findings`; Hubble runtime_engineer returned `no_findings`; Bacon wasm_platform_engineer returned `no_findings`; Franklin producer_system_designer returned `no_findings`.
+- Review Verdicts: repository_health_engineer scope/spec pass and quality/risk pass; qa_engineer scope/spec pass and quality/risk pass; runtime_engineer scope/spec pass and quality/risk pass; wasm_platform_engineer scope/spec pass and quality/risk pass; producer_system_designer scope/spec pass and quality/risk pass.
 - Review Findings Disposition: no_findings
 - Finding Disposition Evidence: n/a
-- Verification Matrix: world-runtime inventory metadata -> direct counts 124/57/7/25/16/5/2/1 and targeted evidence observed; doc governance -> `doc-governance-check: OK`; task truth -> `workflow-lint: OK`; formatting -> `git diff --check` passed; runtime semantics -> runtime_engineer no_findings; WASM semantics -> wasm_platform_engineer no_findings.
+- Verification Matrix: world-runtime inventory metadata -> direct counts 124/57/7/25/16/5/2/1 and targeted evidence observed; doc governance -> `doc-governance-check: OK`; task truth -> `workflow-lint: OK`; formatting -> `git diff --check` passed; runtime semantics -> runtime_engineer no_findings; WASM semantics -> wasm_platform_engineer no_findings; producer/system/public-positioning semantics -> producer_system_designer no_findings.
 - Visual Evidence: n/a; docs-only inventory metadata sync with no UI/visual surface.
 - WASM Evidence: n/a; exemption reason: changed text preserves WASM count and routing semantics, and wasm_platform_engineer confirmed no WASM-specific build, determinism, or release validation is needed.
 - Ops Evidence: n/a; no deployment, rollback, runbook, or operator procedure changed.
@@ -117,3 +117,13 @@ Example:
 - Expected Result: ready-for-PR claim is freshly verified; task YAML records `done` with verification exit 0; current-task workflow lint passes; unrelated repo-wide PM lint debt is not treated as a current task content failure.
 - Actual Result: claim-ready reported `verification_exit_code: 0`, `status: verified`, and `allowed_to_claim: true`; task YAML is `status: done`, `last_verification_exit_code: 0`, `last_verification_status: verified`, and `last_closed_at: 2026-06-23T21:09:05+08:00`; current task `workflow-lint: OK`; closeout helper non-zero came from pre-existing repo-wide historical `.pm` lint failures in other task logs.
 - Blocker / Next Action: commit, prepare PR, then continue normal PR checks/comments/threads/merge path.
+
+## 2026-06-23 21:14:12 CST / tpm
+- 完成内容: `prepare-task-pr --create` requested supplemental `producer_system_designer` coverage from changed-path inference.
+- 遗留事项: supplemental producer/system review pending.
+- Action: Dispatch a narrow producer_system_designer review for product/system/public-positioning semantics.
+- Validation Command: `./scripts/prepare-task-pr.sh --create --title "Sync world-runtime inventory snapshots"`
+- Expected Result: preflight accepts existing review packet or reports exact missing role coverage.
+- Actual Result: preflight reported missing required role `producer_system_designer` (present: repository_health_engineer, qa_engineer, runtime_engineer, wasm_platform_engineer; required: producer_system_designer,runtime_engineer,qa_engineer).
+- Supplemental Review Result: Franklin producer_system_designer returned `no_findings`; scope/spec pass; producer/system quality/risk pass; confirmed the patch is purely internal documentation inventory metadata with no change to product requirements, system design meaning, roadmap/readiness status, operator process, player/user promise, public positioning, or acceptance semantics.
+- Blocker / Next Action: recommit updated review packet and rerun prepare-task-pr.

--- a/.pm/tasks/task_5da43be9aa8f4bb39b6635d4b147d54f.execution.md
+++ b/.pm/tasks/task_5da43be9aa8f4bb39b6635d4b147d54f.execution.md
@@ -91,10 +91,10 @@ Example:
 - Task UID: task_5da43be9aa8f4bb39b6635d4b147d54f
 - Source Worktree: /Users/scc/ccwork/worktrees/oasis7-engineering-repository-health-inspection-20260623i
 - Source Branch: task/engineering-repository-health-inspection-20260623i
-- Source Head: 46927700213840380bd4651459ebedc7cd4d41b3
+- Source Head: 5ba70a4ca46991f01a8a567a490e14d0e852c1ec
 - Comparison Ref: refs/remotes/origin/main
 - Reviewed Changed Paths: `.pm/roles/tpm/backlog/committed.yaml`; `.pm/tasks/task_5da43be9aa8f4bb39b6635d4b147d54f.yaml`; `.pm/tasks/task_5da43be9aa8f4bb39b6635d4b147d54f.execution.md`; `doc/engineering/project.md`; `doc/world-runtime/README.md`; `doc/world-runtime/prd.index.md`
-- Review Package: n/a; uncommitted live diff review because generated package only covered committed `HEAD`.
+- Review Package: n/a; review was performed against the uncommitted live diff that was committed as `5ba70a4ca46991f01a8a567a490e14d0e852c1ec`.
 - Role Selection Basis: repository_health_engineer owns the inventory drift finding and doc/code contract alignment; qa_engineer owns verification sufficiency; runtime_engineer and wasm_platform_engineer were included because the changed world-runtime entrypoints contain runtime and WASM routing semantics even though the intended patch is metadata-only.
 - Review Roles: repository_health_engineer, qa_engineer, runtime_engineer, wasm_platform_engineer
 - Review Evidence: James repository_health_engineer returned `no_findings`; Planck qa_engineer returned `no_findings`; Hubble runtime_engineer returned `no_findings`; Bacon wasm_platform_engineer returned `no_findings`.

--- a/.pm/tasks/task_5da43be9aa8f4bb39b6635d4b147d54f.execution.md
+++ b/.pm/tasks/task_5da43be9aa8f4bb39b6635d4b147d54f.execution.md
@@ -1,0 +1,119 @@
+# task_5da43be9aa8f4bb39b6635d4b147d54f Execution Log
+
+- task_uid: task_5da43be9aa8f4bb39b6635d4b147d54f
+- title: Run next repository health inspection slice
+- owner_role: tpm
+- worktree_hint: /Users/scc/ccwork/worktrees/oasis7-engineering-repository-health-inspection-20260623i
+
+<!-- Append entries using:
+Example:
+  ## YYYY-MM-DD HH:MM:SS CST / role_name
+  - 完成内容: ...
+  - 遗留事项: ...
+  - Action: ...
+  - Validation Command: ...
+  - Expected Result: ...
+  - Actual Result: ...
+  - Blocker / Next Action: ...
+-->
+
+## 2026-06-23 20:57:30 CST / tpm
+- 完成内容: Bootstrap and route decision recorded for the next repository health inspection slice.
+- 遗留事项: repository_health_engineer inspection slice pending.
+- Action: Created canonical task worktree and bound `.pm` task truth before substantive repository-health work.
+- Workflow Bootstrap:
+  - Repository State Impact: may change repository docs/task truth if the inspection finds a valid governance issue.
+  - Isolation Decision: created dedicated worktree `/Users/scc/ccwork/worktrees/oasis7-engineering-repository-health-inspection-20260623i` on branch `task/engineering-repository-health-inspection-20260623i` from `origin/main`.
+  - Task Truth: owner role `tpm`; `.pm` task `.pm/tasks/task_5da43be9aa8f4bb39b6635d4b147d54f.yaml`; execution log `.pm/tasks/task_5da43be9aa8f4bb39b6635d4b147d54f.execution.md`.
+  - Routed Next Phase: `repo-owned-workflow-router` -> bounded repository_health_engineer slice, then focused execution/verification/closeout if a valid issue is found.
+- TPM TODO Decomposition:
+  1. Run current repository-health discovery evidence such as `scripts/doc-inventory-report.sh` and targeted repository searches.
+  2. Dispatch a bounded `repository_health_engineer` slice to identify one non-duplicate, high-confidence governance issue.
+  3. If the slice returns a valid finding, apply the smallest fix, run targeted verification, request required local role review, create PR, watch checks/comments/threads, merge, and clean up.
+  4. If the slice returns no actionable finding, record no_findings with evidence and close the task without inventing a fix.
+- Subagent Slice Contract:
+  - role: repository_health_engineer
+  - slice type: bounded repository-health inspection and one-issue recommendation
+  - intended model configuration: workflow source-of-truth `Default subagent runtime`
+  - actual dispatched model/reasoning: inherited/unverified unless the connector reports exact model metadata
+  - context delivery mode: full-thread/full-history fork preferred; explicit context below is mandatory checklist supplement
+  - mandatory context checklist/packet:
+    - identity and authority: root `AGENTS.md` says `tpm` coordinates only; repository_health_engineer owns repository-health findings.
+    - workflow governance: `doc/engineering/workflow/source-of-truth.md`; default bootstrap/router contracts; all professional findings must sink to this task execution log.
+    - task truth: task UID `task_5da43be9aa8f4bb39b6635d4b147d54f`; worktree `/Users/scc/ccwork/worktrees/oasis7-engineering-repository-health-inspection-20260623i`; branch `task/engineering-repository-health-inspection-20260623i`.
+    - user intent: "继续找下一个待治理问题" means find the next actionable repository governance issue and carry it through normal fix/PR/merge flow if valid.
+    - scoped repo context: immediately previous merged tasks synced inventory snapshots for world-simulator, module READMEs, game/gameplay, world-simulator/launcher, world-simulator+launcher, readme/governance/readme index, including PR #582 production count follow-up; avoid duplicate findings already resolved on `origin/main`.
+    - collaboration boundary: TPM may collect mechanical evidence but must not present TPM analysis as repository_health_engineer conclusion.
+  - write scope: read-only inspection by subagent; TPM owns any edits after integration.
+  - return contract: `findings` or `no_findings`; for each finding include severity, category, exact files/lines/commands, duplicate check against recent merged inventory-sync work, minimal fix recommendation, verification commands, and whether additional role slices are required.
+  - formal sink / writeback surface: `.pm/tasks/task_5da43be9aa8f4bb39b6635d4b147d54f.execution.md`
+  - integration owner/order: TPM records dispatch, integrates repository_health_engineer finding, applies scoped fix if valid, then routes verification/review/PR.
+- Validation Command: `git status --short --branch`; `git rev-parse HEAD origin/main`; role/project/task reads.
+- Expected Result: clean isolated worktree on current `origin/main`, task truth present, slice contract recorded before dispatch.
+- Actual Result: main was clean and at `origin/main` `46927700213840380bd4651459ebedc7cd4d41b3`; new task/worktree created; repository_health_engineer role card and engineering project context read; route and slice contract recorded.
+- Blocker / Next Action: dispatch bounded repository_health_engineer slice.
+
+## 2026-06-23 21:03:18 CST / repository_health_engineer
+- 完成内容: Bounded repository-health inspection returned one actionable, non-duplicate P2 finding.
+- 遗留事项: TPM integration and targeted verification pending.
+- Action: Inspect current doc inventory and classify the next focused governance issue.
+- Validation Command: `bash scripts/doc-inventory-report.sh`; direct `/usr/bin/find ... -name '*.md' | wc -l` counts for `doc/world-runtime`, `doc/world-runtime/runtime`, `doc/world-runtime/wasm`, `doc/world-runtime/module`, `doc/world-runtime/evidence`, `doc/world-runtime/governance`, `doc/world-runtime/templates`, and `doc/world-runtime/checklists`; targeted reads of `doc/world-runtime/README.md` and `doc/world-runtime/prd.index.md`.
+- Expected Result: find one current, non-duplicate repo-health issue or return `no_findings`.
+- Actual Result: P2 finding: `doc/world-runtime/prd.index.md` still had a 2026-04-20 density snapshot with stale `doc/world-runtime/` 121 instead of 124, `runtime/` 55 instead of 57, and `evidence/` 6 instead of 7; matching hotspot table rows were stale. `doc/world-runtime/README.md` already had the current high-density sentence at 124/57, but its hotspot navigation label/counts still showed 2026-04-20, `runtime/` 55, and `evidence/` 6.
+- Duplicate Check: recent merged inventory-sync work covered world-simulator, module READMEs, game/gameplay, launcher, and readme/governance/readme index; this world-runtime file-level index/hotspot-table drift remained distinct.
+- Recommendation: update only `doc/world-runtime/README.md`, `doc/world-runtime/prd.index.md`, and engineering project trace/status to current 2026-06-23 inventory truth; no runtime/WASM platform role required because the patch is inventory metadata only.
+- Attribution Boundary: repository_health_engineer conclusion is limited to documentation/inventory alignment and is not a runtime correctness, WASM platform, release readiness, or product-positioning judgment.
+- Blocker / Next Action: TPM applies minimal patch and runs targeted verification.
+
+## 2026-06-23 21:05:02 CST / tpm
+- 完成内容: Integrated repository_health_engineer finding with a focused documentation patch.
+- 遗留事项: targeted verification, local role review, closeout, PR path.
+- Action: Synchronized world-runtime entrypoint inventory snapshot counts.
+- Changed Paths: `doc/world-runtime/README.md`; `doc/world-runtime/prd.index.md`; `doc/engineering/project.md`; `.pm/tasks/task_5da43be9aa8f4bb39b6635d4b147d54f.execution.md`.
+- Expected Result: world-runtime density snapshot and hotspot navigation now match current direct counts: world-runtime 124, runtime 57, evidence 7; unchanged counts remain wasm 25, module 16, governance 5, templates 2, checklists 1.
+- Actual Result: patch applied.
+- Verification Command: `bash scripts/doc-inventory-report.sh >/tmp/task_5da_world_runtime_inventory.txt && /usr/bin/find doc/world-runtime -type f -name '*.md' | wc -l && /usr/bin/find doc/world-runtime/runtime -type f -name '*.md' | wc -l && /usr/bin/find doc/world-runtime/evidence -type f -name '*.md' | wc -l && /usr/bin/find doc/world-runtime/wasm -type f -name '*.md' | wc -l && /usr/bin/find doc/world-runtime/module -type f -name '*.md' | wc -l && /usr/bin/find doc/world-runtime/governance -type f -name '*.md' | wc -l && /usr/bin/find doc/world-runtime/templates -type f -name '*.md' | wc -l && /usr/bin/find doc/world-runtime/checklists -type f -name '*.md' | wc -l && rg -n '2026-06-23|doc/world-runtime/.+124|runtime/.+57|evidence/.+7|world-runtime-inventory-snapshot-sync' doc/world-runtime/README.md doc/world-runtime/prd.index.md doc/engineering/project.md && ./scripts/doc-governance-check.sh && ./scripts/pm/workflow-lint.sh --task-uid task_5da43be9aa8f4bb39b6635d4b147d54f --phase current && git diff --check`
+- Verification Result: Passed. Direct counts returned 124, 57, 7, 25, 16, 5, 2, and 1; targeted evidence found 2026-06-23, world-runtime 124, runtime 57, evidence 7, and engineering project trace/latest-complete; `doc-governance-check: OK`; `workflow-lint: OK`; `git diff --check` passed.
+- Blocker / Next Action: run pre-PR local role review for involved roles.
+
+## 2026-06-23 21:10:08 CST / tpm
+- Review Trigger: pre-PR local role review
+- Review Scope: uncommitted live diff for `.pm/roles/tpm/backlog/committed.yaml`, `.pm/tasks/task_5da43be9aa8f4bb39b6635d4b147d54f.yaml`, `.pm/tasks/task_5da43be9aa8f4bb39b6635d4b147d54f.execution.md`, `doc/engineering/project.md`, `doc/world-runtime/README.md`, and `doc/world-runtime/prd.index.md`.
+- Review Package: n/a; generated review package only covered committed `HEAD` and this review target is the current uncommitted live diff.
+- Review Roles: repository_health_engineer, qa_engineer, runtime_engineer, wasm_platform_engineer
+- Review Question: confirm or challenge that the patch is a narrow inventory metadata sync, matches current direct counts, preserves world-runtime/WASM/runtime semantics, and has sufficient verification for PR readiness.
+- Evidence Available: direct counts 124/57/7/25/16/5/2/1; targeted `rg` evidence; `doc-governance-check: OK`; `workflow-lint: OK`; `git diff --check` passed.
+- Expected Return Contract: `findings` or `no_findings`; scope/spec compliance verdict; role quality/risk verdict; residual_risk.
+- Slice Ledger: `/Users/scc/ccwork/worktrees/oasis7-engineering-repository-health-inspection-20260623i/.pm/scratch/task_5da43be9aa8f4bb39b6635d4b147d54f/slice-ledger.jsonl`
+- Formal Sink: `.pm/tasks/task_5da43be9aa8f4bb39b6635d4b147d54f.execution.md`
+
+- Pre-PR Local Role Review: passed
+- Task UID: task_5da43be9aa8f4bb39b6635d4b147d54f
+- Source Worktree: /Users/scc/ccwork/worktrees/oasis7-engineering-repository-health-inspection-20260623i
+- Source Branch: task/engineering-repository-health-inspection-20260623i
+- Source Head: 46927700213840380bd4651459ebedc7cd4d41b3
+- Comparison Ref: refs/remotes/origin/main
+- Reviewed Changed Paths: `.pm/roles/tpm/backlog/committed.yaml`; `.pm/tasks/task_5da43be9aa8f4bb39b6635d4b147d54f.yaml`; `.pm/tasks/task_5da43be9aa8f4bb39b6635d4b147d54f.execution.md`; `doc/engineering/project.md`; `doc/world-runtime/README.md`; `doc/world-runtime/prd.index.md`
+- Review Package: n/a; uncommitted live diff review because generated package only covered committed `HEAD`.
+- Role Selection Basis: repository_health_engineer owns the inventory drift finding and doc/code contract alignment; qa_engineer owns verification sufficiency; runtime_engineer and wasm_platform_engineer were included because the changed world-runtime entrypoints contain runtime and WASM routing semantics even though the intended patch is metadata-only.
+- Review Roles: repository_health_engineer, qa_engineer, runtime_engineer, wasm_platform_engineer
+- Review Evidence: James repository_health_engineer returned `no_findings`; Planck qa_engineer returned `no_findings`; Hubble runtime_engineer returned `no_findings`; Bacon wasm_platform_engineer returned `no_findings`.
+- Review Verdicts: repository_health_engineer scope/spec pass and quality/risk pass; qa_engineer scope/spec pass and quality/risk pass; runtime_engineer scope/spec pass and quality/risk pass; wasm_platform_engineer scope/spec pass and quality/risk pass.
+- Review Findings Disposition: no_findings
+- Finding Disposition Evidence: n/a
+- Verification Matrix: world-runtime inventory metadata -> direct counts 124/57/7/25/16/5/2/1 and targeted evidence observed; doc governance -> `doc-governance-check: OK`; task truth -> `workflow-lint: OK`; formatting -> `git diff --check` passed; runtime semantics -> runtime_engineer no_findings; WASM semantics -> wasm_platform_engineer no_findings.
+- Visual Evidence: n/a; docs-only inventory metadata sync with no UI/visual surface.
+- WASM Evidence: n/a; exemption reason: changed text preserves WASM count and routing semantics, and wasm_platform_engineer confirmed no WASM-specific build, determinism, or release validation is needed.
+- Ops Evidence: n/a; no deployment, rollback, runbook, or operator procedure changed.
+- LiveOps Evidence: n/a; exemption reason: no public-facing change, because this patch only updates internal documentation inventory snapshot counts and does not change external messaging, player/community promises, release notes, channel runbooks, or public/community positioning.
+- Residual Risk: ordinary static inventory snapshots may drift again if world-runtime files are added or removed before the next inspection.
+- Slice Ledger: /Users/scc/ccwork/worktrees/oasis7-engineering-repository-health-inspection-20260623i/.pm/scratch/task_5da43be9aa8f4bb39b6635d4b147d54f/slice-ledger.jsonl
+
+## 2026-06-23 21:11:42 CST / tpm
+- 完成内容: Ran ready-for-PR claim verification and task closeout for the world-runtime inventory snapshot sync.
+- 遗留事项: `task-closeout.sh` returned non-zero at its final repo-wide `./scripts/pm/lint.sh` step because of unrelated historical `.pm` execution-log debt; current task state and task-local lint are clean.
+- Action: Close task to `done`, distinguish current-task verification from repo-wide historical PM lint noise, and prepare commit/PR path.
+- Validation Command: `./scripts/pm/claim-ready.sh --claim-type ready_for_pr --verify-command "<world-runtime inventory verification command>"`; `./scripts/pm/task-closeout.sh --role tpm --task-uid task_5da43be9aa8f4bb39b6635d4b147d54f --to-status done --verify-command "<world-runtime inventory verification command>"`; follow-up `./scripts/pm/workflow-lint.sh --task-uid task_5da43be9aa8f4bb39b6635d4b147d54f --phase current`; inspect `.pm/tasks/task_5da43be9aa8f4bb39b6635d4b147d54f.yaml`.
+- Expected Result: ready-for-PR claim is freshly verified; task YAML records `done` with verification exit 0; current-task workflow lint passes; unrelated repo-wide PM lint debt is not treated as a current task content failure.
+- Actual Result: claim-ready reported `verification_exit_code: 0`, `status: verified`, and `allowed_to_claim: true`; task YAML is `status: done`, `last_verification_exit_code: 0`, `last_verification_status: verified`, and `last_closed_at: 2026-06-23T21:09:05+08:00`; current task `workflow-lint: OK`; closeout helper non-zero came from pre-existing repo-wide historical `.pm` lint failures in other task logs.
+- Blocker / Next Action: commit, prepare PR, then continue normal PR checks/comments/threads/merge path.

--- a/.pm/tasks/task_5da43be9aa8f4bb39b6635d4b147d54f.yaml
+++ b/.pm/tasks/task_5da43be9aa8f4bb39b6635d4b147d54f.yaml
@@ -1,0 +1,24 @@
+task_uid: task_5da43be9aa8f4bb39b6635d4b147d54f
+title: "Run next repository health inspection slice"
+owner_role: tpm
+worktree_hint: /Users/scc/ccwork/worktrees/oasis7-engineering-repository-health-inspection-20260623i
+execution_log_path: .pm/tasks/task_5da43be9aa8f4bb39b6635d4b147d54f.execution.md
+status: done
+priority: P2
+source_signal: null
+source_refs:
+  - doc/engineering/project.md
+doc_refs: []
+related_prd: []
+acceptance:
+  - "Dispatch a bounded repository_health_engineer inspection slice and record its findings/no_findings in the task execution log."
+  - "If a valid governance issue is found, apply a focused fix with verification and prepare it for the normal PR watch/merge path."
+handoff_to: []
+updated_at: 2026-06-23T21:09:05+08:00
+last_started_at: 2026-06-23T20:57:15+08:00
+last_claim_type: task_complete
+last_verify_command: "bash scripts/doc-inventory-report.sh >/tmp/task_5da_world_runtime_inventory.txt && /usr/bin/find doc/world-runtime -type f -name '*.md' | wc -l && /usr/bin/find doc/world-runtime/runtime -type f -name '*.md' | wc -l && /usr/bin/find doc/world-runtime/evidence -type f -name '*.md' | wc -l && /usr/bin/find doc/world-runtime/wasm -type f -name '*.md' | wc -l && /usr/bin/find doc/world-runtime/module -type f -name '*.md' | wc -l && /usr/bin/find doc/world-runtime/governance -type f -name '*.md' | wc -l && /usr/bin/find doc/world-runtime/templates -type f -name '*.md' | wc -l && /usr/bin/find doc/world-runtime/checklists -type f -name '*.md' | wc -l && rg -n '2026-06-23|doc/world-runtime/.+124|runtime/.+57|evidence/.+7|world-runtime-inventory-snapshot-sync' doc/world-runtime/README.md doc/world-runtime/prd.index.md doc/engineering/project.md && ./scripts/doc-governance-check.sh && ./scripts/pm/workflow-lint.sh --task-uid task_5da43be9aa8f4bb39b6635d4b147d54f --phase current && git diff --check"
+last_verified_at: 2026-06-23T21:09:04+08:00
+last_verification_exit_code: 0
+last_verification_status: verified
+last_closed_at: 2026-06-23T21:09:05+08:00

--- a/doc/engineering/project.md
+++ b/doc/engineering/project.md
@@ -252,6 +252,7 @@
 - [x] gameplay-inventory-snapshot-sync (PRD-ENGINEERING-024/025) [test_tier_required]: 继续收口 repository health 巡检发现的 `doc/game/gameplay` 热点入口与 game 文件级索引库存快照漂移，将 gameplay 子域计数同步到 2026-06-23 `doc-inventory-report` 当前值，同时保留专题拆分统计的原范围。 Trace: .pm/tasks/task_7ba4f8f2edcf4403824a79c15f5038d2.yaml
 - [x] launcher-inventory-snapshot-sync (PRD-ENGINEERING-024/025) [test_tier_required]: 继续收口 repository health 巡检发现的 `doc/world-simulator/launcher` 热点入口库存快照漂移，将父级 world-simulator 计数同步到 2026-06-23 `doc-inventory-report` 当前值，同时保留 launcher 子域 87 份 Markdown 的现行热点分流语义。 Trace: .pm/tasks/task_61d9adfc0059495c9efdfe7ed073ae1b.yaml
 - [x] readme-governance-inventory-snapshot-sync (PRD-ENGINEERING-024/025) [test_tier_required]: 继续收口 repository health 巡检发现的 `doc/readme/governance` 热点入口与 readme 文件级索引库存快照漂移，将 readme 父级计数同步到 2026-06-23 `doc-inventory-report` 当前值，同时保留 governance 子域 76 份 Markdown 的现行热点分流语义。 Trace: .pm/tasks/task_c6234900cbaf48f49499877b8f838e7b.yaml
+- [x] world-runtime-inventory-snapshot-sync (PRD-ENGINEERING-024/025) [test_tier_required]: 继续收口 repository health 巡检发现的 `doc/world-runtime` 模块入口与文件级索引库存快照漂移，将 world-runtime/runtime/evidence 计数同步到 2026-06-23 `doc-inventory-report` 当前值，同时保留 runtime / wasm / module 热点分流语义。 Trace: .pm/tasks/task_5da43be9aa8f4bb39b6635d4b147d54f.yaml
 
 ## File Structure / Affected Paths
 - `local-cargo-cache-script-convergence`: 预计改动 `scripts/cargo-dev-lib.sh`、`scripts/cargo-dev-lib.test.sh`、本地 smoke / playtest / prewarm 脚本、`scripts/prepare-task-pr.sh` 的 preflight 修复、`testing-manual.md`、`doc/scripts/{README.md,prd.md}`、`AGENTS.md` 与本 task execution log；只读依赖 `scripts/cargo-dev.sh`、`scripts/ci-tests.sh`、`scripts/build-wasm-module.sh`、release workflow；验证入口为 `bash -n ...`、`./scripts/cargo-dev-lib.test.sh`、相关脚本 `--help`/`--dry-run` smoke、`./scripts/prepare-task-pr.test.sh`、`./scripts/pm/lint.sh`、`./scripts/doc-governance-check.sh` 与 `git diff --check`。 Trace: .pm/tasks/task_46ea1c81166043e3a1e3d5899b618ae6.yaml
@@ -320,7 +321,7 @@
 - 更新日期: 2026-06-23
 - 当前状态: active
 - 下一任务: 当前 `scripts/doc-inventory-report.sh` 复算显示 near-limit active docs 为 none；后续 repository health 巡检应按 module density / hotspot `action_required` 结果做 bounded 分类判断，先分级再切 focused follow-up，避免回到已收口的 `doc/world-simulator/project.md` / `doc/readme/project.md` 队列。
-- 最新完成: `readme-governance-inventory-snapshot-sync`（已把 `doc/readme/governance` 热点入口与 readme 文件级索引库存快照同步到 2026-06-23 inventory truth，保留后续按 action_required 热点做 bounded 分类巡检的口径。）
+- 最新完成: `world-runtime-inventory-snapshot-sync`（已把 `doc/world-runtime` 模块入口与文件级索引库存快照同步到 2026-06-23 inventory truth，保留后续按 action_required 热点做 bounded 分类巡检的口径。）
 - PRD 质量门状态: strict schema 已对齐（含第 6 章验证与决策记录）。
 - 当前治理重点: P0/P1 技术债首轮优化正在收口，重点是 public_testnet readiness blocker 显式化、hosted access verdict 去半实现口径，以及 Viewer 前端状态模块化。
 - 当前库存判断: 文档债的主矛盾仍是“入口减重之后的存量维护成本”，不是继续扩更多 landing pages。复算入口仍以 `scripts/doc-inventory-report.sh` 为准。

--- a/doc/world-runtime/README.md
+++ b/doc/world-runtime/README.md
@@ -36,12 +36,12 @@
 - 汇总 runtime / wasm / module / governance / integration / testing 六类专题。
 - 承接候选级证据、发布门禁指标与跨模块 runtime 收口事项。
 
-## 热点子域导航（2026-04-20 快照）
-- `runtime/`（55）：运行时主链路、数值正确性、存储治理、retention 与 replay contract。
+## 热点子域导航（2026-06-23 快照）
+- `runtime/`（57）：运行时主链路、数值正确性、存储治理、retention 与 replay contract。
 - `wasm/`（25）：Docker canonical build、执行器、观测指标、模块级 observe runner、SDK、sandbox 与 ABI 治理。
 - `module/`（16）：模块生命周期、线上发布合法性、模块存储与订阅过滤专题。
 - 根目录入口与 handoff（9）：模块主入口与 runtime 候选/验证交接留痕。
-- `evidence/`（6）：候选级指标、soak、storage gate 与 profile consistency 采证。
+- `evidence/`（7）：候选级指标、soak、storage gate 与 profile consistency 采证。
 - `governance/`（5）：治理事件与收据安全专题。
 
 ## 高密度提示

--- a/doc/world-runtime/prd.index.md
+++ b/doc/world-runtime/prd.index.md
@@ -2,7 +2,7 @@
 
 审计轮次: 8
 
-更新时间：2026-06-16
+更新时间：2026-06-23
 
 ## 入口
 - 模块 PRD：`doc/world-runtime/prd.md`
@@ -20,13 +20,13 @@
 - 想直接进入线上模块发布合法性与 binary-only 边界：先读 `doc/world-runtime/module/online-module-release-legality-closure-2026-03-08.prd.md`
 - 想继续按子域或文件名下钻：使用下方热点子域导航，再跳到对应清单区域
 
-## 密度快照（2026-04-20）
-- `doc/world-runtime/`：121 份文件
-- `doc/world-runtime/runtime/`：55 份文件
+## 密度快照（2026-06-23）
+- `doc/world-runtime/`：124 份文件
+- `doc/world-runtime/runtime/`：57 份文件
 - `doc/world-runtime/wasm/`：25 份文件
 - `doc/world-runtime/module/`：16 份文件
 - 根目录入口与 handoff：9 份文件
-- `doc/world-runtime/evidence/`：6 份文件
+- `doc/world-runtime/evidence/`：7 份文件
 - `doc/world-runtime/governance/`：5 份文件
 - `doc/world-runtime/templates/`：2 份文件
 - `doc/world-runtime/checklists/`：1 份文件
@@ -34,11 +34,11 @@
 ## 热点子域导航
 | 子域 | 文件数 | 适合回答的问题 |
 | --- | --- | --- |
-| `runtime/` | 55 | 确定性运行时主链路、数值正确性、retention / GC、replay contract 与存储预算 |
+| `runtime/` | 57 | 确定性运行时主链路、数值正确性、retention / GC、replay contract 与存储预算 |
 | `wasm/` | 25 | Docker canonical build、执行器、模块级 observe runner、SDK、sandbox、ABI 与发布工件治理 |
 | `module/` | 16 | 模块生命周期、线上发布合法性、模块存储与订阅过滤边界 |
 | 根目录入口与 handoff | 9 | 模块主入口、候选收口交接与当前高频导航 |
-| `evidence/` | 6 | 候选级指标、storage gate、profile consistency 与 soak 采证 |
+| `evidence/` | 7 | 候选级指标、storage gate、profile consistency 与 soak 采证 |
 | `governance/` | 5 | 治理事件、收据安全与运行时审计边界 |
 
 ## 活跃补充文档


### PR DESCRIPTION
## Summary
- sync `doc/world-runtime` inventory snapshot counts/date to current 2026-06-23 doc inventory truth
- update engineering project trace/latest-complete for the governance task
- record repository-health, QA, runtime, WASM, and producer/system local review evidence

## Verification
- `bash scripts/doc-inventory-report.sh`
- direct world-runtime Markdown counts: 124 / 57 / 7 / 25 / 16 / 5 / 2 / 1
- `./scripts/doc-governance-check.sh`
- `./scripts/pm/workflow-lint.sh --task-uid task_5da43be9aa8f4bb39b6635d4b147d54f --phase current`
- `git diff --check`
