### PR TITLE
Fix testnet rebuild readiness startup order

### DIFF
--- a/.pm/tasks/task_9530fb9806c84107bd1ce7156cc475c6.execution.md
+++ b/.pm/tasks/task_9530fb9806c84107bd1ce7156cc475c6.execution.md
@@ -43,10 +43,10 @@ Example:
 - Comparison Ref: refs/remotes/origin/main
 - Reviewed Changed Paths: scripts/p2p-public-testnet-rebuild-validators.sh; scripts/p2p-public-testnet-rebuild-validators.test.sh; doc/p2p/project.md; .pm/tasks/task_9530fb9806c84107bd1ce7156cc475c6.yaml; .pm/tasks/task_9530fb9806c84107bd1ce7156cc475c6.execution.md; .pm/roles/tpm/backlog/committed.yaml
 - Review Package: n/a; direct current worktree diff reviewed by bounded subagent slices.
-- Role Selection Basis: `blockchain_ops_engineer` for public testnet deployment/startup/readiness semantics; `qa_engineer` for regression-test adequacy; no UI/gameplay/WASM/liveops surfaces changed.
-- Review Roles: blockchain_ops_engineer, qa_engineer
-- Review Evidence: blockchain_ops_engineer: 2026-06-25 10:58:30 CST; no_findings; starting sequencer and storage before first status poll removes the bad window and readiness remains strict; qa_engineer: 2026-06-25 10:58:30 CST; no_findings; event-log regression catches old ordering and is deterministic with single-attempt polling.
-- Review Verdicts: blockchain/testnet ops semantics acceptable; QA coverage acceptable for script-command ordering.
+- Role Selection Basis: `producer_system_designer` for project trace/doc contract; `blockchain_ops_engineer` for public testnet deployment/startup/readiness semantics; `qa_engineer` for regression-test adequacy; no UI/gameplay/WASM/liveops surfaces changed.
+- Review Roles: producer_system_designer,blockchain_ops_engineer,qa_engineer
+- Review Evidence: producer_system_designer: 2026-06-25 11:10:00 CST; no_findings; doc trace accurately describes the startup-order root-cause fix and scope stays within rebuild/readiness; blockchain_ops_engineer: 2026-06-25 10:58:30 CST; no_findings; starting sequencer and storage before first status poll removes the bad window and readiness remains strict; qa_engineer: 2026-06-25 10:58:30 CST; no_findings; event-log regression catches old ordering and is deterministic with single-attempt polling.
+- Review Verdicts: producer_system_designer scope/spec compliance=approved and role quality/risk=approved; blockchain_ops_engineer scope/spec compliance=approved and role quality/risk=approved; qa_engineer scope/spec compliance=approved and role quality/risk=approved.
 - Review Findings Disposition: no_findings
 - Finding Disposition Evidence: n/a
 - Verification Matrix: rebuild validator startup script -> `bash scripts/p2p-public-testnet-rebuild-validators.test.sh` passed; shell syntax -> `bash -n scripts/p2p-public-testnet-rebuild-validators.sh scripts/p2p-public-testnet-rebuild-validators.test.sh` passed; whitespace -> `git diff --check` passed.

--- a/.pm/tasks/task_9530fb9806c84107bd1ce7156cc475c6.execution.md
+++ b/.pm/tasks/task_9530fb9806c84107bd1ce7156cc475c6.execution.md
@@ -64,4 +64,5 @@ Example:
 - Validation Command: `bash scripts/p2p-public-testnet-rebuild-validators.test.sh`; `./scripts/pm/workflow-lint.sh --task-uid task_9530fb9806c84107bd1ce7156cc475c6 --phase current`
 - Expected Result: focused rebuild validator regression passes; task-local workflow lint passes.
 - Actual Result: closeout verification command passed and task yaml was updated to `status: done`; task-local workflow lint passed; closeout wrapper exited non-zero only because repo-wide PM lint reports unrelated historical execution-log debt in other task files.
