### PR TITLE
Centralize viewer hosted public join mode

### DIFF
--- a/.pm/tasks/task_44b808199ed84f2bb477026924877eb6.execution.md
+++ b/.pm/tasks/task_44b808199ed84f2bb477026924877eb6.execution.md
@@ -100,3 +100,12 @@ Example:
 - Expected Result: PR exists and post-pr workflow-lint locates task-local PR evidence.
 - Actual Result: PR URL: https://github.com/eng-cc/oasis7/pull/641
 - Blocker / Next Action: Commit and push this PR evidence, then monitor PR #641.
+
+## 2026-06-25 15:21:47 CST / tpm
+- 完成内容: Addressed PR review finding for generated viewer bundle
+- 遗留事项: Push bundle refresh and watch rerun checks
+- Action: Regenerated crates/oasis7_viewer/viewer.js with npm --prefix crates/oasis7_viewer run build:software-safe after Codex review noted the tracked static bundle still had old inline hosted_public_join comparisons.
+- Validation Command: npm --prefix crates/oasis7_viewer run build:software-safe; rg -n 'trim\(\) === "hosted_public_join"|trim\(\) !== "hosted_public_join"' crates/oasis7_viewer/viewer.js crates/oasis7_viewer/software_safe_src crates/oasis7_viewer/scripts || true; npm --prefix crates/oasis7_viewer run test:ui -- --run software_safe_src/software_safe_constants.test.js software_safe_src/main.test.jsx; node crates/oasis7_viewer/scripts/software-safe-feedback-contract.test.mjs; ./scripts/pm/workflow-lint.sh --task-uid task_44b808199ed84f2bb477026924877eb6 --phase current; git diff --check
+- Expected Result: Tracked bundle is refreshed, old inline deployment-mode comparisons are absent, and focused tests still pass.
+- Actual Result: build:software-safe finalized crates/oasis7_viewer/viewer.js. rg found no old trim() ===/!== hosted_public_join comparisons. UI focused tests passed: 2 files / 42 tests. feedback contract passed. workflow-lint current OK. git diff --check OK.
+- Blocker / Next Action: Commit and push viewer.js refresh, then resolve PR review thread after CI reruns.

--- a/.pm/tasks/task_44b808199ed84f2bb477026924877eb6.execution.md
+++ b/.pm/tasks/task_44b808199ed84f2bb477026924877eb6.execution.md
@@ -73,18 +73,18 @@ Example:
 - Comparison Ref: refs/remotes/origin/main
 - Reviewed Changed Paths: crates/oasis7_viewer/software_safe_src/software_safe_constants.js; crates/oasis7_viewer/software_safe_src/software_safe_constants.test.js; crates/oasis7_viewer/software_safe_src/viewer_auth_surface_module.js; crates/oasis7_viewer/software_safe_src/legacy_core.js; crates/oasis7_viewer/software_safe_src/main.jsx; crates/oasis7_viewer/software_safe_src/main.test.jsx; crates/oasis7_viewer/scripts/software-safe-feedback-contract.test.mjs; doc/viewer/project.md; .pm/tasks/task_44b808199ed84f2bb477026924877eb6.yaml; .pm/tasks/task_44b808199ed84f2bb477026924877eb6.execution.md
 - Review Package: n/a; role reviews inspected current diff and observed verification evidence directly before implementation commit.
-- Role Selection Basis: Viewer frontend runtime contract and tests -> viewer_engineer + qa_engineer; repo governance/task evidence -> repository_health_engineer; viewer project trace/product scope -> producer_system_designer.
-- Review Roles: producer_system_designer,viewer_engineer,qa_engineer,repository_health_engineer
-- Review Evidence: viewer_engineer pass/no_findings; qa_engineer pass/no_findings; repository_health_engineer pass/no_findings; producer_system_designer pass/no_findings.
-- Review Verdicts: producer_system_designer: pass; viewer_engineer: pass; qa_engineer: pass; repository_health_engineer: pass.
+- Role Selection Basis: Viewer frontend runtime contract and tests -> viewer_engineer + qa_engineer; touched main.jsx/UI conditional rendering -> game_visual_interaction_designer; repo governance/task evidence -> repository_health_engineer; viewer project trace/product scope -> producer_system_designer.
+- Review Roles: producer_system_designer,viewer_engineer,game_visual_interaction_designer,qa_engineer,repository_health_engineer
+- Review Evidence: viewer_engineer pass/no_findings; game_visual_interaction_designer pass/no_findings and confirmed no visual layout, interaction flow, accessibility, player-visible text, or UI state semantic change; qa_engineer pass/no_findings; repository_health_engineer pass/no_findings; producer_system_designer pass/no_findings.
+- Review Verdicts: producer_system_designer: pass; viewer_engineer: pass; game_visual_interaction_designer: pass; qa_engineer: pass; repository_health_engineer: pass.
 - Review Findings Disposition: no_findings
 - Finding Disposition Evidence: n/a, no role findings required code changes.
 - Verification Matrix: shared deployment-mode predicate -> software_safe_constants.test.js passed; hosted public join UI/runtime paths -> main.test.jsx passed; feedback/auth contract fixture -> software-safe-feedback-contract.test.mjs passed; task workflow current state -> workflow-lint current passed; diff hygiene -> git diff --check passed.
-- Visual Evidence: n/a, no visual layout or interaction-flow change; this centralizes runtime contract predicates.
+- Visual Evidence: specific exemption: game_visual_interaction_designer reviewed the main.jsx conditional-rendering diff and found no visual layout, interaction flow, accessibility, player-visible text, or UI state semantic change; no screenshot/model-review evidence required because this centralizes the existing hosted_public_join predicate without changing DOM structure, styles, labels, buttons, disabled states, or focus behavior.
 - WASM Evidence: n/a, no WASM or determinism artifact changed.
 - Ops Evidence: n/a, no deployment or operator runbook changed.
 - LiveOps Evidence: n/a, no external/player/community message changed.
