### PR TITLE
Align p2p node inventory guidance

### DIFF
--- a/.pm/roles/tpm/backlog/committed.yaml
+++ b/.pm/roles/tpm/backlog/committed.yaml
@@ -99,15 +99,3 @@ tasks:
     handoff_to: []
     status: committed
     task_path: .pm/tasks/task_b442769f7ef74d01894f4b8405c21301.yaml
-  - task_uid: task_76d64040529e464da37f08d075a05120
-    title: "Research AI era opening game"
-    priority: P2
-    source_signal: null
-    related_prd: []
-    acceptance:
-      - "Compare Angry Birds as an Android-era opening work against AI-era technology and player preference signals."
-      - "Record specialist slice contracts and evidence in the .pm execution log."
-      - "Produce a sourced prediction for what an AI-era opening game should be, with risks and validation signals."
-    handoff_to: []
-    status: committed
-    task_path: .pm/tasks/task_76d64040529e464da37f08d075a05120.yaml

--- a/.pm/tasks/task_9b5b64c5d3e34584be5a64fa438595ed.execution.md
+++ b/.pm/tasks/task_9b5b64c5d3e34584be5a64fa438595ed.execution.md
@@ -70,3 +70,33 @@ Example:
 - Expected Result: Current task records verified task_complete evidence and remains locally valid; any repo-wide historical lint debt is explicitly separated from this task scope.
 - Actual Result: Current task status is done with last_claim_type task_complete, last_verification_exit_code 0, and last_verification_status verified. workflow-lint current passed. doc-governance-check passed. git diff --check passed. task-closeout reported pm lint failed after closeout because unrelated historical task execution logs are missing required fields.
 - Blocker / Next Action: Proceed to ready_for_pr evidence and PR creation using current-task verification; do not expand this task into repo-wide historical pm-lint cleanup.
+
+## 2026-06-26 09:40:46 CST / tpm
+- 完成内容: Parser-friendly Pre-PR Local Role Review evidence packet recorded after supplemental producer_system_designer review.
+- 遗留事项: Commit evidence-only packet update, rerun PR preflight, then create PR.
+- Action: Added supplemental producer_system_designer review because prepare-task-pr changed-path inference required producer_system_designer and qa_engineer. Rebuilt review package against committed source head 811b3e2a13a9d39430e3121aed5812fb689fbfa7.
+- Pre-PR Local Role Review: passed
+- Task UID: task_9b5b64c5d3e34584be5a64fa438595ed
+- Source Worktree: /Users/scc/ccwork/worktrees/oasis7-engineering-doc-governance-next-issue-8-20260626
+- Source Branch: task/engineering-doc-governance-next-issue-8-20260626
+- Source Head: 811b3e2a13a9d39430e3121aed5812fb689fbfa7
+- Comparison Ref: refs/remotes/origin/main
+- Reviewed Changed Paths: .pm/roles/tpm/backlog/committed.yaml; .pm/tasks/task_9b5b64c5d3e34584be5a64fa438595ed.execution.md; .pm/tasks/task_9b5b64c5d3e34584be5a64fa438595ed.yaml; doc/engineering/project.md; doc/p2p/node/README.md
+- Review Package: /Users/scc/ccwork/worktrees/oasis7-engineering-doc-governance-next-issue-8-20260626/.pm/scratch/task_9b5b64c5d3e34584be5a64fa438595ed/review-packages/review-83211dcc5..811b3e2a1.diff
+- Role Selection Basis: changed paths in engineering project docs, p2p node README, .pm task truth and generated tpm backlog; repository_health_engineer from doc/source-of-truth drift and task history; qa_engineer from verification sufficiency; producer_system_designer from prepare-task-pr changed-path inference and system planning/status semantics.
+- Review Roles: producer_system_designer, repository_health_engineer, qa_engineer
+- Review Evidence: repository_health_engineer no_findings; qa_engineer no_findings; producer_system_designer no_findings.
+- Review Verdicts: repository_health_engineer scope/spec passed and repository health quality/risk passed; qa_engineer scope/spec passed and verification sufficiency/risk passed; producer_system_designer scope/spec passed and producer/system quality/risk passed.
+- Review Findings Disposition: no_findings
+- Finding Disposition Evidence: n/a
+- Verification Matrix: inventory contract -> ./scripts/doc-inventory-report.sh passed with doc/p2p/node 72 normal and p2p 290 action_required; doc structure -> ./scripts/doc-governance-check.sh passed; stale p2p/node ad hoc wording -> targeted rg no hits; diff hygiene -> git diff --check passed; task truth -> ./scripts/pm/workflow-lint.sh --task-uid task_9b5b64c5d3e34584be5a64fa438595ed --phase current passed; ready_for_pr -> ./scripts/pm/claim-ready.sh --claim-type ready_for_pr --verify-command './scripts/doc-governance-check.sh && ./scripts/pm/workflow-lint.sh --task-uid task_9b5b64c5d3e34584be5a64fa438595ed --phase current && git diff --check' passed.
+- Visual Evidence: n/a doc-only no UI surface.
+- WASM Evidence: n/a no WASM surface.
+- Ops Evidence: n/a no ops surface.
+- LiveOps Evidence: n/a no external messaging or community promise.
+- Residual Risk: This task only fixes p2p/node README inventory wording and does not address p2p module action_required density, world-simulator/testing hotspots, or inventory classifier policy.
+- Slice Ledger: /Users/scc/ccwork/worktrees/oasis7-engineering-doc-governance-next-issue-8-20260626/.pm/scratch/task_9b5b64c5d3e34584be5a64fa438595ed/slice-ledger.jsonl
+- Validation Command: ./scripts/pm/review-package.sh --base origin/main --head HEAD --task-uid task_9b5b64c5d3e34584be5a64fa438595ed; producer_system_designer, repository_health_engineer, and qa_engineer pre-PR local role review slices
+- Expected Result: prepare-task-pr required roles are covered by a top-level parser-friendly Pre-PR Local Role Review packet.
+- Actual Result: producer_system_designer, repository_health_engineer, and qa_engineer all returned no_findings with passing scope/spec and role quality/risk verdicts. Review package review-83211dcc5..811b3e2a1.diff captures the committed task diff.
+- Blocker / Next Action: Commit this evidence-only packet update and rerun prepare-task-pr.