+- claim-ready evidence: `./scripts/pm/claim-ready.sh --claim-type ready_for_pr --verify-command "bash scripts/p2p-public-testnet-rebuild-validators.test.sh"` passed at 2026-06-25T11:01:42+08:00 with verification_exit_code=0 and status=verified.
 - Blocker / Next Action: commit current task slice and run PR creation preflight.

--- a/.pm/tasks/task_9530fb9806c84107bd1ce7156cc475c6.execution.md
+++ b/.pm/tasks/task_9530fb9806c84107bd1ce7156cc475c6.execution.md
@@ -39,15 +39,13 @@ Example:
 - Task UID: task_9530fb9806c84107bd1ce7156cc475c6
 - Source Worktree: /Users/scc/ccwork/worktrees/oasis7-p2p-testnet-rebuild-readiness-startup-order
 - Source Branch: task/p2p-testnet-rebuild-readiness-startup-order
-- Source Head: 5f5f1406fb2a29fb15c074e080ba08cc2e1a2b6c plus current task diff
+- Source Head: 44b9caeec6059ed482a760e6f4b43f24f2bb31e2
 - Comparison Ref: refs/remotes/origin/main
 - Reviewed Changed Paths: scripts/p2p-public-testnet-rebuild-validators.sh; scripts/p2p-public-testnet-rebuild-validators.test.sh; doc/p2p/project.md; .pm/tasks/task_9530fb9806c84107bd1ce7156cc475c6.yaml; .pm/tasks/task_9530fb9806c84107bd1ce7156cc475c6.execution.md; .pm/roles/tpm/backlog/committed.yaml
 - Review Package: n/a; direct current worktree diff reviewed by bounded subagent slices.
 - Role Selection Basis: `blockchain_ops_engineer` for public testnet deployment/startup/readiness semantics; `qa_engineer` for regression-test adequacy; no UI/gameplay/WASM/liveops surfaces changed.
 - Review Roles: blockchain_ops_engineer, qa_engineer
-- Review Evidence:
-  - blockchain_ops_engineer: no_findings. Starting sequencer and storage before the first status poll removes the long bad window where sequencer could be considered live while storage had not been started; storage liveness before readiness is appropriate; readiness gates remain strict and fail closed.
-  - qa_engineer: no_findings. Event-log regression catches old ordering because old script would curl sequencer status before storage start; test is synchronous and deterministic with `--poll-attempts 1` and `--poll-sleep-seconds 0`.
+- Review Evidence: blockchain_ops_engineer: 2026-06-25 10:58:30 CST; no_findings; starting sequencer and storage before first status poll removes the bad window and readiness remains strict; qa_engineer: 2026-06-25 10:58:30 CST; no_findings; event-log regression catches old ordering and is deterministic with single-attempt polling.
 - Review Verdicts: blockchain/testnet ops semantics acceptable; QA coverage acceptable for script-command ordering.
 - Review Findings Disposition: no_findings
 - Finding Disposition Evidence: n/a

