### PR TITLE
Prevent failed node starts from advancing state

### DIFF
--- a/.pm/tasks/task_3203bec287cc43919a32e5e82b1d28b2.execution.md
+++ b/.pm/tasks/task_3203bec287cc43919a32e5e82b1d28b2.execution.md
@@ -102,3 +102,15 @@ Example:
 - Expected Result: QA confirms the verification matrix or identifies a concrete blocker.
 - Actual Result: qa_engineer `019ef8b1-9134-75b2-b5c9-740208063697` returned `no_findings`; verdicts were scope/spec compliant and quality/risk acceptable. QA found no required pre-PR test gap.
 - Blocker / Next Action: Integrate QA review and update passed packet.
+
+## 2026-06-24 17:06:00 CST / tpm
+- 完成内容: Ran ready-for-PR verification and task closeout after integrating runtime, rollout, and QA evidence.
+- Action: `./scripts/pm/claim-ready.sh --claim-type ready_for_pr --verify-command "$VERIFY_CMD" --task-uid task_3203bec287cc43919a32e5e82b1d28b2`
+- Validation Command: `./scripts/cargo-dev.sh test -p oasis7 startup_reconcile -- --nocapture && bash scripts/p2p-public-testnet-package-node-upgrade.test.sh && ./scripts/cargo-dev.sh fmt --check && ./scripts/check-rust-file-size.sh && git diff --check && ./scripts/pm/workflow-lint.sh --task-uid task_3203bec287cc43919a32e5e82b1d28b2 --phase current`
+- Expected Result: Fresh verification passes and records a ready-for-PR claim.
+- Actual Result: passed; claim-ready recorded `ready_for_pr` with exit code 0.
+- Action: `./scripts/pm/task-closeout.sh --role runtime_engineer --task-uid task_3203bec287cc43919a32e5e82b1d28b2 --verify-command "$VERIFY_CMD"`
+- Expected Result: Task-specific verification and closeout metadata are recorded.
+- Actual Result: task-specific verification passed and task metadata was updated to `status: done`; the helper then reported unrelated repo-wide historical `.pm` lint debt outside this task. Current task-specific workflow lint remains green.
+- 遗留事项: Create PR, watch checks/comments, merge, then rebuild/redeploy nodes from clean state after package CI.
+- Blocker / Next Action: Add module project trace, commit closeout evidence, and rerun `prepare-task-pr`.

--- a/.pm/tasks/task_3203bec287cc43919a32e5e82b1d28b2.execution.md
+++ b/.pm/tasks/task_3203bec287cc43919a32e5e82b1d28b2.execution.md
@@ -1,0 +1,87 @@
+# task_3203bec287cc43919a32e5e82b1d28b2 Execution Log
+
+- task_uid: task_3203bec287cc43919a32e5e82b1d28b2
+- title: Prevent failed testnet starts from mutating consensus state
+- owner_role: runtime_engineer
+- worktree_hint: /Users/scc/ccwork/worktrees/oasis7-runtime-testnet-startup-reconcile-bind-failure
+
+<!-- Append entries using:
+Example:
+  ## YYYY-MM-DD HH:MM:SS CST / role_name
+  - 完成内容: ...
+  - 遗留事项: ...
+  - Action: ...
+  - Validation Command: ...
+  - Expected Result: ...
+  - Actual Result: ...
+  - Blocker / Next Action: ...
+-->
+
+## 2026-06-24 15:58:00 CST / tpm
+- 完成内容: Bound a new root-cause task after PR #598/package rollout exposed a fresh public-testnet divergence. Current evidence is intentionally read-only; no node reset/rebuild was used as a fix.
+- Failure signature:
+  - Storage readiness failed with `runtime_last_error`, `consensus_peer_head_unavailable`, `replication_recent_errors`, `storage_degraded`; storage stayed at execution/committed height 1233 and locally replayed sequencer height 1234 to `local_block=d52f... local_state=7129...`, not peer expected `4c060c... / 841b...`.
+  - Sequencer process logs showed repeated extra starts failing `Gossip { reason: "bind 0.0.0.0:6731 failed: Address already in use" }`.
+  - One failed sequencer start logged `startup reconciled node pos state from execution latest: previous_committed_height=1234 reconciled_height=1235` before the bind failure.
+  - Later disk evidence showed sequencer `data/replication-root/node_pos_state.json` at committed/execution height 1235 while the running status endpoint still reported committed/execution height 1234.
+- Professional slice contract:
+  - Intended role: `runtime_engineer` with synchronization consistency lens.
+  - Actual dispatch: bounded read-only explorer subagent `019ef88b-ce70-73c3-bfbd-0ce173a16a8b`.
+  - Mandatory context checklist: PR #598 merged package, post-deploy status JSON, sequencer duplicate-start/bind-failure logs, storage execution mismatch, code paths for startup reconcile and synced replication commit replay.
+  - Attribution boundary: TPM integrates and patches; professional root-cause conclusions below are attributed to the read-only slice and current code/log evidence.
+- Slice conclusion summary:
+  - The storage failure is not merely stale peer-head readiness; it is execution binding mismatch during synced replication replay.
+  - `execute_synced_replication_commit` validates the current height binding but does not prove the predecessor execution binding before replay.
+  - `startup_reconcile` can currently write `node_pos_state.json` from execution `latest.json` without confirming matching persisted replication/consensus commit, and it runs before runtime endpoint bind failures are known.
+- Action: Patch startup/rollout to fail closed before persistent startup reconcile when required node endpoints or process ownership are already occupied; keep deeper predecessor-binding replication hardening as follow-up if not covered by the minimal regression surface.
+- 遗留事项: Existing public-testnet node data remains divergent and must be rebuilt/redeployed only after the code/script guard is merged and packaged.
+- Validation Command: pending.
+- Expected Result: Failed or duplicate starts cannot advance persisted consensus/execution state before the process can own its required endpoints.
+- Actual Result: Implementation added; focused validation passed for `./scripts/cargo-dev.sh test -p oasis7 startup_reconcile -- --nocapture`, `bash scripts/p2p-public-testnet-package-node-upgrade.test.sh`, `./scripts/cargo-dev.sh fmt --check`, `./scripts/check-rust-file-size.sh`, and `git diff --check`.
+- Blocker / Next Action: Re-run workflow lint and dispatch pre-PR local role review.
+
+## 2026-06-24 16:28:00 CST / tpm
+- Review Trigger: pre-PR local role review
+- Review Scope: `crates/oasis7/src/bin/oasis7_chain_runtime.rs`; `crates/oasis7/src/bin/oasis7_chain_runtime/oasis7_chain_runtime_tests.rs`; `scripts/p2p-public-testnet-package-node-upgrade.sh`; `scripts/p2p-public-testnet-package-node-upgrade.test.sh`
+- Review Package: `/Users/scc/ccwork/worktrees/oasis7-runtime-testnet-startup-reconcile-bind-failure/.pm/scratch/task_3203bec287cc43919a32e5e82b1d28b2/review-packages/review-3f966bc05..5d10a14eb.diff`
+- Review Roles: runtime_engineer, blockchain_ops_engineer
+- Review Question: Confirm the fix prevents failed/duplicate starts from mutating persistent consensus state before endpoint ownership, and confirm the package-upgrade stop/orphan guard does not introduce unsafe rollout behavior.
+- Evidence Available: `./scripts/cargo-dev.sh test -p oasis7 startup_reconcile -- --nocapture`; `bash scripts/p2p-public-testnet-package-node-upgrade.test.sh`; `./scripts/cargo-dev.sh fmt --check`; `./scripts/check-rust-file-size.sh`; `git diff --check`; `./scripts/pm/workflow-lint.sh --task-uid task_3203bec287cc43919a32e5e82b1d28b2 --phase current`; post-deploy read-only evidence under `/Users/scc/ccwork/oasis7/.tmp/public-testnet-update-20260624T125/after`.
+- Expected Return Contract: findings | no_findings | scope/spec compliance verdict | role quality/risk verdict | residual_risk
+- Slice Ledger: `/Users/scc/ccwork/worktrees/oasis7-runtime-testnet-startup-reconcile-bind-failure/.pm/scratch/task_3203bec287cc43919a32e5e82b1d28b2/slice-ledger.jsonl`
+- Formal Sink: execution log
+- 遗留事项: Await role review results before PR creation.
+- Action: Dispatch bounded local subagent review slices.
+- Validation Command: n/a
+- Expected Result: Role reviews either return no findings or concrete issues to address before PR creation.
+- Actual Result: runtime_engineer and blockchain_ops_engineer returned `no_findings`; both found scope/spec compliance acceptable. Runtime residual risk: non-ip4/dns/ip6 multiaddr not fully covered and a small preflight-release-to-runtime-bind race remains. Blockchain ops residual risk: process guard depends on node-root remaining visible in argv and non-`--restart-service` mode is not for live public-testnet rollout.
+- Blocker / Next Action: Record passed packet and continue to PR creation.
+
+## 2026-06-24 16:38:00 CST / tpm
+- Pre-PR Local Role Review: passed
+- Task UID: task_3203bec287cc43919a32e5e82b1d28b2
+- Source Worktree: `/Users/scc/ccwork/worktrees/oasis7-runtime-testnet-startup-reconcile-bind-failure`
+- Source Branch: `task/runtime-testnet-startup-reconcile-bind-failure`
+- Source Head: `5d10a14eb7ba4e51f69cbe422a86f32cbb75eff0`.
+- Comparison Ref: `refs/remotes/origin/main`
+- Reviewed Changed Paths: `crates/oasis7/src/bin/oasis7_chain_runtime.rs`; `crates/oasis7/src/bin/oasis7_chain_runtime/oasis7_chain_runtime_tests.rs`; `scripts/p2p-public-testnet-package-node-upgrade.sh`; `scripts/p2p-public-testnet-package-node-upgrade.test.sh`
+- Review Package: `/Users/scc/ccwork/worktrees/oasis7-runtime-testnet-startup-reconcile-bind-failure/.pm/scratch/task_3203bec287cc43919a32e5e82b1d28b2/review-packages/review-3f966bc05..5d10a14eb.diff`
+- Role Selection Basis: runtime startup/reconcile code changed, package rollout script changed, and task history involved public-testnet node divergence/root-cause deployment safety.
+- Review Roles: runtime_engineer, blockchain_ops_engineer
+- Review Evidence: runtime_engineer `019ef8a5-1e86-7e83-9f72-129566085ce7` returned `no_findings`; blockchain_ops_engineer `019ef8a5-5ac9-79b1-9e64-99ae4364db54` returned `no_findings`.
+- Review Verdicts: runtime scope/spec compliance compliant and quality/risk acceptable; blockchain ops scope/spec compliance compliant and quality/risk acceptable.
+- Review Findings Disposition: no_findings
+- Finding Disposition Evidence: n/a
+- Verification Matrix: runtime startup preflight -> `./scripts/cargo-dev.sh test -p oasis7 startup_reconcile -- --nocapture` passed; package upgrade orphan guard -> `bash scripts/p2p-public-testnet-package-node-upgrade.test.sh` passed; formatting -> `./scripts/cargo-dev.sh fmt --check` passed; file size -> `./scripts/check-rust-file-size.sh` passed; diff hygiene -> `git diff --check` passed; workflow packet -> `./scripts/pm/workflow-lint.sh --task-uid task_3203bec287cc43919a32e5e82b1d28b2 --phase current` passed.
+- Visual Evidence: n/a; backend runtime and rollout script change only.
+- WASM Evidence: n/a; no WASM ABI/runtime determinism surface changed.
+- Ops Evidence: read-only incident evidence under `/Users/scc/ccwork/oasis7/.tmp/public-testnet-update-20260624T125/after`; blockchain ops review confirmed stop/guard/start rollout semantics.
+- LiveOps Evidence: n/a; no player/community-facing messaging or release-note text changed.
+- Residual Risk: Low. Runtime guard is intentionally scoped to current public-testnet ip4 listen shapes and has a narrow guard-release-to-real-bind race; deployment script node-root lock and orphan process guard reduce the live rollout path risk. Existing divergent node data still requires clean redeploy/rebuild after this fix lands; no ops-only reset is claimed as a fix.
+- Slice Ledger: `/Users/scc/ccwork/worktrees/oasis7-runtime-testnet-startup-reconcile-bind-failure/.pm/scratch/task_3203bec287cc43919a32e5e82b1d28b2/slice-ledger.jsonl`
+- 遗留事项: Create PR, watch checks/comments, merge, then rebuild/redeploy nodes from clean state after package CI.
+- Action: Continue to `prepare-task-pr`.
+- Validation Command: see Verification Matrix.
+- Expected Result: PR preflight accepts the passed role review evidence.
+- Actual Result: pending.
+- Blocker / Next Action: Commit branch and create PR.

