### PR TITLE
Stabilize testnet rebuild cleanup quiet window

### DIFF
--- a/.pm/tasks/task_b0a073c3b7fd44549767d9540e8e6ec9.execution.md
+++ b/.pm/tasks/task_b0a073c3b7fd44549767d9540e8e6ec9.execution.md
@@ -44,6 +44,15 @@ Example:
 - Actual Result: Passed.
 - Blocker / Next Action: Re-run lightweight gates and request QA re-review.
 
+## 2026-06-24 23:39:12 CST / tpm
+- 完成内容: Addressed GitHub PR review thread on quiet-window deadline.
+- 遗留事项: Push fix, resolve PR thread, and re-watch checks.
+- Action: Verified PR #625 Codex review thread `PRRT_kwDORHhWec6L8z6T` as valid: if a matching process appears/kills near deadline, cleanup could return success from a transient empty scan without ever observing the required quiet window. Added explicit `quiet_window_observed` tracking and fail-closed error when the deadline expires before the stable quiet window. Added a late-cleanup regression with short test-only cleanup deadline/quiet envs.
+- Validation Command: `bash scripts/p2p-public-testnet-rebuild-validators.test.sh`; `bash -n scripts/p2p-public-testnet-rebuild-validators.sh scripts/p2p-public-testnet-rebuild-validators.test.sh`
+- Expected Result: Late respawn without full quiet window fails cleanup; normal delayed process cleanup still passes.
+- Actual Result: Passed.
+- Blocker / Next Action: Run lightweight gates, commit, push, resolve PR thread.
+
 ## 2026-06-24 23:22:10 CST / tpm
 - 完成内容: Completed role reviews and claim-ready.
 - 遗留事项: Commit, closeout, and PR creation pending.

