### PR TITLE
Clean up wasm executor Clippy debt

### DIFF
--- a/.pm/tasks/task_6b2fff9186a844a4b427f21ecf90822a.execution.md
+++ b/.pm/tasks/task_6b2fff9186a844a4b427f21ecf90822a.execution.md
@@ -94,6 +94,36 @@ Example:
 - Actual Result: All four required slices returned no_findings. Residual risk is low; branch is behind origin/main by 3 commits, to be handled by normal PR CI/mergeability watch.
 - Blocker / Next Action: Run final local closeout checks and prepare PR. Pre-PR Local Role Review: passed
 
+## 2026-06-24 12:51:10 CST / tpm
+- 完成内容: STRUCTURED PRE-PR LOCAL ROLE REVIEW PACKET RECORDED.
+- 遗留事项: prepare PR and enter normal CI/comments/mergeability watch.
+- Action: recorded the parser-facing pre-PR local role review packet after code/doc commit, using the reviewed source commit as Source Head and leaving only task evidence updates after review.
+- Validation Command: `git rev-parse HEAD`; `git diff --name-only 2a7cda0eb..HEAD`; `./scripts/prepare-task-pr.sh` preflight pending after evidence commit.
+- Expected Result: prepare-task-pr can match source worktree, branch, reviewed source head, comparison ref, review roles, evidence fields, and verification matrix.
+- Actual Result: review packet below references commit `2a7cda0ebc5354841bb4ee6dd7bc31b304a5fcf3`; post-review changes are limited to this task execution log evidence entry.
+- Blocker / Next Action: commit evidence-only packet, run prepare-task-pr, create PR.
+- Pre-PR Local Role Review: passed
+- Task UID: task_6b2fff9186a844a4b427f21ecf90822a
+- Source Worktree: /Users/scc/ccwork/worktrees/oasis7-engineering-repository-health-next-issue-20260624c
+- Source Branch: task/engineering-repository-health-next-issue-20260624c
+- Source Head: 2a7cda0ebc5354841bb4ee6dd7bc31b304a5fcf3
+- Comparison Ref: refs/remotes/origin/main
+- Reviewed Changed Paths: .pm/tasks/task_6b2fff9186a844a4b427f21ecf90822a.execution.md; .pm/tasks/task_6b2fff9186a844a4b427f21ecf90822a.yaml; crates/oasis7_wasm_executor/src/lib.rs; crates/oasis7_wasm_executor/src/metrics.rs; doc/engineering/project.md
+- Review Package: n/a - bounded role reviews were dispatched directly and recorded in this execution log.
+- Role Selection Basis: changed `crates/oasis7_wasm_executor/**` requires wasm_platform_engineer; verification/readiness claim requires qa_engineer; repository health governance cleanup requires repository_health_engineer; `doc/engineering/project.md` trace update requires producer_system_designer.
+- Review Roles: wasm_platform_engineer,qa_engineer,repository_health_engineer,producer_system_designer
+- Review Evidence: wasm_platform_engineer agent 019ef7ee-e5fb-7741-9051-5d6628a134ef no_findings; qa_engineer agent 019ef7ef-55c5-7eb3-84dd-1d45f71bff6c no_findings; repository_health_engineer agent 019ef7ef-5660-7cd1-9455-b9b0c7f4dd7b no_findings; producer_system_designer agent 019ef7ef-56f0-71c1-8264-a4e75f8e58d1 no_findings.
+- Review Verdicts: wasm_platform_engineer approved executor metrics cfg and sandbox expression rewrites as semantic-preserving; qa_engineer approved focused verification coverage; repository_health_engineer approved scope closure and confirmed no main-worktree pollution in touched executor files; producer_system_designer approved project trace and PRD mapping with no new product/system promise.
+- Review Findings Disposition: no_findings
+- Finding Disposition Evidence: all required role slices returned no_findings; no code or doc follow-up changes required by review.
+- Verification Matrix: Rust format -> `env -u RUSTC_WRAPPER cargo fmt --check` passed; default Clippy -> `env -u RUSTC_WRAPPER cargo clippy -p oasis7_wasm_executor --lib -- -D warnings` passed; wasmtime Clippy -> `env -u RUSTC_WRAPPER cargo clippy -p oasis7_wasm_executor --lib --features wasmtime -- -D warnings` passed; default lib tests -> 8 passed; wasmtime lib tests -> 21 passed, 1 ignored local perf probe; Rust file-size -> `./scripts/check-rust-file-size.sh` OK; task workflow -> `./scripts/pm/workflow-lint.sh --task-uid task_6b2fff9186a844a4b427f21ecf90822a --phase current` OK; whitespace -> `git diff --check` passed.
+- Visual Evidence: n/a - no player-visible UI, visual, screenshot, or browser surface changed.
+- WASM Evidence: `oasis7_wasm_executor` default and `wasmtime` Clippy/tests passed; wasm_platform_engineer reviewed metrics cfg and sandbox fallback semantics with no_findings.
+- Ops Evidence: n/a - no deployment, operator runbook, packaging, rollback, or service topology changed.
+- LiveOps Evidence: n/a - no external messaging, release note, player promise, incident, or community channel runbook changed.
+- Residual Risk: low; branch was observed behind `origin/main` and should rely on normal PR CI/mergeability watch.
+- Slice Ledger: this execution log.
+
 ## 2026-06-24 12:48:28 CST / tpm
 - 完成内容: TASK CLOSEOUT RECORDED WITH CURRENT-TASK VERIFICATION; REPO-WIDE PM LINT HAS HISTORICAL DEBT.
 - 遗留事项: commit task slice, write final Source Head review packet, prepare PR, then watch CI/comments/mergeability.

