### PR TITLE
Refresh AppImage runtime checksum

### DIFF
--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -381,7 +381,7 @@ jobs:
           APPIMAGETOOL_SHA256="ed4ce84f0d9caff66f50bcca6ff6f35aae54ce8135408b3fa33abfc3cb384eb0"
           APPIMAGE_RUNTIME_FILENAME="runtime-x86_64"
           APPIMAGE_RUNTIME_URL="https://github.com/AppImage/type2-runtime/releases/download/continuous/${APPIMAGE_RUNTIME_FILENAME}"
-          APPIMAGE_RUNTIME_SHA256="a2419dce47568395ae79c01ffa9a5a341dd339581352ff104d073527543177e5"
+          APPIMAGE_RUNTIME_SHA256="1cc49bcf1e2ccd593c379adb17c9f85a36d619088296504de95b1d06215aebbf"
 
           mkdir -p "${RUNNER_TEMP}/appimagetool"
           curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 "${APPIMAGETOOL_URL}" \

--- a/.github/workflows/testnet-packages.yml
+++ b/.github/workflows/testnet-packages.yml
@@ -168,7 +168,7 @@ jobs:
           APPIMAGETOOL_SHA256="ed4ce84f0d9caff66f50bcca6ff6f35aae54ce8135408b3fa33abfc3cb384eb0"
           APPIMAGE_RUNTIME_FILENAME="runtime-x86_64"
           APPIMAGE_RUNTIME_URL="https://github.com/AppImage/type2-runtime/releases/download/continuous/${APPIMAGE_RUNTIME_FILENAME}"
-          APPIMAGE_RUNTIME_SHA256="a2419dce47568395ae79c01ffa9a5a341dd339581352ff104d073527543177e5"
+          APPIMAGE_RUNTIME_SHA256="1cc49bcf1e2ccd593c379adb17c9f85a36d619088296504de95b1d06215aebbf"
 
           mkdir -p "${RUNNER_TEMP}/appimagetool"
           curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 "${APPIMAGETOOL_URL}" \

--- a/.pm/roles/repository_health_engineer/backlog/committed.yaml
+++ b/.pm/roles/repository_health_engineer/backlog/committed.yaml
@@ -1,4 +1,14 @@
 version: 1
 role: repository_health_engineer
 status: committed
-tasks: []
+tasks:
+  - task_uid: task_632b598269da4a26b9571713091aed4b
+    title: "Refresh AppImage runtime checksum for release packages"
+    priority: P2
+    source_signal: null
+    related_prd: []
+    acceptance:
+      - "testnet and release Linux package jobs use the current verified AppImage type2 runtime sha256"
+    handoff_to: []
+    status: committed
+    task_path: .pm/tasks/task_632b598269da4a26b9571713091aed4b.yaml