--- a/.pm/tasks/task_b0a073c3b7fd44549767d9540e8e6ec9.execution.md
+++ b/.pm/tasks/task_b0a073c3b7fd44549767d9540e8e6ec9.execution.md
@@ -1,0 +1,88 @@
+# task_b0a073c3b7fd44549767d9540e8e6ec9 Execution Log
+
+- task_uid: task_b0a073c3b7fd44549767d9540e8e6ec9
+- title: Require stable quiet rebuild cleanup
+- owner_role: tpm
+- worktree_hint: /Users/scc/ccwork/worktrees/oasis7-p2p-testnet-rebuild-cleanup-stable-quiet
+
+<!-- Append entries using:
+Example:
+  ## YYYY-MM-DD HH:MM:SS CST / role_name
+  - 完成内容: ...
+  - 遗留事项: ...
+  - Action: ...
+  - Validation Command: ...
+  - Expected Result: ...
+  - Actual Result: ...
+  - Blocker / Next Action: ...
+-->
+
+## 2026-06-24 23:01:50 CST / tpm
+- 完成内容: Bootstrapped and reproduced stable-quiet cleanup race.
+- 遗留事项: Review, closeout, PR, and redeploy validation pending.
+- Action: Created task worktree `/Users/scc/ccwork/worktrees/oasis7-p2p-testnet-rebuild-cleanup-stable-quiet` for `task_b0a073c3b7fd44549767d9540e8e6ec9`. Live rerun after PR #624 still failed sequencer readiness and left a new stack-root orphan listening on `6631/6831` while systemd was inactive. Manual cleanup found pids `2462271`/`2462280` and killed them. Root cause hypothesis: cleanup could observe a transient no-process window after `systemctl stop` and exit before delayed detached child processes appeared.
+- Validation Command: remote process/status inspection; manual stack-root matcher cleanup.
+- Expected Result: Treat failure as code/deployment cleanup race, not ops-only repair.
+- Actual Result: Confirmed delayed orphan race after merged cleanup verification.
+- Blocker / Next Action: Patch cleanup to require stable quiet window.
+
+## 2026-06-24 23:08:30 CST / tpm
+- 完成内容: Implemented stable quiet cleanup.
+- 遗留事项: Run gates and role review.
+- Action: Replaced early-exit cleanup loop with continuous scan/kill until a 2s stable no-match quiet window or 10s deadline. Added fake-ssh regression that creates a delayed stack-root `start-node.sh` process during cleanup and asserts it is not left alive.
+- Validation Command: `bash scripts/p2p-public-testnet-rebuild-validators.test.sh`; `bash -n scripts/p2p-public-testnet-rebuild-validators.sh scripts/p2p-public-testnet-rebuild-validators.test.sh`
+- Expected Result: Cleanup catches delayed matching processes instead of succeeding on a transient empty scan.
+- Actual Result: Passed.
+- Blocker / Next Action: Run lightweight gates and dispatch blockchain_ops_engineer/qa_engineer reviews.
+
+## 2026-06-24 23:20:00 CST / blockchain_ops_engineer
+- Review Trigger: pre-PR local role review
+- Review Scope: `scripts/p2p-public-testnet-rebuild-validators.sh`; `scripts/p2p-public-testnet-rebuild-validators.test.sh`; `doc/p2p/project.md`
+- Review Package: pending committed review package; local working diff reviewed in bounded slice.
+- Review Roles: blockchain_ops_engineer
+- Review Question: Is stable quiet cleanup appropriate/fail-closed for public_testnet validator rebuild? Are there deployment risks from the loop/timing/matching?
+- Evidence Available: current diff; live orphan evidence from failed rebuild after PR #624; focused fake-ssh cleanup tests.
+- Expected Return Contract: findings | no_findings | scope/spec compliance verdict | role quality/risk verdict | residual_risk
+- Slice Ledger: /Users/scc/ccwork/worktrees/oasis7-p2p-testnet-rebuild-cleanup-stable-quiet/.pm/scratch/task_b0a073c3b7fd44549767d9540e8e6ec9/slice-ledger.jsonl
+- Formal Sink: execution log
+
+## 2026-06-24 23:24:00 CST / tpm
+- 完成内容: Integrated pre-PR role review results and stale finding disposition.
+- 遗留事项: Commit, create PR, watch checks, merge, then rerun live validator rebuild.
+- Action: Recorded blockchain ops finding disposition: an earlier review concern that storage start/readiness failure could leave an already-started sequencer serving is addressed in the current diff by `cleanup_started_hosts`, which cleans every validator whose start path was attempted. Storage-not-ready regression asserts post-start cleanup for both sequencer and storage. QA review returned `no_findings` for cleanup invocation/order/failure propagation coverage. Producer review returned `no_findings` for doc scope and did not see a false claim that public_testnet is healthy or redeployed.
+- Validation Command: `bash scripts/p2p-public-testnet-rebuild-validators.test.sh`; `bash -n scripts/p2p-public-testnet-rebuild-validators.sh scripts/p2p-public-testnet-rebuild-validators.test.sh`; `git diff --check`; `./scripts/pm/workflow-lint.sh --task-uid task_b0a073c3b7fd44549767d9540e8e6ec9 --phase current`; `./scripts/check-rust-file-size.sh`
+- Expected Result: Focused cleanup regressions, shell syntax, whitespace, workflow lint, and file-size guard pass.
+- Actual Result: Passed.
+- Blocker / Next Action: Commit task diff, generate committed review package, write Pre-PR Local Role Review packet, and run closeout/PR helper.
+
+## 2026-06-24 23:30:00 CST / tpm
+- Pre-PR Local Role Review: passed
+- Task UID: task_b0a073c3b7fd44549767d9540e8e6ec9
+- Source Worktree: /Users/scc/ccwork/worktrees/oasis7-p2p-testnet-rebuild-cleanup-stable-quiet
+- Source Branch: task/p2p-testnet-rebuild-cleanup-stable-quiet
+- Source Head: 3c25820e4ee5548ebe69ac09e42446f865acacbc
+- Comparison Ref: refs/remotes/origin/main
+- Reviewed Changed Paths: .pm/roles/tpm/backlog/committed.yaml; .pm/tasks/task_b0a073c3b7fd44549767d9540e8e6ec9.execution.md; .pm/tasks/task_b0a073c3b7fd44549767d9540e8e6ec9.yaml; doc/p2p/project.md; scripts/p2p-public-testnet-rebuild-validators.sh; scripts/p2p-public-testnet-rebuild-validators.test.sh
+- Review Package: /Users/scc/ccwork/worktrees/oasis7-p2p-testnet-rebuild-cleanup-stable-quiet/.pm/scratch/task_b0a073c3b7fd44549767d9540e8e6ec9/review-packages/review-53c47f7a6..3c25820e4.diff
+- Role Selection Basis: changed deployment/rebuild script and public testnet project trace require blockchain_ops_engineer; verification sufficiency and regression coverage require qa_engineer; recent-completed doc wording and system-level task scope require producer_system_designer.
+- Review Roles: blockchain_ops_engineer, qa_engineer, producer_system_designer
+- Review Evidence: blockchain_ops_engineer reviewed stable-quiet/fail-closed cleanup and stale storage-failure finding disposition; qa_engineer returned no_findings on cleanup invocation/order/failure propagation/delayed process tests; producer_system_designer returned no_findings on recent-completed wording and no false public_testnet health/redeploy claim.
+- Review Verdicts: blockchain_ops_engineer scope/spec compliance passed with current multi-host cleanup evidence, role quality/risk passed for stack-root-scoped fail-closed cleanup; qa_engineer scope/spec compliance passed for fake-ssh regression coverage, role quality/risk passed with residual kernel-level live-process caveat; producer_system_designer scope/spec compliance passed for doc trace, role quality/risk passed with no external-claim risk.
+- Review Findings Disposition: addressed
+- Finding Disposition Evidence: storage start/readiness half-rebuild concern is addressed by `cleanup_started_hosts` plus storage-not-ready regression asserting post-start cleanup for both validators; stable quiet delayed-process race is addressed by continuous scan/kill until 2s quiet or 10s deadline and delayed-process regression.
+- Verification Matrix: rebuild cleanup script -> `bash scripts/p2p-public-testnet-rebuild-validators.test.sh` passed; shell syntax -> `bash -n scripts/p2p-public-testnet-rebuild-validators.sh scripts/p2p-public-testnet-rebuild-validators.test.sh` passed; diff hygiene -> `git diff --check` passed; workflow task truth -> `./scripts/pm/workflow-lint.sh --task-uid task_b0a073c3b7fd44549767d9540e8e6ec9 --phase current` passed; file-size guard -> `./scripts/check-rust-file-size.sh` passed.
+- Visual Evidence: n/a, no player-visible UI or visual surface changed.
+- WASM Evidence: n/a, no WASM manifest/runtime/determinism surface changed.
+- Ops Evidence: live failed rebuild left delayed sequencer stack-root orphan on 6631/6831; patch enforces stable quiet cleanup and all-started-validator fail-closed cleanup before redeploy retry.
+- LiveOps Evidence: n/a, no external status/community message changed.
+- Residual Risk: fake-ssh regression validates timing, command routing, delayed-process cleanup, and failure propagation, but not an unkillable kernel-level process edge case; live validator rebuild remains the post-merge validation gate.
+- Slice Ledger: /Users/scc/ccwork/worktrees/oasis7-p2p-testnet-rebuild-cleanup-stable-quiet/.pm/scratch/task_b0a073c3b7fd44549767d9540e8e6ec9/slice-ledger.jsonl
+
+## 2026-06-24 23:34:00 CST / tpm
+- 完成内容: Closed the current task locally with verified task-scoped state.
+- 遗留事项: Create PR, watch required checks/comments, merge, then rerun live validator rebuild.
+- Action: Ran `task-closeout.sh`; it marked this task done and recorded a fresh successful verification. The helper exited nonzero only after repo-wide `.pm` lint reported unrelated historical execution-log debt outside this task. Confirmed current task-scoped workflow lint is clean.
+- Validation Command: `./scripts/pm/task-closeout.sh --role tpm --task-uid task_b0a073c3b7fd44549767d9540e8e6ec9 --verify-command "bash scripts/p2p-public-testnet-rebuild-validators.test.sh"`; `./scripts/pm/workflow-lint.sh --task-uid task_b0a073c3b7fd44549767d9540e8e6ec9 --phase current`
+- Expected Result: Current task closes with fresh test verification; any repo-wide PM lint failure is recorded as unrelated historical debt.
+- Actual Result: Current task status is `done`, last verification exit code is `0`, and task-scoped workflow lint passed. Repo-wide `.pm` lint failed on unrelated historical task logs.
+- Blocker / Next Action: Continue through `prepare-task-pr.sh --create`; do not repair unrelated `.pm` historical debt in this task.

