### PR TITLE
Clarify world-runtime legacy entrypoint

### DIFF
--- a/.pm/tasks/task_bdacd20a0dcb4034b52208123be2c832.execution.md
+++ b/.pm/tasks/task_bdacd20a0dcb4034b52208123be2c832.execution.md
@@ -148,3 +148,21 @@ Example:
 - Expected Result: prepare-task-pr required roles are covered by a top-level parser-friendly Pre-PR Local Role Review packet.
 - Actual Result: runtime_engineer, repository_health_engineer, qa_engineer, and producer_system_designer all returned no_findings with passing scope/spec and role quality/risk verdicts. Review package review-4463b0035..a1df58e63.diff captures the committed task diff.
 - Blocker / Next Action: Commit this evidence-only packet update and rerun prepare-task-pr.
+
+## 2026-06-26 11:34:29 CST / tpm
+- 完成内容: PR #656 required checks and review-thread closeout verified.
+- 遗留事项: Record ready_for_merge claim, merge PR through the approved admin path, then sync and clean the task worktree.
+- Action: Checked GitHub PR state after PR creation. The PR is a normal PR CI watch path, not a manual packaging CI hold. Required checks passed; PR comments and review threads have no actionable items. GitHub still reports REVIEW_REQUIRED / BLOCKED only because review approval is absent, which is informational under the task/workflow policy after checks, comments, and threads are clean.
+- Validation Command: gh pr checks 656; gh run view 28215241150 --json status,conclusion,jobs,displayTitle,createdAt,updatedAt,url; gh pr view 656 --json mergeStateStatus,reviewDecision,comments,reviews,headRefName,baseRefName,url; ./scripts/pr-review-thread-closeout.sh 656 --unresolved-only --json
+- Expected Result: Required checks are green, no requested changes/comments/unresolved review threads remain, and any remaining BLOCKED state is approval-only.
+- Actual Result: required-gate passed in 4m26s; wasm determinism plan/collect/verify jobs passed; full-regression and newapi-bridge jobs were skipped by scope; PR comments were empty; review threads total 0 and unresolved 0; mergeStateStatus BLOCKED and reviewDecision REVIEW_REQUIRED are approval-only status signals.
+- Blocker / Next Action: Run ready_for_merge claim and use the repository admin merge path.
+
+## 2026-06-26 11:34:55 CST / tpm
+- 完成内容: Ready-for-merge fresh verification claim passed.
+- 遗留事项: Commit and push this PR-watch evidence, then merge PR #656.
+- Action: Ran ready_for_merge claim after required checks and review-thread closeout passed.
+- Validation Command: ./scripts/pm/claim-ready.sh --claim-type ready_for_merge --verify-command 'gh pr checks 656 && ./scripts/pr-review-thread-closeout.sh 656 --unresolved-only --json' --json
+- Expected Result: Fresh GitHub check/thread verification succeeds and the PR can be claimed ready to merge under the normal PR CI watch path.
+- Actual Result: claim_type ready_for_merge verified_at 2026-06-26T11:34:55+08:00, verification_exit_code 0, status verified, allowed_to_claim true.
+- Blocker / Next Action: Commit/push evidence and merge.

--- a/.pm/tasks/task_bdacd20a0dcb4034b52208123be2c832.execution.md
+++ b/.pm/tasks/task_bdacd20a0dcb4034b52208123be2c832.execution.md
@@ -118,3 +118,33 @@ Example:
 - Expected Result: Fresh verification passes and branch can be claimed ready for PR.
 - Actual Result: claim_type ready_for_pr verified_at 2026-06-26T11:22:57+08:00, verification_exit_code 0, status verified, allowed_to_claim true.
 - Blocker / Next Action: Commit this claim-ready evidence and rerun prepare-task-pr.