--- a/.pm/tasks/task_632b598269da4a26b9571713091aed4b.execution.md
+++ b/.pm/tasks/task_632b598269da4a26b9571713091aed4b.execution.md
@@ -1,0 +1,42 @@
+# task_632b598269da4a26b9571713091aed4b Execution Log
+
+- task_uid: task_632b598269da4a26b9571713091aed4b
+- title: Refresh AppImage runtime checksum for release packages
+- owner_role: repository_health_engineer
+- worktree_hint: /Users/scc/ccwork/worktrees/oasis7-release-appimage-runtime-checksum-refresh
+
+<!-- Append entries using:
+Example:
+  ## YYYY-MM-DD HH:MM:SS CST / role_name
+  - 完成内容: ...
+  - 遗留事项: ...
+  - Action: ...
+  - Validation Command: ...
+  - Expected Result: ...
+  - Actual Result: ...
+  - Blocker / Next Action: ...
+-->
+
+## 2026-06-24 12:06:00 CST / tpm
+- 完成内容: Bound task/worktree bootstrap for the package CI blocker discovered while rolling out PR #590.
+- 遗留事项: none for bootstrap.
+- Action: created standard task worktree and assigned owner role `repository_health_engineer`.
+- Validation Command: `./scripts/new-task-worktree.sh release appimage-runtime-checksum-refresh ... --json`
+- Expected Result: task worktree and `.pm` task are created from `origin/main`.
+- Actual Result: worktree `/Users/scc/ccwork/worktrees/oasis7-release-appimage-runtime-checksum-refresh`, branch `task/release-appimage-runtime-checksum-refresh`, task UID `task_632b598269da4a26b9571713091aed4b`.
+- Blocker / Next Action: fix stale AppImage type2 runtime checksum in package workflows.
+
+## 2026-06-24 12:08:00 CST / repository_health_engineer
+- 完成内容: Updated the pinned `runtime-x86_64` SHA256 used by Linux AppImage packaging in both `testnet-packages.yml` and `release-packages.yml`.
+- 遗留事项: CI rerun required after PR merge to prove Linux package job passes on GitHub-hosted runner.
+- Action: replaced stale `a2419dce47568395ae79c01ffa9a5a341dd339581352ff104d073527543177e5` with verified current `1cc49bcf1e2ccd593c379adb17c9f85a36d619088296504de95b1d06215aebbf`.
+- Validation Command: `for file in .github/workflows/testnet-packages.yml .github/workflows/release-packages.yml; do grep -q "$new" "$file"; ! grep -q "$old" "$file"; done`
+- Expected Result: both workflows contain the new checksum and no stale checksum.
+- Actual Result: passed; both workflow files reported ok.
+- Validation Command: `python3 - <<'PY' ... yaml.safe_load(...) ... PY`
+- Expected Result: both workflow YAML files parse.
+- Actual Result: passed for `.github/workflows/testnet-packages.yml` and `.github/workflows/release-packages.yml`.
+- Validation Command: `git diff --check`
+- Expected Result: no whitespace errors.
+- Actual Result: passed.
+- Blocker / Next Action: complete PR review/merge, then rerun `Testnet Packages` with `package_scope=all_existing`.

--- a/.pm/tasks/task_632b598269da4a26b9571713091aed4b.yaml
+++ b/.pm/tasks/task_632b598269da4a26b9571713091aed4b.yaml
@@ -1,0 +1,18 @@
+task_uid: task_632b598269da4a26b9571713091aed4b
+title: "Refresh AppImage runtime checksum for release packages"
+owner_role: repository_health_engineer
+worktree_hint: /Users/scc/ccwork/worktrees/oasis7-release-appimage-runtime-checksum-refresh
+execution_log_path: .pm/tasks/task_632b598269da4a26b9571713091aed4b.execution.md
+status: committed
+priority: P2
+source_signal: null
+source_refs:
+  - .github/workflows/testnet-packages.yml
+  - .github/workflows/release-packages.yml
+doc_refs: []
+related_prd: []
+acceptance:
+  - "testnet and release Linux package jobs use the current verified AppImage type2 runtime sha256"
+handoff_to: []
+updated_at: 2026-06-24T12:05:25+08:00
+last_started_at: 2026-06-24T12:05:25+08:00


### PR DESCRIPTION
## Summary
- refresh the pinned AppImage type2 runtime checksum used by Linux package jobs
- apply the same checksum to both testnet and release package workflows
- record the package-CI blocker and verification in the task log

## Evidence
- `runtime-x86_64` downloaded from AppImage type2-runtime continuous release verified locally as `1cc49bcf1e2ccd593c379adb17c9f85a36d619088296504de95b1d06215aebbf`
- `for file in .github/workflows/testnet-packages.yml .github/workflows/release-packages.yml; do grep -q "$new" "$file"; ! grep -q "$old" "$file"; done`
- `python3 - <<'PY' ... yaml.safe_load(...) ... PY`
- `./scripts/pm/workflow-lint.sh --task-uid task_632b598269da4a26b9571713091aed4b --phase current`
- `./scripts/doc-governance-check.sh`
- `git diff --check`

## Context
This unblocks `Testnet Packages` run `28073976449`, where `package-linux-x64` failed during `Ensure Linux AppImage tooling` because the runtime checksum drifted while `appimagetool` itself still verified successfully.
