### PR TITLE
Validate launcher bundle asset freshness

### DIFF
--- a/.pm/tasks/task_0ad144b805d84ee5b7b0f248385acd45.execution.md
+++ b/.pm/tasks/task_0ad144b805d84ee5b7b0f248385acd45.execution.md
@@ -1,0 +1,202 @@
+# task_0ad144b805d84ee5b7b0f248385acd45 Execution Log
+
+- task_uid: task_0ad144b805d84ee5b7b0f248385acd45
+- title: frontend code governance next
+- owner_role: tpm
+- worktree_hint: /Users/scc/ccwork/worktrees/oasis7-engineering-frontend-code-governance-next-20260624
+
+<!-- Append entries using:
+Example:
+  ## YYYY-MM-DD HH:MM:SS CST / role_name
+  - 完成内容: ...
+  - 遗留事项: ...
+  - Action: ...
+  - Validation Command: ...
+  - Expected Result: ...
+  - Actual Result: ...
+- Blocker / Next Action: ...
+-->
+
+## 2026-06-24 21:43:56 CST / tpm
+- 完成内容: WORKFLOW BOOTSTRAP DECIDED.
+- 遗留事项: Dispatch repository-health professional slice to find and promote the next frontend governance issue.
+- Repository State Impact: user asked to continue finding and doing frontend/code governance; this will likely change repo state after professional discovery promotes a concrete issue.
+- Isolation Decision: main worktree was clean at `8d57930037ea2fe7479e88197d2187fe7dc54af1`; created dedicated worktree `/Users/scc/ccwork/worktrees/oasis7-engineering-frontend-code-governance-next-20260624` from `origin/main`.
+- Task Truth: owner role `tpm`; task `.pm/tasks/task_0ad144b805d84ee5b7b0f248385acd45.yaml`; execution log `.pm/tasks/task_0ad144b805d84ee5b7b0f248385acd45.execution.md`.
+- Routed Next Phase: `repo-owned-workflow-router` -> repository-health read-only professional discovery, then implementation execution if the finding is concrete and scoped.
+- Required Writeback: `.pm` execution log mandatory; project/doc refs only if implementation touches current contracts.
+- Action: Created standard task worktree and read workflow/role inputs.
+- Validation Command: `rtk ./scripts/new-task-worktree.sh engineering frontend-code-governance-next-20260624 --base origin/main --pm-owner-role tpm --pm-title "frontend code governance next" --pm-source-ref AGENTS.md --json`; `rtk sed -n '1,220p' .agents/roles/repository_health_engineer.md`; `rtk git log --oneline -8 --decorate`.
+- Expected Result: Dedicated task/worktree exists and repository-health role context is available before dispatch.
+- Actual Result: Task `task_0ad144b805d84ee5b7b0f248385acd45` created; worktree is `/Users/scc/ccwork/worktrees/oasis7-engineering-frontend-code-governance-next-20260624`; repo is based on current `origin/main` including PR #615.
+- Blocker / Next Action: Record slice contract and spawn repository_health_engineer.
+
+## 2026-06-24 21:44:10 CST / tpm
+- 完成内容: WORKFLOW ROUTE DECIDED.
+- 遗留事项: Await next repository-health finding, then dispatch implementation/verification roles.
+- Task Phase: read-only frontend governance discovery with expected same-task implementation follow-through.
+- Selected Workflow Skills: `default-workflow-bootstrap` completed; `repo-owned-workflow-router` selected professional discovery first; `executing-project-tasks` will follow if a concrete finding is returned; `verification-before-completion` and `finishing-a-development-branch` will apply after implementation.
+- Specialist Skills Considered: `repository_health_engineer` required for next issue discovery; likely downstream roles include `viewer_engineer`, `qa_engineer`, and possibly `repository_health_engineer` review depending on promoted finding.
+- Subagent Slice Plan: role: `repository_health_engineer`; slice type: `read_only_analysis`; intended model configuration: workflow source-of-truth default subagent runtime; actual dispatched model/reasoning: inherited/unverified due current subagent tool reporting limits; context delivery mode: full-thread fork plus explicit current finding constraints; mandatory context checklist/packet: AGENTS.md authority, `.agents/roles/repository_health_engineer.md`, source-of-truth workflow, task `task_0ad144b805d84ee5b7b0f248385acd45`, user directive "继续找下一个问题并做治理", recent merged governance PRs #602, #610, and #615, and boundary that TPM integrates only.
+- Write Scope: read-only; do not edit files.
+- Return Contract: one next actionable frontend/Viewer/Web code governance issue not duplicating PR #602, PR #610, or PR #615; category/severity; concrete evidence paths/commands; why it is next; recommended owner roles; smallest implementation step; suggested validation; residual risk/non-goals; promotion recommendation.
+- Formal Sink / Writeback Surface: `.pm/tasks/task_0ad144b805d84ee5b7b0f248385acd45.execution.md`.
+- Integration Owner: `tpm`.
+- Integration Order: repository-health finding -> TPM integrates -> implementation owner slice -> QA/review -> PR mainline.
+- Action: Prepared repository-health discovery contract.
+- Validation Command: `rtk sed -n '1,260p' .agents/skills/default-workflow-bootstrap/SKILL.md`; `rtk sed -n '1,260p' .agents/skills/repo-owned-workflow-router/SKILL.md`.
+- Expected Result: Workflow phase and role dispatch requirements are explicit before professional discovery.
+- Actual Result: Bootstrap/router requirements confirmed; dispatch pending.
+- Blocker / Next Action: spawn repository_health_engineer subagent.
+
+## 2026-06-24 21:53:03 CST / repository_health_engineer
+- 完成内容: PROFESSIONAL DISCOVERY RESULT INTEGRATED.
+- 遗留事项: Dispatch Viewer implementation and QA validation slices for promoted issue.
+- Finding: launcher bundle freshness checks source fingerprint and viewer protocol version, but does not validate the `manifest.assets` path/hash fields that bundle creation already records. `run-launcher-stack.sh --bundle-dir` and `run-producer-playtest.sh` can therefore accept a bundle whose workspace sources are fresh but whose packaged web assets were deleted or modified after manifest write.
+- Severity / Category: P1 medium; artifact integrity / freshness contract gap.
+- Evidence: `scripts/build-game-launcher-bundle.sh` copies Viewer Web assets and calls `bundle_write_manifest`; `scripts/bundle-freshness-lib.sh` records asset paths and SHA-256 values such as `viewerJsPath`/`viewerJsSha256`, but `bundle_check_freshness()` only compares `sourceFingerprint` and `viewerProtocolVersion`. Repository-health fixture mutated or deleted `bundle/web/viewer.js` after `bundle_write_manifest` and observed `bundle freshness ok`.
+- Why This Is Next: Does not duplicate PR #602, PR #610, or PR #615. PR #615 tightened source scope; this is the next layer, ensuring the recorded bundle artifact hashes are actually enforced before bundle reuse.
+- Recommended Implementation Owner: `viewer_engineer`.
+- Recommended Validation Owner: `qa_engineer`.
+- Non-Goals: Do not rename `software_safe` taxonomy; do not change Viewer runtime, UI, render mode, PostOnboarding QA semantics, or bundle layout beyond enforcing existing manifest asset integrity.
+- Action: Promoted repository-health finding for same-task implementation.
+- Validation Command: repository-health read-only fixture using `bundle_write_manifest`, post-manifest mutation/removal of `bundle/web/viewer.js`, then `bundle_check_freshness`.
+- Expected Result: Current baseline demonstrates freshness accepts asset mutation/removal despite manifest hashes.
+- Actual Result: Repository-health slice observed `bundle_check=PASS` / `bundle freshness ok` after asset mutation/removal.
+- Blocker / Next Action: Write implementation/QA slice contracts, then patch and verify.
+
+## 2026-06-24 21:53:20 CST / tpm
+- 完成内容: IMPLEMENTATION AND QA SLICE CONTRACTS WRITTEN.
+- 遗留事项: Await role results, integrate patch, run verification, and proceed to closeout/PR.
+- Viewer Implementation Slice Contract: role `viewer_engineer`; slice type `implementation`; intended model configuration: workflow source-of-truth default subagent runtime; actual dispatched model/reasoning: inherited/unverified due current subagent tool reporting limits; context delivery mode: full-thread fork plus explicit current finding; mandatory context checklist/packet: AGENTS.md authority, `.agents/roles/viewer_engineer.md`, task `task_0ad144b805d84ee5b7b0f248385acd45`, repository-health finding above, current worktree path, PR #602/#610/#615 non-duplication boundaries, and non-goals around taxonomy/runtime/UI behavior. Write scope: `scripts/bundle-freshness-lib.sh` and `scripts/bundle-freshness-lib.test.sh` only unless a direct dependency is discovered. Return contract: changed files, implementation rationale, exact verification commands/results, residual risks.
+- QA Slice Contract: role `qa_engineer`; slice type `validation_design_and_execution`; intended model configuration: workflow source-of-truth default subagent runtime; actual dispatched model/reasoning: inherited/unverified due current subagent tool reporting limits; context delivery mode: full-thread fork plus explicit current finding; mandatory context checklist/packet: AGENTS.md authority, `.agents/roles/qa_engineer.md`, task `task_0ad144b805d84ee5b7b0f248385acd45`, repository-health finding above, proposed validation entrypoints, and no UI/runtime behavior changes. Write scope: read-only unless test commands write temp artifacts. Return contract: required/focused verification set, observed pass/fail evidence, release/blocking recommendation, residual risk.
+- Integration Owner: `tpm`.
+- Integration Order: viewer implementation -> TPM review/integration -> QA validation -> repository-health/pre-PR review -> PR.
+- Action: Prepared bounded professional role dispatch for implementation and validation.
+- Validation Command: `rtk sed -n '1,260p' .agents/skills/executing-project-tasks/SKILL.md`; `rtk sed -n '1,220p' .agents/roles/viewer_engineer.md`; `rtk sed -n '1,220p' .agents/roles/qa_engineer.md`; `rtk sed -n '1,260p' scripts/bundle-freshness-lib.sh`; `rtk sed -n '1,220p' scripts/bundle-freshness-lib.test.sh`.
+- Expected Result: Implementation surface and role contracts are explicit before editing.
+- Actual Result: Scope is narrow and implementation-ready: enforce manifest asset hash/path integrity in `bundle_check_freshness()` and extend the focused smoke.
+- Blocker / Next Action: Spawn viewer_engineer and qa_engineer subagents.
+
+## 2026-06-24 21:57:25 CST / viewer_engineer
+- 完成内容: Implemented the minimal bundle asset integrity freshness fix.
+- 遗留事项: TPM should integrate, request/read QA validation, then continue closeout/PR workflow.
+- Changed Files: `scripts/bundle-freshness-lib.sh`; `scripts/bundle-freshness-lib.test.sh`.
+- Implementation Rationale: `bundle_write_manifest()` already records `manifest.assets` path/SHA-256 pairs, so `bundle_check_freshness()` now treats every non-empty `*Path` entry as part of the freshness contract, requiring the file to exist under the bundle directory and match the paired `*Sha256` value. This closes the gap where source fingerprints stayed fresh but packaged artifacts were deleted or mutated.
+- Test Expansion: `scripts/bundle-freshness-lib.test.sh` now creates bundle asset fixtures and asserts freshness fails with `bundle asset drift` after mutating and deleting `bundle/web/viewer.js`, and after mutating and deleting non-viewer `bundle/web-launcher/app.js`.
+- Scope Boundary: Did not rename `software_safe`; did not change Viewer runtime/UI/render mode/PostOnboarding QA behavior; did not change bundle layout; did not touch `third_party`.
+- Action: Patched bundle freshness asset validation and focused smoke coverage.
+- Validation Command: `rtk ./scripts/bundle-freshness-lib.test.sh`; `rtk ./scripts/build-game-launcher-bundle.sh --help`; `rtk ./scripts/run-launcher-stack.sh --help`; `rtk ./scripts/run-producer-playtest.sh --help`; `rtk git diff --check`; `rtk ./scripts/copy-viewer-web-dist.test.sh`; `rtk ./scripts/agent-browser-viewer-dist-freshness-test.sh`.
+- Expected Result: Freshness rejects source drift, viewer bundle asset hash drift/deletion, and launcher web asset hash drift/deletion; launcher entry help still parses; existing Viewer dist contract tests still pass; diff has no whitespace errors.
+- Actual Result: All listed validation commands passed.
+- Blocker / Next Action: None from implementation slice; residual risk is limited to future asset scope completeness outside the currently recorded manifest fields.
+
+## 2026-06-24 21:58:44 CST / qa_engineer
+- 完成内容: QA VALIDATION RESULT INTEGRATED.
+- 遗留事项: TPM reruns local verification in canonical worktree, then proceeds to pre-PR review/closeout.
+- Release Recommendation: allow / non-blocking.
+- QA Scope: Verify that `bundle_check_freshness()` now rejects manifest-recorded asset hash drift and missing assets without requiring unrelated Viewer UI/runtime/browser regressions.
+- QA Evidence: `scripts/bundle-freshness-lib.test.sh` passed and covers `web/viewer.js` mutation/deletion plus non-viewer `web-launcher/app.js` mutation/deletion. `build-game-launcher-bundle.sh --help`, `run-launcher-stack.sh --help`, `run-producer-playtest.sh --help`, and `git diff --check` passed in the QA slice. Extra temporary fixture manually rewrote/deleted `bundle/web/viewer.js` after manifest write and observed `bundle asset drift`.
+- QA Judgment: `copy-viewer-web-dist.test.sh` and `agent-browser-viewer-dist-freshness-test.sh` are not required for QA release recommendation because implementation only changes bundle manifest asset path/hash checking and focused shell smoke; it does not change Viewer dist copy logic, browser/runtime/UI behavior, or bundle layout.
+- Residual Risk: Freshness now enforces manifest-recorded non-empty asset path/hash entries; future assets still need to be written into the manifest to be covered.
+- Action: Integrated QA release recommendation and residual risk.
+- Validation Command: QA slice ran `rtk ./scripts/bundle-freshness-lib.test.sh`; `rtk ./scripts/build-game-launcher-bundle.sh --help`; `rtk ./scripts/run-launcher-stack.sh --help`; `rtk ./scripts/run-producer-playtest.sh --help`; `rtk git diff --check`; plus an extra temporary fixture for `bundle/web/viewer.js` mutation/deletion.
+- Expected Result: Focused verification covers the promoted artifact integrity gap; no blocking release risk remains for this helper/test-only change.
+- Actual Result: QA reported allow / non-blocking with the residual risk above.
+- Blocker / Next Action: TPM fresh verification in canonical worktree.
+
+## 2026-06-24 22:01:11 CST / tpm
+- 完成内容: PRE-PR LOCAL ROLE REVIEW REQUESTED.
+- 遗留事项: Await repository_health_engineer, viewer_engineer, and qa_engineer review verdicts.
+- Review Trigger: pre-PR local role review
+- Review Scope: `scripts/bundle-freshness-lib.sh`; `scripts/bundle-freshness-lib.test.sh`; `.pm/tasks/task_0ad144b805d84ee5b7b0f248385acd45.execution.md`; `.pm/tasks/task_0ad144b805d84ee5b7b0f248385acd45.yaml`; `.pm/roles/tpm/backlog/committed.yaml`
+- Review Package: n/a with reason: current review target is an uncommitted working-tree diff; `./scripts/pm/review-package.sh --base refs/remotes/origin/main --head HEAD --task-uid task_0ad144b805d84ee5b7b0f248385acd45` produced an empty `8d5793003..8d5793003` package before commit.
+- Review Roles: repository_health_engineer, viewer_engineer, qa_engineer
+- Review Question: Confirm `bundle_check_freshness()` now enforces manifest-recorded bundle asset path/SHA-256 integrity, the focused smoke covers viewer and non-viewer asset drift/missing cases, and the diff stays within helper/test/task evidence scope without UI/runtime/taxonomy behavior changes.
+- Evidence Available: `rtk ./scripts/bundle-freshness-lib.test.sh` passed; `rtk ./scripts/build-game-launcher-bundle.sh --help` passed; `rtk ./scripts/run-launcher-stack.sh --help` passed; `rtk ./scripts/run-producer-playtest.sh --help` passed; `rtk git diff --check` passed; `rtk ./scripts/doc-governance-check.sh` passed; `rtk ./scripts/copy-viewer-web-dist.test.sh` passed; `rtk ./scripts/agent-browser-viewer-dist-freshness-test.sh` passed.
+- Expected Return Contract: findings | no_findings | scope/spec compliance verdict | role quality/risk verdict | residual_risk
+- Slice Ledger: /Users/scc/ccwork/worktrees/oasis7-engineering-frontend-code-governance-next-20260624/.pm/scratch/task_0ad144b805d84ee5b7b0f248385acd45/slice-ledger.jsonl
+- Formal Sink: .pm/tasks/task_0ad144b805d84ee5b7b0f248385acd45.execution.md
+- Action: Recorded pre-PR local role review request and dispatched involved role review slices.
+- Validation Command: `rtk ./scripts/pm/review-package.sh --base refs/remotes/origin/main --head HEAD --task-uid task_0ad144b805d84ee5b7b0f248385acd45`; `rtk ./scripts/pm/slice-ledger.sh --task-uid task_0ad144b805d84ee5b7b0f248385acd45 --print`.
+- Expected Result: Review target and slice ledger are identified before PR creation.
+- Actual Result: Slice ledger path was produced; review package helper produced an empty package because the review target was an uncommitted working-tree diff, so role reviewers were instructed to inspect `git diff` directly.
+- Blocker / Next Action: Wait for role review results and integrate findings.
+
+## 2026-06-24 22:05:24 CST / tpm
+- 完成内容: PRE-PR LOCAL ROLE REVIEW PASSED.
+- 遗留事项: Run task closeout, commit, create PR, and watch normal PR CI/comments/mergeability.
+- Pre-PR Local Role Review: passed
+- Task UID: task_0ad144b805d84ee5b7b0f248385acd45
+- Source Worktree: /Users/scc/ccwork/worktrees/oasis7-engineering-frontend-code-governance-next-20260624
+- Source Branch: task/engineering-frontend-code-governance-next-20260624
+- Source Head: 8d57930037ea2fe7479e88197d2187fe7dc54af1
+- Comparison Ref: refs/remotes/origin/main
+- Reviewed Changed Paths: scripts/bundle-freshness-lib.sh; scripts/bundle-freshness-lib.test.sh; .pm/tasks/task_0ad144b805d84ee5b7b0f248385acd45.execution.md; .pm/tasks/task_0ad144b805d84ee5b7b0f248385acd45.yaml; .pm/roles/tpm/backlog/committed.yaml
+- Review Package: n/a with reason: working-tree diff was uncommitted at review time; review-package helper produced empty `8d5793003..8d5793003` package.
+- Role Selection Basis: changed paths touch shared bundle freshness helper/test contract; repository-health promoted the artifact-integrity governance gap; viewer_engineer owns Viewer/Launcher/Web helper behavior; qa_engineer owns verification sufficiency and PR readiness risk.
+- Review Roles: repository_health_engineer,viewer_engineer,qa_engineer
+- Review Evidence: repository_health_engineer: no_findings, scope/spec pass, quality/risk allow, residual risk limited to manifest-recorded assets; viewer_engineer: no_findings, compliant, allow/non-blocking, no runtime/UI/taxonomy/bundle-layout scope creep; qa_engineer: no_findings, pass/PR-ready, verification set sufficient for helper/test-only change.
+- Review Verdicts: repository_health_engineer scope/spec compliance pass and role quality/risk allow; viewer_engineer scope/spec compliance compliant and role quality/risk allow/non-blocking; qa_engineer scope/spec compliance pass and role quality/risk pass/PR-ready.
+- Review Findings Disposition: no_findings
+- Finding Disposition Evidence: No valid findings from local role review; no code changes required after review.
+- Verification Matrix: bundle asset integrity -> `./scripts/bundle-freshness-lib.test.sh` passed and covers `web/viewer.js` mutation/deletion plus `web-launcher/app.js` mutation/deletion; entrypoint parse -> `./scripts/build-game-launcher-bundle.sh --help`, `./scripts/run-launcher-stack.sh --help`, and `./scripts/run-producer-playtest.sh --help` passed; adjacent Viewer dist contract -> `./scripts/copy-viewer-web-dist.test.sh` and `./scripts/agent-browser-viewer-dist-freshness-test.sh` passed; doc/diff hygiene -> `./scripts/doc-governance-check.sh` and `git diff --check` passed.
+- Visual Evidence: n/a with explicit exemption reason: no rendered UI, viewport, player-facing screen flow, visual asset, or interaction surface changed.
+- WASM Evidence: n/a with explicit exemption reason: no WASM ABI, support crate, determinism, receipt, or hash behavior changed beyond checking existing bundle asset hashes.
+- Ops Evidence: n/a with explicit exemption reason: no deployment, operator runbook, rollback, service topology, or release ops procedure changed.
+- LiveOps Evidence: n/a with explicit exemption reason: no public-facing messaging, release note, player promise, status, or community channel wording changed.
+- Residual Risk: Freshness now enforces non-empty asset path/hash pairs already recorded in `manifest.assets`; future bundle assets still need to be recorded in the manifest to be covered.
+- Slice Ledger: /Users/scc/ccwork/worktrees/oasis7-engineering-frontend-code-governance-next-20260624/.pm/scratch/task_0ad144b805d84ee5b7b0f248385acd45/slice-ledger.jsonl
+- Action: Integrated repository-health, viewer, and QA pre-PR review verdicts.
+- Validation Command: `rtk ./scripts/pm/workflow-lint.sh --task-uid task_0ad144b805d84ee5b7b0f248385acd45 --phase current`; pre-PR role review subagent results above.
+- Expected Result: Local role review evidence packet exists before PR creation.
+- Actual Result: workflow-lint passed; all three involved roles returned no findings and allow/pass verdicts.
+- Blocker / Next Action: Run task closeout verification.
+
+## 2026-06-24 22:16:04 CST / tpm
+- 完成内容: Resolved PR preflight task-binding ambiguity.
+- 遗留事项: Re-run PR preflight after branch sync with `origin/main`.
+- Action: Disambiguated stale completed task metadata that still pointed at this task worktree.
+- Validation Command: `rtk ./scripts/prepare-task-pr.sh --help`; `rtk rg -n "expected exactly one bound task|bound task|worktree_hint|current_branch|current_worktree" scripts/pm scripts/prepare-task-pr.sh`; `rtk sed -n '1,80p' .pm/tasks/task_0b89a0662ac94e9aa4b6de7214b6becb.yaml`; `rtk sed -n '500,555p' scripts/prepare-task-pr.sh`; `rtk sed -n '60,110p' scripts/pm/workflow-lint.sh`.
+- Expected Result: Identify why `prepare-task-pr.sh` reported multiple bound tasks without changing implementation scope.
+- Actual Result: `prepare-task-pr.sh` has no `--task-uid` override and matches `.pm/tasks/*.yaml` by exact `worktree_hint`; historical completed task `task_0b89a0662ac94e9aa4b6de7214b6becb` from PR #602 still used this worktree path, so its YAML `worktree_hint` was changed to archived path `/Users/scc/ccwork/worktrees/archived-task-0b89a0662ac94e9aa4b6de7214b6becb`. Historical execution log evidence was left intact.
+- Blocker / Next Action: Validate single bound task, sync branch with latest `origin/main`, then create PR.
+
+## 2026-06-24 22:16:24 CST / tpm
+- 完成内容: Recorded fresh PR-ready verification evidence after rebasing onto latest `origin/main`.
+- 遗留事项: Re-run `prepare-task-pr.sh --create`, then watch normal PR checks/comments/mergeability.
+- Action: Added Viewer project Trace, refreshed task completion claim, and checked closeout immutability.
+- Validation Command: `./scripts/pm/claim-ready.sh --claim-type task_complete --verify-command './scripts/bundle-freshness-lib.test.sh && ./scripts/build-game-launcher-bundle.sh --help >/dev/null && ./scripts/run-launcher-stack.sh --help >/dev/null && ./scripts/run-producer-playtest.sh --help >/dev/null && git diff --check && ./scripts/doc-governance-check.sh && ./scripts/pm/workflow-lint.sh --task-uid task_0ad144b805d84ee5b7b0f248385acd45 --phase current' --task-uid task_0ad144b805d84ee5b7b0f248385acd45`; `./scripts/pm/task-closeout.sh --role tpm --task-uid task_0ad144b805d84ee5b7b0f248385acd45 --verify-command './scripts/bundle-freshness-lib.test.sh && ./scripts/build-game-launcher-bundle.sh --help >/dev/null && ./scripts/run-launcher-stack.sh --help >/dev/null && ./scripts/run-producer-playtest.sh --help >/dev/null && git diff --check && ./scripts/doc-governance-check.sh && ./scripts/pm/workflow-lint.sh --task-uid task_0ad144b805d84ee5b7b0f248385acd45 --phase current'`.
+- Expected Result: Fresh verification updates task YAML and execution log includes both claim-ready and closeout evidence markers required by PR-ready lint.
+- Actual Result: `claim-ready.sh` reran the verification chain successfully with exit code 0 and updated task YAML `last_verified_at: 2026-06-24T22:16:04+08:00`; `task-closeout.sh` returned `task already closed with status=done`, preserving the previous completed closeout rather than reopening the task.
+- Blocker / Next Action: Run workflow-lint and PR preflight again.
+
+## 2026-06-24 22:23:11 CST / tpm
+- 完成内容: PRE-PR LOCAL ROLE REVIEW PASSED with producer scope included.
+- 遗留事项: Create PR and watch normal PR checks/comments/mergeability.
+- Pre-PR Local Role Review: passed
+- Task UID: task_0ad144b805d84ee5b7b0f248385acd45
+- Source Worktree: /Users/scc/ccwork/worktrees/oasis7-engineering-frontend-code-governance-next-20260624
+- Source Branch: task/engineering-frontend-code-governance-next-20260624
+- Source Head: 240579bcc7bf471bec89688780133295bee79a9a
+- Comparison Ref: refs/remotes/origin/main
+- Reviewed Changed Paths: scripts/bundle-freshness-lib.sh; scripts/bundle-freshness-lib.test.sh; doc/viewer/project.md; .pm/tasks/task_0ad144b805d84ee5b7b0f248385acd45.execution.md; .pm/tasks/task_0ad144b805d84ee5b7b0f248385acd45.yaml; .pm/tasks/task_0b89a0662ac94e9aa4b6de7214b6becb.yaml
+- Review Package: n/a with reason: final review integrated role verdicts from live bounded slices and current branch diff after task evidence/project Trace repair.
+- Role Selection Basis: changed paths touch shared bundle freshness helper/test contract and Viewer project task trace; repository-health promoted the artifact-integrity governance gap; producer_system_designer owns product/system acceptance boundary from project Trace; viewer_engineer owns Viewer/Launcher/Web helper behavior; qa_engineer owns verification sufficiency; repository_health_engineer owns governance and architecture-health risk.
+- Review Roles: producer_system_designer,repository_health_engineer,viewer_engineer,qa_engineer
+- Review Evidence: producer_system_designer: no_findings, scope/spec pass, product/system allow/non-blocking, no added player-facing promise or product docs required; repository_health_engineer: no_findings, scope/spec pass, quality/risk allow, residual risk limited to manifest-recorded assets; viewer_engineer: no_findings, compliant, allow/non-blocking, no runtime/UI/taxonomy/bundle-layout scope creep; qa_engineer: no_findings, pass/PR-ready, verification set sufficient for helper/test-only change.
+- Review Verdicts: producer_system_designer scope/spec compliance pass and product/system risk allow; repository_health_engineer scope/spec compliance pass and role quality/risk allow; viewer_engineer scope/spec compliance compliant and role quality/risk allow/non-blocking; qa_engineer scope/spec compliance pass and role quality/risk pass/PR-ready.
+- Review Findings Disposition: no_findings
+- Finding Disposition Evidence: No valid findings from local role review; no code changes required after review. Producer slice inspected current diff and confirmed project Trace is appropriate for completed governance scope.
+- Verification Matrix: product/system acceptance -> producer_system_designer no_findings and no extra product docs/acceptance required; bundle asset integrity -> `./scripts/bundle-freshness-lib.test.sh` passed and covers `web/viewer.js` mutation/deletion plus `web-launcher/app.js` mutation/deletion; entrypoint parse -> `./scripts/build-game-launcher-bundle.sh --help`, `./scripts/run-launcher-stack.sh --help`, and `./scripts/run-producer-playtest.sh --help` passed; adjacent Viewer dist contract -> `./scripts/copy-viewer-web-dist.test.sh` and `./scripts/agent-browser-viewer-dist-freshness-test.sh` passed; doc/diff/PM hygiene -> `./scripts/doc-governance-check.sh`, `git diff --check`, and `./scripts/pm/workflow-lint.sh --phase pr-ready` passed.
+- Visual Evidence: n/a with explicit exemption reason: no rendered UI, viewport, player-facing screen flow, visual asset, or interaction surface changed.
+- WASM Evidence: n/a with explicit exemption reason: no WASM ABI, support crate, determinism, receipt, or hash behavior changed beyond checking existing bundle asset hashes.
+- Ops Evidence: n/a with explicit exemption reason: no deployment, operator runbook, rollback, service topology, or release ops procedure changed.
+- LiveOps Evidence: n/a with explicit exemption reason: no public-facing messaging, release note, player promise, status, or community channel wording changed.
+- Residual Risk: Freshness now enforces non-empty asset path/hash pairs already recorded in `manifest.assets`; future bundle assets still need to be recorded in the manifest to be covered.
+- Slice Ledger: /Users/scc/ccwork/worktrees/oasis7-engineering-frontend-code-governance-next-20260624/.pm/scratch/task_0ad144b805d84ee5b7b0f248385acd45/slice-ledger.jsonl
+- Action: Integrated producer_system_designer review with the previous repository-health, viewer, and QA pre-PR verdicts.
+- Validation Command: producer_system_designer inspected `git diff origin/main...HEAD` for scripts, Viewer project, and task evidence; `./scripts/pm/workflow-lint.sh --phase pr-ready`; `./scripts/prepare-task-pr.sh`.
+- Expected Result: Final pre-PR local role review packet covers every role required by changed paths.
+- Actual Result: All four role verdicts are no_findings/allow or pass; no product/system follow-up is required before PR.
+- Blocker / Next Action: Amend task evidence and rerun PR preflight/create.