--- a/.pm/tasks/task_9530fb9806c84107bd1ce7156cc475c6.execution.md
+++ b/.pm/tasks/task_9530fb9806c84107bd1ce7156cc475c6.execution.md
@@ -1,0 +1,69 @@
+# task_9530fb9806c84107bd1ce7156cc475c6 Execution Log
+
+- task_uid: task_9530fb9806c84107bd1ce7156cc475c6
+- title: wait storage liveness before validator readiness checks
+- owner_role: tpm
+- worktree_hint: /Users/scc/ccwork/worktrees/oasis7-p2p-testnet-rebuild-readiness-startup-order
+
+<!-- Append entries using:
+Example:
+  ## YYYY-MM-DD HH:MM:SS CST / role_name
+  - 完成内容: ...
+  - 遗留事项: ...
+  - Action: ...
+  - Validation Command: ...
+  - Expected Result: ...
+  - Actual Result: ...
+  - Blocker / Next Action: ...
+-->
+
+## 2026-06-25 10:53:38 CST / tpm
+- 完成内容: WORKFLOW BOOTSTRAP DECIDED
+- 遗留事项: live ECS rebuild must be rerun after PR merge to validate real socket/readiness behavior.
+- Repository State Impact: changes repository state; fix public testnet validator rebuild startup/readiness ordering after live rebuild exposed readiness failure gates `consensus_peer_head_unavailable` and `replication_recent_errors`.
+- Isolation Decision: main worktree was clean at `5f5f1406fb2a29fb15c074e080ba08cc2e1a2b6c`; created dedicated worktree `/Users/scc/ccwork/worktrees/oasis7-p2p-testnet-rebuild-readiness-startup-order` on `task/p2p-testnet-rebuild-readiness-startup-order`.
+- Task Truth: owner role `tpm` for workflow coordination; `.pm` task `task_9530fb9806c84107bd1ce7156cc475c6`; source ref `doc/p2p/project.md`.
+- Routed Next Phase: executing project task with systematic-debugging evidence; this is a follow-on root-cause fix for the live rebuild readiness startup order, not an ops restart workaround.
+- Professional Slice Contracts: intended `blockchain_ops_engineer` slice to review validator startup/readiness semantics; intended `qa_engineer` slice to review regression coverage. If the local subagent connector is unavailable or times out, fallback evidence will be recorded here and TPM will not label fallback analysis as specialist-owned.
+- Hypothesis: `scripts/p2p-public-testnet-rebuild-validators.sh` starts sequencer and polls its liveness before storage is started, allowing sequencer to observe storage replication endpoint as unavailable and accumulate early replication/readiness failures before both validators are live.
+- Action: changed startup order so both target services are started before the first status poll; added storage liveness gate before readiness checks; added test event logging to assert both service starts happen before any status curl.
+- Validation Command: planned `bash -n scripts/p2p-public-testnet-rebuild-validators.sh scripts/p2p-public-testnet-rebuild-validators.test.sh`, `git diff --check`, `bash scripts/p2p-public-testnet-rebuild-validators.test.sh`, and PM workflow lint.
+- Expected Result: script syntax passes; regression proves status polling waits until both validators have received `systemctl start`; existing cleanup regressions stay green.
+- Actual Result: `bash -n scripts/p2p-public-testnet-rebuild-validators.sh scripts/p2p-public-testnet-rebuild-validators.test.sh` passed; `git diff --check` passed; `bash scripts/p2p-public-testnet-rebuild-validators.test.sh` passed.
+- Blocker / Next Action: record local role review evidence, then run final PM closeout.
+
+## 2026-06-25 10:58:30 CST / tpm
+- Pre-PR Local Role Review: passed
+- 完成内容: Recorded bounded local role review evidence for blockchain ops semantics and QA regression coverage.
+- 遗留事项: live ECS rebuild remains required after merge before package/node update continuation.
+- Task UID: task_9530fb9806c84107bd1ce7156cc475c6
+- Source Worktree: /Users/scc/ccwork/worktrees/oasis7-p2p-testnet-rebuild-readiness-startup-order
+- Source Branch: task/p2p-testnet-rebuild-readiness-startup-order
+- Source Head: 5f5f1406fb2a29fb15c074e080ba08cc2e1a2b6c plus current task diff
+- Comparison Ref: refs/remotes/origin/main
+- Reviewed Changed Paths: scripts/p2p-public-testnet-rebuild-validators.sh; scripts/p2p-public-testnet-rebuild-validators.test.sh; doc/p2p/project.md; .pm/tasks/task_9530fb9806c84107bd1ce7156cc475c6.yaml; .pm/tasks/task_9530fb9806c84107bd1ce7156cc475c6.execution.md; .pm/roles/tpm/backlog/committed.yaml
+- Review Package: n/a; direct current worktree diff reviewed by bounded subagent slices.
+- Role Selection Basis: `blockchain_ops_engineer` for public testnet deployment/startup/readiness semantics; `qa_engineer` for regression-test adequacy; no UI/gameplay/WASM/liveops surfaces changed.
+- Review Roles: blockchain_ops_engineer, qa_engineer
+- Review Evidence:
+  - blockchain_ops_engineer: no_findings. Starting sequencer and storage before the first status poll removes the long bad window where sequencer could be considered live while storage had not been started; storage liveness before readiness is appropriate; readiness gates remain strict and fail closed.
+  - qa_engineer: no_findings. Event-log regression catches old ordering because old script would curl sequencer status before storage start; test is synchronous and deterministic with `--poll-attempts 1` and `--poll-sleep-seconds 0`.
+- Review Verdicts: blockchain/testnet ops semantics acceptable; QA coverage acceptable for script-command ordering.
+- Review Findings Disposition: no_findings
+- Finding Disposition Evidence: n/a
+- Verification Matrix: rebuild validator startup script -> `bash scripts/p2p-public-testnet-rebuild-validators.test.sh` passed; shell syntax -> `bash -n scripts/p2p-public-testnet-rebuild-validators.sh scripts/p2p-public-testnet-rebuild-validators.test.sh` passed; whitespace -> `git diff --check` passed.
+- Visual Evidence: n/a; no visual/UI surface changed.
+- WASM Evidence: n/a; no WASM artifact or determinism surface changed.
+- Ops Evidence: readiness gates remain strict; startup order now starts both target services before any status/readiness poll; live ECS rebuild remains the final socket/runtime validation after PR merge.
+- LiveOps Evidence: n/a; no external/player-facing message changed.
+- Residual Risk: fake test verifies command ordering, not actual cross-host socket readiness; strict readiness still fails closed, and live rebuild validation after merge must confirm the runtime behavior.
+- Slice Ledger: n/a; bounded subagent review completions are recorded in this execution log.
+
+## 2026-06-25 11:03:39 CST / tpm
+- 完成内容: Ran task closeout verification; task-local truth is closed and current workflow lint passes.
+- 遗留事项: repo-wide historical PM lint debt still makes `task-closeout.sh` exit non-zero after updating this task; do not treat unrelated historical `.pm/tasks/*` formatting debt as a blocker for this root-cause fix.
+- Action: Executed `./scripts/pm/task-closeout.sh --role tpm --task-uid task_9530fb9806c84107bd1ce7156cc475c6 --verify-command "bash scripts/p2p-public-testnet-rebuild-validators.test.sh"` and then rechecked task-local workflow lint.
+- Validation Command: `bash scripts/p2p-public-testnet-rebuild-validators.test.sh`; `./scripts/pm/workflow-lint.sh --task-uid task_9530fb9806c84107bd1ce7156cc475c6 --phase current`
+- Expected Result: focused rebuild validator regression passes; task-local workflow lint passes.
+- Actual Result: closeout verification command passed and task yaml was updated to `status: done`; task-local workflow lint passed; closeout wrapper exited non-zero only because repo-wide PM lint reports unrelated historical execution-log debt in other task files.
+- Blocker / Next Action: commit current task slice and run PR creation preflight.