--- a/.pm/tasks/task_3203bec287cc43919a32e5e82b1d28b2.execution.md
+++ b/.pm/tasks/task_3203bec287cc43919a32e5e82b1d28b2.execution.md
@@ -67,9 +67,9 @@ Example:
 - Reviewed Changed Paths: `crates/oasis7/src/bin/oasis7_chain_runtime.rs`; `crates/oasis7/src/bin/oasis7_chain_runtime/oasis7_chain_runtime_tests.rs`; `scripts/p2p-public-testnet-package-node-upgrade.sh`; `scripts/p2p-public-testnet-package-node-upgrade.test.sh`
 - Review Package: `/Users/scc/ccwork/worktrees/oasis7-runtime-testnet-startup-reconcile-bind-failure/.pm/scratch/task_3203bec287cc43919a32e5e82b1d28b2/review-packages/review-3f966bc05..5d10a14eb.diff`
 - Role Selection Basis: runtime startup/reconcile code changed, package rollout script changed, and task history involved public-testnet node divergence/root-cause deployment safety.
-- Review Roles: runtime_engineer, blockchain_ops_engineer
-- Review Evidence: runtime_engineer `019ef8a5-1e86-7e83-9f72-129566085ce7` returned `no_findings`; blockchain_ops_engineer `019ef8a5-5ac9-79b1-9e64-99ae4364db54` returned `no_findings`.
-- Review Verdicts: runtime scope/spec compliance compliant and quality/risk acceptable; blockchain ops scope/spec compliance compliant and quality/risk acceptable.
+- Review Roles: runtime_engineer, blockchain_ops_engineer, qa_engineer
+- Review Evidence: runtime_engineer `019ef8a5-1e86-7e83-9f72-129566085ce7` returned `no_findings`; blockchain_ops_engineer `019ef8a5-5ac9-79b1-9e64-99ae4364db54` returned `no_findings`; qa_engineer `019ef8b1-9134-75b2-b5c9-740208063697` returned `no_findings`.
+- Review Verdicts: runtime scope/spec compliance compliant and quality/risk acceptable; blockchain ops scope/spec compliance compliant and quality/risk acceptable; QA scope/spec compliance compliant and quality/risk acceptable.
 - Review Findings Disposition: no_findings
 - Finding Disposition Evidence: n/a
 - Verification Matrix: runtime startup preflight -> `./scripts/cargo-dev.sh test -p oasis7 startup_reconcile -- --nocapture` passed; package upgrade orphan guard -> `bash scripts/p2p-public-testnet-package-node-upgrade.test.sh` passed; formatting -> `./scripts/cargo-dev.sh fmt --check` passed; file size -> `./scripts/check-rust-file-size.sh` passed; diff hygiene -> `git diff --check` passed; workflow packet -> `./scripts/pm/workflow-lint.sh --task-uid task_3203bec287cc43919a32e5e82b1d28b2 --phase current` passed.
@@ -85,3 +85,20 @@ Example:
 - Expected Result: PR preflight accepts the passed role review evidence.
 - Actual Result: pending.
 - Blocker / Next Action: Commit branch and create PR.