--- a/.pm/tasks/task_0ad144b805d84ee5b7b0f248385acd45.execution.md
+++ b/.pm/tasks/task_0ad144b805d84ee5b7b0f248385acd45.execution.md
@@ -209,3 +209,12 @@ Example:
 - Expected Result: Create a normal implementation PR for the current task branch.
 - Actual Result: Branch pushed successfully; helper's `gh pr create` invocation failed in non-interactive mode requiring title/body/fill, so fallback `gh pr create` opened https://github.com/eng-cc/oasis7/pull/622. PR purpose decision: `normal_pr_ci_watch`.
 - Blocker / Next Action: Check PR status, comments, review threads, required checks, and mergeability.
+
+## 2026-06-24 22:39:54 CST / tpm
+- 完成内容: Addressed PR #622 review feedback for entrypoint HTML asset freshness.
+- 遗留事项: Push review fix, resolve the review thread, and restart PR checks watch.
+- Action: Classified the Codex review thread as valid missing asset-integrity coverage; added manifest path/SHA-256 entries for `web/index.html` and `web-launcher/index.html`, plus smoke coverage for mutating and deleting both entrypoint files.
+- Validation Command: `./scripts/pr-review-thread-closeout.sh 622 --unresolved-only`; `gh api repos/eng-cc/oasis7/pulls/622/comments --paginate`; `./scripts/bundle-freshness-lib.test.sh`; `./scripts/build-game-launcher-bundle.sh --help`; `./scripts/run-launcher-stack.sh --help`; `./scripts/run-producer-playtest.sh --help`; `git diff --check`; `./scripts/doc-governance-check.sh`; `./scripts/pm/workflow-lint.sh --phase post-pr`.
+- Expected Result: Review feedback is validated against repo truth, fixed with minimal scope, and covered by focused freshness tests.
+- Actual Result: Unresolved thread `PRRT_kwDORHhWec6L758R` was valid: entrypoint HTML files are required by release entrypoint validation but were not in `manifest.assets`; focused freshness test passed after adding those assets. `workflow-lint --phase post-pr` initially required a local PR evidence chain, so `PR.md` was added with PR #622 and task UID.
+- Blocker / Next Action: Re-run post-pr lint, commit, push, resolve thread, and re-check PR state.