--- a/.pm/tasks/task_9b5b64c5d3e34584be5a64fa438595ed.execution.md
+++ b/.pm/tasks/task_9b5b64c5d3e34584be5a64fa438595ed.execution.md
@@ -1,0 +1,72 @@
+# task_9b5b64c5d3e34584be5a64fa438595ed Execution Log
+
+- task_uid: task_9b5b64c5d3e34584be5a64fa438595ed
+- title: Find and fix next documentation governance issue
+- owner_role: tpm
+- worktree_hint: /Users/scc/ccwork/worktrees/oasis7-engineering-doc-governance-next-issue-8-20260626
+
+<!-- Append entries using:
+Example:
+  ## YYYY-MM-DD HH:MM:SS CST / role_name
+  - 完成内容: ...
+  - 遗留事项: ...
+  - Action: ...
+  - Validation Command: ...
+  - Expected Result: ...
+  - Actual Result: ...
+  - Blocker / Next Action: ...
+-->
+
+## 2026-06-26 09:25:54 CST / tpm
+- 完成内容: Bootstrap and route documentation governance discovery.
+- 遗留事项: Dispatch repository_health_engineer bounded discovery slice; TPM will integrate only after professional finding returns.
+- Action: Created dedicated task worktree on branch task/engineering-doc-governance-next-issue-8-20260626; reviewed task truth, engineering project surface, repository health role card, and doc inventory report.
+- Validation Command: ./scripts/new-task-worktree.sh engineering doc-governance-next-issue-8-20260626 --base main --pm-owner-role tpm --pm-title 'Find and fix next documentation governance issue' --pm-related-prd PRD-ENGINEERING-021 --pm-related-prd PRD-ENGINEERING-025 --pm-source-ref doc/engineering/project.md --pm-doc-ref doc/engineering/project.md --pm-acceptance 'Find the next actionable documentation governance issue from repository evidence, route professional judgment through the appropriate role slice, implement the minimal safe remediation, verify the changed surfaces, and carry the normal PR/merge/cleanup flow.' --json; ./scripts/doc-inventory-report.sh
+- Expected Result: Task/worktree truth exists; inventory gives current documentation health signal for routing.
+- Actual Result: Task task_9b5b64c5d3e34584be5a64fa438595ed created in /Users/scc/ccwork/worktrees/oasis7-engineering-doc-governance-next-issue-8-20260626. Inventory reports 1698 markdown files, action_required density in world-simulator/p2p/testing, and no near-limit active docs.
+- Blocker / Next Action: Dispatch repository_health_engineer bounded discovery slice; TPM will integrate only after professional finding returns.
+
+## 2026-06-26 09:27:14 CST / tpm
+- 完成内容: Recorded repository_health_engineer bounded slice dispatch contract.
+- 遗留事项: Await slice finding before editing documentation.
+- Action: Dispatched repository_health_engineer bounded discovery slice via multi_agent_v1 agent 019f0188-e786-76e2-8ba1-2ca54fbfbf2e. Requested full-thread fork; actual tool accepted inherited full-history fork with default model/runtime. Mandatory context checklist covered task truth, worktree, branch, repository health role boundary, doc inventory signal, recent completed doc governance tasks, and candidate search themes.
+- Validation Command: multi_agent_v1.spawn_agent with fork_context=true
+- Expected Result: A professional repository health slice returns one evidence-backed doc-level governance finding, recommended minimal remediation, verification commands, residual risk, and specialist-slice needs.
+- Actual Result: Agent 019f0188-e786-76e2-8ba1-2ca54fbfbf2e spawned as repository_health_engineer discovery slice. No file edits delegated.
+- Blocker / Next Action: TPM will wait for the slice result, then integrate the selected finding into the single task/PR chain.
+
+## 2026-06-26 09:30:25 CST / tpm
+- 完成内容: Implemented repository_health_engineer finding and ran targeted verification.
+- 遗留事项: Run Pre-PR Local Role Review, address findings if any, then close out and prepare PR.
+- Action: Updated doc/p2p/node/README.md to use canonical ./scripts/doc-inventory-report.sh for current file count and inventory status; updated doc/engineering/project.md with the task trace and latest-completed status.
+- Validation Command: ./scripts/doc-inventory-report.sh; ./scripts/doc-governance-check.sh; rg -n "find doc/p2p/node|git ls-files 'doc/p2p/node|需要当前文件数量时" doc/p2p/node/README.md doc/p2p/README.md || true; git diff --check; ./scripts/pm/workflow-lint.sh --task-uid task_9b5b64c5d3e34584be5a64fa438595ed --phase current
+- Expected Result: Inventory report runs; doc governance passes; old p2p/node ad hoc inventory wording is absent; diff hygiene and workflow lint pass.
+- Actual Result: All verification commands passed. Inventory confirms doc/p2p/node = 72 files / normal while p2p module = 290 files / action_required; doc-governance-check OK; targeted rg returned no stale p2p/node ad hoc wording; git diff --check passed; workflow-lint current passed.
+- Blocker / Next Action: Dispatch Pre-PR Local Role Review slices for repository_health_engineer and qa_engineer.
+
+## 2026-06-26 09:30:49 CST / tpm
+- 完成内容: Opened Pre-PR Local Role Review request.
+- 遗留事项: Await repository_health_engineer and qa_engineer review verdicts; address findings if any.
+- Action: Selected review roles repository_health_engineer and qa_engineer based on changed docs, prior repository health finding, task claim, and verification sufficiency requirement. Review scope: doc/p2p/node/README.md, doc/engineering/project.md, .pm task truth, and generated tpm backlog view.
+- Validation Command: ./scripts/pm/review-package.sh --base origin/main --head HEAD --task-uid task_9b5b64c5d3e34584be5a64fa438595ed; ./scripts/pm/slice-ledger.sh --task-uid task_9b5b64c5d3e34584be5a64fa438595ed --print; git diff --name-only
+- Expected Result: Review target, slice ledger, role selection, evidence, and package boundary are recorded before review dispatch.
+- Actual Result: Review package helper produced committed-only empty package because implementation diff is uncommitted; review target will therefore use explicit changed paths and uncommitted diff evidence. Slice ledger path is .pm/scratch/task_9b5b64c5d3e34584be5a64fa438595ed/slice-ledger.jsonl. Changed paths: doc/p2p/node/README.md, doc/engineering/project.md, .pm task files, and generated .pm/roles/tpm/backlog/committed.yaml.
+- Blocker / Next Action: Dispatch repository_health_engineer and qa_engineer review slices with expected return contract: findings/no_findings, scope/spec compliance verdict, role quality/risk verdict, residual_risk.
+
+## 2026-06-26 09:35:26 CST / tpm
+- 完成内容: Pre-PR Local Role Review passed.
+- 遗留事项: Run closeout and claim-ready before PR creation.
+- Action: Integrated repository_health_engineer and qa_engineer pre-PR review results. Pre-PR Local Role Review: passed. Task UID: task_9b5b64c5d3e34584be5a64fa438595ed. Source Worktree: /Users/scc/ccwork/worktrees/oasis7-engineering-doc-governance-next-issue-8-20260626. Source Branch: task/engineering-doc-governance-next-issue-8-20260626. Source Head: 83211dcc57de8a2c0d1022b1d5315e796d5ab0f3 plus uncommitted implementation and review evidence; later commit may only materialize this reviewed diff and task evidence. Comparison Ref: refs/remotes/origin/main. Reviewed Changed Paths: doc/p2p/node/README.md; doc/engineering/project.md; .pm/tasks/task_9b5b64c5d3e34584be5a64fa438595ed.*; .pm/roles/tpm/backlog/committed.yaml. Role Selection Basis: repository health doc/source-of-truth drift, doc-only PR claim, verification sufficiency, and prior repository_health_engineer finding. Review Roles: repository_health_engineer, qa_engineer. Review Evidence: repository_health_engineer no_findings; qa_engineer no_findings. Review Verdicts: repository_health scope/spec passed and quality/risk passed; QA scope/spec passed and verification sufficiency passed. Review Findings Disposition: no_findings. Finding Disposition Evidence: n/a. Verification Matrix: inventory contract -> doc-inventory-report passed; doc structure -> doc-governance-check passed; stale ad hoc p2p/node wording -> targeted rg no hits; diff hygiene -> git diff --check passed; task truth -> workflow-lint current passed. Visual Evidence: n/a doc-only no UI. WASM Evidence: n/a no WASM. Ops Evidence: n/a no ops surface. LiveOps Evidence: n/a no external messaging. Residual Risk: This task only fixes p2p/node README inventory wording, not p2p module action_required density, world-simulator/testing hotspots, or inventory classifier policy. Slice Ledger: .pm/scratch/task_9b5b64c5d3e34584be5a64fa438595ed/slice-ledger.jsonl.
+- Validation Command: repository_health_engineer and qa_engineer pre-PR local review slices
+- Expected Result: All involved roles return no findings or resolved findings before PR preparation.
+- Actual Result: Both review slices returned no_findings and confirmed the scope/spec, repository health quality/risk, and QA verification sufficiency verdicts. No remediation required.
+- Blocker / Next Action: Run closeout verification and ready_for_pr claim.
+
+## 2026-06-26 09:37:02 CST / tpm
+- 完成内容: Task closeout fresh verification completed; repo-wide historical pm-lint debt documented as non-current blocker.
+- 遗留事项: Create ready_for_pr evidence, commit, run PR preflight, and open PR.
+- Action: Ran task-closeout helper. The helper wrote task_complete verification evidence, moved task status to done, and then failed only at repo-wide pm lint due unrelated historical execution-log format debt across older task files.
+- Validation Command: ./scripts/pm/task-closeout.sh --role tpm --task-uid task_9b5b64c5d3e34584be5a64fa438595ed --verify-command './scripts/doc-governance-check.sh && ./scripts/pm/workflow-lint.sh --task-uid task_9b5b64c5d3e34584be5a64fa438595ed --phase current && git diff --check'; sed -n '1,120p' .pm/tasks/task_9b5b64c5d3e34584be5a64fa438595ed.yaml; ./scripts/pm/workflow-lint.sh --task-uid task_9b5b64c5d3e34584be5a64fa438595ed --phase current; ./scripts/doc-governance-check.sh && git diff --check
+- Expected Result: Current task records verified task_complete evidence and remains locally valid; any repo-wide historical lint debt is explicitly separated from this task scope.
+- Actual Result: Current task status is done with last_claim_type task_complete, last_verification_exit_code 0, and last_verification_status verified. workflow-lint current passed. doc-governance-check passed. git diff --check passed. task-closeout reported pm lint failed after closeout because unrelated historical task execution logs are missing required fields.
+- Blocker / Next Action: Proceed to ready_for_pr evidence and PR creation using current-task verification; do not expand this task into repo-wide historical pm-lint cleanup.

