### PR TITLE
Sync engineering latest completed status

### DIFF
--- a/.pm/tasks/task_5ca263b753114c08ab7bb6303fd49449.execution.md
+++ b/.pm/tasks/task_5ca263b753114c08ab7bb6303fd49449.execution.md
@@ -71,14 +71,14 @@ Example:
 - Task UID: task_5ca263b753114c08ab7bb6303fd49449
 - Source Worktree: /Users/scc/ccwork/worktrees/oasis7-engineering-governance-next-issue-6-20260625
 - Source Branch: task/engineering-governance-next-issue-6-20260625
-- Source Head: 55bb040a91bff7ffe2231a0c01c9e321da5499e1
+- Source Head: b39c3f75557c1049026970680359e2ba4b5aa65b
 - Comparison Ref: refs/remotes/origin/main
 - Reviewed Changed Paths: doc/engineering/project.md; .pm/roles/tpm/backlog/committed.yaml; .pm/tasks/task_5ca263b753114c08ab7bb6303fd49449.execution.md
 - Review Package: n/a; review target was the uncommitted working tree diff before first commit.
 - Role Selection Basis: changed path `doc/engineering/project.md` and task history require repository_health_engineer; verification/evidence sufficiency claim requires qa_engineer. Product, runtime, viewer, WASM, ops, agent, gameplay, game visual, and liveops roles skipped because the patch is doc/PM-truth scoped and does not touch those professional surfaces.
-- Review Roles: repository_health_engineer, qa_engineer
-- Review Evidence: repository_health_engineer `019efe22-919e-7370-bacd-c93257ef0144`: no_findings; scope/spec compliant; repository-health quality/risk acceptable for PR; residual risk low because `最新完成` remains manual. qa_engineer `019efe22-caf8-7142-91b0-80d38d6a844a`: no_findings; scope/spec compliant; QA quality/risk low; no additional QA-specific verification required before PR, while normal closeout/prepare-task-pr remains required.
-- Review Verdicts: repository_health_engineer pass/low risk; qa_engineer pass/low risk.
+- Review Roles: repository_health_engineer, qa_engineer, producer_system_designer
+- Review Evidence: repository_health_engineer `019efe22-919e-7370-bacd-c93257ef0144`: no_findings; scope/spec compliant; repository-health quality/risk acceptable for PR; residual risk low because `最新完成` remains manual. qa_engineer `019efe22-caf8-7142-91b0-80d38d6a844a`: no_findings; scope/spec compliant; QA quality/risk low; no additional QA-specific verification required before PR, while normal closeout/prepare-task-pr remains required. producer_system_designer fallback `019efe3b-f269-7252-88ac-e4dd61b54934`: no_findings; scope/spec compliant; producer/system quality/risk pass/low risk; no product/system direction, player promise, stage/gate, inventory threshold, runtime, UI, ops, LiveOps, or release behavior change introduced.
+- Review Verdicts: repository_health_engineer pass/low risk; qa_engineer pass/low risk; producer_system_designer pass/low risk.
 - Review Findings Disposition: no_findings
 - Finding Disposition Evidence: n/a; no valid findings required remediation.
 - Verification Matrix: engineering project latest-completed truth sync -> targeted `rg` confirmed current row/status; doc governance -> `./scripts/doc-governance-check.sh` OK; task governance -> `./scripts/pm/workflow-lint.sh --task-uid task_5ca263b753114c08ab7bb6303fd49449 --phase current` OK; whitespace hygiene -> `git diff --check` clean.
@@ -115,4 +115,33 @@ Example:
 - Validation Command: ./scripts/pm/claim-ready.sh --claim-type ready_for_pr --verify-command "./scripts/doc-governance-check.sh" --json
 - Expected Result: Fresh doc-governance verification passes and claim-ready allows the branch to be claimed ready for PR.
 - Actual Result: Passed: claim_type ready_for_pr, verify_command ./scripts/doc-governance-check.sh, verified_at 2026-06-25T17:48:21+08:00, verification_exit_code 0, status verified, allowed_to_claim true.