+
+## 2026-06-26 11:29:00 CST / tpm
+- 完成内容: Current-head Pre-PR Local Role Review packet refreshed after runtime_engineer backstop review.
+- 遗留事项: Commit evidence-only packet update and rerun PR preflight.
+- Action: Added runtime_engineer pre-PR review because prepare-task-pr changed-path inference requires runtime_engineer for doc/world-runtime/prd.md. Refreshed the parser-friendly review packet against committed implementation head a1df58e636696edfbdf7daaa3d89705e4e8029ed.
+- Pre-PR Local Role Review: passed
+- Task UID: task_bdacd20a0dcb4034b52208123be2c832
+- Source Worktree: /Users/scc/ccwork/worktrees/oasis7-engineering-doc-governance-next-issue-9-20260626
+- Source Branch: task/engineering-doc-governance-next-issue-9-20260626
+- Source Head: a1df58e636696edfbdf7daaa3d89705e4e8029ed
+- Comparison Ref: refs/remotes/origin/main
+- Reviewed Changed Paths: .pm/tasks/task_bdacd20a0dcb4034b52208123be2c832.execution.md; .pm/tasks/task_bdacd20a0dcb4034b52208123be2c832.yaml; doc/engineering/project.md; doc/world-runtime/prd.md
+- Review Package: /Users/scc/ccwork/worktrees/oasis7-engineering-doc-governance-next-issue-9-20260626/.pm/scratch/task_bdacd20a0dcb4034b52208123be2c832/review-packages/review-4463b0035..a1df58e63.diff
+- Role Selection Basis: changed paths in engineering project docs, world-runtime active PRD, and .pm task truth; repository_health_engineer from doc source-of-truth drift and task history; qa_engineer from verification sufficiency; producer_system_designer from engineering project status and system planning semantics; runtime_engineer from changed-path inference for doc/world-runtime/prd.md.
+- Review Roles: producer_system_designer, repository_health_engineer, runtime_engineer, qa_engineer
+- Review Evidence: repository_health_engineer no_findings; qa_engineer no_findings; producer_system_designer no_findings; runtime_engineer no_findings.
+- Review Verdicts: repository_health_engineer scope/spec passed and repository health quality/risk passed; qa_engineer scope/spec passed and verification sufficiency/risk passed; producer_system_designer scope/spec passed and producer/system quality/risk passed; runtime_engineer scope/spec passed and runtime quality/risk passed.
+- Review Findings Disposition: no_findings
+- Finding Disposition Evidence: n/a
+- Verification Matrix: doc structure -> ./scripts/doc-governance-check.sh passed; target legacy entrypoint wording -> rg confirmed doc/world-runtime/prd.md uses compatibility redirect backlink and not root execution entry; inventory contract -> ./scripts/doc-inventory-report.sh passed with doc/world-runtime 124 normal; diff hygiene -> git diff --check passed; task truth -> ./scripts/pm/workflow-lint.sh --task-uid task_bdacd20a0dcb4034b52208123be2c832 --phase current passed; ready_for_pr -> ./scripts/pm/claim-ready.sh --claim-type ready_for_pr --verify-command './scripts/doc-governance-check.sh && ./scripts/pm/workflow-lint.sh --task-uid task_bdacd20a0dcb4034b52208123be2c832 --phase current && git diff --check' passed.
+- Visual Evidence: n/a doc-only no UI surface.
+- WASM Evidence: n/a no WASM behavior change; runtime_engineer confirmed no runtime/WASM behavior contract changed or misstated.
+- Ops Evidence: n/a no ops surface.
+- LiveOps Evidence: n/a no external messaging or community promise.
+- Residual Risk: This task only fixes world-runtime active PRD legacy redirect wording and does not judge world-runtime runtime/WASM correctness or other modules with possible legacy redirect phrasing.
+- Slice Ledger: /Users/scc/ccwork/worktrees/oasis7-engineering-doc-governance-next-issue-9-20260626/.pm/scratch/task_bdacd20a0dcb4034b52208123be2c832/slice-ledger.jsonl
+- Validation Command: ./scripts/pm/review-package.sh --base origin/main --head HEAD --task-uid task_bdacd20a0dcb4034b52208123be2c832; runtime_engineer, repository_health_engineer, qa_engineer, and producer_system_designer pre-PR local role review slices
+- Expected Result: prepare-task-pr required roles are covered by a top-level parser-friendly Pre-PR Local Role Review packet.
+- Actual Result: runtime_engineer, repository_health_engineer, qa_engineer, and producer_system_designer all returned no_findings with passing scope/spec and role quality/risk verdicts. Review package review-4463b0035..a1df58e63.diff captures the committed task diff.
+- Blocker / Next Action: Commit this evidence-only packet update and rerun prepare-task-pr.