--- a/.pm/tasks/task_6b2fff9186a844a4b427f21ecf90822a.execution.md
+++ b/.pm/tasks/task_6b2fff9186a844a4b427f21ecf90822a.execution.md
@@ -1,0 +1,104 @@
+# task_6b2fff9186a844a4b427f21ecf90822a Execution Log
+
+- task_uid: task_6b2fff9186a844a4b427f21ecf90822a
+- title: Clean up wasm executor focused Clippy debt
+- owner_role: tpm
+- worktree_hint: /Users/scc/ccwork/worktrees/oasis7-engineering-repository-health-next-issue-20260624c
+
+<!-- Append entries using:
+Example:
+  ## YYYY-MM-DD HH:MM:SS CST / role_name
+  - 完成内容: ...
+  - 遗留事项: ...
+  - Action: ...
+  - Validation Command: ...
+  - Expected Result: ...
+  - Actual Result: ...
+  - Blocker / Next Action: ...
+-->
+
+## 2026-06-24 12:03:18 CST / tpm
+- 完成内容: WORKFLOW BOOTSTRAP DECIDED.
+- 遗留事项: repository_health_engineer inspection slice pending.
+- Action: created and bound the standard task worktree, task truth, route, and subagent slice plan before professional repository-health judgment.
+- Repository State Impact: likely repository-changing if a valid focused governance issue is found; user asked to continue finding the next issue after the merged Rust/WASM router cleanup.
+- Isolation Decision: main worktree was clean and aligned with `origin/main`; created dedicated task worktree `/Users/scc/ccwork/worktrees/oasis7-engineering-repository-health-next-issue-20260624c` on branch `task/engineering-repository-health-next-issue-20260624c`.
+- Task Truth: owner role `tpm`; `.pm` task `task_6b2fff9186a844a4b427f21ecf90822a`; formal docs `doc/engineering/project.md`.
+- Routed Next Phase: repo-owned workflow router -> bounded repository_health_engineer inspection, then execute a focused fix only if a valid governance issue is found.
+- Required Writeback: `.pm/tasks/task_6b2fff9186a844a4b427f21ecf90822a.execution.md` mandatory; `doc/engineering/project.md` only if a fix/task result needs formal project trace; PRD update only if governance policy changes.
+- Subagent Slice Plan:
+  - role: repository_health_engineer
+  - slice type: read-only repository health inspection with exactly one actionable finding recommendation or no_findings
+  - intended model configuration: workflow source-of-truth Default subagent runtime
+  - actual dispatched model/reasoning: inherited/unverified unless tool reports otherwise
+  - context delivery mode: full-thread/full-history fork preferred; explicit prompt contains mandatory context checklist as delivery supplement
+  - mandatory context checklist/packet: identity and authority = repository_health_engineer bounded slice under TPM; workflow governance = AGENTS.md + source-of-truth; task truth = `task_6b2fff9186a844a4b427f21ecf90822a`; user intent = find next repository-health governance issue; scoped repo context = first-party code/docs/scripts/PM evidence, recent completed governance tasks, and current engineering project status; collaboration boundary = no file edits, return findings/no_findings only
+  - write scope: none for subagent
+  - return contract: findings/no_findings with severity, category, file/line/command evidence, owner suggestion, smallest fix, verification commands, residual risk, and additional required role slices
+  - formal sink / writeback surface: this execution log
+  - integration owner/order: TPM records slice result, then applies only a validated focused fix if one is accepted
+  - context exemption: none
+- Validation Command: `./scripts/new-task-worktree.sh ... --pm-*`; `sed -n` on task truth and role card; `git status --short --branch`.
+- Expected Result: task/worktree truth exists before professional repository-health judgment.
+- Actual Result: task/worktree created and bound; route and repository_health_engineer slice contract recorded.
+- Blocker / Next Action: dispatch repository_health_engineer slice and collect non-authoritative mechanical evidence while waiting.
+
+## 2026-06-24 12:11:32 CST / repository_health_engineer
+- 完成内容: READ-ONLY REPOSITORY HEALTH INSPECTION RESULT: findings.
+- 遗留事项: TPM to integrate the accepted finding with a focused fix and verification.
+- Action: inspected first-party repository health signals and ran focused package Clippy checks to find one actionable, non-duplicate governance issue.
+- Finding: P3 Rust code-health lint debt: `oasis7_wasm_executor` fails focused Clippy `-D warnings` on feature-gated metrics hygiene.
+- Evidence Command: `env -u RUSTC_WRAPPER cargo clippy -p oasis7_wasm_executor --lib -- -D warnings`.
+- Evidence Result: failed with five Clippy errors.
+- Evidence Paths:
+  - `crates/oasis7_wasm_executor/src/metrics.rs:121`: `observe_wasm_executor_compile` is dead under default features.
+  - `crates/oasis7_wasm_executor/src/metrics.rs:145`: `observe_wasm_executor_instantiate` is dead under default features.
+  - `crates/oasis7_wasm_executor/src/metrics.rs:152`: `observe_wasm_executor_entrypoint_call` is dead under default features.
+  - `crates/oasis7_wasm_executor/src/metrics.rs:164`: `observe_wasm_executor_decode` is dead under default features.
+  - `crates/oasis7_wasm_executor/src/lib.rs:932`: needless `return result;` in the non-`wasmtime` fallback branch.
+- Governance Rationale: this is a new first-party Rust package lint failure in `oasis7_wasm_executor`, distinct from the completed `oasis7_wasm_abi` and `oasis7_wasm_router` focused Clippy cleanups; it is small, reproducible, and blocks treating focused package Clippy as a reliable governance signal for this crate.
+- Smallest Safe Fix: gate the four metrics observer helpers with `#[cfg(feature = "wasmtime")]` and remove needless `return result` tail returns without changing counters, snapshots, public snapshot helpers, or sandbox failure semantics.
+- Required Follow-up Role Slices: `wasm_platform_engineer` for executor metrics and sandbox fallback semantic equivalence; `qa_engineer` for verification sufficiency; `repository_health_engineer` for pre-PR closure.
+- Residual Risk: low; `oasis7_wasm_executor` touches sandbox execution and metrics, so semantic review must confirm no default-feature fallback or `wasmtime` metric behavior drift.
+- Attribution Boundary: bounded repository_health_engineer read-only inspection; no file edits by subagent.
+- TPM Integration Action: accepted finding and applied smallest safe code-health fix in `crates/oasis7_wasm_executor/src/metrics.rs` and `crates/oasis7_wasm_executor/src/lib.rs`.
+- Validation Command: `env -u RUSTC_WRAPPER cargo clippy -p oasis7_wasm_executor --lib -- -D warnings`; `bash scripts/check-rust-file-size.sh`.
+- Expected Result: identify one focused, reproducible governance issue or no_findings, avoiding recent completed cleanup topics.
+- Actual Result: found focused `oasis7_wasm_executor` Clippy debt with file/line evidence and a minimal fix recommendation; Rust file-size scan stayed green.
+- Blocker / Next Action: run focused formatting, default/wasmtime Clippy, default/wasmtime tests, Rust-size, and whitespace verification.
+
+## 2026-06-24 12:27:48 CST / tpm
+- 完成内容: IMPLEMENTATION + FOCUSED VERIFICATION COMPLETE: cleaned oasis7_wasm_executor focused Clippy debt.
+- 遗留事项: pre-PR bounded role review, closeout, PR creation, CI/comments watch, and merge path.
+- Action: Gated wasmtime-only metrics observer helpers with cfg(feature = "wasmtime"), removed needless tail returns in both sandbox branches, applied wasmtime-feature Clippy idioms for request limit propagation, memory page sizing, and div_ceil, updated engineering project trace and task title.
+- Validation Command: env -u RUSTC_WRAPPER cargo fmt --check; env -u RUSTC_WRAPPER cargo clippy -p oasis7_wasm_executor --lib -- -D warnings; env -u RUSTC_WRAPPER cargo clippy -p oasis7_wasm_executor --lib --features wasmtime -- -D warnings; env -u RUSTC_WRAPPER cargo test -p oasis7_wasm_executor --lib; env -u RUSTC_WRAPPER cargo test -p oasis7_wasm_executor --lib --features wasmtime; ./scripts/check-rust-file-size.sh; ./scripts/pm/workflow-lint.sh --task-uid task_6b2fff9186a844a4b427f21ecf90822a --phase current; git diff --check
+- Expected Result: Default and wasmtime focused package Clippy pass with -D warnings; default and wasmtime lib tests pass; governance lint, Rust file-size gate, formatting, and whitespace checks pass.
+- Actual Result: All listed focused verification commands passed. Default tests: 8 passed. Wasmtime tests: 21 passed, 1 ignored local perf probe. Rust file-size gate reported oversized code files=0, test files=0, structural slice files=0. Cargo lock waits were caused by another worktree's shared-target build and resolved without changing CARGO_TARGET_DIR.
+- Blocker / Next Action: Dispatch/collect wasm_platform_engineer, qa_engineer, repository_health_engineer, and producer_system_designer pre-PR review slices, then run closeout and prepare PR.
+
+## 2026-06-24 12:41:12 CST / tpm
+- 完成内容: PRE-PR ROLE REVIEW DISPATCH ATTEMPT INTERRUPTED BY TOOL TRANSPORT.
+- 遗留事项: retry bounded role review slices with shorter prompts; do not attribute fallback TPM analysis as professional role conclusions.
+- Action: Attempted to dispatch wasm_platform_engineer, qa_engineer, repository_health_engineer, and producer_system_designer bounded read-only pre-PR review slices using full-history fork. All four agents errored before completion with transport/network response-body decode errors.
+- Validation Command: multi_agent_v1.spawn_agent and wait_agent notifications for agents 019ef7e3-43f7-7c10-9f5c-ddf22f04f815, 019ef7e3-4644-7120-8e64-df70bf2a37e1, 019ef7e3-4b98-7660-846c-6d05a4273f70, 019ef7e3-4f3d-7a41-94dc-5f78434dd74a
+- Expected Result: Each bounded professional role slice returns findings/no_findings for PR readiness.
+- Actual Result: All four slices failed due to tool transport disconnect before completion; no professional findings/no_findings were produced and no role conclusion is attributed from these failed slices.
+- Blocker / Next Action: Retry with shorter no-fork prompts containing explicit context packet; if tool policy still prevents dispatch, record limitation and fallback evidence path before deciding next workflow step.
+
+## 2026-06-24 12:45:40 CST / tpm
+- 完成内容: PRE-PR LOCAL ROLE REVIEW: collected all required bounded professional role slices.
+- 遗留事项: run closeout, prepare PR, and enter CI/comments watch.
+- Action: Integrated no_findings from wasm_platform_engineer, qa_engineer, repository_health_engineer, and producer_system_designer. wasm_platform_engineer approved executor metrics cfg and sandbox expression rewrites as semantic-preserving. qa_engineer approved focused verification coverage. repository_health_engineer approved scope closure and confirmed no main-worktree pollution in touched executor files. producer_system_designer approved project trace and PRD mapping without new product/system promise.
+- Validation Command: multi_agent_v1 bounded read-only review slices: wasm_platform_engineer agent 019ef7ee-e5fb-7741-9051-5d6628a134ef; qa_engineer agent 019ef7ef-55c5-7eb3-84dd-1d45f71bff6c; repository_health_engineer agent 019ef7ef-5660-7cd1-9455-b9b0c7f4dd7b; producer_system_designer agent 019ef7ef-56f0-71c1-8264-a4e75f8e58d1
+- Expected Result: Required pre-PR roles return findings/no_findings and residual risk for the focused executor Clippy cleanup.
+- Actual Result: All four required slices returned no_findings. Residual risk is low; branch is behind origin/main by 3 commits, to be handled by normal PR CI/mergeability watch.
+- Blocker / Next Action: Run final local closeout checks and prepare PR. Pre-PR Local Role Review: passed
+
+## 2026-06-24 12:48:28 CST / tpm
+- 完成内容: TASK CLOSEOUT RECORDED WITH CURRENT-TASK VERIFICATION; REPO-WIDE PM LINT HAS HISTORICAL DEBT.
+- 遗留事项: commit task slice, write final Source Head review packet, prepare PR, then watch CI/comments/mergeability.
+- Action: Ran task-closeout after claim-ready. The helper updated the current task to done with verified status and close timestamp, but exited non-zero during its repo-wide pm-lint tail because of unrelated historical execution-log format debt across many older task files.
+- Validation Command: ./scripts/pm/task-closeout.sh --role tpm --task-uid task_6b2fff9186a844a4b427f21ecf90822a --verify-command '<fresh focused verification matrix>'; ./scripts/pm/workflow-lint.sh --task-uid task_6b2fff9186a844a4b427f21ecf90822a --phase current
+- Expected Result: Current task records verified closeout, and any failure is separated between current-task truth and repo-wide historical debt.
+- Actual Result: Current task YAML now has status: done, last_claim_type: task_complete, last_verification_status: verified, last_closed_at: 2026-06-24T12:47:37+08:00. Current task workflow-lint passed. task-closeout exit code was 1 only because repo-wide pm-lint reported historical missing-field debt in unrelated older execution logs.
+- Blocker / Next Action: Do not edit unrelated historical PM debt in this task. Continue with commit and PR preflight using current-task evidence.