-- Residual Risk: doc-governance-check was locally long-running in broad all-doc scanning and did not complete; PR required gate should provide the full CI surface. Existing auth hint strings still include hosted_public_join in diagnostic labels, intentionally separate from deployment-mode matching.
+- Residual Risk: doc-governance-check was locally long-running in broad all-doc scanning and did not complete; PR required gate should provide the full CI surface. Existing auth hint strings still include hosted_public_join in diagnostic labels, intentionally separate from deployment-mode matching. Visual-review residual risk is low because the UI role confirmed behavior and presentation are unchanged.
 - Slice Ledger: /Users/scc/ccwork/worktrees/oasis7-viewer-frontend-governance-next-20260625/.pm/scratch/task_44b808199ed84f2bb477026924877eb6/slice-ledger.jsonl
 - Action: Recorded final role review packet for implementation source head b5f8ccf65a489e78d304ffcb1b4787fdce60478d.
 - Validation Command: npm --prefix crates/oasis7_viewer run test:ui -- --run software_safe_src/software_safe_constants.test.js software_safe_src/main.test.jsx; node crates/oasis7_viewer/scripts/software-safe-feedback-contract.test.mjs; ./scripts/pm/workflow-lint.sh --task-uid task_44b808199ed84f2bb477026924877eb6 --phase current; git diff --check

--- a/.pm/tasks/task_44b808199ed84f2bb477026924877eb6.execution.md
+++ b/.pm/tasks/task_44b808199ed84f2bb477026924877eb6.execution.md
@@ -61,3 +61,33 @@ Example:
 - Expected Result: Focused verification passes, role reviews are no_findings, and task truth reaches done/verified; unrelated repo-wide historical pm lint debt is recorded if helper exits nonzero after current verification.
 - Actual Result: claim-ready passed with 2 UI test files / 42 tests, feedback contract passed, workflow-lint current OK, git diff --check OK. task-closeout reran verification successfully and updated task YAML to status done, last_verification_status verified, last_closed_at 2026-06-25T15:00:55+08:00, then exited 1 on unrelated historical .pm lint debt. Role reviews: viewer_engineer pass/no_findings, qa_engineer pass/no_findings, repository_health_engineer pass/no_findings, producer_system_designer pass/no_findings.
 - Blocker / Next Action: Rebase latest origin/main, commit implementation, and append final Pre-PR Local Role Review packet.
+
+## 2026-06-25 15:03:18 CST / tpm
+- 完成内容: PRE-PR LOCAL ROLE REVIEW PASSED
+- 遗留事项: Run PR preflight, create PR, watch CI/comments, and merge when gates pass.
+- Pre-PR Local Role Review: passed
+- Task UID: task_44b808199ed84f2bb477026924877eb6
+- Source Worktree: /Users/scc/ccwork/worktrees/oasis7-viewer-frontend-governance-next-20260625
+- Source Branch: task/viewer-frontend-governance-next-20260625
+- Source Head: b5f8ccf65a489e78d304ffcb1b4787fdce60478d
+- Comparison Ref: refs/remotes/origin/main
+- Reviewed Changed Paths: crates/oasis7_viewer/software_safe_src/software_safe_constants.js; crates/oasis7_viewer/software_safe_src/software_safe_constants.test.js; crates/oasis7_viewer/software_safe_src/viewer_auth_surface_module.js; crates/oasis7_viewer/software_safe_src/legacy_core.js; crates/oasis7_viewer/software_safe_src/main.jsx; crates/oasis7_viewer/software_safe_src/main.test.jsx; crates/oasis7_viewer/scripts/software-safe-feedback-contract.test.mjs; doc/viewer/project.md; .pm/tasks/task_44b808199ed84f2bb477026924877eb6.yaml; .pm/tasks/task_44b808199ed84f2bb477026924877eb6.execution.md
+- Review Package: n/a; role reviews inspected current diff and observed verification evidence directly before implementation commit.
+- Role Selection Basis: Viewer frontend runtime contract and tests -> viewer_engineer + qa_engineer; repo governance/task evidence -> repository_health_engineer; viewer project trace/product scope -> producer_system_designer.
+- Review Roles: producer_system_designer,viewer_engineer,qa_engineer,repository_health_engineer
+- Review Evidence: viewer_engineer pass/no_findings; qa_engineer pass/no_findings; repository_health_engineer pass/no_findings; producer_system_designer pass/no_findings.
+- Review Verdicts: producer_system_designer: pass; viewer_engineer: pass; qa_engineer: pass; repository_health_engineer: pass.
+- Review Findings Disposition: no_findings
+- Finding Disposition Evidence: n/a, no role findings required code changes.
+- Verification Matrix: shared deployment-mode predicate -> software_safe_constants.test.js passed; hosted public join UI/runtime paths -> main.test.jsx passed; feedback/auth contract fixture -> software-safe-feedback-contract.test.mjs passed; task workflow current state -> workflow-lint current passed; diff hygiene -> git diff --check passed.
+- Visual Evidence: n/a, no visual layout or interaction-flow change; this centralizes runtime contract predicates.
+- WASM Evidence: n/a, no WASM or determinism artifact changed.
+- Ops Evidence: n/a, no deployment or operator runbook changed.
+- LiveOps Evidence: n/a, no external/player/community message changed.
+- Residual Risk: doc-governance-check was locally long-running in broad all-doc scanning and did not complete; PR required gate should provide the full CI surface. Existing auth hint strings still include hosted_public_join in diagnostic labels, intentionally separate from deployment-mode matching.
+- Slice Ledger: /Users/scc/ccwork/worktrees/oasis7-viewer-frontend-governance-next-20260625/.pm/scratch/task_44b808199ed84f2bb477026924877eb6/slice-ledger.jsonl
+- Action: Recorded final role review packet for implementation source head b5f8ccf65a489e78d304ffcb1b4787fdce60478d.
+- Validation Command: npm --prefix crates/oasis7_viewer run test:ui -- --run software_safe_src/software_safe_constants.test.js software_safe_src/main.test.jsx; node crates/oasis7_viewer/scripts/software-safe-feedback-contract.test.mjs; ./scripts/pm/workflow-lint.sh --task-uid task_44b808199ed84f2bb477026924877eb6 --phase current; git diff --check
+- Expected Result: PR-ready role review evidence covers the implementation source head.
+- Actual Result: All selected roles returned pass/no_findings; fresh verification passed after latest rebase.
+- Blocker / Next Action: Commit review evidence and run prepare-task-pr.

--- a/.pm/tasks/task_44b808199ed84f2bb477026924877eb6.execution.md
+++ b/.pm/tasks/task_44b808199ed84f2bb477026924877eb6.execution.md
@@ -91,3 +91,12 @@ Example:
 - Expected Result: PR-ready role review evidence covers the implementation source head.
 - Actual Result: All selected roles returned pass/no_findings; fresh verification passed after latest rebase.
 - Blocker / Next Action: Commit review evidence and run prepare-task-pr.