--- a/.pm/tasks/task_9b5b64c5d3e34584be5a64fa438595ed.yaml
+++ b/.pm/tasks/task_9b5b64c5d3e34584be5a64fa438595ed.yaml
@@ -1,0 +1,27 @@
+task_uid: task_9b5b64c5d3e34584be5a64fa438595ed
+title: "Find and fix next documentation governance issue"
+owner_role: tpm
+module: engineering
+worktree_hint: /Users/scc/ccwork/worktrees/oasis7-engineering-doc-governance-next-issue-8-20260626
+execution_log_path: .pm/tasks/task_9b5b64c5d3e34584be5a64fa438595ed.execution.md
+status: done
+priority: P2
+source_signal: null
+source_refs:
+  - doc/engineering/project.md
+doc_refs:
+  - doc/engineering/project.md
+related_prd:
+  - PRD-ENGINEERING-021
+  - PRD-ENGINEERING-025
+acceptance:
+  - "Find the next actionable documentation governance issue from repository evidence, route professional judgment through the appropriate role slice, implement the minimal safe remediation, verify the changed surfaces, and carry the normal PR/merge/cleanup flow."
+handoff_to: []
+updated_at: 2026-06-26T09:36:11+08:00
+last_started_at: 2026-06-26T09:25:07+08:00
+last_claim_type: task_complete
+last_verify_command: "./scripts/doc-governance-check.sh && ./scripts/pm/workflow-lint.sh --task-uid task_9b5b64c5d3e34584be5a64fa438595ed --phase current && git diff --check"
+last_verified_at: 2026-06-26T09:36:10+08:00
+last_verification_exit_code: 0
+last_verification_status: verified
+last_closed_at: 2026-06-26T09:36:11+08:00