+- Blocker / Next Action: No blocker. Commit evidence-only update and rerun prepare-task-pr.
+
+## 2026-06-25 17:51:00 CST / tpm
+- Review Trigger: supplemental pre-PR local role review after `prepare-task-pr` changed-path inference required `producer_system_designer`.
+- Review Scope: Rebased branch diff against `origin/main`, limited to `doc/engineering/project.md` latest-completed status/current task trace row and current task `.pm` evidence.
+- Review Package: n/a; supplemental review target is the committed/rebased branch diff before PR creation.
+- Review Roles: producer_system_designer
+- Review Question: Confirm this engineering project status sync does not alter product/system direction, player promises, stage/gate, or broader inventory governance, and that the completed task row/status text is acceptable as system/project truth.
+- Evidence Available: repository_health_engineer no_findings; qa_engineer no_findings; targeted `rg`; `./scripts/doc-governance-check.sh` OK; `./scripts/pm/workflow-lint.sh --task-uid task_5ca263b753114c08ab7bb6303fd49449 --phase current` OK; `git diff --check` clean; branch rebased onto `origin/main`.
+- Expected Return Contract: findings | no_findings | scope/spec compliance verdict | producer/system quality/risk verdict | residual_risk
+- Slice Ledger: `/Users/scc/ccwork/worktrees/oasis7-engineering-governance-next-issue-6-20260625/.pm/scratch/task_5ca263b753114c08ab7bb6303fd49449/slice-ledger.jsonl`
+- Formal Sink: `.pm/tasks/task_5ca263b753114c08ab7bb6303fd49449.execution.md`
+
+## 2026-06-25 18:02:00 CST / tpm
+- 完成内容: Full-history producer_system_designer supplemental review slice stalled and was closed without a result.
+- 遗留事项: Dispatch explicit-context fallback producer review, integrate result, update passed packet, commit evidence, rerun prepare-task-pr, create PR, watch, merge, and cleanup.
+- Action: Record fallback boundary for stalled subagent `019efe2f-e934-79b1-aa6f-e1cf0da84f75`; do not treat TPM analysis as producer/system conclusion. Dispatch explicit-context fallback with the same review scope and return contract.
+- Validation Command: `multi_agent_v1.wait_agent` for `019efe2f-e934-79b1-aa6f-e1cf0da84f75`; `multi_agent_v1.close_agent`
+- Expected Result: If full-history review returns, integrate it; if it stalls, close it and use explicit-context fallback while preserving attribution boundary.
+- Actual Result: Full-history slice timed out twice and was closed while still running; no producer/system conclusion was received from that slice.
+- Blocker / Next Action: No blocker. Dispatch explicit-context fallback producer_system_designer review.
+
+## 2026-06-25 18:04:00 CST / tpm
+- 完成内容: Integrated fallback producer_system_designer supplemental review and refreshed the passed review packet for the rebased branch.
+- 遗留事项: Commit this evidence-only update, rerun prepare-task-pr, create PR, watch, merge, and cleanup.
+- Action: Add producer_system_designer to Review Roles/Evidence/Verdicts and refresh Source Head to rebased commit `b39c3f75557c1049026970680359e2ba4b5aa65b`.
+- Validation Command: producer_system_designer fallback review `019efe3b-f269-7252-88ac-e4dd61b54934`; `git rev-parse HEAD`
+- Expected Result: Supplemental review satisfies prepare-task-pr role inference and introduces no required fixes.
+- Actual Result: producer_system_designer returned no_findings; scope/spec compliant; producer/system quality/risk pass/low risk; residual risk low; no required fix before PR.
 - Blocker / Next Action: No blocker. Commit evidence-only update and rerun prepare-task-pr.