+
+## 2026-06-24 16:52:00 CST / tpm
+- Review Trigger: prepare-task-pr inferred missing role
+- Review Scope: verification matrix and regression evidence for runtime startup preflight and package upgrade orphan guard.
+- Review Package: `/Users/scc/ccwork/worktrees/oasis7-runtime-testnet-startup-reconcile-bind-failure/.pm/scratch/task_3203bec287cc43919a32e5e82b1d28b2/review-packages/review-3f966bc05..5d10a14eb.diff`
+- Review Roles: qa_engineer
+- Review Question: Confirm the focused verification is sufficient for PR creation and identify any missing test/evidence blocker.
+- Evidence Available: `./scripts/cargo-dev.sh test -p oasis7 startup_reconcile -- --nocapture`; `bash scripts/p2p-public-testnet-package-node-upgrade.test.sh`; `./scripts/cargo-dev.sh fmt --check`; `./scripts/check-rust-file-size.sh`; `git diff --check`; `./scripts/pm/workflow-lint.sh --task-uid task_3203bec287cc43919a32e5e82b1d28b2 --phase current`; runtime_engineer and blockchain_ops_engineer no-findings reviews.
+- Expected Return Contract: findings | no_findings | scope/spec compliance verdict | role quality/risk verdict | residual_risk
+- Slice Ledger: `/Users/scc/ccwork/worktrees/oasis7-runtime-testnet-startup-reconcile-bind-failure/.pm/scratch/task_3203bec287cc43919a32e5e82b1d28b2/slice-ledger.jsonl`
+- Formal Sink: execution log
+- 遗留事项: Await QA review before PR creation.
+- Action: Dispatch qa_engineer review slice.
+- Validation Command: n/a
+- Expected Result: QA confirms the verification matrix or identifies a concrete blocker.
+- Actual Result: qa_engineer `019ef8b1-9134-75b2-b5c9-740208063697` returned `no_findings`; verdicts were scope/spec compliant and quality/risk acceptable. QA found no required pre-PR test gap.
+- Blocker / Next Action: Integrate QA review and update passed packet.

--- a/.pm/tasks/task_3203bec287cc43919a32e5e82b1d28b2.execution.md
+++ b/.pm/tasks/task_3203bec287cc43919a32e5e82b1d28b2.execution.md
@@ -125,3 +125,10 @@ Example:
 - Actual Result: producer_system_designer `019ef8ba-c8ec-73c0-8770-5f3d4198fb46` returned `no_findings`; verdicts were scope/spec compliant and quality/risk acceptable. It confirmed the wording does not claim testnet is already healthy, does not present ops reset/restart as a fix, and keeps clean redeploy/rebuild after merge/package as the remaining live-state step.
 - Residual Risk: Low; live-state risk remains open until PR merge, package CI, and clean node redeploy/rebuild.
 - Blocker / Next Action: Commit updated review evidence and rerun `prepare-task-pr`.
+
+## 2026-06-24 17:27:00 CST / tpm
+- 完成内容: Created PR #604 after `prepare-task-pr` pushed the branch but failed to pass a non-interactive PR body to `gh pr create`.
+- PR: https://github.com/eng-cc/oasis7/pull/604
+- PR Purpose Decision: normal_pr_ci_watch
+- Action: Continue watching required checks, mergeability, comments, and review threads; merge only after checks/comments/thread gates are clean. After merge, trigger package CI and clean redeploy/rebuild the divergent public-testnet nodes.
+- Blocker / Next Action: Check PR status and review/comment threads.

--- a/.pm/tasks/task_3203bec287cc43919a32e5e82b1d28b2.execution.md
+++ b/.pm/tasks/task_3203bec287cc43919a32e5e82b1d28b2.execution.md
@@ -60,10 +60,10 @@ Example:
 ## 2026-06-24 16:38:00 CST / tpm
 - Pre-PR Local Role Review: passed
 - Task UID: task_3203bec287cc43919a32e5e82b1d28b2
-- Source Worktree: `/Users/scc/ccwork/worktrees/oasis7-runtime-testnet-startup-reconcile-bind-failure`
-- Source Branch: `task/runtime-testnet-startup-reconcile-bind-failure`
-- Source Head: `5d10a14eb7ba4e51f69cbe422a86f32cbb75eff0`.
-- Comparison Ref: `refs/remotes/origin/main`
+- Source Worktree: /Users/scc/ccwork/worktrees/oasis7-runtime-testnet-startup-reconcile-bind-failure
+- Source Branch: task/runtime-testnet-startup-reconcile-bind-failure
+- Source Head: 41e51c3bf9dd1ea7cbbd5ff85a91deef79f1046f
+- Comparison Ref: refs/remotes/origin/main
 - Reviewed Changed Paths: `crates/oasis7/src/bin/oasis7_chain_runtime.rs`; `crates/oasis7/src/bin/oasis7_chain_runtime/oasis7_chain_runtime_tests.rs`; `scripts/p2p-public-testnet-package-node-upgrade.sh`; `scripts/p2p-public-testnet-package-node-upgrade.test.sh`
 - Review Package: `/Users/scc/ccwork/worktrees/oasis7-runtime-testnet-startup-reconcile-bind-failure/.pm/scratch/task_3203bec287cc43919a32e5e82b1d28b2/review-packages/review-3f966bc05..5d10a14eb.diff`
 - Role Selection Basis: runtime startup/reconcile code changed, package rollout script changed, and task history involved public-testnet node divergence/root-cause deployment safety.

--- a/.pm/tasks/task_3203bec287cc43919a32e5e82b1d28b2.execution.md
+++ b/.pm/tasks/task_3203bec287cc43919a32e5e82b1d28b2.execution.md
@@ -132,3 +132,14 @@ Example:
 - PR Purpose Decision: normal_pr_ci_watch
 - Action: Continue watching required checks, mergeability, comments, and review threads; merge only after checks/comments/thread gates are clean. After merge, trigger package CI and clean redeploy/rebuild the divergent public-testnet nodes.
 - Blocker / Next Action: Check PR status and review/comment threads.
+
+## 2026-06-24 17:42:00 CST / tpm
+- 完成内容: Addressed two GitHub automated review threads on PR #604.
+- Review Threads:
+  - `scripts/p2p-public-testnet-package-node-upgrade.sh`: process scan could match its own scanner argv. Fixed by parsing `ps` in shell and requiring argv to contain the node root as a path prefix plus `/oasis7_chain_runtime` or `/start-node.sh`; added scanner-like regression coverage.
+  - `crates/oasis7/src/bin/oasis7_chain_runtime.rs`: replication listen preflight skipped non-IPv4 multiaddrs. Fixed by reserving `/ip6/.../(tcp|udp)/port` through `IpAddr`/`SocketAddr` and failing closed on unsupported listen forms; added IPv6 and unsupported-address regression coverage.
+- Validation Command: `./scripts/cargo-dev.sh test -p oasis7 startup_reconcile -- --nocapture && bash scripts/p2p-public-testnet-package-node-upgrade.test.sh && ./scripts/cargo-dev.sh fmt --check`
+- Actual Result: passed; startup reconcile focused tests now include 8 passing cases.
+- Validation Command: `./scripts/check-rust-file-size.sh && git diff --check && ./scripts/pm/workflow-lint.sh --task-uid task_3203bec287cc43919a32e5e82b1d28b2 --phase current`
+- Actual Result: passed.
+- Blocker / Next Action: Commit/push review fixes, recheck PR threads/checks, then merge when clean.

--- a/.pm/tasks/task_3203bec287cc43919a32e5e82b1d28b2.execution.md
+++ b/.pm/tasks/task_3203bec287cc43919a32e5e82b1d28b2.execution.md
@@ -67,9 +67,9 @@ Example:
 - Reviewed Changed Paths: `crates/oasis7/src/bin/oasis7_chain_runtime.rs`; `crates/oasis7/src/bin/oasis7_chain_runtime/oasis7_chain_runtime_tests.rs`; `scripts/p2p-public-testnet-package-node-upgrade.sh`; `scripts/p2p-public-testnet-package-node-upgrade.test.sh`; `.pm/tasks/task_3203bec287cc43919a32e5e82b1d28b2.yaml`; `.pm/tasks/task_3203bec287cc43919a32e5e82b1d28b2.execution.md`; `doc/p2p/project.md`
 - Review Package: `/Users/scc/ccwork/worktrees/oasis7-runtime-testnet-startup-reconcile-bind-failure/.pm/scratch/task_3203bec287cc43919a32e5e82b1d28b2/review-packages/review-3f966bc05..5d10a14eb.diff`
 - Role Selection Basis: runtime startup/reconcile code changed, package rollout script changed, task/project evidence changed, and task history involved public-testnet node divergence/root-cause deployment safety.