--- a/.pm/tasks/task_bdacd20a0dcb4034b52208123be2c832.execution.md
+++ b/.pm/tasks/task_bdacd20a0dcb4034b52208123be2c832.execution.md
@@ -109,3 +109,12 @@ Example:
 - Expected Result: Current task records verified task_complete evidence and remains locally valid; any repo-wide historical lint debt is explicitly separated from this task scope.
 - Actual Result: Current task status is done with last_claim_type task_complete, last_verification_exit_code 0, and last_verification_status verified. doc-governance-check passed. workflow-lint current passed. git diff --check passed. task-closeout reported pm lint failed after closeout because unrelated historical task execution logs are missing required fields.
 - Blocker / Next Action: Proceed to ready_for_pr evidence and PR creation using current-task verification; do not expand this task into repo-wide historical pm-lint cleanup.
+
+## 2026-06-26 11:23:23 CST / tpm
+- 完成内容: Ready-for-PR fresh verification claim recorded.
+- 遗留事项: Commit evidence-only update and rerun PR preflight.
+- Action: Ran ready_for_pr claim after closeout and pre-PR local role review passed.
+- Validation Command: ./scripts/pm/claim-ready.sh --claim-type ready_for_pr --verify-command './scripts/doc-governance-check.sh && ./scripts/pm/workflow-lint.sh --task-uid task_bdacd20a0dcb4034b52208123be2c832 --phase current && git diff --check' --json
+- Expected Result: Fresh verification passes and branch can be claimed ready for PR.
+- Actual Result: claim_type ready_for_pr verified_at 2026-06-26T11:22:57+08:00, verification_exit_code 0, status verified, allowed_to_claim true.
+- Blocker / Next Action: Commit this claim-ready evidence and rerun prepare-task-pr.