--- a/.pm/tasks/task_6b2fff9186a844a4b427f21ecf90822a.execution.md
+++ b/.pm/tasks/task_6b2fff9186a844a4b427f21ecf90822a.execution.md
@@ -100,13 +100,13 @@ Example:
 - Action: recorded the parser-facing pre-PR local role review packet after code/doc commit, using the reviewed source commit as Source Head and leaving only task evidence updates after review.
 - Validation Command: `git rev-parse HEAD`; `git diff --name-only 2a7cda0eb..HEAD`; `./scripts/prepare-task-pr.sh` preflight pending after evidence commit.
 - Expected Result: prepare-task-pr can match source worktree, branch, reviewed source head, comparison ref, review roles, evidence fields, and verification matrix.
-- Actual Result: review packet below references commit `2a7cda0ebc5354841bb4ee6dd7bc31b304a5fcf3`; post-review changes are limited to this task execution log evidence entry.
+- Actual Result: review packet below references commit `3970a896cac18be7f7fd13add2c604a124731940`; post-review changes are limited to this task execution log evidence entry.
 - Blocker / Next Action: commit evidence-only packet, run prepare-task-pr, create PR.
 - Pre-PR Local Role Review: passed
 - Task UID: task_6b2fff9186a844a4b427f21ecf90822a
 - Source Worktree: /Users/scc/ccwork/worktrees/oasis7-engineering-repository-health-next-issue-20260624c
 - Source Branch: task/engineering-repository-health-next-issue-20260624c