--- a/.pm/tasks/task_0ad144b805d84ee5b7b0f248385acd45.execution.md
+++ b/.pm/tasks/task_0ad144b805d84ee5b7b0f248385acd45.execution.md
@@ -200,3 +200,12 @@ Example:
 - Expected Result: Final pre-PR local role review packet covers every role required by changed paths.
 - Actual Result: All four role verdicts are no_findings/allow or pass; no product/system follow-up is required before PR.
 - Blocker / Next Action: Amend task evidence and rerun PR preflight/create.
+
+## 2026-06-24 22:27:48 CST / tpm
+- 完成内容: PR #622 created and classified for normal CI watch.
+- 遗留事项: Watch required checks, mergeability, PR comments, and review threads through merge.
+- Action: Pushed branch and opened GitHub PR.
+- Validation Command: `./scripts/prepare-task-pr.sh --create --title "Validate launcher bundle asset freshness"`; fallback `gh pr create --base main --head task/engineering-frontend-code-governance-next-20260624 --title "Validate launcher bundle asset freshness" --body <summary>`.
+- Expected Result: Create a normal implementation PR for the current task branch.
+- Actual Result: Branch pushed successfully; helper's `gh pr create` invocation failed in non-interactive mode requiring title/body/fill, so fallback `gh pr create` opened https://github.com/eng-cc/oasis7/pull/622. PR purpose decision: `normal_pr_ci_watch`.
+- Blocker / Next Action: Check PR status, comments, review threads, required checks, and mergeability.