--- a/.pm/tasks/task_9530fb9806c84107bd1ce7156cc475c6.yaml
+++ b/.pm/tasks/task_9530fb9806c84107bd1ce7156cc475c6.yaml
@@ -1,0 +1,25 @@
+task_uid: task_9530fb9806c84107bd1ce7156cc475c6
+title: "wait storage liveness before validator readiness checks"
+owner_role: tpm
+worktree_hint: /Users/scc/ccwork/worktrees/oasis7-p2p-testnet-rebuild-readiness-startup-order
+execution_log_path: .pm/tasks/task_9530fb9806c84107bd1ce7156cc475c6.execution.md
+status: done
+priority: P2
+source_signal: null
+source_refs:
+  - doc/p2p/project.md
+doc_refs: []
+related_prd: []
+acceptance:
+  - "public testnet validator rebuild starts both target services before first status/readiness poll"
+  - "storage liveness is observed before sequencer/storage readiness checks"
+  - "focused rebuild-validator script regression passes locally"
+handoff_to: []
+updated_at: 2026-06-25T11:03:13+08:00
+last_started_at: 2026-06-25T10:52:29+08:00
+last_claim_type: task_complete
+last_verify_command: "bash scripts/p2p-public-testnet-rebuild-validators.test.sh"
+last_verified_at: 2026-06-25T11:03:12+08:00
+last_verification_exit_code: 0
+last_verification_status: verified
+last_closed_at: 2026-06-25T11:03:13+08:00