--- a/.pm/tasks/task_bdacd20a0dcb4034b52208123be2c832.execution.md
+++ b/.pm/tasks/task_bdacd20a0dcb4034b52208123be2c832.execution.md
@@ -1,0 +1,111 @@
+# task_bdacd20a0dcb4034b52208123be2c832 Execution Log
+
+- task_uid: task_bdacd20a0dcb4034b52208123be2c832
+- title: Find and fix next documentation governance issue
+- owner_role: tpm
+- worktree_hint: /Users/scc/ccwork/worktrees/oasis7-engineering-doc-governance-next-issue-9-20260626
+
+<!-- Append entries using:
+Example:
+  ## YYYY-MM-DD HH:MM:SS CST / role_name
+  - 完成内容: ...
+  - 遗留事项: ...
+  - Action: ...
+  - Validation Command: ...
+  - Expected Result: ...
+  - Actual Result: ...
+  - Blocker / Next Action: ...
+-->
+
+## 2026-06-26 10:43:00 CST / tpm
+- 完成内容: Bootstrap and route documentation governance discovery.
+- 遗留事项: Dispatch repository_health_engineer bounded discovery slice before TPM edits.
+- Action: Created dedicated task worktree on branch task/engineering-doc-governance-next-issue-9-20260626; reviewed task truth, engineering project status, repository_health_engineer role card, and current doc inventory report.
+- Validation Command: ./scripts/new-task-worktree.sh engineering doc-governance-next-issue-9-20260626 --base main --pm-owner-role tpm --pm-title 'Find and fix next documentation governance issue' --pm-related-prd PRD-ENGINEERING-021 --pm-related-prd PRD-ENGINEERING-025 --pm-source-ref doc/engineering/project.md --pm-doc-ref doc/engineering/project.md --pm-acceptance 'Find the next actionable documentation governance issue from repository evidence, route professional judgment through the appropriate role slice, implement the minimal safe remediation, verify the changed surfaces, and carry the normal PR/merge/cleanup flow.' --json; ./scripts/doc-inventory-report.sh; ./scripts/pm/workflow-lint.sh --task-uid task_bdacd20a0dcb4034b52208123be2c832 --phase current
+- Expected Result: Dedicated task/worktree truth exists; inventory gives the current documentation health signal; workflow-lint reports only missing initial execution entry before this writeback.
+- Actual Result: Task task_bdacd20a0dcb4034b52208123be2c832 created in /Users/scc/ccwork/worktrees/oasis7-engineering-doc-governance-next-issue-9-20260626. Inventory reports 1698 markdown files, action_required density in world-simulator/p2p/testing, doc/p2p/node normal at 72, and no near-limit active docs. Initial workflow-lint failed only because execution log had no real entries yet.
+- Blocker / Next Action: Dispatch repository_health_engineer bounded slice with no write scope; TPM will integrate the selected finding only after professional result returns.
+
+## 2026-06-26 10:51:56 CST / tpm
+- 完成内容: Recorded first repository_health_engineer discovery dispatch limitation.
+- 遗留事项: Respawn repository_health_engineer bounded discovery slice; do not treat TPM scan as professional finding.
+- Action: Initial repository_health_engineer discovery slice 019f01cf-53d0-7090-91e2-07b224550d15 was dispatched with full-history fork and no write scope, but the subagent stream disconnected before completion.
+- Validation Command: multi_agent_v1.spawn_agent; subagent notification for 019f01cf-53d0-7090-91e2-07b224550d15
+- Expected Result: Repository health slice returns one evidence-backed doc governance finding.
+- Actual Result: The slice errored with stream disconnected before completion. No professional finding was returned and no file edits were delegated. TPM local scans remain fallback evidence only, not a repository_health_engineer conclusion.
+- Blocker / Next Action: Respawn a fresh repository_health_engineer discovery slice with the same bounded read-only contract.
+
+## 2026-06-26 10:55:23 CST / tpm
+- 完成内容: Integrated repository_health_engineer discovery finding.
+- 遗留事项: Apply minimal doc patch and run targeted verification.
+- Action: repository_health_engineer slice 019f01d7-927d-71f1-8670-0af048b23cb1 found P2 doc source-of-truth drift: doc/world-runtime/prd.md active interface section exposes doc/world-runtime.project.md as a root-level compatibility execution entry even though TASK-WORLD_RUNTIME-037 and engineering redirect rules require canonical in-module project.md as the execution entry.
+- Validation Command: repository_health_engineer bounded discovery slice
+- Expected Result: One evidence-backed doc governance issue with minimal remediation and verification commands.
+- Actual Result: Finding returned: delete the root-level compatibility execution entry from doc/world-runtime/prd.md, keep canonical PRD/project/index entries, and record task trace in doc/engineering/project.md. No extra domain specialist required for discovery; QA review recommended after implementation.
+- Blocker / Next Action: Patch doc/world-runtime/prd.md and doc/engineering/project.md, then run doc-governance, targeted rg, inventory report, diff check, and workflow-lint.
+
+## 2026-06-26 10:57:53 CST / tpm
+- 完成内容: Implemented world-runtime PRD legacy entrypoint wording fix and verified target surface.
+- 遗留事项: Run Pre-PR Local Role Review, address findings if any, then close out and prepare PR.
+- Action: Changed doc/world-runtime/prd.md interface section from root-level compatibility execution entry to explicit compatibility redirect backlink, preserving doc-governance paired-doc link while making doc/world-runtime/project.md the only current execution entry. Updated doc/engineering/project.md with task trace and latest-completed status.
+- Validation Command: ./scripts/doc-governance-check.sh; rg -n '根级兼容执行入口:.*doc/world-runtime\.project\.md|兼容跳转互链: |doc/world-runtime\.project\.md' doc/world-runtime/prd.md doc/world-runtime/README.md doc/world-runtime.project.md doc/engineering/prd.md; ./scripts/doc-inventory-report.sh; git diff --check; ./scripts/pm/workflow-lint.sh --task-uid task_bdacd20a0dcb4034b52208123be2c832 --phase current
+- Expected Result: Doc governance passes; target scan shows no active PRD root-level compatibility execution entry and only redirect/backlink-safe references remain; inventory, diff hygiene, and task workflow lint pass.
+- Actual Result: doc-governance-check OK. Target rg shows doc/world-runtime/prd.md now uses '兼容跳转互链' for doc/world-runtime.project.md, while README and engineering PRD retain redirect-context references. doc-inventory-report passed with world-runtime normal at 124 files. git diff --check passed. workflow-lint current passed.
+- Blocker / Next Action: Dispatch Pre-PR Local Role Review slices for repository_health_engineer, qa_engineer, and producer_system_designer.
+
+## 2026-06-26 10:58:20 CST / tpm
+- 完成内容: Opened Pre-PR Local Role Review request.
+- 遗留事项: Await producer_system_designer, repository_health_engineer, and qa_engineer review verdicts; address findings if any.
+- Action: Selected review roles producer_system_designer, repository_health_engineer, and qa_engineer based on changed paths, doc/source-of-truth drift, engineering project status update, and verification sufficiency. Review scope: doc/world-runtime/prd.md, doc/engineering/project.md, current task truth, and generated tpm backlog view.
+- Validation Command: git diff --name-only; git diff -- doc/world-runtime/prd.md doc/engineering/project.md; ./scripts/doc-governance-check.sh; targeted rg without shell backtick substitution; ./scripts/doc-inventory-report.sh; git diff --check; ./scripts/pm/workflow-lint.sh --task-uid task_bdacd20a0dcb4034b52208123be2c832 --phase current
+- Expected Result: Review target, role selection, and evidence are recorded before review dispatch.
+- Actual Result: Changed paths currently include doc/world-runtime/prd.md, doc/engineering/project.md, .pm task files, and generated .pm/roles/tpm/backlog/committed.yaml. Verification passed: doc-governance-check OK, targeted rg shows active PRD uses compatibility redirect backlink not root execution entry, doc-inventory-report passed, git diff --check passed, workflow-lint current passed.
+- Blocker / Next Action: Dispatch pre-PR local review slices with expected return contract: findings/no_findings, scope/spec compliance verdict, role quality/risk verdict, residual_risk.
+
+## 2026-06-26 11:09:19 CST / tpm
+- 完成内容: Recorded producer_system_designer review timeout limitation.
+- 遗留事项: Respawn producer_system_designer pre-PR review slice before recording passed review packet.
+- Action: producer_system_designer review slice 019f01dd-c4d0-7f80-b149-0722e2d9c6c1 was dispatched read-only but did not return within two wait windows. TPM is not treating that missing response as a verdict.
+- Validation Command: multi_agent_v1.wait_agent for 019f01dd-c4d0-7f80-b149-0722e2d9c6c1
+- Expected Result: producer_system_designer returns findings/no_findings, scope/spec verdict, producer/system risk verdict, and residual risk.
+- Actual Result: No completed status returned after two wait windows. repository_health_engineer and qa_engineer reviews already returned no_findings, but producer/system review remains missing.
+- Blocker / Next Action: Respawn a concise producer_system_designer review slice and only proceed after a professional verdict returns.
+
+## 2026-06-26 11:12:05 CST / tpm
+- 完成内容: Pre-PR Local Role Review passed.
+- 遗留事项: Run closeout and ready_for_pr verification before committing.
+- Action: Integrated repository_health_engineer, qa_engineer, and respawned producer_system_designer pre-PR review results. The original producer_system_designer review timeout remains recorded above and is superseded by the completed respawned review.
+- Pre-PR Local Role Review: passed
+- Task UID: task_bdacd20a0dcb4034b52208123be2c832
+- Source Worktree: /Users/scc/ccwork/worktrees/oasis7-engineering-doc-governance-next-issue-9-20260626
+- Source Branch: task/engineering-doc-governance-next-issue-9-20260626
+- Source Head: 4463b003529e87f31cdb31435559540d6e322cca plus uncommitted implementation and review evidence; later commit may only materialize this reviewed diff and task evidence.
+- Comparison Ref: refs/remotes/origin/main
+- Reviewed Changed Paths: .pm/roles/tpm/backlog/committed.yaml; .pm/tasks/task_bdacd20a0dcb4034b52208123be2c832.execution.md; .pm/tasks/task_bdacd20a0dcb4034b52208123be2c832.yaml; doc/engineering/project.md; doc/world-runtime/prd.md
+- Review Package: n/a pre-commit uncommitted diff reviewed by explicit changed paths and command evidence
+- Role Selection Basis: changed paths in engineering project docs, world-runtime active PRD, .pm task truth, and generated tpm backlog; repository_health_engineer from doc source-of-truth drift and task history; qa_engineer from verification sufficiency; producer_system_designer from engineering project status and system planning semantics.
+- Review Roles: producer_system_designer, repository_health_engineer, qa_engineer
+- Review Evidence: repository_health_engineer no_findings; qa_engineer no_findings; producer_system_designer no_findings.
+- Review Verdicts: repository_health_engineer scope/spec passed and repository health quality/risk passed; qa_engineer scope/spec passed and verification sufficiency/risk passed; producer_system_designer scope/spec passed and producer/system quality/risk passed.
+- Review Findings Disposition: no_findings
+- Finding Disposition Evidence: n/a
+- Verification Matrix: doc structure -> ./scripts/doc-governance-check.sh passed; target legacy entrypoint wording -> rg confirmed doc/world-runtime/prd.md uses compatibility redirect backlink and not root execution entry; inventory contract -> ./scripts/doc-inventory-report.sh passed with doc/world-runtime 124 normal; diff hygiene -> git diff --check passed; task truth -> ./scripts/pm/workflow-lint.sh --task-uid task_bdacd20a0dcb4034b52208123be2c832 --phase current passed.
+- Visual Evidence: n/a doc-only no UI surface.
+- WASM Evidence: n/a no WASM behavior surface.
+- Ops Evidence: n/a no ops surface.
+- LiveOps Evidence: n/a no external messaging or community promise.
+- Residual Risk: This task only fixes world-runtime active PRD legacy redirect wording and does not judge world-runtime runtime/WASM correctness or other modules with possible legacy redirect phrasing.
+- Slice Ledger: /Users/scc/ccwork/worktrees/oasis7-engineering-doc-governance-next-issue-9-20260626/.pm/scratch/task_bdacd20a0dcb4034b52208123be2c832/slice-ledger.jsonl
+- Validation Command: repository_health_engineer, qa_engineer, and producer_system_designer pre-PR local role review slices
+- Expected Result: All involved roles return no findings or resolved findings before PR preparation.
+- Actual Result: All three completed review slices returned no_findings with passing scope/spec and role quality/risk verdicts. No remediation required.
+- Blocker / Next Action: Run closeout verification and ready_for_pr claim.
+
+## 2026-06-26 11:22:34 CST / tpm
+- 完成内容: Task closeout fresh verification completed; repo-wide historical pm-lint debt documented as non-current blocker.
+- 遗留事项: Create ready_for_pr evidence, commit, run PR preflight, and open PR.
+- Action: Ran task-closeout helper. The helper wrote task_complete verification evidence, moved task status to done, and then failed only at repo-wide pm lint due unrelated historical execution-log format debt across older task files.
+- Validation Command: ./scripts/pm/task-closeout.sh --role tpm --task-uid task_bdacd20a0dcb4034b52208123be2c832 --verify-command './scripts/doc-governance-check.sh && ./scripts/pm/workflow-lint.sh --task-uid task_bdacd20a0dcb4034b52208123be2c832 --phase current && git diff --check'; sed -n '1,80p' .pm/tasks/task_bdacd20a0dcb4034b52208123be2c832.yaml; ./scripts/doc-governance-check.sh && ./scripts/pm/workflow-lint.sh --task-uid task_bdacd20a0dcb4034b52208123be2c832 --phase current && git diff --check
+- Expected Result: Current task records verified task_complete evidence and remains locally valid; any repo-wide historical lint debt is explicitly separated from this task scope.
+- Actual Result: Current task status is done with last_claim_type task_complete, last_verification_exit_code 0, and last_verification_status verified. doc-governance-check passed. workflow-lint current passed. git diff --check passed. task-closeout reported pm lint failed after closeout because unrelated historical task execution logs are missing required fields.
+- Blocker / Next Action: Proceed to ready_for_pr evidence and PR creation using current-task verification; do not expand this task into repo-wide historical pm-lint cleanup.