-- Review Roles: runtime_engineer, blockchain_ops_engineer, qa_engineer
-- Review Evidence: runtime_engineer `019ef8a5-1e86-7e83-9f72-129566085ce7` returned `no_findings`; blockchain_ops_engineer `019ef8a5-5ac9-79b1-9e64-99ae4364db54` returned `no_findings`; qa_engineer `019ef8b1-9134-75b2-b5c9-740208063697` returned `no_findings`.
-- Review Verdicts: runtime scope/spec compliance compliant and quality/risk acceptable; blockchain ops scope/spec compliance compliant and quality/risk acceptable; QA scope/spec compliance compliant and quality/risk acceptable.
+- Review Roles: runtime_engineer, blockchain_ops_engineer, qa_engineer, producer_system_designer
+- Review Evidence: runtime_engineer `019ef8a5-1e86-7e83-9f72-129566085ce7` returned `no_findings`; blockchain_ops_engineer `019ef8a5-5ac9-79b1-9e64-99ae4364db54` returned `no_findings`; qa_engineer `019ef8b1-9134-75b2-b5c9-740208063697` returned `no_findings`; producer_system_designer `019ef8ba-c8ec-73c0-8770-5f3d4198fb46` returned `no_findings`.
+- Review Verdicts: runtime scope/spec compliance compliant and quality/risk acceptable; blockchain ops scope/spec compliance compliant and quality/risk acceptable; QA scope/spec compliance compliant and quality/risk acceptable; producer/system scope/spec compliance compliant and quality/risk acceptable.
 - Review Findings Disposition: no_findings
 - Finding Disposition Evidence: n/a
 - Verification Matrix: runtime startup preflight -> `./scripts/cargo-dev.sh test -p oasis7 startup_reconcile -- --nocapture` passed; package upgrade orphan guard -> `bash scripts/p2p-public-testnet-package-node-upgrade.test.sh` passed; formatting -> `./scripts/cargo-dev.sh fmt --check` passed; file size -> `./scripts/check-rust-file-size.sh` passed; diff hygiene -> `git diff --check` passed; workflow packet and project trace -> `./scripts/pm/workflow-lint.sh --task-uid task_3203bec287cc43919a32e5e82b1d28b2 --phase current` passed.
@@ -114,3 +114,14 @@ Example:
 - Actual Result: task-specific verification passed and task metadata was updated to `status: done`; the helper then reported unrelated repo-wide historical `.pm` lint debt outside this task. Current task-specific workflow lint remains green.
 - 遗留事项: Create PR, watch checks/comments, merge, then rebuild/redeploy nodes from clean state after package CI.
 - Blocker / Next Action: Add module project trace, commit closeout evidence, and rerun `prepare-task-pr`.
+
+## 2026-06-24 17:21:00 CST / tpm
+- Review Trigger: prepare-task-pr inferred product/system role from `doc/p2p/project.md`.
+- Review Scope: `doc/p2p/project.md` recent-completed trace and task evidence wording for product/system state claims.
+- Review Roles: producer_system_designer
+- Review Question: Confirm the project/task wording does not overclaim public testnet health, does not treat ops reset/restart as the fix, and preserves the root-cause-first redeploy/rebuild principle for multi-node divergence.
+- Evidence Available: `doc/p2p/project.md`; `.pm/tasks/task_3203bec287cc43919a32e5e82b1d28b2.execution.md`; existing runtime/blockchain_ops/QA no-findings review evidence.
+- Expected Return Contract: findings | no_findings | scope/spec compliance verdict | role quality/risk verdict | residual_risk
+- Actual Result: producer_system_designer `019ef8ba-c8ec-73c0-8770-5f3d4198fb46` returned `no_findings`; verdicts were scope/spec compliant and quality/risk acceptable. It confirmed the wording does not claim testnet is already healthy, does not present ops reset/restart as a fix, and keeps clean redeploy/rebuild after merge/package as the remaining live-state step.
+- Residual Risk: Low; live-state risk remains open until PR merge, package CI, and clean node redeploy/rebuild.
+- Blocker / Next Action: Commit updated review evidence and rerun `prepare-task-pr`.

--- a/.pm/tasks/task_3203bec287cc43919a32e5e82b1d28b2.execution.md
+++ b/.pm/tasks/task_3203bec287cc43919a32e5e82b1d28b2.execution.md
@@ -62,17 +62,17 @@ Example:
 - Task UID: task_3203bec287cc43919a32e5e82b1d28b2
 - Source Worktree: /Users/scc/ccwork/worktrees/oasis7-runtime-testnet-startup-reconcile-bind-failure
 - Source Branch: task/runtime-testnet-startup-reconcile-bind-failure
-- Source Head: 41e51c3bf9dd1ea7cbbd5ff85a91deef79f1046f
+- Source Head: a2f23aa91cd63bb25ee915844d2ad645adcc825f
 - Comparison Ref: refs/remotes/origin/main
-- Reviewed Changed Paths: `crates/oasis7/src/bin/oasis7_chain_runtime.rs`; `crates/oasis7/src/bin/oasis7_chain_runtime/oasis7_chain_runtime_tests.rs`; `scripts/p2p-public-testnet-package-node-upgrade.sh`; `scripts/p2p-public-testnet-package-node-upgrade.test.sh`
+- Reviewed Changed Paths: `crates/oasis7/src/bin/oasis7_chain_runtime.rs`; `crates/oasis7/src/bin/oasis7_chain_runtime/oasis7_chain_runtime_tests.rs`; `scripts/p2p-public-testnet-package-node-upgrade.sh`; `scripts/p2p-public-testnet-package-node-upgrade.test.sh`; `.pm/tasks/task_3203bec287cc43919a32e5e82b1d28b2.yaml`; `.pm/tasks/task_3203bec287cc43919a32e5e82b1d28b2.execution.md`; `doc/p2p/project.md`
 - Review Package: `/Users/scc/ccwork/worktrees/oasis7-runtime-testnet-startup-reconcile-bind-failure/.pm/scratch/task_3203bec287cc43919a32e5e82b1d28b2/review-packages/review-3f966bc05..5d10a14eb.diff`
-- Role Selection Basis: runtime startup/reconcile code changed, package rollout script changed, and task history involved public-testnet node divergence/root-cause deployment safety.
+- Role Selection Basis: runtime startup/reconcile code changed, package rollout script changed, task/project evidence changed, and task history involved public-testnet node divergence/root-cause deployment safety.
 - Review Roles: runtime_engineer, blockchain_ops_engineer, qa_engineer
 - Review Evidence: runtime_engineer `019ef8a5-1e86-7e83-9f72-129566085ce7` returned `no_findings`; blockchain_ops_engineer `019ef8a5-5ac9-79b1-9e64-99ae4364db54` returned `no_findings`; qa_engineer `019ef8b1-9134-75b2-b5c9-740208063697` returned `no_findings`.
 - Review Verdicts: runtime scope/spec compliance compliant and quality/risk acceptable; blockchain ops scope/spec compliance compliant and quality/risk acceptable; QA scope/spec compliance compliant and quality/risk acceptable.
 - Review Findings Disposition: no_findings
 - Finding Disposition Evidence: n/a