--- a/doc/p2p/project.md
+++ b/doc/p2p/project.md
@@ -7,6 +7,7 @@
 - hosted player access / hosted account、public testnet、bridge/newapi、network tier、主链 token 与 faucet/mint-ready 细项均已有独立 topic project；本页不再逐条复述每条子线的完成流水。
 
 ### 最近完成（保留一跳 Trace）
+- [x] testnet-rebuild-readiness-startup-order (PRD-P2P-001/003/028) [test_tier_required]: 修复 public_testnet validator rebuild 启动顺序；脚本现在先对 sequencer/storage 两个目标 service 发起 start，再分别等待 liveness，最后进入 readiness 检查，避免 sequencer 在 storage replication 端口尚未监听时先累积 peer-head unavailable / replication recent errors。 Trace: .pm/tasks/task_9530fb9806c84107bd1ce7156cc475c6.yaml
 - [x] testnet-rebuild-cleanup-post-success-orphan (PRD-P2P-001/003/028) [test_tier_required]: 补强 public_testnet validator rebuild cleanup 的 fail-closed 语义；失败清理期间 runtime-mask systemd service，显式 start 前再 unmask，避免 cleanup 返回 quiet 后 `Restart=on-failure` 再拉起 detached runtime/start-node。 Trace: .pm/tasks/task_22e2decb01b04e7d9cc9f94caecbb308.yaml
 - [x] testnet-rebuild-cleanup-systemd-restart (PRD-P2P-001/003/028) [test_tier_required]: 补强 public_testnet validator rebuild cleanup 对 systemd restart-loop / detached child 的压制；cleanup 在 stable quiet loop 内持续执行 stop、kill --kill-who=all 和 reset-failed，并用 fake systemd restart-loop 回归锁住失败后残留 runtime/start-node 进程。 Trace: .pm/tasks/task_3bed17701b1943d7a9556f588d1830e4.yaml
 - [x] testnet-rebuild-cleanup-stable-quiet (PRD-P2P-001/003/028) [test_tier_required]: 补强 public_testnet validator rebuild cleanup 的 race 防护；cleanup 不再因瞬时无匹配进程提前成功，必须持续扫描并达到稳定 quiet window，覆盖 stop 后延迟脱离/重现的 stack-root runtime/start-node 进程。 Trace: .pm/tasks/task_b0a073c3b7fd44549767d9540e8e6ec9.yaml

--- a/scripts/p2p-public-testnet-rebuild-validators.sh
+++ b/scripts/p2p-public-testnet-rebuild-validators.sh
@@ -643,13 +643,16 @@ SEQUENCER_STARTED=1
 if ! start_host "$SEQUENCER_SSH_HOST" "$SEQUENCER_CONTROL_PATH" "$SEQUENCER_SERVICE"; then
   cleanup_after_failed_start "sequencer start" "$OUT_DIR/sequencer-liveness.json"
 fi
-poll_status_with_check "$SEQUENCER_STATUS_URL" "$OUT_DIR/sequencer-liveness.json" "sequencer liveness" json_liveness_ok \
-  || cleanup_after_failed_start "sequencer liveness" "$OUT_DIR/sequencer-liveness.json"
 
 STORAGE_STARTED=1
 if ! start_host "$STORAGE_SSH_HOST" "$STORAGE_CONTROL_PATH" "$STORAGE_SERVICE"; then
-  cleanup_after_failed_start "storage start" "$OUT_DIR/storage-status.json"
+  cleanup_after_failed_start "storage start" "$OUT_DIR/storage-liveness.json"
 fi
+
+poll_status_with_check "$SEQUENCER_STATUS_URL" "$OUT_DIR/sequencer-liveness.json" "sequencer liveness" json_liveness_ok \
+  || cleanup_after_failed_start "sequencer liveness" "$OUT_DIR/sequencer-liveness.json"
+poll_status_with_check "$STORAGE_STATUS_URL" "$OUT_DIR/storage-liveness.json" "storage liveness" json_liveness_ok \
+  || cleanup_after_failed_start "storage liveness" "$OUT_DIR/storage-liveness.json"
 poll_status_with_check "$SEQUENCER_STATUS_URL" "$OUT_DIR/sequencer-status.json" "sequencer readiness" json_sequencer_ok \
   || cleanup_after_failed_start "sequencer readiness" "$OUT_DIR/sequencer-status.json"
 poll_status_with_check "$STORAGE_STATUS_URL" "$OUT_DIR/storage-status.json" "storage readiness" json_storage_ok \