--- a/.pm/tasks/task_5ca263b753114c08ab7bb6303fd49449.execution.md
+++ b/.pm/tasks/task_5ca263b753114c08ab7bb6303fd49449.execution.md
@@ -71,7 +71,7 @@ Example:
 - Task UID: task_5ca263b753114c08ab7bb6303fd49449
 - Source Worktree: /Users/scc/ccwork/worktrees/oasis7-engineering-governance-next-issue-6-20260625
 - Source Branch: task/engineering-governance-next-issue-6-20260625
-- Source Head: fec19f0fb3ceef6b2c798a1f97799ac7cfee6635
+- Source Head: 55bb040a91bff7ffe2231a0c01c9e321da5499e1
 - Comparison Ref: refs/remotes/origin/main
 - Reviewed Changed Paths: doc/engineering/project.md; .pm/roles/tpm/backlog/committed.yaml; .pm/tasks/task_5ca263b753114c08ab7bb6303fd49449.execution.md
 - Review Package: n/a; review target was the uncommitted working tree diff before first commit.
@@ -98,3 +98,12 @@ Example:
 - Expected Result: Task yaml records done/verified closeout and task-local workflow lint passes; any repo-wide lint debt is identified as unrelated.
 - Actual Result: task-closeout executed fresh ./scripts/doc-governance-check.sh successfully and updated task yaml to status done, last_verified_at 2026-06-25T17:44:50+08:00, last_verification_exit_code 0, last_verification_status verified, last_closed_at 2026-06-25T17:44:56+08:00. Helper exited non-zero only after repo-wide .pm lint reported unrelated historical execution-log debt in older tasks. Current task workflow-lint passed.
 - Blocker / Next Action: No current-task blocker. Commit this task slice and run PR preflight.
+
+## 2026-06-25 17:46:47 CST / tpm
+- 完成内容: Committed the implementation and refreshed the pre-PR local role review packet Source Head to the implementation commit.
+- 遗留事项: Commit this evidence-only packet refresh, run prepare-task-pr, create PR, watch, merge, and cleanup.
+- Action: Refresh Pre-PR Local Role Review packet Source Head from the pre-commit base to implementation commit 55bb040a91bff7ffe2231a0c01c9e321da5499e1.
+- Validation Command: git diff -- .pm/tasks/task_5ca263b753114c08ab7bb6303fd49449.execution.md
+- Expected Result: Remaining diff is only execution-log evidence refresh after the reviewed implementation commit.
+- Actual Result: Source Head now points to 55bb040a91bff7ffe2231a0c01c9e321da5499e1; pending commit is evidence-only execution log update.
+- Blocker / Next Action: No blocker. Commit evidence-only refresh.

--- a/.pm/tasks/task_5ca263b753114c08ab7bb6303fd49449.execution.md
+++ b/.pm/tasks/task_5ca263b753114c08ab7bb6303fd49449.execution.md
@@ -107,3 +107,12 @@ Example:
 - Expected Result: Remaining diff is only execution-log evidence refresh after the reviewed implementation commit.
 - Actual Result: Source Head now points to 55bb040a91bff7ffe2231a0c01c9e321da5499e1; pending commit is evidence-only execution log update.
 - Blocker / Next Action: No blocker. Commit evidence-only refresh.
+
+## 2026-06-25 17:48:34 CST / tpm
+- 完成内容: Added fresh ready_for_pr claim-ready evidence requested by prepare-task-pr preflight.
+- 遗留事项: Commit this evidence-only update, rerun prepare-task-pr, create PR, watch, merge, and cleanup.
+- Action: Run claim-ready for PR readiness without task YAML writeback because the task is already closed and non-completion claim evidence is immutable on closed tasks.
+- Validation Command: ./scripts/pm/claim-ready.sh --claim-type ready_for_pr --verify-command "./scripts/doc-governance-check.sh" --json
+- Expected Result: Fresh doc-governance verification passes and claim-ready allows the branch to be claimed ready for PR.
+- Actual Result: Passed: claim_type ready_for_pr, verify_command ./scripts/doc-governance-check.sh, verified_at 2026-06-25T17:48:21+08:00, verification_exit_code 0, status verified, allowed_to_claim true.
+- Blocker / Next Action: No blocker. Commit evidence-only update and rerun prepare-task-pr.