--- a/.pm/tasks/task_b0a073c3b7fd44549767d9540e8e6ec9.execution.md
+++ b/.pm/tasks/task_b0a073c3b7fd44549767d9540e8e6ec9.execution.md
@@ -53,7 +53,7 @@ Example:
 - Actual Result: Passed at `2026-06-24T23:20:32+08:00`; `verification_exit_code=0`, `status=verified`, `allowed_to_claim=true`.
 - Blocker / Next Action: Write Pre-PR Local Role Review marker and run PR helper.
 
-- Pre-PR Local Role Review: passed
+- Pre-PR Local Role Review Status: passed
 - Task UID: task_b0a073c3b7fd44549767d9540e8e6ec9
 - Source Worktree: /Users/scc/ccwork/worktrees/oasis7-p2p-testnet-rebuild-cleanup-stable-quiet
 - Source Branch: task/p2p-testnet-rebuild-cleanup-stable-quiet
@@ -100,7 +100,7 @@ Example:
 - Task UID: task_b0a073c3b7fd44549767d9540e8e6ec9
 - Source Worktree: /Users/scc/ccwork/worktrees/oasis7-p2p-testnet-rebuild-cleanup-stable-quiet
 - Source Branch: task/p2p-testnet-rebuild-cleanup-stable-quiet
-- Source Head: d8ffba112765bd63bd8b09d2322baa77b60e1cb5
+- Source Head: aad812771adb5068d5aca46665ab32098a486e34
 - Comparison Ref: refs/remotes/origin/main
 - Reviewed Changed Paths: .pm/roles/tpm/backlog/committed.yaml; .pm/tasks/task_b0a073c3b7fd44549767d9540e8e6ec9.execution.md; .pm/tasks/task_b0a073c3b7fd44549767d9540e8e6ec9.yaml; doc/p2p/project.md; scripts/p2p-public-testnet-rebuild-validators.sh; scripts/p2p-public-testnet-rebuild-validators.test.sh
 - Review Package: /Users/scc/ccwork/worktrees/oasis7-p2p-testnet-rebuild-cleanup-stable-quiet/.pm/scratch/task_b0a073c3b7fd44549767d9540e8e6ec9/review-packages/review-53c47f7a6..3c25820e4.diff

--- a/.pm/tasks/task_b0a073c3b7fd44549767d9540e8e6ec9.execution.md
+++ b/.pm/tasks/task_b0a073c3b7fd44549767d9540e8e6ec9.execution.md
@@ -60,7 +60,7 @@ Example:
 - Task UID: task_b0a073c3b7fd44549767d9540e8e6ec9
 - Source Worktree: /Users/scc/ccwork/worktrees/oasis7-p2p-testnet-rebuild-cleanup-stable-quiet
 - Source Branch: task/p2p-testnet-rebuild-cleanup-stable-quiet
-- Source Head: 3c25820e4ee5548ebe69ac09e42446f865acacbc
+- Source Head: d8ffba112765bd63bd8b09d2322baa77b60e1cb5
 - Comparison Ref: refs/remotes/origin/main
 - Reviewed Changed Paths: .pm/roles/tpm/backlog/committed.yaml; .pm/tasks/task_b0a073c3b7fd44549767d9540e8e6ec9.execution.md; .pm/tasks/task_b0a073c3b7fd44549767d9540e8e6ec9.yaml; doc/p2p/project.md; scripts/p2p-public-testnet-rebuild-validators.sh; scripts/p2p-public-testnet-rebuild-validators.test.sh
 - Review Package: /Users/scc/ccwork/worktrees/oasis7-p2p-testnet-rebuild-cleanup-stable-quiet/.pm/scratch/task_b0a073c3b7fd44549767d9540e8e6ec9/review-packages/review-53c47f7a6..3c25820e4.diff