-- Verification Matrix: runtime startup preflight -> `./scripts/cargo-dev.sh test -p oasis7 startup_reconcile -- --nocapture` passed; package upgrade orphan guard -> `bash scripts/p2p-public-testnet-package-node-upgrade.test.sh` passed; formatting -> `./scripts/cargo-dev.sh fmt --check` passed; file size -> `./scripts/check-rust-file-size.sh` passed; diff hygiene -> `git diff --check` passed; workflow packet -> `./scripts/pm/workflow-lint.sh --task-uid task_3203bec287cc43919a32e5e82b1d28b2 --phase current` passed.
+- Verification Matrix: runtime startup preflight -> `./scripts/cargo-dev.sh test -p oasis7 startup_reconcile -- --nocapture` passed; package upgrade orphan guard -> `bash scripts/p2p-public-testnet-package-node-upgrade.test.sh` passed; formatting -> `./scripts/cargo-dev.sh fmt --check` passed; file size -> `./scripts/check-rust-file-size.sh` passed; diff hygiene -> `git diff --check` passed; workflow packet and project trace -> `./scripts/pm/workflow-lint.sh --task-uid task_3203bec287cc43919a32e5e82b1d28b2 --phase current` passed.
 - Visual Evidence: n/a; backend runtime and rollout script change only.
 - WASM Evidence: n/a; no WASM ABI/runtime determinism surface changed.
 - Ops Evidence: read-only incident evidence under `/Users/scc/ccwork/oasis7/.tmp/public-testnet-update-20260624T125/after`; blockchain ops review confirmed stop/guard/start rollout semantics.

--- a/.pm/tasks/task_3203bec287cc43919a32e5e82b1d28b2.yaml
+++ b/.pm/tasks/task_3203bec287cc43919a32e5e82b1d28b2.yaml
@@ -3,18 +3,26 @@ title: "Prevent failed testnet starts from mutating consensus state"
 owner_role: runtime_engineer
 worktree_hint: /Users/scc/ccwork/worktrees/oasis7-runtime-testnet-startup-reconcile-bind-failure
 execution_log_path: .pm/tasks/task_3203bec287cc43919a32e5e82b1d28b2.execution.md
-status: committed
+status: done
 priority: P1
 source_signal: null
 source_refs:
   - AGENTS.md
 doc_refs:
   - doc/engineering/workflow/source-of-truth.md
+  - doc/p2p/project.md
+  - doc/scripts/project.md
 related_prd: []
 acceptance:
   - "Failed or duplicate node startups cannot persist consensus/reconciled head state before required network/status endpoints are successfully acquired."
   - "Package rollout/start scripts fail closed when an existing node process for the same app root is still alive or required ports are occupied."
   - "Regression tests cover startup bind failure and rollout orphan-process guard."
 handoff_to: []
-updated_at: 2026-06-24T15:37:05+08:00
+updated_at: 2026-06-24T16:20:26+08:00
 last_started_at: 2026-06-24T15:37:05+08:00
+last_claim_type: task_complete
+last_verify_command: "./scripts/cargo-dev.sh test -p oasis7 startup_reconcile -- --nocapture && bash scripts/p2p-public-testnet-package-node-upgrade.test.sh && ./scripts/cargo-dev.sh fmt --check && ./scripts/check-rust-file-size.sh && git diff --check && ./scripts/pm/workflow-lint.sh --task-uid task_3203bec287cc43919a32e5e82b1d28b2 --phase current"
+last_verified_at: 2026-06-24T16:20:25+08:00
+last_verification_exit_code: 0
+last_verification_status: verified
+last_closed_at: 2026-06-24T16:20:26+08:00

--- a/.pm/tasks/task_3203bec287cc43919a32e5e82b1d28b2.yaml
+++ b/.pm/tasks/task_3203bec287cc43919a32e5e82b1d28b2.yaml
@@ -1,0 +1,20 @@
+task_uid: task_3203bec287cc43919a32e5e82b1d28b2
+title: "Prevent failed testnet starts from mutating consensus state"
+owner_role: runtime_engineer
+worktree_hint: /Users/scc/ccwork/worktrees/oasis7-runtime-testnet-startup-reconcile-bind-failure
+execution_log_path: .pm/tasks/task_3203bec287cc43919a32e5e82b1d28b2.execution.md
+status: committed
+priority: P1
+source_signal: null
+source_refs:
+  - AGENTS.md
+doc_refs:
+  - doc/engineering/workflow/source-of-truth.md
+related_prd: []
+acceptance:
+  - "Failed or duplicate node startups cannot persist consensus/reconciled head state before required network/status endpoints are successfully acquired."
+  - "Package rollout/start scripts fail closed when an existing node process for the same app root is still alive or required ports are occupied."
+  - "Regression tests cover startup bind failure and rollout orphan-process guard."
+handoff_to: []
+updated_at: 2026-06-24T15:37:05+08:00
+last_started_at: 2026-06-24T15:37:05+08:00

--- a/crates/oasis7/src/bin/oasis7_chain_runtime.rs
+++ b/crates/oasis7/src/bin/oasis7_chain_runtime.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 use std::env;
 use std::fs;
 use std::io::{Read, Write};
-use std::net::{TcpListener, TcpStream, UdpSocket};
+use std::net::{IpAddr, SocketAddr, TcpListener, TcpStream, UdpSocket};
 use std::path::{Path, PathBuf};
 use std::process;
 use std::sync::mpsc::{self, Receiver, Sender, TryRecvError};