--- a/.pm/tasks/task_5ca263b753114c08ab7bb6303fd49449.execution.md
+++ b/.pm/tasks/task_5ca263b753114c08ab7bb6303fd49449.execution.md
@@ -1,0 +1,100 @@
+# task_5ca263b753114c08ab7bb6303fd49449 Execution Log
+
+- task_uid: task_5ca263b753114c08ab7bb6303fd49449
+- title: Find and fix next engineering governance issue
+- owner_role: tpm
+- worktree_hint: /Users/scc/ccwork/worktrees/oasis7-engineering-governance-next-issue-6-20260625
+
+<!-- Append entries using:
+Example:
+  ## YYYY-MM-DD HH:MM:SS CST / role_name
+  - 完成内容: ...
+  - 遗留事项: ...
+  - Action: ...
+  - Validation Command: ...
+  - Expected Result: ...
+  - Actual Result: ...
+  - Blocker / Next Action: ...
+-->
+
+## 2026-06-25 17:23:28 CST / tpm
+- 完成内容: Bootstrapped dedicated task worktree and gathered initial engineering governance context for the next repository-health doc governance issue.
+- 遗留事项: Dispatch repository_health_engineer discovery slice, integrate the finding, implement the minimal safe remediation, verify, close out, PR, watch, merge, and cleanup.
+- Action: Use default-workflow-bootstrap then repo-owned-workflow-router; route into repository-health discovery slice before any professional governance conclusion.
+- Validation Command: ./scripts/doc-inventory-report.sh; ./scripts/doc-governance-check.sh; ./scripts/pm/workflow-lint.sh --task-uid task_5ca263b753114c08ab7bb6303fd49449 --phase current
+- Expected Result: Task truth exists, inventory/governance evidence is available, and workflow-lint passes after this real execution entry.
+- Actual Result: Task worktree created at /Users/scc/ccwork/worktrees/oasis7-engineering-governance-next-issue-6-20260625 on branch task/engineering-governance-next-issue-6-20260625; task uid task_5ca263b753114c08ab7bb6303fd49449. Initial doc inventory generated at /tmp/oasis7-doc-inventory-task_5ca263.txt with total Markdown files 1698 action_required and hotspots world-simulator/viewer 216, world-simulator/launcher 87, game/gameplay 83. Initial workflow-lint failed only because the execution log had no real entries before this append.
+- Blocker / Next Action: No blocker. Finish doc-governance-check, rerun workflow-lint, then dispatch repository_health_engineer.
+
+## 2026-06-25 17:24:13 CST / tpm
+- 完成内容: Recorded route into repository_health discovery for the next actionable doc governance issue.
+- 遗留事项: Integrate repository_health finding, apply the minimal safe remediation, then run verification and PR flow.
+- Action: Dispatch bounded repository_health_engineer slice. Slice type: doc_governance_discovery_and_remediation_recommendation. Intended model: workflow source-of-truth Default subagent runtime. Actual dispatched model/reasoning: inherited/unverified because the multi_agent tool inherits parent settings unless an override is explicitly supplied and does not report the resolved runtime. Context delivery mode: full-thread/full-history fork with this explicit checklist as supplement. Mandatory context checklist: identity and authority = repository_health_engineer role card, tpm owner/integrator; workflow governance = AGENTS.md plus doc/engineering/workflow/source-of-truth.md plus default-workflow-bootstrap/repo-owned-workflow-router; task truth = task_5ca263b753114c08ab7bb6303fd49449 in canonical worktree /Users/scc/ccwork/worktrees/oasis7-engineering-governance-next-issue-6-20260625 on branch task/engineering-governance-next-issue-6-20260625; user intent = continue finding and fixing the next governance issue, preferably doc-level; scoped repo context = doc/engineering/prd.md, doc/engineering/project.md, /tmp/oasis7-doc-inventory-task_5ca263.txt, doc-governance-check OK, workflow-lint OK; collaboration boundary = repository_health owns professional finding/recommendation, TPM integrates mechanically into same task/PR chain; write scope = no file edits by subagent, recommend one minimal fix; return contract = findings/no_findings, evidence paths/lines/commands, recommended owner, exact minimal remediation, verification commands, residual risk.
+- Validation Command: multi_agent_v1.spawn_agent repository_health_engineer bounded discovery
+- Expected Result: Subagent returns one actionable repository-health finding suitable for minimal same-task remediation, or no_findings with evidence.
+- Actual Result: Pending subagent dispatch.
+- Blocker / Next Action: Dispatch repository_health_engineer slice now.
+
+## 2026-06-25 17:31:31 CST / tpm
+- 完成内容: Integrated repository_health_engineer finding and applied the minimal doc truth fix in doc/engineering/project.md.
+- 遗留事项: Run targeted verification, request pre-PR local role review, close out, commit, create PR, watch, merge, and cleanup.
+- Action: Repository_health finding: engineering project status field `最新完成` still pointed to `libp2p-default-runtime-rustsec-burndown`, whose task closed at 2026-06-25T14:20:45+08:00, while later completed governance work existed, including `stale-cargo-cache-project-plan-cleanup` with closeout at 2026-06-25T17:01:44+08:00. Minimal remediation: add current task row `engineering-project-latest-completed-sync` with Trace to task_5ca263b753114c08ab7bb6303fd49449.yaml and update `最新完成` to that slug; keep `下一任务` unchanged.
+- Validation Command: rg -n "engineering-project-latest-completed-sync|最新完成|stale-cargo-cache-project-plan-cleanup|libp2p-default-runtime-rustsec-burndown|task_5ca263b753114c08ab7bb6303fd49449" doc/engineering/project.md && ./scripts/doc-governance-check.sh && ./scripts/pm/workflow-lint.sh --task-uid task_5ca263b753114c08ab7bb6303fd49449 --phase current && git diff --check
+- Expected Result: The project task row and latest-completed status point to the current remediation task; doc governance, task workflow lint, and whitespace checks pass.
+- Actual Result: Pending verification.
+- Blocker / Next Action: Run the targeted verification commands.
+
+## 2026-06-25 17:34:20 CST / tpm
+- 完成内容: Ran targeted verification after the project latest-completed sync patch.
+- 遗留事项: Dispatch pre-PR local role reviews, address findings if any, close out, commit, create PR, watch, merge, and cleanup.
+- Action: Verify the changed doc truth surface before local role review.
+- Validation Command: rg -n "engineering-project-latest-completed-sync|最新完成|stale-cargo-cache-project-plan-cleanup|libp2p-default-runtime-rustsec-burndown|task_5ca263b753114c08ab7bb6303fd49449" doc/engineering/project.md && ./scripts/doc-governance-check.sh && ./scripts/pm/workflow-lint.sh --task-uid task_5ca263b753114c08ab7bb6303fd49449 --phase current && git diff --check
+- Expected Result: Project row/status update is present and all governance/task/diff checks pass.
+- Actual Result: Passed. Targeted rg shows the retained historical libp2p row, retained prior stale-cargo row, new current task trace row, and latest-completed status updated to engineering-project-latest-completed-sync. doc-governance-check: OK. workflow-lint: OK. git diff --check: clean.
+- Blocker / Next Action: No blocker. Dispatch pre-PR local role reviews for repository_health_engineer and qa_engineer.
+
+## 2026-06-25 17:35:00 CST / tpm
+- Review Trigger: pre-PR local role review
+- Review Scope: `doc/engineering/project.md` latest-completed status and current task trace row; `.pm/roles/tpm/backlog/committed.yaml` bootstrap/generated PM view update; `.pm/tasks/task_5ca263b753114c08ab7bb6303fd49449.execution.md` task evidence.
+- Review Package: n/a; review target is the current uncommitted working tree diff before first commit.
+- Review Roles: repository_health_engineer, qa_engineer
+- Review Question: Confirm the minimal doc-truth sync is scoped correctly, does not broaden inventory governance, and has sufficient verification evidence for PR creation.
+- Evidence Available: repository_health finding from Noether; targeted `rg`; `./scripts/doc-governance-check.sh` OK; `./scripts/pm/workflow-lint.sh --task-uid task_5ca263b753114c08ab7bb6303fd49449 --phase current` OK; `git diff --check` clean.
+- Expected Return Contract: findings | no_findings | scope/spec compliance verdict | role quality/risk verdict | residual_risk
+- Slice Ledger: `/Users/scc/ccwork/worktrees/oasis7-engineering-governance-next-issue-6-20260625/.pm/scratch/task_5ca263b753114c08ab7bb6303fd49449/slice-ledger.jsonl`
+- Formal Sink: `.pm/tasks/task_5ca263b753114c08ab7bb6303fd49449.execution.md`
+
+## 2026-06-25 17:39:00 CST / tpm
+- 完成内容: Integrated pre-PR local role review results.
+- 遗留事项: Close out the task, commit, refresh the Source Head packet to the implementation commit if required, run PR preflight/create, watch, merge, and clean up.
+- Pre-PR Local Role Review: passed
+- Task UID: task_5ca263b753114c08ab7bb6303fd49449
+- Source Worktree: /Users/scc/ccwork/worktrees/oasis7-engineering-governance-next-issue-6-20260625
+- Source Branch: task/engineering-governance-next-issue-6-20260625
+- Source Head: fec19f0fb3ceef6b2c798a1f97799ac7cfee6635
+- Comparison Ref: refs/remotes/origin/main
+- Reviewed Changed Paths: doc/engineering/project.md; .pm/roles/tpm/backlog/committed.yaml; .pm/tasks/task_5ca263b753114c08ab7bb6303fd49449.execution.md
+- Review Package: n/a; review target was the uncommitted working tree diff before first commit.
+- Role Selection Basis: changed path `doc/engineering/project.md` and task history require repository_health_engineer; verification/evidence sufficiency claim requires qa_engineer. Product, runtime, viewer, WASM, ops, agent, gameplay, game visual, and liveops roles skipped because the patch is doc/PM-truth scoped and does not touch those professional surfaces.
+- Review Roles: repository_health_engineer, qa_engineer
+- Review Evidence: repository_health_engineer `019efe22-919e-7370-bacd-c93257ef0144`: no_findings; scope/spec compliant; repository-health quality/risk acceptable for PR; residual risk low because `最新完成` remains manual. qa_engineer `019efe22-caf8-7142-91b0-80d38d6a844a`: no_findings; scope/spec compliant; QA quality/risk low; no additional QA-specific verification required before PR, while normal closeout/prepare-task-pr remains required.
+- Review Verdicts: repository_health_engineer pass/low risk; qa_engineer pass/low risk.
+- Review Findings Disposition: no_findings
+- Finding Disposition Evidence: n/a; no valid findings required remediation.
+- Verification Matrix: engineering project latest-completed truth sync -> targeted `rg` confirmed current row/status; doc governance -> `./scripts/doc-governance-check.sh` OK; task governance -> `./scripts/pm/workflow-lint.sh --task-uid task_5ca263b753114c08ab7bb6303fd49449 --phase current` OK; whitespace hygiene -> `git diff --check` clean.
+- Visual Evidence: n/a with explicit exemption reason: no visual/UI/player-facing surface changed.
+- WASM Evidence: n/a; no WASM ABI/build/determinism surface touched.
+- Ops Evidence: n/a; no deployment/operator/runbook surface touched.
+- LiveOps Evidence: n/a; no external messaging/release/status/community surface touched.
+- Residual Risk: low. The manual `最新完成` field can drift again after future tasks; automation or removal is a separate governance task.
+- Slice Ledger: `/Users/scc/ccwork/worktrees/oasis7-engineering-governance-next-issue-6-20260625/.pm/scratch/task_5ca263b753114c08ab7bb6303fd49449/slice-ledger.jsonl`
+- Blocker / Next Action: No blocker. Run final closeout with fresh doc governance verification.
+
+## 2026-06-25 17:45:47 CST / tpm
+- 完成内容: Ran task closeout; current task is closed with fresh doc-governance verification.
+- 遗留事项: Commit, refresh review Source Head if needed, run prepare-task-pr, create PR, watch, merge, and cleanup.
+- Action: Close out task with fresh verification after pre-PR local role review passed.
+- Validation Command: ./scripts/pm/task-closeout.sh --role tpm --task-uid task_5ca263b753114c08ab7bb6303fd49449 --verify-command "./scripts/doc-governance-check.sh"; ./scripts/pm/workflow-lint.sh --task-uid task_5ca263b753114c08ab7bb6303fd49449 --phase current
+- Expected Result: Task yaml records done/verified closeout and task-local workflow lint passes; any repo-wide lint debt is identified as unrelated.
+- Actual Result: task-closeout executed fresh ./scripts/doc-governance-check.sh successfully and updated task yaml to status done, last_verified_at 2026-06-25T17:44:50+08:00, last_verification_exit_code 0, last_verification_status verified, last_closed_at 2026-06-25T17:44:56+08:00. Helper exited non-zero only after repo-wide .pm lint reported unrelated historical execution-log debt in older tasks. Current task workflow-lint passed.
+- Blocker / Next Action: No current-task blocker. Commit this task slice and run PR preflight.