--- a/.pm/tasks/task_0ad144b805d84ee5b7b0f248385acd45.execution.md
+++ b/.pm/tasks/task_0ad144b805d84ee5b7b0f248385acd45.execution.md
@@ -178,7 +178,7 @@ Example:
 - Task UID: task_0ad144b805d84ee5b7b0f248385acd45
 - Source Worktree: /Users/scc/ccwork/worktrees/oasis7-engineering-frontend-code-governance-next-20260624
 - Source Branch: task/engineering-frontend-code-governance-next-20260624
-- Source Head: 240579bcc7bf471bec89688780133295bee79a9a
+- Source Head: 1391b64f3cf12838f0d013912a6acca634e8e96c
 - Comparison Ref: refs/remotes/origin/main
 - Reviewed Changed Paths: scripts/bundle-freshness-lib.sh; scripts/bundle-freshness-lib.test.sh; doc/viewer/project.md; .pm/tasks/task_0ad144b805d84ee5b7b0f248385acd45.execution.md; .pm/tasks/task_0ad144b805d84ee5b7b0f248385acd45.yaml; .pm/tasks/task_0b89a0662ac94e9aa4b6de7214b6becb.yaml
 - Review Package: n/a with reason: final review integrated role verdicts from live bounded slices and current branch diff after task evidence/project Trace repair.