--- a/doc/engineering/project.md
+++ b/doc/engineering/project.md
@@ -292,6 +292,7 @@
 - [x] world-bounds-copy-consistency (PRD-ENGINEERING-021/025) [test_tier_required]: 收口 codebase audit Task 3 的 world bounds / anchor fallback 双语文案一致性，保持 software-safe source 与 checked-in viewer bundle 同步，不改变 anchor fallback 行为。 Trace: .pm/tasks/task_456c5ba10a964ea69c679450d215aa64.yaml
 - [x] stale-cargo-cache-project-plan-cleanup (PRD-ENGINEERING-021/025) [test_tier_required]: 收口 engineering project 中已完成 `local-cargo-cache-script-convergence` 的过期 File Structure / Affected Paths 计划残留，保留完成行与 `.pm` task trace，不改 cargo-dev 行为。 Trace: .pm/tasks/task_42b496aae8c8456a882acea4c2116a22.yaml
 - [x] engineering-project-latest-completed-sync (PRD-ENGINEERING-021/025) [test_tier_required]: 收口 engineering project 状态区的 `最新完成` 漂移，将其从较早的 libp2p RustSec burn-down 任务同步到当前 doc governance truth refresh，保留下一任务 inventory 分类口径不变。 Trace: .pm/tasks/task_5ca263b753114c08ab7bb6303fd49449.yaml