--- a/.pm/tasks/task_5ca263b753114c08ab7bb6303fd49449.yaml
+++ b/.pm/tasks/task_5ca263b753114c08ab7bb6303fd49449.yaml
@@ -1,0 +1,26 @@
+task_uid: task_5ca263b753114c08ab7bb6303fd49449
+title: "Find and fix next engineering governance issue"
+owner_role: tpm
+worktree_hint: /Users/scc/ccwork/worktrees/oasis7-engineering-governance-next-issue-6-20260625
+execution_log_path: .pm/tasks/task_5ca263b753114c08ab7bb6303fd49449.execution.md
+status: done
+priority: P2
+source_signal: null
+source_refs:
+  - doc/engineering/project.md
+doc_refs:
+  - doc/engineering/project.md
+related_prd:
+  - PRD-ENGINEERING-021
+  - PRD-ENGINEERING-025
+acceptance:
+  - "Find the next actionable engineering governance issue from repository evidence, route professional judgment through the appropriate role slice, implement the minimal safe remediation, verify the changed surfaces, and carry the normal PR/merge/cleanup flow."
+handoff_to: []
+updated_at: 2026-06-25T17:44:57+08:00
+last_started_at: 2026-06-25T17:21:01+08:00
+last_claim_type: task_complete
+last_verify_command: ./scripts/doc-governance-check.sh
+last_verified_at: 2026-06-25T17:44:50+08:00
+last_verification_exit_code: 0
+last_verification_status: verified
+last_closed_at: 2026-06-25T17:44:56+08:00