--- a/.pm/tasks/task_0ad144b805d84ee5b7b0f248385acd45.yaml
+++ b/.pm/tasks/task_0ad144b805d84ee5b7b0f248385acd45.yaml
@@ -1,0 +1,23 @@
+task_uid: task_0ad144b805d84ee5b7b0f248385acd45
+title: "frontend code governance next"
+owner_role: tpm
+worktree_hint: /Users/scc/ccwork/worktrees/oasis7-engineering-frontend-code-governance-next-20260624
+execution_log_path: .pm/tasks/task_0ad144b805d84ee5b7b0f248385acd45.execution.md
+status: done
+priority: P2
+source_signal: null
+source_refs:
+  - AGENTS.md
+doc_refs:
+  - doc/viewer/project.md
+related_prd: []
+acceptance: []
+handoff_to: []
+updated_at: 2026-06-24T22:16:04+08:00
+last_started_at: 2026-06-24T21:43:44+08:00
+last_claim_type: task_complete
+last_verify_command: "./scripts/bundle-freshness-lib.test.sh && ./scripts/build-game-launcher-bundle.sh --help >/dev/null && ./scripts/run-launcher-stack.sh --help >/dev/null && ./scripts/run-producer-playtest.sh --help >/dev/null && git diff --check && ./scripts/doc-governance-check.sh && ./scripts/pm/workflow-lint.sh --task-uid task_0ad144b805d84ee5b7b0f248385acd45 --phase current"
+last_verified_at: 2026-06-24T22:16:04+08:00
+last_verification_exit_code: 0
+last_verification_status: verified
+last_closed_at: 2026-06-24T22:06:18+08:00