+- [x] p2p-node-inventory-report-contract-sync (PRD-ENGINEERING-021/025) [test_tier_required]: 收口 doc 层 repository health 巡检发现的 `doc/p2p/node/README.md` inventory 口径漂移，将当前文件数量入口从 ad hoc `find` / `git ls-files` 改回 canonical `scripts/doc-inventory-report.sh`，避免子域 landing page 与 p2p 模块根入口互相冲突。 Trace: .pm/tasks/task_9b5b64c5d3e34584be5a64fa438595ed.yaml
 
 ## File Structure / Affected Paths
 
@@ -356,10 +357,10 @@
 - `doc/*/README.md`
 
 ## 状态
-- 更新日期: 2026-06-25
+- 更新日期: 2026-06-26
 - 当前状态: active
 - 下一任务: 当前 `scripts/doc-inventory-report.sh` 复算显示 near-limit active docs 为 none；后续 repository health 巡检应按 module density / hotspot `action_required` 结果做 bounded 分类判断，先分级再切 focused follow-up，避免回到已收口的 `doc/world-simulator/project.md` / `doc/readme/project.md` 队列。
-- 最新完成: `engineering-project-latest-completed-sync`（已将本状态区从较早的 `libp2p-default-runtime-rustsec-burndown` 同步到当前 doc governance truth refresh，补齐 `.pm` task trace，并保留下一任务 inventory 分类口径不变。）
+- 最新完成: `p2p-node-inventory-report-contract-sync`（已将 `doc/p2p/node/README.md` 的当前文件数量入口从 ad hoc `find` / `git ls-files` 改回 canonical `scripts/doc-inventory-report.sh`，与 p2p 模块根入口的 inventory 口径保持一致。）
 - PRD 质量门状态: strict schema 已对齐（含第 6 章验证与决策记录）。
 - 当前治理重点: P0/P1 技术债首轮优化正在收口，重点是 public_testnet readiness blocker 显式化、hosted access verdict 去半实现口径，以及 Viewer 前端状态模块化。
 - 当前库存判断: 文档债的主矛盾仍是“入口减重之后的存量维护成本”，不是继续扩更多 landing pages。复算入口仍以 `scripts/doc-inventory-report.sh` 为准。