--- a/doc/engineering/project.md
+++ b/doc/engineering/project.md
@@ -289,6 +289,7 @@
 - [x] pixel-world-bridge-focused-clippy-cleanup (PRD-ENGINEERING-001/021/025) [test_tier_required]: 继续收口 repository health 巡检发现的 Rust/viewer 代码层治理点，使 `pixel_world_bridge` focused Clippy `-D warnings` 通过，并保持 Bevy render system 注册、lib tests 与 wasm target compile surface。 Trace: .pm/tasks/task_31ee2a7dc18e4f578f2fd5ebcc87800d.yaml
 - [x] world-bounds-copy-consistency (PRD-ENGINEERING-021/025) [test_tier_required]: 收口 codebase audit Task 3 的 world bounds / anchor fallback 双语文案一致性，保持 software-safe source 与 checked-in viewer bundle 同步，不改变 anchor fallback 行为。 Trace: .pm/tasks/task_456c5ba10a964ea69c679450d215aa64.yaml
 - [x] stale-cargo-cache-project-plan-cleanup (PRD-ENGINEERING-021/025) [test_tier_required]: 收口 engineering project 中已完成 `local-cargo-cache-script-convergence` 的过期 File Structure / Affected Paths 计划残留，保留完成行与 `.pm` task trace，不改 cargo-dev 行为。 Trace: .pm/tasks/task_42b496aae8c8456a882acea4c2116a22.yaml