-- Source Head: 2a7cda0ebc5354841bb4ee6dd7bc31b304a5fcf3
+- Source Head: 3970a896cac18be7f7fd13add2c604a124731940
 - Comparison Ref: refs/remotes/origin/main
 - Reviewed Changed Paths: .pm/tasks/task_6b2fff9186a844a4b427f21ecf90822a.execution.md; .pm/tasks/task_6b2fff9186a844a4b427f21ecf90822a.yaml; crates/oasis7_wasm_executor/src/lib.rs; crates/oasis7_wasm_executor/src/metrics.rs; doc/engineering/project.md
 - Review Package: n/a - bounded role reviews were dispatched directly and recorded in this execution log.
@@ -132,3 +132,30 @@ Example:
 - Expected Result: Current task records verified closeout, and any failure is separated between current-task truth and repo-wide historical debt.
 - Actual Result: Current task YAML now has status: done, last_claim_type: task_complete, last_verification_status: verified, last_closed_at: 2026-06-24T12:47:37+08:00. Current task workflow-lint passed. task-closeout exit code was 1 only because repo-wide pm-lint reported historical missing-field debt in unrelated older execution logs.
 - Blocker / Next Action: Do not edit unrelated historical PM debt in this task. Continue with commit and PR preflight using current-task evidence.