+
+## 2026-06-25 15:07:02 CST / tpm
+- 完成内容: Created PR and recorded post-PR evidence
+- 遗留事项: Watch required checks, mergeability, comments, and review threads.
+- Action: Created GitHub PR for hosted_public_join deployment-mode governance and recorded PR evidence in this task-local execution log.
+- Validation Command: gh pr create --base main --head task/viewer-frontend-governance-next-20260625 --title "Centralize viewer hosted public join mode"; ./scripts/pm/workflow-lint.sh --task-uid task_44b808199ed84f2bb477026924877eb6 --phase post-pr
+- Expected Result: PR exists and post-pr workflow-lint locates task-local PR evidence.
+- Actual Result: PR URL: https://github.com/eng-cc/oasis7/pull/641
+- Blocker / Next Action: Commit and push this PR evidence, then monitor PR #641.

--- a/.pm/tasks/task_44b808199ed84f2bb477026924877eb6.execution.md
+++ b/.pm/tasks/task_44b808199ed84f2bb477026924877eb6.execution.md
@@ -1,0 +1,63 @@
+# task_44b808199ed84f2bb477026924877eb6 Execution Log
+
+- task_uid: task_44b808199ed84f2bb477026924877eb6
+- title: find and govern next frontend code issue
+- owner_role: tpm
+- worktree_hint: /Users/scc/ccwork/worktrees/oasis7-viewer-frontend-governance-next-20260625
+
+<!-- Append entries using:
+Example:
+  ## YYYY-MM-DD HH:MM:SS CST / role_name
+  - 完成内容: ...
+  - 遗留事项: ...
+  - Action: ...
+  - Validation Command: ...
+  - Expected Result: ...
+  - Actual Result: ...
+  - Blocker / Next Action: ...
+-->
+
+## 2026-06-25 14:35:27 CST / tpm
+- 完成内容: WORKFLOW BOOTSTRAP DECIDED
+- 遗留事项: Dispatch bounded professional slices to identify a small frontend governance issue
+- Action: Created standard task worktree and bound .pm task for next frontend governance pass.
+- Validation Command: ./scripts/new-task-worktree.sh viewer frontend-governance-next-20260625 --base origin/main --pm-owner-role tpm ... --json
+- Expected Result: Dedicated task worktree, branch, .pm task, and execution log exist before substantive frontend analysis.
+- Actual Result: Worktree /Users/scc/ccwork/worktrees/oasis7-viewer-frontend-governance-next-20260625 on branch task/viewer-frontend-governance-next-20260625; task task_44b808199ed84f2bb477026924877eb6 owner tpm; source/doc refs doc/engineering/project.md.
+- Blocker / Next Action: Dispatch viewer_engineer and repository_health_engineer bounded discovery slices.
+
+## 2026-06-25 14:40:10 CST / tpm
+- 完成内容: Selected frontend governance issue
+- 遗留事项: Implement hosted_public_join deployment-mode constant and predicate across Viewer frontend
+- Action: Integrated discovery slices. viewer_engineer recommended centralizing hosted_public_join deployment-mode semantics; repository_health_engineer identified a separate feedback contract package-script drift candidate for a future task.
+- Validation Command: bounded subagent discovery slices
+- Expected Result: One bounded issue is selected with role-attributed evidence before editing.
+- Actual Result: Selected viewer_engineer candidate: hosted_public_join裸字符串分散在 auth surface, legacy core, and Solid UI entrypoints; no visual/browser screenshot required. Deferred repository_health package script candidate to avoid scope mixing.
+- Blocker / Next Action: Patch constants/imports/usages and add focused regression coverage.
+
+## 2026-06-25 14:44:31 CST / tpm
+- 完成内容: Implemented hosted_public_join deployment-mode governance
+- 遗留事项: Rebase onto latest origin/main, rerun verification, and request role reviews
+- Action: Added HOSTED_PUBLIC_JOIN_DEPLOYMENT_MODE and isHostedPublicJoinDeploymentMode; replaced production deployment_mode literal comparisons in auth surface, legacy core, and Solid UI; updated fixtures to use the constant; added focused constants regression coverage and viewer project trace.
+- Validation Command: npm --prefix crates/oasis7_viewer ci; npm --prefix crates/oasis7_viewer run test:ui -- --run software_safe_src/software_safe_constants.test.js software_safe_src/main.test.jsx; node crates/oasis7_viewer/scripts/software-safe-feedback-contract.test.mjs; git diff --check
+- Expected Result: Focused Viewer tests and feedback contract pass after dependencies are installed; diff hygiene passes.
+- Actual Result: Initial test attempt failed because node_modules were absent; npm ci installed 158 packages. Rerun passed: 2 test files / 42 tests; software-safe feedback contract tests passed; git diff --check passed. npm audit reported existing dependency vulnerabilities, not introduced by this patch.
+- Blocker / Next Action: Branch is behind origin/main by one commit; rebase before final verification/review.
+
+## 2026-06-25 14:54:59 CST / tpm
+- 完成内容: Rebased and reran focused verification
+- 遗留事项: Collect pre-PR role reviews
+- Action: Rebased onto latest origin/main and reran focused verification after hosted_public_join deployment-mode governance patch.
+- Validation Command: npm --prefix crates/oasis7_viewer run test:ui -- --run software_safe_src/software_safe_constants.test.js software_safe_src/main.test.jsx; node crates/oasis7_viewer/scripts/software-safe-feedback-contract.test.mjs; ./scripts/pm/workflow-lint.sh --task-uid task_44b808199ed84f2bb477026924877eb6 --phase current; git diff --check; ./scripts/doc-governance-check.sh
+- Expected Result: Focused Viewer tests, feedback contract, current workflow lint, and diff hygiene pass; doc governance either completes or is recorded if too slow for local loop.
+- Actual Result: Focused Viewer tests passed: 2 files / 42 tests. feedback contract passed. workflow-lint current passed. git diff --check passed. doc-governance-check produced no failure output but did not complete after several minutes; bash -x showed it was in broad all-doc scanning, so this is recorded as local long-running verification rather than a scoped code failure.
+- Blocker / Next Action: Dispatch viewer_engineer, qa_engineer, repository_health_engineer, and producer_system_designer reviews.
+
+## 2026-06-25 15:01:49 CST / tpm
+- 完成内容: Integrated role reviews and task closeout
+- 遗留事项: Rebase latest main, commit implementation, append pre-PR review packet
+- Action: Integrated viewer_engineer, qa_engineer, repository_health_engineer, and producer_system_designer review verdicts. Ran claim-ready and task-closeout verification.
+- Validation Command: ./scripts/pm/claim-ready.sh --claim-type task_complete --task-uid task_44b808199ed84f2bb477026924877eb6 --verify-command '<focused verification>'; ./scripts/pm/task-closeout.sh --role tpm --task-uid task_44b808199ed84f2bb477026924877eb6 --verify-command '<focused verification>'
+- Expected Result: Focused verification passes, role reviews are no_findings, and task truth reaches done/verified; unrelated repo-wide historical pm lint debt is recorded if helper exits nonzero after current verification.
+- Actual Result: claim-ready passed with 2 UI test files / 42 tests, feedback contract passed, workflow-lint current OK, git diff --check OK. task-closeout reran verification successfully and updated task YAML to status done, last_verification_status verified, last_closed_at 2026-06-25T15:00:55+08:00, then exited 1 on unrelated historical .pm lint debt. Role reviews: viewer_engineer pass/no_findings, qa_engineer pass/no_findings, repository_health_engineer pass/no_findings, producer_system_designer pass/no_findings.
+- Blocker / Next Action: Rebase latest origin/main, commit implementation, and append final Pre-PR Local Role Review packet.