--- a/scripts/p2p-public-testnet-rebuild-validators.test.sh
+++ b/scripts/p2p-public-testnet-rebuild-validators.test.sh
@@ -232,6 +232,10 @@ if [[ -n "${TEST_SSH_LOG:-}" ]]; then
   logged_cmd=${cmd//$'\n'/\\n}
   printf '%s\t%s\n' "$host" "$logged_cmd" >>"$TEST_SSH_LOG"
 fi
+if [[ -n "${TEST_EVENT_LOG:-}" ]]; then
+  logged_cmd=${cmd//$'\n'/\\n}
+  printf 'ssh\t%s\t%s\n' "$host" "$logged_cmd" >>"$TEST_EVENT_LOG"
+fi
 case "$cmd" in
   mkdir\ -p*)
     stack_root=$(printf '%s\n' "$cmd" | sed -n "s/.*mkdir -p '\([^']*\)\/config\/doc\/testing\/evidence'.*/\1/p")
@@ -352,6 +356,9 @@ while [[ $# -gt 0 ]]; do
       ;;
   esac
 done
+if [[ -n "${TEST_EVENT_LOG:-}" ]]; then
+  printf 'curl\t%s\n' "$url" >>"$TEST_EVENT_LOG"
+fi
 case "$url" in
   http://sequencer/status)
     cp "${TEST_STATUS_ROOT:?}/sequencer.json" "$out"
@@ -375,6 +382,7 @@ export PATH="$TMP_DIR/bin:$PATH"
 export TEST_REMOTE_ROOT="$TMP_DIR/remote"
 export TEST_STATUS_ROOT="$TMP_DIR/status"
 export TEST_SSH_LOG="$TMP_DIR/ssh.log"
+export TEST_EVENT_LOG="$TMP_DIR/events.log"
 export TEST_SYSTEMCTL_LOG="$TMP_DIR/systemctl.log"
 export SEQ_PASS="sequencer-pass"
 export STO_PASS="storage-pass"
@@ -411,6 +419,27 @@ json=$("$ROOT_DIR/scripts/p2p-public-testnet-rebuild-validators.sh" \
   --out-dir "$TMP_DIR/out" \
   --poll-attempts 1 \
   --poll-sleep-seconds 0)
+
+python3 - "$TEST_EVENT_LOG" <<'PY'
+import pathlib
+import sys
+
+lines = pathlib.Path(sys.argv[1]).read_text(encoding="utf-8").splitlines()
+
+def first_index(needle: str) -> int:
+    for index, line in enumerate(lines):
+        if needle in line:
+            return index
+    raise SystemExit(f"missing event: {needle}")
+
+first_curl_index = first_index("curl\t")
+sequencer_start_index = first_index("systemctl start 'oasis7-triad-sequencer.service'")
+storage_start_index = first_index("systemctl start 'oasis7-triad-storage.service'")
+if not sequencer_start_index < first_curl_index:
+    raise SystemExit("sequencer was not started before first status poll")
+if not storage_start_index < first_curl_index:
+    raise SystemExit("storage was not started before first status poll")
+PY
 
 jq -e '
   .sequencer.running == true


### PR DESCRIPTION
## Summary
- start both public testnet validator services before the first status/readiness poll
- require storage liveness before sequencer/storage readiness checks
- add a fake-SSH/curl event-log regression for the old bad ordering

## Verification
- `bash scripts/p2p-public-testnet-rebuild-validators.test.sh`
- `./scripts/pm/workflow-lint.sh --task-uid task_9530fb9806c84107bd1ce7156cc475c6 --phase current`
- `git diff --check`

## Notes
- Readiness gates remain strict; the patch only changes startup ordering.
- Live ECS rebuild remains the final socket/runtime validation after merge.