--- a/.pm/tasks/task_b0a073c3b7fd44549767d9540e8e6ec9.execution.md
+++ b/.pm/tasks/task_b0a073c3b7fd44549767d9540e8e6ec9.execution.md
@@ -35,6 +35,46 @@ Example:
 - Actual Result: Passed.
 - Blocker / Next Action: Run lightweight gates and dispatch blockchain_ops_engineer/qa_engineer reviews.
 
+## 2026-06-24 23:15:18 CST / tpm
+- 完成内容: Addressed QA delayed-test false-pass finding.
+- 遗留事项: Re-run gates and collect QA re-review.
+- Action: `qa_engineer` slice `019efa28-a969-7763-9c53-51297998e11d` found the delayed-process test could false pass if cleanup was never invoked, because the delayed fake process is spawned inside the cleanup branch. Added an assertion that the delayed scenario's SSH log contains the sequencer cleanup heredoc command.
+- Validation Command: `bash scripts/p2p-public-testnet-rebuild-validators.test.sh`; `bash -n scripts/p2p-public-testnet-rebuild-validators.sh scripts/p2p-public-testnet-rebuild-validators.test.sh`
+- Expected Result: Delayed-process test now proves cleanup was invoked and no delayed matching process survives.
+- Actual Result: Passed.
+- Blocker / Next Action: Re-run lightweight gates and request QA re-review.
+
+## 2026-06-24 23:22:10 CST / tpm
+- 完成内容: Completed role reviews and claim-ready.
+- 遗留事项: Commit, closeout, and PR creation pending.
+- Action: `blockchain_ops_engineer` slice `019efa28-79d3-7920-8152-dd025fd1d3af` returned `no_findings` for stable quiet cleanup loop; `producer_system_designer` slice `019efa28-d0ce-7751-8853-34d7a4787fc7` returned `no_findings` for project trace wording; `qa_engineer` slice `019efa28-a969-7763-9c53-51297998e11d` found a delayed-test false-pass, then re-review returned `no_findings` after adding cleanup-command assertion.
+- Validation Command: `./scripts/pm/claim-ready.sh --claim-type task_complete --verify-command "bash scripts/p2p-public-testnet-rebuild-validators.test.sh" --task-uid task_b0a073c3b7fd44549767d9540e8e6ec9 --json`
+- Expected Result: Fresh focused verification gates completion after review finding disposition.
+- Actual Result: Passed at `2026-06-24T23:20:32+08:00`; `verification_exit_code=0`, `status=verified`, `allowed_to_claim=true`.
+- Blocker / Next Action: Write Pre-PR Local Role Review marker and run PR helper.
+
+- Pre-PR Local Role Review: passed
+- Task UID: task_b0a073c3b7fd44549767d9540e8e6ec9
+- Source Worktree: /Users/scc/ccwork/worktrees/oasis7-p2p-testnet-rebuild-cleanup-stable-quiet
+- Source Branch: task/p2p-testnet-rebuild-cleanup-stable-quiet
+- Source Head: 22dfaeedbc7809dd616bf352269be4ddd9a9c94b
+- Comparison Ref: refs/remotes/origin/main
+- Reviewed Changed Paths: scripts/p2p-public-testnet-rebuild-validators.sh; scripts/p2p-public-testnet-rebuild-validators.test.sh; doc/p2p/project.md; .pm/tasks/task_b0a073c3b7fd44549767d9540e8e6ec9.yaml; .pm/tasks/task_b0a073c3b7fd44549767d9540e8e6ec9.execution.md; .pm/roles/tpm/backlog/committed.yaml
+- Review Package: n/a; bounded full-context subagent reviews inspected the current worktree diff.
+- Role Selection Basis: validator rebuild deployment cleanup touched `blockchain_ops_engineer`; fake ssh delayed-process regression touched `qa_engineer`; project trace wording touched `producer_system_designer`.
+- Review Roles: blockchain_ops_engineer, qa_engineer, producer_system_designer
+- Review Evidence: `blockchain_ops_engineer` slice `019efa28-79d3-7920-8152-dd025fd1d3af`; `qa_engineer` slice `019efa28-a969-7763-9c53-51297998e11d` initial finding and no_findings re-review; `producer_system_designer` slice `019efa28-d0ce-7751-8853-34d7a4787fc7`.
+- Review Verdicts: `blockchain_ops_engineer`: no_findings; `qa_engineer`: no_findings after false-pass finding disposition; `producer_system_designer`: no_findings.
+- Review Findings Disposition: addressed
+- Finding Disposition Evidence: QA false-pass fixed by asserting the delayed-process test's SSH log contains the sequencer cleanup heredoc command, so the test fails if cleanup is never invoked.
+- Verification Matrix: focused rebuild cleanup -> `bash scripts/p2p-public-testnet-rebuild-validators.test.sh` passed; shell syntax -> `bash -n scripts/p2p-public-testnet-rebuild-validators.sh scripts/p2p-public-testnet-rebuild-validators.test.sh` passed; whitespace -> `git diff --check` passed; workflow -> `./scripts/pm/workflow-lint.sh --task-uid task_b0a073c3b7fd44549767d9540e8e6ec9 --phase current` passed; doc governance -> `./scripts/doc-governance-check.sh` passed; file size -> `./scripts/check-rust-file-size.sh` passed; claim-ready -> passed.
+- Visual Evidence: n/a; script-only deployment tooling change.
+- WASM Evidence: n/a; no wasm build/runtime determinism surface changed.
+- Ops Evidence: live failed rebuild after PR #624 showed systemd inactive with delayed stack-root sequencer orphan still binding `6631/6831`; manual matcher killed pids `2462271`/`2462280`; blockchain_ops confirmed stable quiet cleanup is fail-closed and stack-root scoped.
+- LiveOps Evidence: n/a; no external/player-facing messaging changed.
+- Residual Risk: low; cleanup remains destructive only within selected validator stack roots and is covered by shell/fake-ssh regression rather than live systemd integration.
+- Slice Ledger: .pm/tasks/task_b0a073c3b7fd44549767d9540e8e6ec9.execution.md
+
 ## 2026-06-24 23:20:00 CST / blockchain_ops_engineer
 - Review Trigger: pre-PR local role review
 - Review Scope: `scripts/p2p-public-testnet-rebuild-validators.sh`; `scripts/p2p-public-testnet-rebuild-validators.test.sh`; `doc/p2p/project.md`