--- a/.pm/tasks/task_bdacd20a0dcb4034b52208123be2c832.yaml
+++ b/.pm/tasks/task_bdacd20a0dcb4034b52208123be2c832.yaml
@@ -1,0 +1,27 @@
+task_uid: task_bdacd20a0dcb4034b52208123be2c832
+title: "Find and fix next documentation governance issue"
+owner_role: tpm
+module: engineering
+worktree_hint: /Users/scc/ccwork/worktrees/oasis7-engineering-doc-governance-next-issue-9-20260626
+execution_log_path: .pm/tasks/task_bdacd20a0dcb4034b52208123be2c832.execution.md
+status: done
+priority: P2
+source_signal: null
+source_refs:
+  - doc/engineering/project.md
+doc_refs:
+  - doc/engineering/project.md
+related_prd:
+  - PRD-ENGINEERING-021
+  - PRD-ENGINEERING-025
+acceptance:
+  - "Find the next actionable documentation governance issue from repository evidence, route professional judgment through the appropriate role slice, implement the minimal safe remediation, verify the changed surfaces, and carry the normal PR/merge/cleanup flow."
+handoff_to: []
+updated_at: 2026-06-26T11:21:44+08:00
+last_started_at: 2026-06-26T10:42:27+08:00
+last_claim_type: task_complete
+last_verify_command: "./scripts/doc-governance-check.sh && ./scripts/pm/workflow-lint.sh --task-uid task_bdacd20a0dcb4034b52208123be2c832 --phase current && git diff --check"
+last_verified_at: 2026-06-26T11:21:43+08:00
+last_verification_exit_code: 0
+last_verification_status: verified
+last_closed_at: 2026-06-26T11:21:44+08:00