+- [x] engineering-project-latest-completed-sync (PRD-ENGINEERING-021/025) [test_tier_required]: 收口 engineering project 状态区的 `最新完成` 漂移，将其从较早的 libp2p RustSec burn-down 任务同步到当前 doc governance truth refresh，保留下一任务 inventory 分类口径不变。 Trace: .pm/tasks/task_5ca263b753114c08ab7bb6303fd49449.yaml
 
 ## File Structure / Affected Paths
 
@@ -356,7 +357,7 @@
 - 更新日期: 2026-06-25
 - 当前状态: active
 - 下一任务: 当前 `scripts/doc-inventory-report.sh` 复算显示 near-limit active docs 为 none；后续 repository health 巡检应按 module density / hotspot `action_required` 结果做 bounded 分类判断，先分级再切 focused follow-up，避免回到已收口的 `doc/world-simulator/project.md` / `doc/readme/project.md` 队列。
-- 最新完成: `libp2p-default-runtime-rustsec-burndown`（已将默认 node/runtime p2p 闭包升级到 `libp2p 0.56` 并迁移到 tokio executor/transport，移除 `async-std`、`ring@0.16.20`、旧 `rustls-webpki@0.101.7` 与未接入自定义 transport 的 `libp2p-dns -> hickory-proto@0.25.2` RustSec 债务，将 RustSec ignore baseline 从 11 项降到 4 项，并用 S4 net/node 测试与 600 秒 triad S9 smoke 验证本地 runtime/ops 行为。）
+- 最新完成: `engineering-project-latest-completed-sync`（已将本状态区从较早的 `libp2p-default-runtime-rustsec-burndown` 同步到当前 doc governance truth refresh，补齐 `.pm` task trace，并保留下一任务 inventory 分类口径不变。）
 - PRD 质量门状态: strict schema 已对齐（含第 6 章验证与决策记录）。
 - 当前治理重点: P0/P1 技术债首轮优化正在收口，重点是 public_testnet readiness blocker 显式化、hosted access verdict 去半实现口径，以及 Viewer 前端状态模块化。
 - 当前库存判断: 文档债的主矛盾仍是“入口减重之后的存量维护成本”，不是继续扩更多 landing pages。复算入口仍以 `scripts/doc-inventory-report.sh` 为准。


### PR DESCRIPTION
## Summary
- update engineering project latest-completed status to the current doc governance truth refresh
- add the current task trace row for this bounded status sync
- preserve the existing next-task inventory classification

## Verification
- rg -n "engineering-project-latest-completed-sync|最新完成|stale-cargo-cache-project-plan-cleanup|libp2p-default-runtime-rustsec-burndown|task_5ca263b753114c08ab7bb6303fd49449" doc/engineering/project.md
- ./scripts/doc-governance-check.sh
- ./scripts/pm/workflow-lint.sh --task-uid task_5ca263b753114c08ab7bb6303fd49449 --phase current
- git diff --check
- ./scripts/pm/claim-ready.sh --claim-type ready_for_pr --verify-command "./scripts/doc-governance-check.sh" --json
- ./scripts/prepare-task-pr.sh --json