--- a/.pm/tasks/task_b0a073c3b7fd44549767d9540e8e6ec9.execution.md
+++ b/.pm/tasks/task_b0a073c3b7fd44549767d9540e8e6ec9.execution.md
@@ -78,6 +78,12 @@ Example:
 - Residual Risk: fake-ssh regression validates timing, command routing, delayed-process cleanup, and failure propagation, but not an unkillable kernel-level process edge case; live validator rebuild remains the post-merge validation gate.
 - Slice Ledger: /Users/scc/ccwork/worktrees/oasis7-p2p-testnet-rebuild-cleanup-stable-quiet/.pm/scratch/task_b0a073c3b7fd44549767d9540e8e6ec9/slice-ledger.jsonl
 
+## 2026-06-24 23:13:07 CST / tpm
+- Claim Ready Evidence: task_complete
+- Validation Command: `bash scripts/p2p-public-testnet-rebuild-validators.test.sh && bash -n scripts/p2p-public-testnet-rebuild-validators.sh scripts/p2p-public-testnet-rebuild-validators.test.sh && git diff --check && ./scripts/check-rust-file-size.sh && ./scripts/pm/workflow-lint.sh --task-uid task_b0a073c3b7fd44549767d9540e8e6ec9 --phase current`
+- Expected Result: Fresh verification passes before task completion/PR readiness claim.
+- Actual Result: Passed; task yaml records `last_verification_status: verified` and `last_verification_exit_code: 0`.
+
 ## 2026-06-24 23:34:00 CST / tpm
 - 完成内容: Closed the current task locally with verified task-scoped state.
 - 遗留事项: Create PR, watch required checks/comments, merge, then rerun live validator rebuild.

--- a/.pm/tasks/task_b0a073c3b7fd44549767d9540e8e6ec9.execution.md
+++ b/.pm/tasks/task_b0a073c3b7fd44549767d9540e8e6ec9.execution.md
@@ -79,10 +79,14 @@ Example:
 - Slice Ledger: /Users/scc/ccwork/worktrees/oasis7-p2p-testnet-rebuild-cleanup-stable-quiet/.pm/scratch/task_b0a073c3b7fd44549767d9540e8e6ec9/slice-ledger.jsonl
 
 ## 2026-06-24 23:13:07 CST / tpm
+- 完成内容: Recorded claim-ready verification evidence.
+- 遗留事项: Create PR, watch required checks/comments, merge, then rerun live validator rebuild.
+- Action: Persisted `claim-ready` evidence for `task_complete` after a fresh verification command succeeded.
 - Claim Ready Evidence: task_complete
 - Validation Command: `bash scripts/p2p-public-testnet-rebuild-validators.test.sh && bash -n scripts/p2p-public-testnet-rebuild-validators.sh scripts/p2p-public-testnet-rebuild-validators.test.sh && git diff --check && ./scripts/check-rust-file-size.sh && ./scripts/pm/workflow-lint.sh --task-uid task_b0a073c3b7fd44549767d9540e8e6ec9 --phase current`
 - Expected Result: Fresh verification passes before task completion/PR readiness claim.
 - Actual Result: Passed; task yaml records `last_verification_status: verified` and `last_verification_exit_code: 0`.
+- Blocker / Next Action: Continue task closeout and PR creation.
 
 ## 2026-06-24 23:34:00 CST / tpm
 - 完成内容: Closed the current task locally with verified task-scoped state.

--- a/.pm/tasks/task_b0a073c3b7fd44549767d9540e8e6ec9.yaml
+++ b/.pm/tasks/task_b0a073c3b7fd44549767d9540e8e6ec9.yaml
@@ -1,0 +1,26 @@
+task_uid: task_b0a073c3b7fd44549767d9540e8e6ec9
+title: "Require stable quiet rebuild cleanup"
+owner_role: tpm
+worktree_hint: /Users/scc/ccwork/worktrees/oasis7-p2p-testnet-rebuild-cleanup-stable-quiet
+execution_log_path: .pm/tasks/task_b0a073c3b7fd44549767d9540e8e6ec9.execution.md
+status: done
+priority: P1
+source_signal: null
+source_refs:
+  - doc/p2p/project.md
+  - scripts/p2p-public-testnet-rebuild-validators.sh
+doc_refs:
+  - doc/p2p/project.md
+related_prd: []
+acceptance:
+  - "Validator rebuild cleanup keeps scanning after transient no-process windows and requires a stable quiet period before success."
+  - "Focused test covers a delayed stack-root process appearing during cleanup."
+handoff_to: []
+updated_at: 2026-06-24T23:11:57+08:00
+last_started_at: 2026-06-24T22:58:57+08:00
+last_claim_type: task_complete
+last_verify_command: "bash scripts/p2p-public-testnet-rebuild-validators.test.sh"
+last_verified_at: 2026-06-24T23:11:56+08:00
+last_verification_exit_code: 0
+last_verification_status: verified
+last_closed_at: 2026-06-24T23:11:57+08:00