--- a/.pm/tasks/task_0b89a0662ac94e9aa4b6de7214b6becb.yaml
+++ b/.pm/tasks/task_0b89a0662ac94e9aa4b6de7214b6becb.yaml
@@ -1,7 +1,7 @@
 task_uid: task_0b89a0662ac94e9aa4b6de7214b6becb
 title: "frontend code governance next issue"
 owner_role: tpm
-worktree_hint: /Users/scc/ccwork/worktrees/oasis7-engineering-frontend-code-governance-next-20260624
+worktree_hint: /Users/scc/ccwork/worktrees/archived-task-0b89a0662ac94e9aa4b6de7214b6becb
 execution_log_path: .pm/tasks/task_0b89a0662ac94e9aa4b6de7214b6becb.execution.md
 status: done
 priority: P2

--- a/PR.md
+++ b/PR.md
@@ -1,3 +1,10 @@
+## Current PR Evidence
+
+- PR: https://github.com/eng-cc/oasis7/pull/622
+- Task UID: task_0ad144b805d84ee5b7b0f248385acd45
+- Branch: task/engineering-frontend-code-governance-next-20260624
+- Purpose: normal_pr_ci_watch
+
 ## Summary
 
 - Add explicit `version = "0.1.0"` metadata to the two remaining optional internal path dependencies visible in all-features workspace metadata.

--- a/doc/viewer/project.md
+++ b/doc/viewer/project.md
@@ -2,6 +2,11 @@
 
 ## Active / Recent Tasks
 
+- [x] launcher-bundle-asset-freshness-governance (PRD-VIEWER/GOVERNANCE) [test_tier_required]: Enforce manifest-recorded launcher bundle asset path/SHA-256 integrity so stale source fingerprints cannot mask mutated or missing packaged Web assets. Trace: .pm/tasks/task_0ad144b805d84ee5b7b0f248385acd45.yaml
+  - Status: done
+  - Owner role: tpm
+  - Evidence: repository-health finding, Viewer/Web implementation, QA verification, focused bundle freshness smoke, adjacent Viewer dist regression, and pre-PR local role review are recorded in `.pm/tasks/task_0ad144b805d84ee5b7b0f248385acd45.execution.md`.
+
 - [x] viewer-bundle-freshness-contract-scope (PRD-VIEWER/GOVERNANCE) [test_tier_required]: Align launcher bundle freshness fingerprinting with the Viewer Web dist contract so changes to compat JS and dist helper scripts stale packaged bundles. Trace: .pm/tasks/task_e90a10e12a4b4f498ad5691fe3aeefa8.yaml
   - Status: done
   - Owner role: tpm