+
+## 2026-06-24 13:14:08 CST / tpm
+- 完成内容: PRE-PR TARGETED REQUIRED GATE PASSED.
+- 遗留事项: create PR and enter normal PR CI/comments/mergeability watch.
+- Action: Ran prepare-task-pr recommended targeted required command directly because claim-ready rejects non-completion claims after the task has already been closed as done.
+- Validation Command: OASIS7_CI_RUN_OASIS7_REQUIRED_TESTS=true OASIS7_CI_RUN_CONSENSUS_TESTS=false OASIS7_CI_RUN_DISTFS_TESTS=false OASIS7_CI_RUN_OASIS7_NODE_TESTS=false OASIS7_CI_RUN_OASIS7_NET_TESTS=false OASIS7_CI_RUN_OASIS7_NET_LIBP2P_TESTS=false OASIS7_CI_RUN_VIEWER_CONTRACT_TESTS=false OASIS7_CI_RUN_VIEWER_WASM_CHECK=false OASIS7_CI_RUN_VIEWER_PERF_SMOKE=false OASIS7_CI_RUN_LAUNCHER_WEB_BUILD=false OASIS7_CI_RUN_WORKSPACE_SUPPORT_CRATE_TESTS=true ./scripts/ci-tests.sh required
+- Expected Result: Targeted required gate passes for the changed WASM support/runtime support surface.
+- Actual Result: Passed with exit code 0. Covered doc-governance, skill lint, Windows path check, script executable bits, cargo-dev-lib tests, rust required scope planner test, terminology scan test, release gate preflight test, local letai game test CLI smoke, provider remote HTTPS contract tests, oasis7_newapi_bridge_service tests, Rust file-size, cargo fmt --all --check, cargo deny advisories, oasis7 test_tier_required tests, workspace support crate lib tests, oasis7_wasm_executor wasmtime lib tests, oasis7_client_launcher bin tests, and oasis7 correctness/suspicious Clippy subset. Existing non-denied warnings were observed but did not fail the command.
+- Blocker / Next Action: Commit evidence-only update, run prepare-task-pr --create, then watch PR checks/comments/mergeability.
+
+## 2026-06-24 13:19:16 CST / tpm
+- 完成内容: POST-REBASE VERIFICATION PASSED.
+- 遗留事项: force-push rebased branch and continue PR CI/comments/mergeability watch.
+- Action: Rebased the PR branch onto current origin/main after GitHub reported mergeStateStatus=DIRTY. Resolved the only conflict in doc/engineering/project.md by preserving the mainline doc-inventory-report-executable-mode entry and appending this wasm-executor completion entry. Updated the pre-PR review packet Source Head to the rebased code/doc commit.
+- Validation Command: env -u RUSTC_WRAPPER cargo fmt --check; env -u RUSTC_WRAPPER cargo clippy -p oasis7_wasm_executor --lib -- -D warnings; env -u RUSTC_WRAPPER cargo clippy -p oasis7_wasm_executor --lib --features wasmtime -- -D warnings; env -u RUSTC_WRAPPER cargo test -p oasis7_wasm_executor --lib; env -u RUSTC_WRAPPER cargo test -p oasis7_wasm_executor --lib --features wasmtime; ./scripts/check-rust-file-size.sh; ./scripts/pm/workflow-lint.sh --task-uid task_6b2fff9186a844a4b427f21ecf90822a --phase current; git diff --check
+- Expected Result: Focused checks pass after branch sync and conflict resolution.
+- Actual Result: Passed. Default tests: 8 passed. Wasmtime tests: 21 passed, 1 ignored local perf probe. Rust file-size OK. Workflow-lint current OK. No conflict markers or whitespace errors remain.
+- Blocker / Next Action: Amend evidence commit, run prepare-task-pr preflight, push with --force-with-lease, and watch PR #596.
+
+## 2026-06-24 13:40:26 CST / tpm
+- 完成内容: SECOND POST-REBASE VERIFICATION PASSED.
+- 遗留事项: force-push rebased branch and continue PR #596 watch.
+- Action: Rebased again after main advanced during CI watch and GitHub returned mergeStateStatus=DIRTY. Resolved doc/engineering/project.md by preserving the new rustsec-advisory-ignore-baseline-ratchet entry from main and appending this wasm-executor completion entry. Updated review packet Source Head to the latest rebased code/doc commit.
+- Validation Command: env -u RUSTC_WRAPPER cargo fmt --check; env -u RUSTC_WRAPPER cargo clippy -p oasis7_wasm_executor --lib -- -D warnings; env -u RUSTC_WRAPPER cargo clippy -p oasis7_wasm_executor --lib --features wasmtime -- -D warnings; env -u RUSTC_WRAPPER cargo test -p oasis7_wasm_executor --lib; env -u RUSTC_WRAPPER cargo test -p oasis7_wasm_executor --lib --features wasmtime; ./scripts/check-rust-file-size.sh; ./scripts/pm/workflow-lint.sh --task-uid task_6b2fff9186a844a4b427f21ecf90822a --phase current; git diff --check
+- Expected Result: Focused checks pass after second branch sync and conflict resolution.
+- Actual Result: Passed. Default tests: 8 passed. Wasmtime tests: 21 passed, 1 ignored local perf probe. Rust file-size OK. Workflow-lint current OK. No conflict markers or whitespace errors remain.
+- Blocker / Next Action: Amend evidence commit, run prepare-task-pr preflight, push with --force-with-lease, and watch PR #596.