--- a/.pm/tasks/task_44b808199ed84f2bb477026924877eb6.yaml
+++ b/.pm/tasks/task_44b808199ed84f2bb477026924877eb6.yaml
@@ -1,0 +1,27 @@
+task_uid: task_44b808199ed84f2bb477026924877eb6
+title: "find and govern next frontend code issue"
+owner_role: tpm
+worktree_hint: /Users/scc/ccwork/worktrees/oasis7-viewer-frontend-governance-next-20260625
+execution_log_path: .pm/tasks/task_44b808199ed84f2bb477026924877eb6.execution.md
+status: done
+priority: P2
+source_signal: null
+source_refs:
+  - doc/engineering/project.md
+  - doc/viewer/project.md
+doc_refs:
+  - doc/engineering/project.md
+  - doc/viewer/project.md
+related_prd: []
+acceptance:
+  - "Find one bounded frontend code governance issue and fix it with regression coverage."
+  - "Record professional role evidence and verification in the task execution log."
+handoff_to: []
+updated_at: 2026-06-25T15:00:58+08:00
+last_started_at: 2026-06-25T14:34:58+08:00
+last_claim_type: task_complete
+last_verify_command: "npm --prefix crates/oasis7_viewer run test:ui -- --run software_safe_src/software_safe_constants.test.js software_safe_src/main.test.jsx && node crates/oasis7_viewer/scripts/software-safe-feedback-contract.test.mjs && ./scripts/pm/workflow-lint.sh --task-uid task_44b808199ed84f2bb477026924877eb6 --phase current && git diff --check"
+last_verified_at: 2026-06-25T15:00:49+08:00
+last_verification_exit_code: 0
+last_verification_status: verified
+last_closed_at: 2026-06-25T15:00:55+08:00