--- a/doc/engineering/project.md
+++ b/doc/engineering/project.md
@@ -296,6 +296,7 @@
 - [x] stale-cargo-cache-project-plan-cleanup (PRD-ENGINEERING-021/025) [test_tier_required]: 收口 engineering project 中已完成 `local-cargo-cache-script-convergence` 的过期 File Structure / Affected Paths 计划残留，保留完成行与 `.pm` task trace，不改 cargo-dev 行为。 Trace: .pm/tasks/task_42b496aae8c8456a882acea4c2116a22.yaml
 - [x] engineering-project-latest-completed-sync (PRD-ENGINEERING-021/025) [test_tier_required]: 收口 engineering project 状态区的 `最新完成` 漂移，将其从较早的 libp2p RustSec burn-down 任务同步到当前 doc governance truth refresh，保留下一任务 inventory 分类口径不变。 Trace: .pm/tasks/task_5ca263b753114c08ab7bb6303fd49449.yaml
 - [x] p2p-node-inventory-report-contract-sync (PRD-ENGINEERING-021/025) [test_tier_required]: 收口 doc 层 repository health 巡检发现的 `doc/p2p/node/README.md` inventory 口径漂移，将当前文件数量入口从 ad hoc `find` / `git ls-files` 改回 canonical `scripts/doc-inventory-report.sh`，避免子域 landing page 与 p2p 模块根入口互相冲突。 Trace: .pm/tasks/task_9b5b64c5d3e34584be5a64fa438595ed.yaml