--- a/scripts/bundle-freshness-lib.sh
+++ b/scripts/bundle-freshness-lib.sh
@@ -129,6 +129,7 @@ def hash_exact(rel_path: str) -> tuple[str | None, str | None]:
     digest = hashlib.sha256(candidate.read_bytes()).hexdigest()
     return candidate.relative_to(bundle_dir).as_posix(), digest
 
+viewer_index_path, viewer_index_sha256 = hash_exact("web/index.html")
 viewer_js_path, viewer_js_sha256 = hash_exact("web/viewer.js")
 viewer_wasm_path, viewer_wasm_sha256 = hash_first("web/*.wasm")
 pixel_world_runtime_module_path, pixel_world_runtime_module_sha256 = hash_exact(
@@ -143,6 +144,7 @@ pixel_world_webgl2_bindgen_js_path, pixel_world_webgl2_bindgen_js_sha256 = hash_
 pixel_world_webgl2_bindgen_wasm_path, pixel_world_webgl2_bindgen_wasm_sha256 = hash_exact(
     "web/pixel-world-bridge/webgl2/pixel_world_bridge_bindgen_bg.wasm"
 )
+launcher_index_path, launcher_index_sha256 = hash_exact("web-launcher/index.html")
 launcher_js_path, launcher_js_sha256 = hash_first("web-launcher/*.js")
 launcher_wasm_path, launcher_wasm_sha256 = hash_first("web-launcher/*.wasm")
 
@@ -151,6 +153,8 @@ manifest = {
     "generatedAtUnixMs": int(time.time() * 1000),
     **source_metadata,
     "assets": {
+        "viewerIndexPath": viewer_index_path,
+        "viewerIndexSha256": viewer_index_sha256,
         "viewerJsPath": viewer_js_path,
         "viewerJsSha256": viewer_js_sha256,
         "viewerWasmPath": viewer_wasm_path,
@@ -163,6 +167,8 @@ manifest = {
         "pixelWorldWebgl2BindgenJsSha256": pixel_world_webgl2_bindgen_js_sha256,
         "pixelWorldWebgl2BindgenWasmPath": pixel_world_webgl2_bindgen_wasm_path,
         "pixelWorldWebgl2BindgenWasmSha256": pixel_world_webgl2_bindgen_wasm_sha256,
+        "launcherIndexPath": launcher_index_path,
+        "launcherIndexSha256": launcher_index_sha256,
         "launcherJsPath": launcher_js_path,
         "launcherJsSha256": launcher_js_sha256,
         "launcherWasmPath": launcher_wasm_path,

--- a/scripts/bundle-freshness-lib.sh
+++ b/scripts/bundle-freshness-lib.sh
@@ -186,11 +186,13 @@ bundle_check_freshness() {
   python3 - "$manifest_path" "$current_json" <<'PY'
 from __future__ import annotations
 
+import hashlib
 import json
 import sys
 from pathlib import Path
 
 manifest_path = Path(sys.argv[1])
+bundle_dir = manifest_path.parent
 manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
 current = json.loads(sys.argv[2])
 errors: list[str] = []
@@ -204,6 +206,25 @@ if manifest.get("viewerProtocolVersion") != current.get("viewerProtocolVersion")
         "viewer protocol version drift "
         f"(bundle={manifest.get('viewerProtocolVersion')}, current={current.get('viewerProtocolVersion')})"
     )
+assets = manifest.get("assets") or {}
+for path_key, rel_path in sorted(assets.items()):
+    if not path_key.endswith("Path") or not rel_path:
+        continue
+    sha_key = path_key[:-4] + "Sha256"
+    expected_sha = assets.get(sha_key)
+    if not expected_sha:
+        errors.append(f"bundle asset drift: {rel_path} missing manifest {sha_key}")
+        continue
+    asset_path = bundle_dir / rel_path
+    if not asset_path.is_file():
+        errors.append(f"bundle asset drift: {rel_path} missing")
+        continue
+    actual_sha = hashlib.sha256(asset_path.read_bytes()).hexdigest()
+    if actual_sha != expected_sha:
+        errors.append(
+            f"bundle asset drift: {rel_path} sha256 mismatch "
+            f"(bundle={expected_sha}, current={actual_sha})"
+        )
 if errors:
     print("bundle is stale relative to current workspace: " + "; ".join(errors))
     sys.exit(1)

--- a/scripts/bundle-freshness-lib.test.sh
+++ b/scripts/bundle-freshness-lib.test.sh
@@ -26,7 +26,9 @@ printf 'console.log("viewer");\n' > "$tmp_repo/crates/oasis7_viewer/viewer.js"
 printf 'import "./viewer.js";\n' > "$tmp_repo/crates/oasis7_viewer/software_safe.js"
 printf '#!/usr/bin/env bash\nset -euo pipefail\n' > "$tmp_repo/scripts/copy-viewer-web-dist.sh"
 printf '#!/usr/bin/env bash\nset -euo pipefail\n' > "$tmp_repo/scripts/viewer-web-dist-contract.sh"
+printf '<!doctype html><script type="module" src="./viewer.js"></script>\n' > "$tmp_repo/bundle/web/index.html"
 printf 'console.log("bundle viewer");\n' > "$tmp_repo/bundle/web/viewer.js"
+printf '<!doctype html><script type="module" src="./app.js"></script>\n' > "$tmp_repo/bundle/web-launcher/index.html"
 printf 'console.log("launcher app");\n' > "$tmp_repo/bundle/web-launcher/app.js"
 
 required_scope_entries=(
@@ -72,20 +74,43 @@ expect_asset_drift() {
 }
 
 bundle_write_manifest "$tmp_repo" "$tmp_repo/bundle"
+printf '<!doctype html>mutated viewer entry\n' > "$tmp_repo/bundle/web/index.html"
+expect_asset_drift "mutating bundle/web/index.html"
+
+printf '<!doctype html><script type="module" src="./viewer.js"></script>\n' > "$tmp_repo/bundle/web/index.html"
+bundle_write_manifest "$tmp_repo" "$tmp_repo/bundle"
+rm -f "$tmp_repo/bundle/web/index.html"
+expect_asset_drift "deleting bundle/web/index.html"
+
+printf '<!doctype html><script type="module" src="./viewer.js"></script>\n' > "$tmp_repo/bundle/web/index.html"
+bundle_write_manifest "$tmp_repo" "$tmp_repo/bundle"
 printf 'console.log("mutated viewer");\n' > "$tmp_repo/bundle/web/viewer.js"
 expect_asset_drift "mutating bundle/web/viewer.js"
 
+printf '<!doctype html><script type="module" src="./viewer.js"></script>\n' > "$tmp_repo/bundle/web/index.html"
 printf 'console.log("bundle viewer");\n' > "$tmp_repo/bundle/web/viewer.js"
 bundle_write_manifest "$tmp_repo" "$tmp_repo/bundle"
 rm -f "$tmp_repo/bundle/web/viewer.js"
 expect_asset_drift "deleting bundle/web/viewer.js"
 
 printf 'console.log("bundle viewer");\n' > "$tmp_repo/bundle/web/viewer.js"
+printf '<!doctype html><script type="module" src="./app.js"></script>\n' > "$tmp_repo/bundle/web-launcher/index.html"
 printf 'console.log("launcher app");\n' > "$tmp_repo/bundle/web-launcher/app.js"
+bundle_write_manifest "$tmp_repo" "$tmp_repo/bundle"
+printf '<!doctype html>mutated launcher entry\n' > "$tmp_repo/bundle/web-launcher/index.html"
+expect_asset_drift "mutating bundle/web-launcher/index.html"
+
+printf '<!doctype html><script type="module" src="./app.js"></script>\n' > "$tmp_repo/bundle/web-launcher/index.html"
+bundle_write_manifest "$tmp_repo" "$tmp_repo/bundle"
+rm -f "$tmp_repo/bundle/web-launcher/index.html"
+expect_asset_drift "deleting bundle/web-launcher/index.html"
+
+printf '<!doctype html><script type="module" src="./app.js"></script>\n' > "$tmp_repo/bundle/web-launcher/index.html"
 bundle_write_manifest "$tmp_repo" "$tmp_repo/bundle"
 printf 'console.log("mutated launcher");\n' > "$tmp_repo/bundle/web-launcher/app.js"
 expect_asset_drift "mutating bundle/web-launcher/app.js"
 
+printf '<!doctype html><script type="module" src="./app.js"></script>\n' > "$tmp_repo/bundle/web-launcher/index.html"
 printf 'console.log("launcher app");\n' > "$tmp_repo/bundle/web-launcher/app.js"
 bundle_write_manifest "$tmp_repo" "$tmp_repo/bundle"
 rm -f "$tmp_repo/bundle/web-launcher/app.js"

--- a/scripts/bundle-freshness-lib.test.sh
+++ b/scripts/bundle-freshness-lib.test.sh
@@ -12,6 +12,8 @@ trap cleanup EXIT
 
 mkdir -p \
   "$tmp_repo/bundle" \
+  "$tmp_repo/bundle/web" \
+  "$tmp_repo/bundle/web-launcher" \
   "$tmp_repo/crates/oasis7_proto/src" \
   "$tmp_repo/crates/oasis7_viewer" \
   "$tmp_repo/scripts"
@@ -24,6 +26,8 @@ printf 'console.log("viewer");\n' > "$tmp_repo/crates/oasis7_viewer/viewer.js"
 printf 'import "./viewer.js";\n' > "$tmp_repo/crates/oasis7_viewer/software_safe.js"
 printf '#!/usr/bin/env bash\nset -euo pipefail\n' > "$tmp_repo/scripts/copy-viewer-web-dist.sh"
 printf '#!/usr/bin/env bash\nset -euo pipefail\n' > "$tmp_repo/scripts/viewer-web-dist-contract.sh"
+printf 'console.log("bundle viewer");\n' > "$tmp_repo/bundle/web/viewer.js"
+printf 'console.log("launcher app");\n' > "$tmp_repo/bundle/web-launcher/app.js"
 
 required_scope_entries=(
   "crates/oasis7_viewer/software_safe.js"
@@ -54,5 +58,37 @@ for entry in "${required_scope_entries[@]}"; do
     exit 1
   fi
 done
+
+expect_asset_drift() {
+  local label=$1
+  if freshness_output="$(bundle_check_freshness "$tmp_repo" "$tmp_repo/bundle" 2>&1)"; then
+    echo "expected bundle freshness to fail after $label" >&2
+    exit 1
+  fi
+  if ! grep -Fq "bundle asset drift" <<<"$freshness_output"; then
+    echo "expected bundle asset drift after $label, got: $freshness_output" >&2
+    exit 1
+  fi
+}
+
+bundle_write_manifest "$tmp_repo" "$tmp_repo/bundle"
+printf 'console.log("mutated viewer");\n' > "$tmp_repo/bundle/web/viewer.js"
+expect_asset_drift "mutating bundle/web/viewer.js"
+
+printf 'console.log("bundle viewer");\n' > "$tmp_repo/bundle/web/viewer.js"
+bundle_write_manifest "$tmp_repo" "$tmp_repo/bundle"
+rm -f "$tmp_repo/bundle/web/viewer.js"
+expect_asset_drift "deleting bundle/web/viewer.js"
+
+printf 'console.log("bundle viewer");\n' > "$tmp_repo/bundle/web/viewer.js"
+printf 'console.log("launcher app");\n' > "$tmp_repo/bundle/web-launcher/app.js"
+bundle_write_manifest "$tmp_repo" "$tmp_repo/bundle"
+printf 'console.log("mutated launcher");\n' > "$tmp_repo/bundle/web-launcher/app.js"
+expect_asset_drift "mutating bundle/web-launcher/app.js"
+
+printf 'console.log("launcher app");\n' > "$tmp_repo/bundle/web-launcher/app.js"
+bundle_write_manifest "$tmp_repo" "$tmp_repo/bundle"
+rm -f "$tmp_repo/bundle/web-launcher/app.js"
+expect_asset_drift "deleting bundle/web-launcher/app.js"
 
 echo "bundle freshness lib tests passed"


### PR DESCRIPTION
## Summary
- validate manifest-recorded launcher bundle asset paths and SHA-256 values during bundle freshness checks
- extend bundle freshness smoke coverage for mutated/deleted Viewer and launcher Web assets
- record Viewer project trace and task workflow evidence for the governance slice

## Verification
- ./scripts/bundle-freshness-lib.test.sh
- ./scripts/build-game-launcher-bundle.sh --help
- ./scripts/run-launcher-stack.sh --help
- ./scripts/run-producer-playtest.sh --help
- git diff --check
- ./scripts/doc-governance-check.sh
- ./scripts/pm/workflow-lint.sh --phase pr-ready

## Local role review
- producer_system_designer: no findings
- repository_health_engineer: no findings
- viewer_engineer: no findings
- qa_engineer: no findings