--- a/.pm/tasks/task_b0a073c3b7fd44549767d9540e8e6ec9.yaml
+++ b/.pm/tasks/task_b0a073c3b7fd44549767d9540e8e6ec9.yaml
@@ -16,11 +16,11 @@ acceptance:
   - "Validator rebuild cleanup keeps scanning after transient no-process windows and requires a stable quiet period before success."
   - "Focused test covers a delayed stack-root process appearing during cleanup."
 handoff_to: []
-updated_at: 2026-06-24T23:11:57+08:00
+updated_at: 2026-06-24T23:13:07+08:00
 last_started_at: 2026-06-24T22:58:57+08:00
 last_claim_type: task_complete
-last_verify_command: "bash scripts/p2p-public-testnet-rebuild-validators.test.sh"
-last_verified_at: 2026-06-24T23:11:56+08:00
+last_verify_command: "bash scripts/p2p-public-testnet-rebuild-validators.test.sh && bash -n scripts/p2p-public-testnet-rebuild-validators.sh scripts/p2p-public-testnet-rebuild-validators.test.sh && git diff --check && ./scripts/check-rust-file-size.sh && ./scripts/pm/workflow-lint.sh --task-uid task_b0a073c3b7fd44549767d9540e8e6ec9 --phase current"
+last_verified_at: 2026-06-24T23:13:05+08:00
 last_verification_exit_code: 0
 last_verification_status: verified
-last_closed_at: 2026-06-24T23:11:57+08:00
+last_closed_at: 2026-06-24T23:13:07+08:00

--- a/.pm/tasks/task_b0a073c3b7fd44549767d9540e8e6ec9.yaml
+++ b/.pm/tasks/task_b0a073c3b7fd44549767d9540e8e6ec9.yaml
@@ -16,11 +16,11 @@ acceptance:
   - "Validator rebuild cleanup keeps scanning after transient no-process windows and requires a stable quiet period before success."
   - "Focused test covers a delayed stack-root process appearing during cleanup."
 handoff_to: []
-updated_at: 2026-06-24T23:13:07+08:00
+updated_at: 2026-06-24T23:20:32+08:00
 last_started_at: 2026-06-24T22:58:57+08:00
 last_claim_type: task_complete
-last_verify_command: "bash scripts/p2p-public-testnet-rebuild-validators.test.sh && bash -n scripts/p2p-public-testnet-rebuild-validators.sh scripts/p2p-public-testnet-rebuild-validators.test.sh && git diff --check && ./scripts/check-rust-file-size.sh && ./scripts/pm/workflow-lint.sh --task-uid task_b0a073c3b7fd44549767d9540e8e6ec9 --phase current"
-last_verified_at: 2026-06-24T23:13:05+08:00
+last_verify_command: "bash scripts/p2p-public-testnet-rebuild-validators.test.sh"
+last_verified_at: 2026-06-24T23:20:32+08:00
 last_verification_exit_code: 0
 last_verification_status: verified
 last_closed_at: 2026-06-24T23:13:07+08:00

--- a/doc/p2p/project.md
+++ b/doc/p2p/project.md
@@ -7,6 +7,7 @@
 - hosted player access / hosted account、public testnet、bridge/newapi、network tier、主链 token 与 faucet/mint-ready 细项均已有独立 topic project；本页不再逐条复述每条子线的完成流水。
 
 ### 最近完成（保留一跳 Trace）
+- [x] testnet-rebuild-cleanup-stable-quiet (PRD-P2P-001/003/028) [test_tier_required]: 补强 public_testnet validator rebuild cleanup 的 race 防护；cleanup 不再因瞬时无匹配进程提前成功，必须持续扫描并达到稳定 quiet window，覆盖 stop 后延迟脱离/重现的 stack-root runtime/start-node 进程。 Trace: .pm/tasks/task_b0a073c3b7fd44549767d9540e8e6ec9.yaml
 - [x] testnet-rebuild-cleanup-verifies-orphans (PRD-P2P-001/003/028) [test_tier_required]: 补强 public_testnet validator rebuild 失败清理合同；cleanup 在 SIGKILL 后必须复查 stack-root runtime/start-node 进程并非零暴露残留，失败路径不再吞掉 cleanup command failure，fake ssh 测试也真正执行 cleanup heredoc 而不是只匹配命令字符串。 Trace: .pm/tasks/task_3b25db6324f14489adaa95eba13bb32a.yaml
 - [x] testnet-rebuild-fail-cleanup (PRD-P2P-028) [test_tier_required]: 修复 public_testnet validator clean rebuild 在服务 start/readiness 失败后没有清理 node-root 残留 runtime/start-node 进程的问题；rebuild 现在在失败路径复用服务 stop、reset-failed 和 orphan process cleanup，避免失败启动留下端口占用并触发后续 bind 冲突。 Trace: .pm/tasks/task_540dc25f45af4065b58ab8e45a121075.yaml
 - [x] testnet-stage-track-contract (PRD-P2P-028) [test_tier_required]: 修复 public_testnet deployment-stage 生成器默认 release-candidate bundle track 漂移到不受支持的 `public_testnet`，导致 clean validator redeploy 无法生成 stage 的问题；默认 track 重新对齐到受支持的 `public_testnet_rehearsal`，并在 stage smoke 中断言 bundle track 契约。 Trace: .pm/tasks/task_e479687218a94f698ef7715458543fc9.yaml