@@ -639,21 +639,35 @@ fn reserve_replication_listen_addr_for_startup_reconcile(
         .split('/')
         .filter(|segment| !segment.is_empty())
         .collect::<Vec<_>>();
-    let Some(ip_index) = segments.iter().position(|segment| *segment == "ip4") else {
-        return Ok(());
+    let Some(ip_index) = segments
+        .iter()
+        .position(|segment| *segment == "ip4" || *segment == "ip6")
+    else {
+        return Err(format!(
+            "startup reconcile preflight failed: unsupported replication listen address {listen_addr}"
+        ));
     };
     let Some(host) = segments.get(ip_index + 1) else {
-        return Ok(());
+        return Err(format!(
+            "startup reconcile preflight failed: unsupported replication listen address {listen_addr}"
+        ));
     };
+    let ip = host.parse::<IpAddr>().map_err(|err| {
+        format!(
+            "startup reconcile preflight failed: unsupported replication listen address {listen_addr}: {err}"
+        )
+    })?;
     if let Some(tcp_index) = segments.iter().position(|segment| *segment == "tcp") {
         let Some(port) = segments
             .get(tcp_index + 1)
             .and_then(|raw| raw.parse::<u16>().ok())
         else {
-            return Ok(());
+            return Err(format!(
+                "startup reconcile preflight failed: unsupported replication tcp listen {listen_addr}"
+            ));
         };
         tcp_listeners
-            .push(TcpListener::bind((*host, port)).map_err(|err| {
+            .push(TcpListener::bind(SocketAddr::new(ip, port)).map_err(|err| {
                 format!(
                     "startup reconcile preflight failed: replication tcp listen {listen_addr} unavailable: {err}"
                 )
@@ -665,15 +679,20 @@ fn reserve_replication_listen_addr_for_startup_reconcile(
             .get(udp_index + 1)
             .and_then(|raw| raw.parse::<u16>().ok())
         else {
-            return Ok(());
+            return Err(format!(
+                "startup reconcile preflight failed: unsupported replication udp listen {listen_addr}"
+            ));
         };
-        udp_sockets.push(UdpSocket::bind((*host, port)).map_err(|err| {
+        udp_sockets.push(UdpSocket::bind(SocketAddr::new(ip, port)).map_err(|err| {
             format!(
                 "startup reconcile preflight failed: replication udp listen {listen_addr} unavailable: {err}"
             )
         })?);
+        return Ok(());
     }
-    Ok(())
+    Err(format!(
+        "startup reconcile preflight failed: unsupported replication listen address {listen_addr}"
+    ))
 }
 
 fn resolve_runtime_paths(options: &CliOptions) -> RuntimePaths {

--- a/crates/oasis7/src/bin/oasis7_chain_runtime.rs
+++ b/crates/oasis7/src/bin/oasis7_chain_runtime.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 use std::env;
 use std::fs;
 use std::io::{Read, Write};
-use std::net::{TcpListener, TcpStream};
+use std::net::{TcpListener, TcpStream, UdpSocket};
 use std::path::{Path, PathBuf};
 use std::process;
 use std::sync::mpsc::{self, Receiver, Sender, TryRecvError};
@@ -414,6 +414,7 @@ fn run_chain_runtime(options: CliOptions) -> Result<(), String> {
         replication_fetch_requester_allowlist.as_slice(),
         allow_any_signed_fetch_requester,
     )?);
+    let startup_reconcile_bind_guard = reserve_startup_reconcile_bind_guard(&options)?;
     if let Some(report) = startup_reconcile::reconcile_startup_state_from_execution_latest(
         &paths,
         options.world_id.as_str(),
@@ -428,6 +429,7 @@ fn run_chain_runtime(options: CliOptions) -> Result<(), String> {
             "startup reconciled node pos state from execution latest",
         );
     }
+    drop(startup_reconcile_bind_guard);
 
     let mut runtime = NodeRuntime::new(config);
     if materialize_execution {
@@ -579,6 +581,99 @@ fn run_chain_runtime(options: CliOptions) -> Result<(), String> {
 
         thread::sleep(Duration::from_millis(300));
     }
+}
+
+#[derive(Debug)]
+struct StartupReconcileBindGuard {
+    _tcp_listeners: Vec<TcpListener>,
+    _udp_sockets: Vec<UdpSocket>,
+}
+
+fn reserve_startup_reconcile_bind_guard(
+    options: &CliOptions,
+) -> Result<StartupReconcileBindGuard, String> {
+    let mut tcp_listeners = Vec::new();
+    let mut udp_sockets = Vec::new();
+    let (status_host, status_port) =
+        parse_host_port(options.status_bind.as_str(), "--status-bind")?;
+    tcp_listeners.push(
+        TcpListener::bind((status_host.as_str(), status_port)).map_err(|err| {
+            format!(
+                "startup reconcile preflight failed: status bind {} unavailable: {err}",
+                options.status_bind
+            )
+        })?,
+    );
+    if let Some(gossip_bind) = options.node_gossip_bind {
+        udp_sockets.push(UdpSocket::bind(gossip_bind).map_err(|err| {
+            format!(
+                "startup reconcile preflight failed: gossip bind {} unavailable: {err}",
+                gossip_bind
+            )
+        })?);
+    }
+    let listen_addrs = if options.replication_network_listen_addrs.is_empty() {
+        vec![DEFAULT_REPLICATION_NETWORK_LISTEN.to_string()]
+    } else {
+        options.replication_network_listen_addrs.clone()
+    };
+    for listen_addr in listen_addrs {
+        reserve_replication_listen_addr_for_startup_reconcile(
+            listen_addr.as_str(),
+            &mut tcp_listeners,
+            &mut udp_sockets,
+        )?;
+    }
+    Ok(StartupReconcileBindGuard {
+        _tcp_listeners: tcp_listeners,
+        _udp_sockets: udp_sockets,
+    })
+}
+
+fn reserve_replication_listen_addr_for_startup_reconcile(
+    listen_addr: &str,
+    tcp_listeners: &mut Vec<TcpListener>,
+    udp_sockets: &mut Vec<UdpSocket>,
+) -> Result<(), String> {
+    let segments = listen_addr
+        .split('/')
+        .filter(|segment| !segment.is_empty())
+        .collect::<Vec<_>>();
+    let Some(ip_index) = segments.iter().position(|segment| *segment == "ip4") else {
+        return Ok(());
+    };
+    let Some(host) = segments.get(ip_index + 1) else {
+        return Ok(());
+    };
+    if let Some(tcp_index) = segments.iter().position(|segment| *segment == "tcp") {
+        let Some(port) = segments
+            .get(tcp_index + 1)
+            .and_then(|raw| raw.parse::<u16>().ok())
+        else {
+            return Ok(());
+        };
+        tcp_listeners
+            .push(TcpListener::bind((*host, port)).map_err(|err| {
+                format!(
+                    "startup reconcile preflight failed: replication tcp listen {listen_addr} unavailable: {err}"
+                )
+            })?);
+        return Ok(());
+    }
+    if let Some(udp_index) = segments.iter().position(|segment| *segment == "udp") {
+        let Some(port) = segments
+            .get(udp_index + 1)
+            .and_then(|raw| raw.parse::<u16>().ok())
+        else {
+            return Ok(());
+        };
+        udp_sockets.push(UdpSocket::bind((*host, port)).map_err(|err| {
+            format!(
+                "startup reconcile preflight failed: replication udp listen {listen_addr} unavailable: {err}"
+            )
+        })?);
+    }
+    Ok(())
 }
 
 fn resolve_runtime_paths(options: &CliOptions) -> RuntimePaths {

--- a/crates/oasis7/src/bin/oasis7_chain_runtime/oasis7_chain_runtime_tests.rs
+++ b/crates/oasis7/src/bin/oasis7_chain_runtime/oasis7_chain_runtime_tests.rs
@@ -267,6 +267,34 @@ fn startup_reconcile_bind_guard_rejects_occupied_replication_tcp_listen() {
 }
 
 #[test]
+fn startup_reconcile_bind_guard_rejects_occupied_replication_ipv6_tcp_listen() {
+    let Ok(occupied) = TcpListener::bind("[::1]:0") else {
+        return;
+    };
+    let port = occupied.local_addr().expect("replication addr").port();
+    let status_addr = unused_loopback_tcp_addr();
+    let mut options =
+        parse_options(["--status-bind", status_addr.as_str()].into_iter()).expect("parse options");
+    options.replication_network_listen_addrs = vec![format!("/ip6/::1/tcp/{port}")];
+
+    let err = reserve_startup_reconcile_bind_guard(&options)
+        .expect_err("occupied ipv6 replication listen must fail before startup reconcile");
+    assert!(err.contains("startup reconcile preflight failed: replication tcp listen"));
+}
+
+#[test]
+fn startup_reconcile_bind_guard_rejects_unsupported_replication_listen_addr() {
+    let status_addr = unused_loopback_tcp_addr();
+    let mut options =
+        parse_options(["--status-bind", status_addr.as_str()].into_iter()).expect("parse options");
+    options.replication_network_listen_addrs = vec!["/dns4/example.test/tcp/30333".to_string()];
+
+    let err = reserve_startup_reconcile_bind_guard(&options)
+        .expect_err("unsupported replication listen must fail closed before startup reconcile");
+    assert!(err.contains("unsupported replication listen address"));
+}
+
+#[test]
 fn parse_options_reads_validator_signer_public_key_overrides() {
     let options = parse_options(
         [

--- a/crates/oasis7/src/bin/oasis7_chain_runtime/oasis7_chain_runtime_tests.rs
+++ b/crates/oasis7/src/bin/oasis7_chain_runtime/oasis7_chain_runtime_tests.rs
@@ -10,7 +10,7 @@ use super::{
     build_replication_remote_writer_allowlist, build_validator_signer_public_keys,
     derive_node_consensus_signer_keypair, derive_node_libp2p_identity_keypair_config,
     network_tier_allows_open_observer_fetch, node_keypair_config, parse_options,
-    parse_validator_spec,
+    parse_validator_spec, reserve_startup_reconcile_bind_guard,
 };
 use ed25519_dalek::SigningKey;
 use oasis7::network_tier_manifest::{
@@ -29,7 +29,13 @@ use oasis7_proto::distributed_dht::{
 };
 use oasis7_proto::storage_profile::{StorageProfile, StorageProfileConfig};
 use std::collections::BTreeMap;
+use std::net::{TcpListener, UdpSocket};
 use std::path::Path;
+
+fn unused_loopback_tcp_addr() -> String {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("reserve unused tcp port");
+    listener.local_addr().expect("tcp addr").to_string()
+}
 
 #[test]
 fn status_http_request_waits_for_full_content_length_body() {
@@ -210,6 +216,54 @@ fn parse_options_rejects_peer_without_bind() {
     let err = parse_options(["--node-gossip-peer", "127.0.0.1:9001"].into_iter())
         .expect_err("should reject peer without bind");
     assert!(err.contains("requires --node-gossip-bind"));
+}
+
+#[test]
+fn startup_reconcile_bind_guard_rejects_occupied_status_bind() {
+    let occupied = TcpListener::bind("127.0.0.1:0").expect("reserve status port");
+    let status_addr = occupied.local_addr().expect("status addr").to_string();
+    let mut options =
+        parse_options(["--status-bind", status_addr.as_str()].into_iter()).expect("parse options");
+    options.replication_network_listen_addrs = vec!["/ip4/127.0.0.1/tcp/0".to_string()];
+
+    let err = reserve_startup_reconcile_bind_guard(&options)
+        .expect_err("occupied status bind must fail before startup reconcile");
+    assert!(err.contains("startup reconcile preflight failed: status bind"));
+}
+
+#[test]
+fn startup_reconcile_bind_guard_rejects_occupied_gossip_bind() {
+    let occupied = UdpSocket::bind("127.0.0.1:0").expect("reserve gossip port");
+    let gossip_addr = occupied.local_addr().expect("gossip addr").to_string();
+    let mut options = parse_options(
+        [
+            "--status-bind",
+            unused_loopback_tcp_addr().as_str(),
+            "--node-gossip-bind",
+            gossip_addr.as_str(),
+        ]
+        .into_iter(),
+    )
+    .expect("parse options");
+    options.replication_network_listen_addrs = vec!["/ip4/127.0.0.1/tcp/0".to_string()];
+
+    let err = reserve_startup_reconcile_bind_guard(&options)
+        .expect_err("occupied gossip bind must fail before startup reconcile");
+    assert!(err.contains("startup reconcile preflight failed: gossip bind"));
+}
+
+#[test]
+fn startup_reconcile_bind_guard_rejects_occupied_replication_tcp_listen() {
+    let occupied = TcpListener::bind("127.0.0.1:0").expect("reserve replication port");
+    let port = occupied.local_addr().expect("replication addr").port();
+    let status_addr = unused_loopback_tcp_addr();
+    let mut options =
+        parse_options(["--status-bind", status_addr.as_str()].into_iter()).expect("parse options");
+    options.replication_network_listen_addrs = vec![format!("/ip4/127.0.0.1/tcp/{port}")];
+
+    let err = reserve_startup_reconcile_bind_guard(&options)
+        .expect_err("occupied replication listen must fail before startup reconcile");
+    assert!(err.contains("startup reconcile preflight failed: replication tcp listen"));
 }
 
 #[test]

--- a/doc/p2p/project.md
+++ b/doc/p2p/project.md
@@ -7,6 +7,7 @@
 - hosted player access / hosted account、public testnet、bridge/newapi、network tier、主链 token 与 faucet/mint-ready 细项均已有独立 topic project；本页不再逐条复述每条子线的完成流水。
 
 ### 最近完成（保留一跳 Trace）
+- [x] runtime-testnet-startup-reconcile-bind-failure (PRD-P2P-001/003/028) [test_tier_required]: 修复 public_testnet 重复/失败启动在端口 bind 失败前已写入 startup reconcile 持久头状态的问题；runtime 在 reconcile 前预占 status/gossip/replication endpoint，package upgrade live path 在切换 bundle 前 stop 服务并拒绝同 node-root 残留进程，避免故障启动推进共识/执行状态。 Trace: .pm/tasks/task_3203bec287cc43919a32e5e82b1d28b2.yaml
 - [x] fix-replication-peer-head-freshness (PRD-P2P-001/003/028) [test_tier_required]: 修复 public_testnet 节点同高但 peer head 长期停旧的问题；head request timeout 可继续尝试后续 peer，storage/validator-core 的 replicated commit head 与 local commit head 使用独立 rebroadcast 账本，同时同高度冲突 head 在发布前 fail-closed，避免扩散分叉状态。 Trace: .pm/tasks/task_49ae72ce192c4151b0f150e12bb95605.yaml
 - [x] fix-public-testnet-peer-head-readiness (PRD-P2P-001/003/028) [test_tier_required]: 修复 public_testnet 低提交频率下 peer head age 超 TTL 导致 readiness 误判的问题；旧 peer head 仅在 committed/network height、block hash 与 execution binding 均匹配当前本地头时可作为有效 fresh，同时补充分叉/追块负向测试并记录多节点状态不一致必须根因修复后 redeploy/rebuild 的 runbook 原则。 Trace: .pm/tasks/task_06b409262b4846618e6cc9a0867de99c.yaml
 - [x] testnet-execution-hash-replay-readiness (PRD-P2P-001/003) [test_tier_required]: 修复 synced replication 执行哈希回放的 expected-hash 校验、回滚安全与 committed tick v2 schema，避免拒绝的 peer mismatch 污染 runtime/simulator 持久状态。 Trace: .pm/tasks/task_41f5ad97727c4641b65241d4141601b9.yaml

--- a/scripts/p2p-public-testnet-package-node-upgrade.sh
+++ b/scripts/p2p-public-testnet-package-node-upgrade.sh
@@ -66,6 +66,39 @@ for index, token in enumerate(tokens):
 PY
 }
 
+cleanup_upgrade_lock() {
+  if [[ -n "${upgrade_lock_dir:-}" && -d "$upgrade_lock_dir" ]]; then
+    rmdir "$upgrade_lock_dir" 2>/dev/null || true
+  fi
+}
+
+assert_no_node_processes() {
+  local root=$1
+  local matches
+  matches="$(
+    ps -eo pid=,ppid=,args= | awk -v root="$root" '
+      index($0, root) > 0 && ($0 ~ /oasis7_chain_runtime/ || $0 ~ /start-node[.]sh/) {
+        print
+      }
+    ' || true
+  )"
+  if [[ -n "$matches" ]]; then
+    printf '%s\n' "$matches" >&2
+    die "node-root still has running oasis7 process after stop: $root"
+  fi
+}
+
+ensure_governed_bootstrap_bundle_exists() {
+  local root=$1
+  local first_bundle
+  first_bundle="$(
+    find "$root/config" -type f \
+      -name "public-testnet-governed-bootstrap-bundle-2026-06-06.json" \
+      -print -quit 2>/dev/null || true
+  )"
+  [[ -n "$first_bundle" ]] || die "no governed bootstrap bundle found under $root/config"
+}
+
 migrate_legacy_replication_root() {
   local root=$1
   local node_id=$2
@@ -279,6 +312,11 @@ node_root=$(abs_path "$node_root")
 bundle_tar=$(abs_path "$bundle_tar")
 artifact_ref=${artifact_ref:-"oasis7-linux-x64-bundle.tar.gz!/bin/oasis7_chain_runtime"}
 node_id=$(parse_node_id "$node_root/bin/start-node.sh")
+upgrade_lock_dir="$node_root/.package-upgrade.lock"
+if ! mkdir "$upgrade_lock_dir" 2>/dev/null; then
+  die "another package upgrade is already running for $node_root"
+fi
+trap cleanup_upgrade_lock EXIT
 
 release_dir="$node_root/releases/$package_version"
 tmp_dir="$node_root/releases/.${package_version}.tmp.$$"
@@ -291,6 +329,14 @@ tar -xzf "$bundle_tar" -C "$tmp_dir"
 bundle_root="$tmp_dir/oasis7-linux-x64"
 runtime_bin="$bundle_root/bin/oasis7_chain_runtime"
 [[ -x "$runtime_bin" ]] || die "bundle missing executable runtime: $runtime_bin"
+ensure_governed_bootstrap_bundle_exists "$node_root"
+
+if [[ "$restart_service" -eq 1 ]]; then
+  systemctl daemon-reload
+  systemctl stop "$systemd_service"
+  sleep 2
+  assert_no_node_processes "$node_root"
+fi
 
 python3 - "$node_root" "$bundle_root" "$package_version" "$commit" "$run_id" "$artifact_ref" <<'PY'
 from __future__ import annotations
@@ -392,7 +438,7 @@ prune_old_releases "$node_root/releases" "$current_path" "$release_retention_cou
 
 if [[ "$restart_service" -eq 1 ]]; then
   systemctl daemon-reload
-  systemctl restart "$systemd_service"
+  systemctl start "$systemd_service"
   sleep 3
   systemctl is-active --quiet "$systemd_service"
   systemctl --no-pager --full status "$systemd_service" | sed -n '1,18p'

--- a/scripts/p2p-public-testnet-package-node-upgrade.sh
+++ b/scripts/p2p-public-testnet-package-node-upgrade.sh
@@ -76,11 +76,15 @@ assert_no_node_processes() {
   local root=$1
   local matches
   matches="$(
-    ps -eo pid=,ppid=,args= | awk -v root="$root" '
-      index($0, root) > 0 && ($0 ~ /oasis7_chain_runtime/ || $0 ~ /start-node[.]sh/) {
-        print
-      }
-    ' || true
+    while IFS= read -r line; do
+      if [[ "$line" =~ ^[[:space:]]*([0-9]+)[[:space:]]+([0-9]+)[[:space:]]+(.*)$ ]]; then
+        args="${BASH_REMATCH[3]}"
+        if [[ "$args" == *"$root"/* ]] \
+          && { [[ "$args" == *"/oasis7_chain_runtime"* ]] || [[ "$args" == *"/start-node.sh"* ]]; }; then
+          printf '%s\n' "$line"
+        fi
+      fi
+    done < <(ps -eo pid=,ppid=,args=) || true
   )"
   if [[ -n "$matches" ]]; then
     printf '%s\n' "$matches" >&2

--- a/scripts/p2p-public-testnet-package-node-upgrade.test.sh
+++ b/scripts/p2p-public-testnet-package-node-upgrade.test.sh
@@ -140,4 +140,43 @@ grep -q "no governed bootstrap bundle found" /tmp/oasis7-package-node-upgrade-ne
 negative_current=$(python3 -c 'import pathlib,sys; print(pathlib.Path(sys.argv[1]).resolve())' "$missing_bundle_node_abs/current")
 test "$negative_current" = "$missing_bundle_node_abs/releases/old"
 
+orphan_node="$TMP_DIR/orphan-node"
+mkdir -p "$orphan_node/releases/old/bin" "$orphan_node/config/doc/testing/evidence" "$TMP_DIR/fake-bin"
+printf 'runtime-v1\n' >"$orphan_node/releases/old/bin/oasis7_chain_runtime"
+chmod +x "$orphan_node/releases/old/bin/oasis7_chain_runtime"
+ln -s "$orphan_node/releases/old" "$orphan_node/current"
+cp \
+  "$node_root_abs/config/doc/testing/evidence/public-testnet-governed-bootstrap-bundle-2026-06-06.json" \
+  "$orphan_node/config/doc/testing/evidence/public-testnet-governed-bootstrap-bundle-2026-06-06.json"
+orphan_node_abs=$(python3 -c 'import pathlib,sys; print(pathlib.Path(sys.argv[1]).resolve())' "$orphan_node")
+cat >"$TMP_DIR/fake-bin/systemctl" <<'SH'
+#!/usr/bin/env bash
+printf 'systemctl %s\n' "$*" >>"$FAKE_SYSTEMCTL_LOG"
+exit 0
+SH
+cat >"$TMP_DIR/fake-bin/ps" <<SH
+#!/usr/bin/env bash
+printf '999 1 ${orphan_node_abs}/current/bin/oasis7_chain_runtime --runtime-root ${orphan_node_abs}/data/runtime-root\\n'
+SH
+chmod +x "$TMP_DIR/fake-bin/systemctl" "$TMP_DIR/fake-bin/ps"
+set +e
+FAKE_SYSTEMCTL_LOG="$TMP_DIR/fake-systemctl.log" \
+PATH="$TMP_DIR/fake-bin:$PATH" \
+"$ROOT_DIR/scripts/p2p-public-testnet-package-node-upgrade.sh" \
+  --node-root "$orphan_node" \
+  --bundle-tar "$TMP_DIR/oasis7-linux-x64-bundle.tar.gz" \
+  --package-version "$package_version-orphan" \
+  --commit "$commit" \
+  --run-id "$run_id" \
+  --systemd-service oasis7-testnet-orphan.service \
+  --restart-service \
+  >/tmp/oasis7-package-node-upgrade-orphan.out 2>&1
+orphan_status=$?
+set -e
+test "$orphan_status" -ne 0
+grep -q "node-root still has running oasis7 process after stop" /tmp/oasis7-package-node-upgrade-orphan.out
+grep -q "systemctl stop oasis7-testnet-orphan.service" "$TMP_DIR/fake-systemctl.log"
+orphan_current=$(python3 -c 'import pathlib,sys; print(pathlib.Path(sys.argv[1]).resolve())' "$orphan_node_abs/current")
+test "$orphan_current" = "$orphan_node_abs/releases/old"
+
 echo "ok: package node upgrade pins current runtime hash into governed bootstrap bundle"

--- a/scripts/p2p-public-testnet-package-node-upgrade.test.sh
+++ b/scripts/p2p-public-testnet-package-node-upgrade.test.sh
@@ -179,4 +179,35 @@ grep -q "systemctl stop oasis7-testnet-orphan.service" "$TMP_DIR/fake-systemctl.
 orphan_current=$(python3 -c 'import pathlib,sys; print(pathlib.Path(sys.argv[1]).resolve())' "$orphan_node_abs/current")
 test "$orphan_current" = "$orphan_node_abs/releases/old"
 
+scanner_node="$TMP_DIR/scanner-node"
+mkdir -p "$scanner_node/releases/old/bin" "$scanner_node/config/doc/testing/evidence"
+printf 'runtime-v1\n' >"$scanner_node/releases/old/bin/oasis7_chain_runtime"
+chmod +x "$scanner_node/releases/old/bin/oasis7_chain_runtime"
+ln -s "$scanner_node/releases/old" "$scanner_node/current"
+cp \
+  "$node_root_abs/config/doc/testing/evidence/public-testnet-governed-bootstrap-bundle-2026-06-06.json" \
+  "$scanner_node/config/doc/testing/evidence/public-testnet-governed-bootstrap-bundle-2026-06-06.json"
+scanner_node_abs=$(python3 -c 'import pathlib,sys; print(pathlib.Path(sys.argv[1]).resolve())' "$scanner_node")
+cat >"$TMP_DIR/fake-bin/ps" <<SH
+#!/usr/bin/env bash
+printf '888 1 awk -v root=${scanner_node_abs} index root /oasis7_chain_runtime/ /start-node[.]sh/\\n'
+SH
+set +e
+FAKE_SYSTEMCTL_LOG="$TMP_DIR/fake-systemctl.log" \
+PATH="$TMP_DIR/fake-bin:$PATH" \
+"$ROOT_DIR/scripts/p2p-public-testnet-package-node-upgrade.sh" \
+  --node-root "$scanner_node" \
+  --bundle-tar "$TMP_DIR/oasis7-linux-x64-bundle.tar.gz" \
+  --package-version "$package_version-scanner" \
+  --commit "$commit" \
+  --run-id "$run_id" \
+  --systemd-service oasis7-testnet-scanner.service \
+  --restart-service \
+  >/tmp/oasis7-package-node-upgrade-scanner.out 2>&1
+scanner_status=$?
+set -e
+test "$scanner_status" -eq 0
+scanner_current=$(python3 -c 'import pathlib,sys; print(pathlib.Path(sys.argv[1]).resolve())' "$scanner_node_abs/current")
+test "$scanner_current" = "$scanner_node_abs/releases/$package_version-scanner"
+
 echo "ok: package node upgrade pins current runtime hash into governed bootstrap bundle"


### PR DESCRIPTION
## Summary
- pre-bind status, gossip, and replication listen endpoints before startup reconcile can write persistent node position state
- make public testnet package upgrade fail closed if service stop leaves node-root processes alive before switching the governed bundle/current release
- record the public testnet divergence root-cause evidence and the requirement to clean redeploy/rebuild nodes after this fix is packaged

## Verification
- ./scripts/cargo-dev.sh test -p oasis7 startup_reconcile -- --nocapture
- bash scripts/p2p-public-testnet-package-node-upgrade.test.sh
- ./scripts/cargo-dev.sh fmt --check
- ./scripts/check-rust-file-size.sh
- git diff --check
- ./scripts/pm/workflow-lint.sh --task-uid task_3203bec287cc43919a32e5e82b1d28b2 --phase current

## PR Purpose
normal_pr_ci_watch