+- [x] world-runtime-prd-legacy-entrypoint-sync (PRD-ENGINEERING-021/025) [test_tier_required]: 收口 doc 层 repository health 巡检发现的 `doc/world-runtime/prd.md` legacy entrypoint 漂移，将 active PRD 接口区中的根级 `doc/world-runtime.project.md` 从“兼容执行入口”改为“兼容跳转互链”，保持当前执行入口唯一指向 `doc/world-runtime/project.md`。 Trace: .pm/tasks/task_bdacd20a0dcb4034b52208123be2c832.yaml
 
 ## File Structure / Affected Paths
 
@@ -363,7 +364,7 @@
 - 更新日期: 2026-06-26
 - 当前状态: active
 - 下一任务: 当前 `scripts/doc-inventory-report.sh` 复算显示 near-limit active docs 为 none；后续 repository health 巡检应按 module density / hotspot `action_required` 结果做 bounded 分类判断，先分级再切 focused follow-up，避免回到已收口的 `doc/world-simulator/project.md` / `doc/readme/project.md` 队列。
-- 最新完成: `p2p-node-inventory-report-contract-sync`（已将 `doc/p2p/node/README.md` 的当前文件数量入口从 ad hoc `find` / `git ls-files` 改回 canonical `scripts/doc-inventory-report.sh`，与 p2p 模块根入口的 inventory 口径保持一致。）
+- 最新完成: `world-runtime-prd-legacy-entrypoint-sync`（已将 `doc/world-runtime/prd.md` active PRD 接口区中的根级 `doc/world-runtime.project.md` 从“兼容执行入口”改为“兼容跳转互链”，保持当前执行入口唯一指向 `doc/world-runtime/project.md`。）
 - PRD 质量门状态: strict schema 已对齐（含第 6 章验证与决策记录）。
 - 当前治理重点: P0/P1 技术债首轮优化正在收口，重点是 public_testnet readiness blocker 显式化、hosted access verdict 去半实现口径，以及 Viewer 前端状态模块化。
 - 当前库存判断: 文档债的主矛盾仍是“入口减重之后的存量维护成本”，不是继续扩更多 landing pages。复算入口仍以 `scripts/doc-inventory-report.sh` 为准。