--- a/scripts/p2p-public-testnet-rebuild-validators.sh
+++ b/scripts/p2p-public-testnet-rebuild-validators.sh
@@ -489,21 +489,24 @@ def matching_pids():
     return pids
 
 deadline = time.monotonic() + 10
+quiet_since = None
 while time.monotonic() < deadline:
-    if not matching_pids():
-        break
-    time.sleep(0.25)
-
-for sig in (signal.SIGTERM, signal.SIGKILL):
     pids = matching_pids()
-    if not pids:
-        break
-    for pid in pids:
-        try:
-            os.kill(pid, sig)
-        except ProcessLookupError:
-            pass
-    time.sleep(1)
+    if pids:
+        quiet_since = None
+        for sig in (signal.SIGTERM, signal.SIGKILL):
+            for pid in matching_pids():
+                try:
+                    os.kill(pid, sig)
+                except ProcessLookupError:
+                    pass
+            time.sleep(0.25)
+    else:
+        if quiet_since is None:
+            quiet_since = time.monotonic()
+        if time.monotonic() - quiet_since >= 2:
+            break
+        time.sleep(0.25)
 
 remaining = matching_pids()
 if remaining:

--- a/scripts/p2p-public-testnet-rebuild-validators.sh
+++ b/scripts/p2p-public-testnet-rebuild-validators.sh
@@ -488,8 +488,11 @@ def matching_pids():
             pids.append(pid)
     return pids
 
-deadline = time.monotonic() + 10
+cleanup_deadline_seconds = float(os.environ.get('CLEANUP_DEADLINE_SECONDS', '10'))
+cleanup_quiet_seconds = float(os.environ.get('CLEANUP_QUIET_SECONDS', '2'))
+deadline = time.monotonic() + cleanup_deadline_seconds
 quiet_since = None
+quiet_window_observed = False
 while time.monotonic() < deadline:
     pids = matching_pids()
     if pids:
@@ -504,13 +507,17 @@ while time.monotonic() < deadline:
     else:
         if quiet_since is None:
             quiet_since = time.monotonic()
-        if time.monotonic() - quiet_since >= 2:
+        if time.monotonic() - quiet_since >= cleanup_quiet_seconds:
+            quiet_window_observed = True
             break
         time.sleep(0.25)
 
 remaining = matching_pids()
 if remaining:
     print(f'cleanup failed: stack-root processes remain after SIGKILL: {remaining}', file=sys.stderr)
+    raise SystemExit(1)
+if not quiet_window_observed:
+    print('cleanup failed: stable quiet window was not observed before deadline', file=sys.stderr)
     raise SystemExit(1)
 PY
 "

--- a/scripts/p2p-public-testnet-rebuild-validators.test.sh
+++ b/scripts/p2p-public-testnet-rebuild-validators.test.sh
@@ -433,6 +433,23 @@ if pgrep -f "$TEST_REMOTE_ROOT/root@sequencer/opt/oasis7/p2p-testnet/bin/start-n
   exit 1
 fi
 
+python3 - "$TEST_SSH_LOG" <<'PY'
+import pathlib
+import sys
+
+log_path = pathlib.Path(sys.argv[1])
+lines = log_path.read_text(encoding="utf-8").splitlines()
+sequencer_commands = [line.split("\t", 1)[1] for line in lines if line.startswith("root@sequencer\t")]
+if not any(
+    "systemctl stop 'oasis7-triad-sequencer.service'" in command
+    and "STACK_ROOT='/opt/oasis7/p2p-testnet' python3" in command
+    and "oasis7_chain_runtime" in command
+    and "start-node.sh" in command
+    for command in sequencer_commands
+):
+    raise SystemExit("missing sequencer cleanup command for delayed cleanup process test")
+PY
+
 : >"$TEST_SSH_LOG"
 if TEST_FAIL_START_HOST=root@sequencer "$ROOT_DIR/scripts/p2p-public-testnet-rebuild-validators.sh" \
   --config-dir "$TMP_DIR/config" \

--- a/scripts/p2p-public-testnet-rebuild-validators.test.sh
+++ b/scripts/p2p-public-testnet-rebuild-validators.test.sh
@@ -203,6 +203,13 @@ case "$cmd" in
     stack_root=$(printf '%s\n' "$cmd" | sed -n "s/STACK_ROOT='\([^']*\)'.*/\1/p")
     cleanup_cmd="STACK_ROOT=${cmd#*STACK_ROOT=}"
     mapped_cmd=${cleanup_cmd//STACK_ROOT=\'$stack_root\'/STACK_ROOT=\'$root$stack_root\'}
+    if [[ "${TEST_SPAWN_DELAYED_CLEANUP_PROCESS_HOST:-}" == "$host" ]]; then
+      mkdir -p "$root$stack_root/bin"
+      (
+        sleep 0.4
+        exec -a "$root$stack_root/bin/start-node.sh" sleep 30
+      ) &
+    fi
     bash -c "$mapped_cmd"
     ;;
   systemctl\ stop*)
@@ -399,6 +406,32 @@ if not start_indexes:
 if not any(index > start_indexes[-1] for index in cleanup_indexes):
     raise SystemExit("missing post-start cleanup after failed sequencer readiness")
 PY