--- a/crates/oasis7_viewer/scripts/software-safe-feedback-contract.test.mjs
+++ b/crates/oasis7_viewer/scripts/software-safe-feedback-contract.test.mjs
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { HOSTED_PUBLIC_JOIN_DEPLOYMENT_MODE } from "../software_safe_src/software_safe_constants.js";
 
 globalThis.window = {
   location: { search: "?test_api=1", href: "http://127.0.0.1:4173/software_safe.html?ws=ws://127.0.0.1:5011&test_api=1", pathname: "/software_safe.html" },
@@ -157,7 +158,7 @@ const core = await import("../software_safe_src/legacy_core.js");
 
 {
   core.state.hostedAccess = {
-    deployment_mode: "hosted_public_join",
+    deployment_mode: HOSTED_PUBLIC_JOIN_DEPLOYMENT_MODE,
     action_matrix: [
       {
         action_id: "prompt_control_apply",
@@ -199,7 +200,7 @@ const core = await import("../software_safe_src/legacy_core.js");
 
 {
   core.state.hostedAccess = {
-    deployment_mode: "hosted_public_join",
+    deployment_mode: HOSTED_PUBLIC_JOIN_DEPLOYMENT_MODE,
     action_matrix: [],
   };
   core.state.auth = {

--- a/crates/oasis7_viewer/software_safe_src/legacy_core.js
+++ b/crates/oasis7_viewer/software_safe_src/legacy_core.js
@@ -27,6 +27,7 @@ import {
   VIEWER_AUTH_PUBLIC_KEY,
   VIEWER_PLAYER_ID_KEY,
   VIEWER_RENDER_MODE,
+  isHostedPublicJoinDeploymentMode,
 } from "./software_safe_constants.js";
 import { createSoftwareSafeState } from "./software_safe_state.js";
 import {
@@ -293,7 +294,7 @@ async function ensureHostedAuthSigningKey(auth = state.auth) {
 }
 
 async function refreshHostedAdmissionState() {
-  if (String(state.hostedAccess?.deployment_mode || "").trim() !== "hosted_public_join") {
+  if (!isHostedPublicJoinDeploymentMode(state.hostedAccess?.deployment_mode)) {
     state.hostedAdmission = null;
     return null;
   }
@@ -1261,7 +1262,7 @@ async function buildGameplayActionAuthProof(request, auth) {
 }
 
 function canAutoIssueHostedPlayerSession() {
-  return String(state.hostedAccess?.deployment_mode || "").trim() === "hosted_public_join"
+  return isHostedPublicJoinDeploymentMode(state.hostedAccess?.deployment_mode)
     && state.auth.source !== "legacy_viewer_auth_bootstrap";
 }
 
@@ -1284,7 +1285,7 @@ function canAutoIssueLocalTestPlayerSession() {
   if (state.auth.available) {
     return false;
   }
-  if (String(state.hostedAccess?.deployment_mode || "").trim() === "hosted_public_join") {
+  if (isHostedPublicJoinDeploymentMode(state.hostedAccess?.deployment_mode)) {
     return false;
   }
   const pageHost = String(window.location.hostname || "").trim();
@@ -2105,7 +2106,7 @@ function sendPromptControl(mode, payload = null) {
       render();
       await ensureRegisteredPlayerSession(agentId);
       let strongAuthGrant = null;
-      if (String(state.hostedAccess?.deployment_mode || "").trim() === "hosted_public_join") {
+      if (isHostedPublicJoinDeploymentMode(state.hostedAccess?.deployment_mode)) {
         feedback.stage = "authorizing";
         feedback.effect = "requesting backend strong-auth grant";
         render();
@@ -3002,7 +3003,7 @@ function renderSummary() {
             </div>
           </div>`
         : ""}
-      ${!state.auth.available && String(state.hostedAccess?.deployment_mode || "").trim() === "hosted_public_join"
+      ${!state.auth.available && isHostedPublicJoinDeploymentMode(state.hostedAccess?.deployment_mode)
         ? hostedRecoveryHint
           ? ""
           : `<div class="toolbar"><button data-auth-action="retry-issue" ${state.auth.issueInFlight ? "disabled" : ""}>Acquire Hosted Player Session</button></div>`
@@ -3141,7 +3142,7 @@ function renderInteractionPanel() {
   const mainTokenTransferPolicy = hostedActionPolicy("main_token_transfer");
   const interactionEnabled = promptCapability.enabled;
   const strongAuthGrantHint = authSurface.capabilities.prompt_control.enabled
-    && String(state.hostedAccess?.deployment_mode || "").trim() === "hosted_public_join"
+    && isHostedPublicJoinDeploymentMode(state.hostedAccess?.deployment_mode)
     ? `<div class="field">
          <label for="strong-auth-approval-code">Backend Approval Code</label>
          <input id="strong-auth-approval-code" type="password" autocomplete="off" value="${escapeHtml(state.strongAuth.approvalCode || "")}" />

--- a/crates/oasis7_viewer/software_safe_src/main.jsx
+++ b/crates/oasis7_viewer/software_safe_src/main.jsx
@@ -3,6 +3,10 @@ import { render as mount } from "solid-js/web";
 
 import * as core from "./legacy_core.js";
 import { PixelWorldHost } from "./pixel_world_host.jsx";
+import {
+  HOSTED_PUBLIC_JOIN_DEPLOYMENT_MODE,
+  isHostedPublicJoinDeploymentMode,
+} from "./software_safe_constants.js";
 
 const VIEWER_VISUAL_FIXTURE_GLOBAL = "__OASIS7_VIEWER_VISUAL_FIXTURES__";
 
@@ -573,7 +577,7 @@ function HostedLoginForm(props) {
 
 function shouldShowHostedLoginGate() {
   return !core.state.auth.available
-    && String(core.state.hostedAccess?.deployment_mode || "").trim() === "hosted_public_join";
+    && isHostedPublicJoinDeploymentMode(core.state.hostedAccess?.deployment_mode);
 }
 
 function focusableElements(root) {
@@ -1431,7 +1435,7 @@ function WorldSummaryPanel() {
     !!hostedRecoveryHint()
       || (
         !state.auth.available
-        && String(state.hostedAccess?.deployment_mode || "").trim() === "hosted_public_join"
+        && isHostedPublicJoinDeploymentMode(state.hostedAccess?.deployment_mode)
       )
       || showRebindNotice();
   const diagnosticsSummaryBadges = () => [
@@ -1752,7 +1756,7 @@ function WorldSummaryPanel() {
           <Show
             when={
               !state.auth.available
-              && String(state.hostedAccess?.deployment_mode || "").trim() === "hosted_public_join"
+              && isHostedPublicJoinDeploymentMode(state.hostedAccess?.deployment_mode)
             }
           >
             <HostedLoginForm locale={locale()} />
@@ -1889,7 +1893,7 @@ function WorldSummaryPanel() {
           <Show
             when={
               !state.auth.available
-              && String(state.hostedAccess?.deployment_mode || "").trim() === "hosted_public_join"
+              && isHostedPublicJoinDeploymentMode(state.hostedAccess?.deployment_mode)
             }
           >
             <HostedLoginForm
@@ -2223,7 +2227,7 @@ function InteractionPanel() {
           <Show
             when={
               authSurface().capabilities.prompt_control.enabled
-              && String(core.state.hostedAccess?.deployment_mode || "").trim() === "hosted_public_join"
+              && isHostedPublicJoinDeploymentMode(core.state.hostedAccess?.deployment_mode)
             }
           >
             <div class="field">
@@ -2808,7 +2812,7 @@ function setFixtureDiagnostics() {
 
 function setFixtureHostedGate() {
   core.state.hostedAccess = {
-    deployment_mode: "hosted_public_join",
+    deployment_mode: HOSTED_PUBLIC_JOIN_DEPLOYMENT_MODE,
     action_matrix: [
       {
         action_id: "prompt_control_apply",

--- a/crates/oasis7_viewer/software_safe_src/main.test.jsx
+++ b/crates/oasis7_viewer/software_safe_src/main.test.jsx
@@ -1,5 +1,6 @@
 import { fireEvent, screen, waitFor, within } from "@solidjs/testing-library";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { HOSTED_PUBLIC_JOIN_DEPLOYMENT_MODE } from "./software_safe_constants.js";
 
 vi.mock("./pixel_world_host.jsx", () => ({
   PixelWorldHost: (props) => (
@@ -152,7 +153,7 @@ function sampleAgentClaimSnapshot() {
 
 function sampleHostedPublicJoinAccess(overrides = {}) {
   return {
-    deployment_mode: "hosted_public_join",
+    deployment_mode: HOSTED_PUBLIC_JOIN_DEPLOYMENT_MODE,
     action_matrix: [
       {
         action_id: "prompt_control_apply",

--- a/crates/oasis7_viewer/software_safe_src/software_safe_constants.js
+++ b/crates/oasis7_viewer/software_safe_src/software_safe_constants.js
@@ -16,6 +16,7 @@ export const HOSTED_PLAYER_SESSION_RELEASE_ROUTE = "/api/public/player-session/r
 export const HOSTED_ACCOUNT_LOGIN_START_ROUTE = "/api/public/hosted-account/login/start";
 export const HOSTED_ACCOUNT_LOGIN_COMPLETE_ROUTE = "/api/public/hosted-account/login/complete";
 export const HOSTED_STRONG_AUTH_GRANT_ROUTE = "/api/public/strong-auth/grant";
+export const HOSTED_PUBLIC_JOIN_DEPLOYMENT_MODE = "hosted_public_join";
 export const HOSTED_PLAYER_SESSION_REFRESH_INTERVAL_MS = 30000;
 export const DEFAULT_WS_ADDR = "ws://127.0.0.1:5011";
 export const MAX_EVENTS = 24;
@@ -28,3 +29,7 @@ export const SOFTWARE_RENDERER_MARKERS = [
   "softpipe",
   "lavapipe",
 ];
+
+export function isHostedPublicJoinDeploymentMode(deploymentMode) {
+  return String(deploymentMode || "").trim() === HOSTED_PUBLIC_JOIN_DEPLOYMENT_MODE;
+}

--- a/crates/oasis7_viewer/software_safe_src/software_safe_constants.test.js
+++ b/crates/oasis7_viewer/software_safe_src/software_safe_constants.test.js
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import {
+  HOSTED_PUBLIC_JOIN_DEPLOYMENT_MODE,
+  isHostedPublicJoinDeploymentMode,
+} from "./software_safe_constants.js";
+
+describe("software safe constants", () => {
+  it("centralizes hosted public join deployment-mode matching", () => {
+    expect(isHostedPublicJoinDeploymentMode(HOSTED_PUBLIC_JOIN_DEPLOYMENT_MODE)).toBe(true);
+    expect(isHostedPublicJoinDeploymentMode(` ${HOSTED_PUBLIC_JOIN_DEPLOYMENT_MODE} `)).toBe(true);
+
+    expect(isHostedPublicJoinDeploymentMode("trusted_local_only")).toBe(false);
+    expect(isHostedPublicJoinDeploymentMode("hosted-public-join")).toBe(false);
+    expect(isHostedPublicJoinDeploymentMode(null)).toBe(false);
+    expect(isHostedPublicJoinDeploymentMode(undefined)).toBe(false);
+  });
+});

--- a/crates/oasis7_viewer/software_safe_src/viewer_auth_surface_module.js
+++ b/crates/oasis7_viewer/software_safe_src/viewer_auth_surface_module.js
@@ -1,3 +1,5 @@
+import { isHostedPublicJoinDeploymentMode } from "./software_safe_constants.js";
+
 export function createViewerAuthSurfaceModule({
   getSearchParams,
   localeText,
@@ -34,7 +36,7 @@ export function createViewerAuthSurfaceModule({
 
   function authDeploymentHint(auth) {
     const hostedMode = String(state.hostedAccess?.deployment_mode || "").trim();
-    if (hostedMode === "hosted_public_join") {
+    if (isHostedPublicJoinDeploymentMode(hostedMode)) {
       if (auth.available && auth.source === "legacy_viewer_auth_bootstrap") {
         return "hosted_public_join_contract_with_legacy_bootstrap";
       }
@@ -339,7 +341,7 @@ export function createViewerAuthSurfaceModule({
   }
 
   function buildHostedRecoveryHint(locale = state.uiLocale) {
-    if (String(state.hostedAccess?.deployment_mode || "").trim() !== "hosted_public_join") {
+    if (!isHostedPublicJoinDeploymentMode(state.hostedAccess?.deployment_mode)) {
       return null;
     }
     if (state.auth.available) {

--- a/crates/oasis7_viewer/viewer.js
+++ b/crates/oasis7_viewer/viewer.js
@@ -728,6 +728,40 @@ function cleanChildren(parent, current, marker, replacement) {
   } else parent.insertBefore(node, marker);
   return [node];
 }
+const TEST_API_GLOBAL_NAME = "__AW_TEST__";
+const RENDER_META_GLOBAL_NAME = "__AW_VIEWER_RENDER_META__";
+const VIEWER_RENDER_MODE = "viewer";
+const SOFTWARE_SAFE_RENDER_MODE_ALIAS = "software_safe";
+const VIEWER_AUTH_BOOTSTRAP_OBJECT = "__OASIS7_VIEWER_AUTH_ENV";
+const VIEWER_PLAYER_ID_KEY = "OASIS7_VIEWER_PLAYER_ID";
+const VIEWER_AUTH_PUBLIC_KEY = "OASIS7_VIEWER_AUTH_PUBLIC_KEY";
+const VIEWER_AUTH_PRIVATE_KEY = "OASIS7_VIEWER_AUTH_PRIVATE_KEY";
+const VIEWER_AUTH_SIGNATURE_PREFIX = "awviewauth:v1:";
+const HOSTED_PLAYER_SESSION_STORAGE_PREFIX = "oasis7.hosted_player_session.v1";
+const UI_LOCALE_STORAGE_PREFIX = "oasis7.viewer.locale.v1";
+const PROMPT_OVERRIDES_VISIBILITY_STORAGE_PREFIX = "oasis7.viewer.prompt_overrides_visible.v1";
+const HOSTED_PLAYER_SESSION_ADMISSION_ROUTE = "/api/public/player-session/admission";
+const HOSTED_PLAYER_SESSION_REFRESH_ROUTE = "/api/public/player-session/refresh";
+const HOSTED_PLAYER_SESSION_RELEASE_ROUTE = "/api/public/player-session/release";
+const HOSTED_ACCOUNT_LOGIN_START_ROUTE = "/api/public/hosted-account/login/start";
+const HOSTED_ACCOUNT_LOGIN_COMPLETE_ROUTE = "/api/public/hosted-account/login/complete";
+const HOSTED_STRONG_AUTH_GRANT_ROUTE = "/api/public/strong-auth/grant";
+const HOSTED_PUBLIC_JOIN_DEPLOYMENT_MODE = "hosted_public_join";
+const HOSTED_PLAYER_SESSION_REFRESH_INTERVAL_MS = 3e4;
+const DEFAULT_WS_ADDR = "ws://127.0.0.1:5011";
+const MAX_EVENTS = 24;
+const MAX_DECISION_TRACES = 12;
+const SOFTWARE_RENDERER_MARKERS = [
+  "swiftshader",
+  "llvmpipe",
+  "software rasterizer",
+  "basic render driver",
+  "softpipe",
+  "lavapipe"
+];
+function isHostedPublicJoinDeploymentMode(deploymentMode) {
+  return String(deploymentMode || "").trim() === HOSTED_PUBLIC_JOIN_DEPLOYMENT_MODE;
+}
 function createViewerAuthSurfaceModule({
   getSearchParams: getSearchParams2,
   localeText: localeText2,
@@ -761,7 +795,7 @@ function createViewerAuthSurfaceModule({
   }
   function authDeploymentHint(auth) {
     const hostedMode = String(state2.hostedAccess?.deployment_mode || "").trim();
-    if (hostedMode === "hosted_public_join") {
+    if (isHostedPublicJoinDeploymentMode(hostedMode)) {
       if (auth.available && auth.source === "legacy_viewer_auth_bootstrap") {
         return "hosted_public_join_contract_with_legacy_bootstrap";
       }
@@ -1011,7 +1045,7 @@ function createViewerAuthSurfaceModule({
     });
   }
   function buildHostedRecoveryHint2(locale = state2.uiLocale) {
-    if (String(state2.hostedAccess?.deployment_mode || "").trim() !== "hosted_public_join") {
+    if (!isHostedPublicJoinDeploymentMode(state2.hostedAccess?.deployment_mode)) {
       return null;
     }
     if (state2.auth.available) {
@@ -2430,36 +2464,6 @@ function createViewerWorldScaleModule({
     detectRendererMeta: detectRendererMeta2
   };
 }
-const TEST_API_GLOBAL_NAME = "__AW_TEST__";
-const RENDER_META_GLOBAL_NAME = "__AW_VIEWER_RENDER_META__";
-const VIEWER_RENDER_MODE = "viewer";
-const SOFTWARE_SAFE_RENDER_MODE_ALIAS = "software_safe";
-const VIEWER_AUTH_BOOTSTRAP_OBJECT = "__OASIS7_VIEWER_AUTH_ENV";
-const VIEWER_PLAYER_ID_KEY = "OASIS7_VIEWER_PLAYER_ID";
-const VIEWER_AUTH_PUBLIC_KEY = "OASIS7_VIEWER_AUTH_PUBLIC_KEY";
-const VIEWER_AUTH_PRIVATE_KEY = "OASIS7_VIEWER_AUTH_PRIVATE_KEY";
-const VIEWER_AUTH_SIGNATURE_PREFIX = "awviewauth:v1:";
-const HOSTED_PLAYER_SESSION_STORAGE_PREFIX = "oasis7.hosted_player_session.v1";
-const UI_LOCALE_STORAGE_PREFIX = "oasis7.viewer.locale.v1";
-const PROMPT_OVERRIDES_VISIBILITY_STORAGE_PREFIX = "oasis7.viewer.prompt_overrides_visible.v1";
-const HOSTED_PLAYER_SESSION_ADMISSION_ROUTE = "/api/public/player-session/admission";
-const HOSTED_PLAYER_SESSION_REFRESH_ROUTE = "/api/public/player-session/refresh";
-const HOSTED_PLAYER_SESSION_RELEASE_ROUTE = "/api/public/player-session/release";
-const HOSTED_ACCOUNT_LOGIN_START_ROUTE = "/api/public/hosted-account/login/start";
-const HOSTED_ACCOUNT_LOGIN_COMPLETE_ROUTE = "/api/public/hosted-account/login/complete";
-const HOSTED_STRONG_AUTH_GRANT_ROUTE = "/api/public/strong-auth/grant";
-const HOSTED_PLAYER_SESSION_REFRESH_INTERVAL_MS = 3e4;
-const DEFAULT_WS_ADDR = "ws://127.0.0.1:5011";
-const MAX_EVENTS = 24;
-const MAX_DECISION_TRACES = 12;
-const SOFTWARE_RENDERER_MARKERS = [
-  "swiftshader",
-  "llvmpipe",
-  "software rasterizer",
-  "basic render driver",
-  "softpipe",
-  "lavapipe"
-];
 const $RAW = /* @__PURE__ */ Symbol("store-raw"), $NODE = /* @__PURE__ */ Symbol("store-node"), $HAS = /* @__PURE__ */ Symbol("store-has"), $SELF = /* @__PURE__ */ Symbol("store-self");
 function isWrappable(obj) {
   let proto;
@@ -3104,7 +3108,7 @@ async function ensureHostedAuthSigningKey(auth = state.auth) {
   return auth;
 }
 async function refreshHostedAdmissionState() {
-  if (String(state.hostedAccess?.deployment_mode || "").trim() !== "hosted_public_join") {
+  if (!isHostedPublicJoinDeploymentMode(state.hostedAccess?.deployment_mode)) {
     state.hostedAdmission = null;
     return null;
   }
@@ -3992,7 +3996,7 @@ async function buildGameplayActionAuthProof(request, auth) {
   };
 }
 function canAutoIssueHostedPlayerSession() {
-  return String(state.hostedAccess?.deployment_mode || "").trim() === "hosted_public_join" && state.auth.source !== "legacy_viewer_auth_bootstrap";
+  return isHostedPublicJoinDeploymentMode(state.hostedAccess?.deployment_mode) && state.auth.source !== "legacy_viewer_auth_bootstrap";
 }
 function isLoopbackHostname(raw) {
   const value = String(raw || "").trim().toLowerCase();
@@ -4011,7 +4015,7 @@ function canAutoIssueLocalTestPlayerSession() {
   if (state.auth.available) {
     return false;
   }
-  if (String(state.hostedAccess?.deployment_mode || "").trim() === "hosted_public_join") {
+  if (isHostedPublicJoinDeploymentMode(state.hostedAccess?.deployment_mode)) {
     return false;
   }
   const pageHost = String(window.location.hostname || "").trim();
@@ -4768,7 +4772,7 @@ function sendPromptControl(mode, payload = null) {
       render();
       await ensureRegisteredPlayerSession(agentId);
       let strongAuthGrant = null;
-      if (String(state.hostedAccess?.deployment_mode || "").trim() === "hosted_public_join") {
+      if (isHostedPublicJoinDeploymentMode(state.hostedAccess?.deployment_mode)) {
         feedback.stage = "authorizing";
         feedback.effect = "requesting backend strong-auth grant";
         render();
@@ -8357,7 +8361,7 @@ function HostedLoginForm(props) {
   })();
 }
 function shouldShowHostedLoginGate() {
-  return !state.auth.available && String(state.hostedAccess?.deployment_mode || "").trim() === "hosted_public_join";
+  return !state.auth.available && isHostedPublicJoinDeploymentMode(state.hostedAccess?.deployment_mode);
 }
 function focusableElements(root) {
   return [...root.querySelectorAll(["a[href]", "button:not([disabled])", "input:not([disabled])", "select:not([disabled])", "textarea:not([disabled])", "[tabindex]:not([tabindex='-1'])"].join(","))].filter((element) => !element.hasAttribute("aria-hidden"));
@@ -9143,7 +9147,7 @@ function WorldSummaryPanel() {
   const hostedRecoveryHint = () => buildHostedRecoveryHint(locale());
   const tierBadgeClass = (status) => status === "active" || status === "active_legacy_preview" || status === "active_hosted_issue" || status === "active_hosted_session" || status === "preview_backend_reauth_available" ? "badge badge--good" : status === "issued_pending_register" || status === "upgrade_after_player_session" || status === "preview_only" ? "badge badge--accent" : status === "superseded" ? "badge" : "badge badge--warn";
   const showRebindNotice = () => Boolean(state$1.auth.pendingRequestedAgentId) && (state$1.auth.pendingForceRebind || state$1.auth.runtimeStatus === "rebind_retrying" || state$1.auth.runtimeStatus === "rebind_registering");
-  const showPlayerSessionSurface = () => !!hostedRecoveryHint() || !state$1.auth.available && String(state$1.hostedAccess?.deployment_mode || "").trim() === "hosted_public_join" || showRebindNotice();
+  const showPlayerSessionSurface = () => !!hostedRecoveryHint() || !state$1.auth.available && isHostedPublicJoinDeploymentMode(state$1.hostedAccess?.deployment_mode) || showRebindNotice();
   const diagnosticsSummaryBadges = () => [`auth=${state$1.auth.available ? state$1.auth.registrationStatus || "ready" : "missing"}`, `events=${state$1.recentEvents.length}`];
   return (() => {
     var _el$157 = _tmpl$38(), _el$158 = _el$157.firstChild, _el$159 = _el$158.firstChild, _el$160 = _el$159.firstChild, _el$161 = _el$160.nextSibling, _el$162 = _el$158.nextSibling, _el$166 = _el$162.firstChild, _el$167 = _el$166.firstChild, _el$168 = _el$167.firstChild, _el$169 = _el$168.firstChild, _el$170 = _el$169.nextSibling, _el$171 = _el$168.nextSibling, _el$172 = _el$167.nextSibling, _el$173 = _el$172.firstChild, _el$174 = _el$173.nextSibling, _el$175 = _el$174.nextSibling, _el$183 = _el$175.nextSibling, _el$184 = _el$183.nextSibling, _el$185 = _el$184.firstChild, _el$186 = _el$185.nextSibling;
@@ -9719,7 +9723,7 @@ function WorldSummaryPanel() {
               })
             }), createComponent(Show, {
               get when() {
-                return memo(() => !!!state$1.auth.available)() && String(state$1.hostedAccess?.deployment_mode || "").trim() === "hosted_public_join";
+                return memo(() => !!!state$1.auth.available)() && isHostedPublicJoinDeploymentMode(state$1.hostedAccess?.deployment_mode);
               },
               get children() {
                 return createComponent(HostedLoginForm, {
@@ -9978,7 +9982,7 @@ function WorldSummaryPanel() {
     }), _el$183);
     insert(_el$172, createComponent(Show, {
       get when() {
-        return memo(() => !!!state$1.auth.available)() && String(state$1.hostedAccess?.deployment_mode || "").trim() === "hosted_public_join";
+        return memo(() => !!!state$1.auth.available)() && isHostedPublicJoinDeploymentMode(state$1.hostedAccess?.deployment_mode);
       },
       get children() {
         return createComponent(HostedLoginForm, {
@@ -10643,7 +10647,7 @@ function InteractionPanel() {
               return _el$243;
             })(), createComponent(Show, {
               get when() {
-                return memo(() => !!authSurface().capabilities.prompt_control.enabled)() && String(state.hostedAccess?.deployment_mode || "").trim() === "hosted_public_join";
+                return memo(() => !!authSurface().capabilities.prompt_control.enabled)() && isHostedPublicJoinDeploymentMode(state.hostedAccess?.deployment_mode);
               },
               get children() {
                 var _el$244 = _tmpl$45(), _el$245 = _el$244.firstChild, _el$246 = _el$245.nextSibling;
@@ -11375,7 +11379,7 @@ function setFixtureDiagnostics() {
 }
 function setFixtureHostedGate() {
   state.hostedAccess = {
-    deployment_mode: "hosted_public_join",
+    deployment_mode: HOSTED_PUBLIC_JOIN_DEPLOYMENT_MODE,
     action_matrix: [{
       action_id: "prompt_control_apply",
       required_auth: "strong_auth",

--- a/doc/viewer/project.md
+++ b/doc/viewer/project.md
@@ -2,6 +2,11 @@
 
 ## Active / Recent Tasks
 
+- [x] viewer-hosted-public-join-mode-governance (PRD-VIEWER/GOVERNANCE) [test_tier_required]: Centralize the Viewer `hosted_public_join` deployment-mode contract behind a shared constant/predicate so auth surface, hosted session issue, strong-auth UI, and contract fixtures cannot drift through repeated literal comparisons. Trace: .pm/tasks/task_44b808199ed84f2bb477026924877eb6.yaml
+  - Status: done
+  - Owner role: tpm
+  - Evidence: viewer_engineer discovery, implementation, focused constants/UI tests, feedback contract verification, and role review evidence are recorded in `.pm/tasks/task_44b808199ed84f2bb477026924877eb6.execution.md`.
+
 - [x] launcher-bundle-asset-freshness-governance (PRD-VIEWER/GOVERNANCE) [test_tier_required]: Enforce manifest-recorded launcher bundle asset path/SHA-256 integrity so stale source fingerprints cannot mask mutated or missing packaged Web assets. Trace: .pm/tasks/task_0ad144b805d84ee5b7b0f248385acd45.yaml
   - Status: done
   - Owner role: tpm


### PR DESCRIPTION
## Summary
- Centralize the Viewer `hosted_public_join` deployment-mode contract behind a shared constant and predicate.
- Replace production literal deployment-mode comparisons in auth surface, legacy core, and Solid UI conditions.
- Add focused predicate coverage and keep hosted-public-join fixtures on the shared constant.

## Task
- task_44b808199ed84f2bb477026924877eb6

## Verification
- npm --prefix crates/oasis7_viewer run test:ui -- --run software_safe_src/software_safe_constants.test.js software_safe_src/main.test.jsx
- node crates/oasis7_viewer/scripts/software-safe-feedback-contract.test.mjs
- ./scripts/pm/workflow-lint.sh --task-uid task_44b808199ed84f2bb477026924877eb6 --phase current
- git diff --check

## Review
- producer_system_designer: pass/no_findings
- viewer_engineer: pass/no_findings
- game_visual_interaction_designer: pass/no_findings
- qa_engineer: pass/no_findings
- repository_health_engineer: pass/no_findings

## Notes
- No screenshot evidence required: game_visual_interaction_designer confirmed no layout, interaction flow, accessibility, player-visible text, or UI state semantic change.
- doc-governance-check was locally long-running in broad all-doc scanning; required PR gate should cover the full CI surface.