--- a/doc/world-runtime/prd.md
+++ b/doc/world-runtime/prd.md
@@ -14,7 +14,7 @@
 ## 接口 / 数据
 - PRD 主入口: `doc/world-runtime/prd.md`
 - 项目管理入口: `doc/world-runtime/project.md`
-- 根级兼容执行入口: `doc/world-runtime.project.md`
+- 兼容跳转互链: `doc/world-runtime.project.md`（legacy redirect，不作为当前执行入口）
 - 文件级索引: `doc/world-runtime/prd.index.md`
 - 追踪主键: `PRD-WORLD_RUNTIME-xxx`
 - 测试与发布参考: `testing-manual.md`


### PR DESCRIPTION
## Summary
- clarify doc/world-runtime PRD so the root project file is a legacy redirect backlink, not a current execution entry
- record engineering project trace and task evidence for the doc governance follow-up

## Verification
- ./scripts/doc-governance-check.sh
- targeted legacy entrypoint rg
- ./scripts/doc-inventory-report.sh
- git diff --check
- ./scripts/pm/workflow-lint.sh --task-uid task_bdacd20a0dcb4034b52208123be2c832 --phase current
- ./scripts/pm/claim-ready.sh --claim-type ready_for_pr --verify-command './scripts/doc-governance-check.sh && ./scripts/pm/workflow-lint.sh --task-uid task_bdacd20a0dcb4034b52208123be2c832 --phase current && git diff --check'