--- a/.pm/tasks/task_6b2fff9186a844a4b427f21ecf90822a.yaml
+++ b/.pm/tasks/task_6b2fff9186a844a4b427f21ecf90822a.yaml
@@ -1,0 +1,28 @@
+task_uid: task_6b2fff9186a844a4b427f21ecf90822a
+title: "Clean up wasm executor focused Clippy debt"
+owner_role: tpm
+worktree_hint: /Users/scc/ccwork/worktrees/oasis7-engineering-repository-health-next-issue-20260624c
+execution_log_path: .pm/tasks/task_6b2fff9186a844a4b427f21ecf90822a.execution.md
+status: done
+priority: P2
+source_signal: null
+source_refs:
+  - doc/engineering/project.md
+doc_refs:
+  - doc/engineering/project.md
+related_prd:
+  - PRD-ENGINEERING-001
+  - PRD-ENGINEERING-021
+  - PRD-ENGINEERING-025
+acceptance:
+  - "Dispatch a bounded repository_health_engineer inspection slice and record findings/no_findings in the task execution log."
+  - "If a valid focused governance issue is found, apply the smallest safe fix with verification and prepare it for the normal PR watch/merge path."
+handoff_to: []
+updated_at: 2026-06-24T12:47:37+08:00
+last_started_at: 2026-06-24T12:01:46+08:00
+last_claim_type: task_complete
+last_verify_command: "env -u RUSTC_WRAPPER cargo fmt --check && env -u RUSTC_WRAPPER cargo clippy -p oasis7_wasm_executor --lib -- -D warnings && env -u RUSTC_WRAPPER cargo clippy -p oasis7_wasm_executor --lib --features wasmtime -- -D warnings && env -u RUSTC_WRAPPER cargo test -p oasis7_wasm_executor --lib && env -u RUSTC_WRAPPER cargo test -p oasis7_wasm_executor --lib --features wasmtime && ./scripts/check-rust-file-size.sh && ./scripts/pm/workflow-lint.sh --task-uid task_6b2fff9186a844a4b427f21ecf90822a --phase current && git diff --check"
+last_verified_at: 2026-06-24T12:47:36+08:00
+last_verification_exit_code: 0
+last_verification_status: verified
+last_closed_at: 2026-06-24T12:47:37+08:00