+
+: >"$TEST_SSH_LOG"
+rm -f "$TEST_REMOTE_ROOT"/started-*
+if TEST_SPAWN_DELAYED_CLEANUP_PROCESS_HOST=root@sequencer "$ROOT_DIR/scripts/p2p-public-testnet-rebuild-validators.sh" \
+  --config-dir "$TMP_DIR/config" \
+  --world-dir "$TMP_DIR/world" \
+  --sequencer-ssh-host root@sequencer \
+  --sequencer-sshpass-env SEQ_PASS \
+  --sequencer-service oasis7-triad-sequencer.service \
+  --sequencer-status-url http://sequencer/status \
+  --storage-ssh-host root@storage \
+  --storage-sshpass-env STO_PASS \
+  --storage-service oasis7-triad-storage.service \
+  --storage-status-url http://storage/status \
+  --stack-root /opt/oasis7/p2p-testnet \
+  --out-dir "$TMP_DIR/out-delayed-cleanup" \
+  --poll-attempts 1 \
+  --poll-sleep-seconds 0 >/tmp/oasis7-rebuild-validators-delayed-cleanup.out 2>&1; then
+  :
+fi
+
+if pgrep -f "$TEST_REMOTE_ROOT/root@sequencer/opt/oasis7/p2p-testnet/bin/start-node.sh" >/dev/null; then
+  pkill -f "$TEST_REMOTE_ROOT/root@sequencer/opt/oasis7/p2p-testnet/bin/start-node.sh" || true
+  echo "delayed cleanup process survived stable quiet cleanup" >&2
+  exit 1
+fi
 
 : >"$TEST_SSH_LOG"
 if TEST_FAIL_START_HOST=root@sequencer "$ROOT_DIR/scripts/p2p-public-testnet-rebuild-validators.sh" \

--- a/scripts/p2p-public-testnet-rebuild-validators.test.sh
+++ b/scripts/p2p-public-testnet-rebuild-validators.test.sh
@@ -210,6 +210,14 @@ case "$cmd" in
         exec -a "$root$stack_root/bin/start-node.sh" sleep 30
       ) &
     fi
+    if [[ "${TEST_SPAWN_LATE_CLEANUP_PROCESS_HOST:-}" == "$host" ]]; then
+      mapped_cmd="CLEANUP_DEADLINE_SECONDS=1 CLEANUP_QUIET_SECONDS=2 $mapped_cmd"
+      mkdir -p "$root$stack_root/bin"
+      (
+        sleep 0.8
+        exec -a "$root$stack_root/bin/start-node.sh" sleep 30
+      ) &
+    fi
     bash -c "$mapped_cmd"
     ;;
   systemctl\ stop*)
@@ -449,6 +457,30 @@ if not any(
 ):
     raise SystemExit("missing sequencer cleanup command for delayed cleanup process test")
 PY
+
+: >"$TEST_SSH_LOG"
+rm -f "$TEST_REMOTE_ROOT"/started-*
+if TEST_SPAWN_LATE_CLEANUP_PROCESS_HOST=root@sequencer "$ROOT_DIR/scripts/p2p-public-testnet-rebuild-validators.sh" \
+  --config-dir "$TMP_DIR/config" \
+  --world-dir "$TMP_DIR/world" \
+  --sequencer-ssh-host root@sequencer \
+  --sequencer-sshpass-env SEQ_PASS \
+  --sequencer-service oasis7-triad-sequencer.service \
+  --sequencer-status-url http://sequencer/status \
+  --storage-ssh-host root@storage \
+  --storage-sshpass-env STO_PASS \
+  --storage-service oasis7-triad-storage.service \
+  --storage-status-url http://storage/status \
+  --stack-root /opt/oasis7/p2p-testnet \
+  --out-dir "$TMP_DIR/out-late-cleanup" \
+  --poll-attempts 1 \
+  --poll-sleep-seconds 0 >/tmp/oasis7-rebuild-validators-late-cleanup.out 2>&1; then
+  echo "expected rebuild cleanup to fail when stable quiet window is not observed" >&2
+  exit 1
+fi
+grep -q "cleanup failed: stable quiet window was not observed before deadline" \
+  /tmp/oasis7-rebuild-validators-late-cleanup.out
+pkill -f "$TEST_REMOTE_ROOT/root@sequencer/opt/oasis7/p2p-testnet/bin/start-node.sh" || true
 
 : >"$TEST_SSH_LOG"
 if TEST_FAIL_START_HOST=root@sequencer "$ROOT_DIR/scripts/p2p-public-testnet-rebuild-validators.sh" \


### PR DESCRIPTION
## Summary
- require validator rebuild cleanup to keep scanning until a stable quiet window before success
- keep fail-closed cleanup for all validators started by the current rebuild run
- add fake-ssh regression coverage for delayed stack-root start-node processes

## Verification
- bash scripts/p2p-public-testnet-rebuild-validators.test.sh
- bash -n scripts/p2p-public-testnet-rebuild-validators.sh scripts/p2p-public-testnet-rebuild-validators.test.sh
- git diff --check
- ./scripts/check-rust-file-size.sh
- ./scripts/pm/workflow-lint.sh --task-uid task_b0a073c3b7fd44549767d9540e8e6ec9 --phase current

## Review
- Pre-PR Local Role Review: passed
- Roles: blockchain_ops_engineer, qa_engineer, producer_system_designer
- Residual risk: fake-ssh coverage does not prove a kernel-level unkillable-process edge case; live validator rebuild remains the post-merge validation gate.