--- a/doc/p2p/node/README.md
+++ b/doc/p2p/node/README.md
@@ -1,6 +1,6 @@
 # `p2p/node` 热点子域入口
 
-更新时间: 2026-06-13
+更新时间: 2026-06-26
 
 ## 从这里开始
 - 想确认 P2P/DistFS/consensus/execution/observer 的整体闭环、测试层级与 claim boundary：先读 `testing-manual.md#s9a链上大世界状态底座自闭环`；本页只负责 node 子域入口。
@@ -20,7 +20,7 @@
 
 ## 高密度提示
 - 当前子域属于 `p2p` 模块最高密度热点路径之一；本页的目标是压缩首读路径，而不是按文件数维护专题清单。
-- 需要当前文件数量时，以 `find doc/p2p/node -type f | wc -l` 或 `git ls-files 'doc/p2p/node/**'` 为准。
+- 需要当前文件数量和 inventory 状态时，以仓库根目录运行 `./scripts/doc-inventory-report.sh` 为准；`find` / `git ls-files` 仅作为本地探索辅助，不作为正式 inventory 口径。
 
 ## 首读主题簇
 


### PR DESCRIPTION
## Summary
- align doc/p2p/node README inventory guidance to the canonical doc-inventory-report entrypoint
- add engineering project trace and task evidence for the doc governance follow-up

## Verification
- ./scripts/doc-inventory-report.sh
- ./scripts/doc-governance-check.sh
- targeted stale p2p/node wording rg
- git diff --check
- ./scripts/pm/workflow-lint.sh --task-uid task_9b5b64c5d3e34584be5a64fa438595ed --phase current
- ./scripts/pm/claim-ready.sh --claim-type ready_for_pr --verify-command './scripts/doc-governance-check.sh && ./scripts/pm/workflow-lint.sh --task-uid task_9b5b64c5d3e34584be5a64fa438595ed --phase current && git diff --check'