--- a/crates/oasis7_wasm_executor/src/lib.rs
+++ b/crates/oasis7_wasm_executor/src/lib.rs
@@ -629,9 +629,7 @@ impl ModuleSandbox for WasmExecutor {
         #[cfg(feature = "wasmtime")]
         {
             let result = (|| {
-                if let Err(failure) = self.validate_request_limits(request) {
-                    return Err(failure);
-                }
+                self.validate_request_limits(request)?;
 
                 if request.wasm_bytes.is_empty() {
                     return Err(self.failure(
@@ -773,11 +771,11 @@ impl ModuleSandbox for WasmExecutor {
                 }
                 if input_len > 0 {
                     const WASM_PAGE_SIZE: u64 = 65_536;
-                    let current_pages = memory.size(&store) as u64;
+                    let current_pages = memory.size(&store);
                     let current_size = current_pages.saturating_mul(WASM_PAGE_SIZE);
                     let needed_size = (input_ptr as u64).saturating_add(input_len as u64);
                     if needed_size > current_size {
-                        let required_pages = (needed_size + WASM_PAGE_SIZE - 1) / WASM_PAGE_SIZE;
+                        let required_pages = needed_size.div_ceil(WASM_PAGE_SIZE);
                         let delta = required_pages.saturating_sub(current_pages);
                         if delta > 0 {
                             memory.grow(&mut store, delta).map_err(|err| {
@@ -913,7 +911,7 @@ impl ModuleSandbox for WasmExecutor {
                 elapsed_ms(total_started),
                 result.as_ref().err().map(|failure| failure.code.clone()),
             );
-            return result;
+            result
         }
 
         #[cfg(not(feature = "wasmtime"))]
@@ -929,7 +927,7 @@ impl ModuleSandbox for WasmExecutor {
                 elapsed_ms(total_started),
                 result.as_ref().err().map(|failure| failure.code.clone()),
             );
-            return result;
+            result
         }
     }
 }

--- a/crates/oasis7_wasm_executor/src/metrics.rs
+++ b/crates/oasis7_wasm_executor/src/metrics.rs
@@ -118,6 +118,7 @@ pub fn snapshot_global_wasm_executor_metrics() -> WasmExecutorMetricsSnapshot {
     snapshot_wasm_executor_metrics(&shared)
 }
 
+#[cfg(feature = "wasmtime")]
 pub fn observe_wasm_executor_compile(
     metrics: &SharedWasmExecutorMetrics,
     cache_path: CompileCachePathKind,
@@ -142,6 +143,7 @@ pub fn observe_wasm_executor_compile(
     locked.deserialize_ms_total = locked.deserialize_ms_total.saturating_add(deserialize_ms);
 }
 
+#[cfg(feature = "wasmtime")]
 pub fn observe_wasm_executor_instantiate(metrics: &SharedWasmExecutorMetrics, instantiate_ms: u64) {
     let Ok(mut locked) = metrics.lock() else {
         return;
@@ -149,6 +151,7 @@ pub fn observe_wasm_executor_instantiate(metrics: &SharedWasmExecutorMetrics, in
     locked.instantiate_ms_total = locked.instantiate_ms_total.saturating_add(instantiate_ms);
 }
 
+#[cfg(feature = "wasmtime")]
 pub fn observe_wasm_executor_entrypoint_call(
     metrics: &SharedWasmExecutorMetrics,
     entrypoint_call_ms: u64,
@@ -161,6 +164,7 @@ pub fn observe_wasm_executor_entrypoint_call(
         .saturating_add(entrypoint_call_ms);
 }
 
+#[cfg(feature = "wasmtime")]
 pub fn observe_wasm_executor_decode(metrics: &SharedWasmExecutorMetrics, decode_ms: u64) {
     let Ok(mut locked) = metrics.lock() else {
         return;

--- a/doc/engineering/project.md
+++ b/doc/engineering/project.md
@@ -262,6 +262,7 @@
 - [x] doc-inventory-report-executable-mode (PRD-ENGINEERING-021/025) [test_tier_required]: 收口 repository health 巡检发现的 operator-facing doc/script contract drift，恢复 `scripts/doc-inventory-report.sh` 可直接执行的 Git mode，使手动巡检 runbook 首条命令与脚本 usage 可复制执行。 Trace: .pm/tasks/task_71d621935d414158b95df9d88dd5278a.yaml
 - [x] rustsec-advisory-ignore-baseline-ratchet (PRD-ENGINEERING-021/025) [test_tier_required]: 收口 Rust 依赖层治理点，为 libp2p network closure 的 RustSec advisory ignore baseline 补 owner/expiry/validation 元数据、CI ratchet 与 governance report 证据，阻止 ignored advisory 集合静默增长，并保留后续依赖 burn-down 风险边界。 Trace: .pm/tasks/task_d1eac391d57b48dd926a33eeafde29d0.yaml
 - [x] worktree-cleanup-bounded-batch (PRD-ENGINEERING-021/025) [test_tier_required]: 收口 repository health 巡检发现的 worktree lifecycle cleanup backlog，按 `worktree-gc-report --prunable-only` 确认 clean / closed-task / non-main 边界后移除首批 10 个本地 worktree，并保留 safe branch delete 拒绝的未 fully merged 分支。 Trace: .pm/tasks/task_1b0ed1997b82438381e8578e6b71215c.yaml
+- [x] wasm-executor-focused-clippy-debt-cleanup (PRD-ENGINEERING-001/021) [test_tier_required]: 继续收口 repository health 巡检发现的 Rust 代码层治理点，使 `oasis7_wasm_executor` focused Clippy `-D warnings` 在默认与 `wasmtime` 特性下通过，并保留 executor metrics 与 sandbox fallback 语义不变。 Trace: .pm/tasks/task_6b2fff9186a844a4b427f21ecf90822a.yaml
 
 ## File Structure / Affected Paths
 - `local-cargo-cache-script-convergence`: 预计改动 `scripts/cargo-dev-lib.sh`、`scripts/cargo-dev-lib.test.sh`、本地 smoke / playtest / prewarm 脚本、`scripts/prepare-task-pr.sh` 的 preflight 修复、`testing-manual.md`、`doc/scripts/{README.md,prd.md}`、`AGENTS.md` 与本 task execution log；只读依赖 `scripts/cargo-dev.sh`、`scripts/ci-tests.sh`、`scripts/build-wasm-module.sh`、release workflow；验证入口为 `bash -n ...`、`./scripts/cargo-dev-lib.test.sh`、相关脚本 `--help`/`--dry-run` smoke、`./scripts/prepare-task-pr.test.sh`、`./scripts/pm/lint.sh`、`./scripts/doc-governance-check.sh` 与 `git diff --check`。 Trace: .pm/tasks/task_46ea1c81166043e3a1e3d5899b618ae6.yaml
@@ -330,7 +331,7 @@
 - 更新日期: 2026-06-24
 - 当前状态: active
 - 下一任务: 当前 `scripts/doc-inventory-report.sh` 复算显示 near-limit active docs 为 none；后续 repository health 巡检应按 module density / hotspot `action_required` 结果做 bounded 分类判断，先分级再切 focused follow-up，避免回到已收口的 `doc/world-simulator/project.md` / `doc/readme/project.md` 队列。
-- 最新完成: `wasm-router-focused-clippy-debt-cleanup`（已清理 `oasis7_wasm_router` focused Clippy `-D warnings` 债务，保持订阅过滤校验与 router metrics 快照语义不变并通过 focused package tests。）
+- 最新完成: `wasm-executor-focused-clippy-debt-cleanup`（已清理 `oasis7_wasm_executor` focused Clippy `-D warnings` 债务，保持 executor metrics 与 sandbox fallback 语义不变，并通过默认 / `wasmtime` focused package tests。）
 - PRD 质量门状态: strict schema 已对齐（含第 6 章验证与决策记录）。
 - 当前治理重点: P0/P1 技术债首轮优化正在收口，重点是 public_testnet readiness blocker 显式化、hosted access verdict 去半实现口径，以及 Viewer 前端状态模块化。
 - 当前库存判断: 文档债的主矛盾仍是“入口减重之后的存量维护成本”，不是继续扩更多 landing pages。复算入口仍以 `scripts/doc-inventory-report.sh` 为准。


### PR DESCRIPTION
## Summary
- Clean up focused `oasis7_wasm_executor` Clippy debt under default and `wasmtime` features.
- Gate wasmtime-only metrics observers with `cfg(feature = "wasmtime")` and use Clippy-preferred expression forms without changing executor semantics.
- Record task/project trace and bounded role-review evidence.

## Verification
- `env -u RUSTC_WRAPPER cargo fmt --check`
- `env -u RUSTC_WRAPPER cargo clippy -p oasis7_wasm_executor --lib -- -D warnings`
- `env -u RUSTC_WRAPPER cargo clippy -p oasis7_wasm_executor --lib --features wasmtime -- -D warnings`
- `env -u RUSTC_WRAPPER cargo test -p oasis7_wasm_executor --lib`
- `env -u RUSTC_WRAPPER cargo test -p oasis7_wasm_executor --lib --features wasmtime`
- `./scripts/check-rust-file-size.sh`
- `./scripts/pm/workflow-lint.sh --task-uid task_6b2fff9186a844a4b427f21ecf90822a --phase current`
- `git diff --check`
- targeted required gate from `prepare-task-pr.sh` passed: `OASIS7_CI_RUN_OASIS7_REQUIRED_TESTS=true ... OASIS7_CI_RUN_WORKSPACE_SUPPORT_CRATE_TESTS=true ./scripts/ci-tests.sh required`

## Review
Pre-PR local role review: passed. Roles: `wasm_platform_engineer`, `qa_engineer`, `repository_health_engineer`, `producer_system_designer`.
