### PR TITLE
Converge world-runtime evidence docs

### DIFF
--- a/.pm/tasks/task_cec36d733eaa4d418223792f8227c0a6.execution.md
+++ b/.pm/tasks/task_cec36d733eaa4d418223792f8227c0a6.execution.md
@@ -131,7 +131,7 @@ Example:
 - Task UID: task_cec36d733eaa4d418223792f8227c0a6
 - Source Worktree: /Users/scc/ccwork/worktrees/oasis7-engineering-legacy-doc-semantics-convergence-next-2
 - Source Branch: task/engineering-legacy-doc-semantics-convergence-next-2
-- Source Head: c37a886b7bc05b62fe3c87a01554208a1012e097 plus current reviewed working-tree diff; later changes before PR creation are limited to task review evidence and PR metadata.
+- Source Head: eb94dc211dcf4420dcaf175c25d2e98b594972f8; later changes before PR creation are limited to task review evidence and PR metadata.
 - Comparison Ref: refs/remotes/origin/main
 - Reviewed Changed Paths: `.pm/roles/tpm/backlog/committed.yaml`; `.pm/tasks/task_cec36d733eaa4d418223792f8227c0a6.yaml`; `.pm/tasks/task_cec36d733eaa4d418223792f8227c0a6.execution.md`; `doc/world-runtime/project.md`; `doc/world-runtime/checklists/runtime-core-boundary-acceptance-checklist.md`; `doc/world-runtime/templates/runtime-security-numeric-regression-template.md`
 - Review Package: `.pm/scratch/task_cec36d733eaa4d418223792f8227c0a6/review-packages/review-c37a886b7..c37a886b7.diff`; limitation recorded above because the package was generated before local diff commit and is empty, so reviewers used current `git diff` and listed paths.

--- a/.pm/tasks/task_cec36d733eaa4d418223792f8227c0a6.execution.md
+++ b/.pm/tasks/task_cec36d733eaa4d418223792f8227c0a6.execution.md
@@ -131,7 +131,7 @@ Example:
 - Task UID: task_cec36d733eaa4d418223792f8227c0a6
 - Source Worktree: /Users/scc/ccwork/worktrees/oasis7-engineering-legacy-doc-semantics-convergence-next-2
 - Source Branch: task/engineering-legacy-doc-semantics-convergence-next-2
-- Source Head: eb94dc211dcf4420dcaf175c25d2e98b594972f8; later changes before PR creation are limited to task review evidence and PR metadata.
+- Source Head: eb94dc211dcf4420dcaf175c25d2e98b594972f8
 - Comparison Ref: refs/remotes/origin/main
 - Reviewed Changed Paths: `.pm/roles/tpm/backlog/committed.yaml`; `.pm/tasks/task_cec36d733eaa4d418223792f8227c0a6.yaml`; `.pm/tasks/task_cec36d733eaa4d418223792f8227c0a6.execution.md`; `doc/world-runtime/project.md`; `doc/world-runtime/checklists/runtime-core-boundary-acceptance-checklist.md`; `doc/world-runtime/templates/runtime-security-numeric-regression-template.md`
 - Review Package: `.pm/scratch/task_cec36d733eaa4d418223792f8227c0a6/review-packages/review-c37a886b7..c37a886b7.diff`; limitation recorded above because the package was generated before local diff commit and is empty, so reviewers used current `git diff` and listed paths.

--- a/.pm/tasks/task_cec36d733eaa4d418223792f8227c0a6.execution.md
+++ b/.pm/tasks/task_cec36d733eaa4d418223792f8227c0a6.execution.md
@@ -1,0 +1,186 @@
+# task_cec36d733eaa4d418223792f8227c0a6 Execution Log
+
+- task_uid: task_cec36d733eaa4d418223792f8227c0a6
+- title: Converge next stale legacy document semantics
+- owner_role: tpm
+- worktree_hint: /Users/scc/ccwork/worktrees/oasis7-engineering-legacy-doc-semantics-convergence-next-2
+
+<!-- Append entries using:
+Example:
+  ## YYYY-MM-DD HH:MM:SS CST / role_name
+  - 完成内容: ...
+  - 遗留事项: ...
+  - Action: ...
+  - Validation Command: ...
+  - Expected Result: ...
+  - Actual Result: ...
+- Blocker / Next Action: ...
+-->
+
+## 2026-06-26 14:50:00 CST / tpm
+- 完成内容: Workflow bootstrap and route selected for the next old-document / old-semantics convergence pass.
+- 遗留事项: Dispatch repository_health_engineer discovery slice, integrate one actionable finding, and remediate only live/current documentation.
+- Action: Created canonical task worktree with `./scripts/new-task-worktree.sh engineering legacy-doc-semantics-convergence-next-2 --pm-owner-role tpm ... --json`. Routed through default-workflow-bootstrap and repo-owned-workflow-router. Scope is documentation governance / semantic convergence, not broad historical rewrite.
+- Validation Command: git status --short --branch; ./scripts/new-task-worktree.sh ... --json; read `.pm` task yaml and execution log.
+- Expected Result: A single task UID, owner role, worktree, and branch exist before professional discovery or edits.
+- Actual Result: task_uid task_cec36d733eaa4d418223792f8227c0a6; owner_role tpm; branch task/engineering-legacy-doc-semantics-convergence-next-2; worktree /Users/scc/ccwork/worktrees/oasis7-engineering-legacy-doc-semantics-convergence-next-2; status committed.
+- Blocker / Next Action: Record subagent slice contract and dispatch repository_health_engineer.
+
+## 2026-06-26 14:54:00 CST / tpm
+- 完成内容: repository_health_engineer discovery slice contract recorded.
+- 遗留事项: Wait for slice finding, then integrate with minimal scoped remediation.
+- Action: Planned one bounded read-only repository health slice focused on stale old-document / old-semantics drift in current docs after prior convergence of root design legacy entrypoint wording and headless-runtime devlog evidence-sink wording.
+- Validation Command: sed -n .agents/roles/repository_health_engineer.md; sed -n doc/engineering/workflow/source-of-truth.md; rg memory boundary for historical project rows.
+- Expected Result: Dispatch inputs cover role authority, workflow governance, current task truth, user intent, prior adjacent fixes, and historical-row non-goal.
+- Actual Result: Required role card and workflow source-of-truth context were read in the task worktree; memory boundary confirms current/live docs should be prioritized and historical task/project rows should not be mechanically rewritten.
+- Subagent Slice Plan:
+  - role: repository_health_engineer
+  - slice type: read_only_analysis / finding recommendation
+  - intended model configuration: workflow source-of-truth Default subagent runtime by default
+  - actual dispatched model/reasoning: inherited/unverified; subagent tool inherits parent model unless override is explicitly set, no override requested
+  - context delivery mode: full-thread/full-history fork requested
+  - mandatory context checklist/packet: AGENTS workflow requirements; .agents/roles/repository_health_engineer.md; doc/engineering/workflow/source-of-truth.md; current .pm task yaml/execution log; user intent to find the next governance point focusing on old docs / old semantics convergence; prior adjacent fixes for `world-runtime` PRD legacy entrypoint, root `design.md` legacy entrypoint wording, and `headless-runtime` devlog evidence-sink wording; non-goal to bulk rewrite historical project rows; source worktree /Users/scc/ccwork/worktrees/oasis7-engineering-legacy-doc-semantics-convergence-next-2 and branch task/engineering-legacy-doc-semantics-convergence-next-2
+  - write scope: no file edits by the slice
+  - return contract: one prioritized actionable finding with file/line evidence, category, risk, minimal remediation recommendation, required verification commands, and whether extra professional roles are needed
+  - formal sink / writeback surface: .pm/tasks/task_cec36d733eaa4d418223792f8227c0a6.execution.md
+  - integration owner: tpm
+  - integration order: TPM integrates one finding, applies minimal patch, verifies, then requests pre-PR local role review
+- Blocker / Next Action: Dispatch the read-only slice.
+
+## 2026-06-26 15:02:00 CST / repository_health_engineer
+- 完成内容: Read-only discovery slice identified the next old-document / old-semantics convergence point.
+- 遗留事项: TPM to integrate a minimal docs patch and request pre-PR local role review.
+- Action: Reviewed current world-runtime project guidance, checklist, and template surfaces for stale centralized `doc/devlog` evidence-sink wording after `.pm/tasks/*.execution.md` became canonical process evidence.
+- Validation Command: rg -n 'doc/devlog/(README|YYYY-MM-DD)\.md|devlog 记录' doc/world-runtime/project.md doc/world-runtime/checklists doc/world-runtime/templates
+- Expected Result: One current/live documentation drift point with exact evidence and bounded remediation recommendation; no edits from the slice.
+- Actual Result: Finding: `doc/world-runtime/project.md`, `doc/world-runtime/checklists/runtime-core-boundary-acceptance-checklist.md`, and `doc/world-runtime/templates/runtime-security-numeric-regression-template.md` still instructed maintainers to record active work in `doc/devlog`; recommendation was to replace those active evidence-sink references with task-local `.pm/tasks/task_<32hex>.execution.md` wording while leaving historical `doc/world-runtime/runtime/*.project.md` rows untouched.
+- Blocker / Next Action: Apply scoped wording convergence in the three live world-runtime docs.
+
+## 2026-06-26 15:08:00 CST / tpm
+- 完成内容: Applied scoped world-runtime doc semantic convergence patch.
+- 遗留事项: Run verification and request pre-PR local role review.
+- Action: Updated current world-runtime project status text, runtime core boundary checklist, and runtime security/numeric regression template so active task evidence points at `.pm/tasks/task_<32hex>.execution.md`; preserved `doc/devlog/README.md` only as historical process archive wording.
+- Validation Command: rg -n 'doc/devlog/YYYY-MM-DD\.md|devlog 记录' doc/world-runtime/project.md doc/world-runtime/checklists doc/world-runtime/templates; ./scripts/doc-governance-check.sh; git diff --check
+- Expected Result: Live world-runtime guidance no longer directs new process evidence to `doc/devlog/YYYY-MM-DD.md` or calls it `devlog 记录`.
+- Actual Result: targeted `rg` returned no matches; `./scripts/doc-governance-check.sh` returned OK; `git diff --check` passed.
+- Blocker / Next Action: Request pre-PR local role review.
+
+## 2026-06-26 15:18:00 CST / tpm
+- Review Trigger: pre-PR local role review
+- Review Scope: `.pm/roles/tpm/backlog/committed.yaml`; `.pm/tasks/task_cec36d733eaa4d418223792f8227c0a6.yaml`; `.pm/tasks/task_cec36d733eaa4d418223792f8227c0a6.execution.md`; `doc/world-runtime/project.md`; `doc/world-runtime/checklists/runtime-core-boundary-acceptance-checklist.md`; `doc/world-runtime/templates/runtime-security-numeric-regression-template.md`
+- Review Package: `.pm/scratch/task_cec36d733eaa4d418223792f8227c0a6/review-packages/review-c37a886b7..c37a886b7.diff` generated by `./scripts/pm/review-package.sh --base refs/remotes/origin/main --head HEAD --task-uid task_cec36d733eaa4d418223792f8227c0a6`; limitation: package is empty because the local task diff is not committed yet, so reviewers must use current `git diff` plus listed paths as the review target.
+- Review Roles: repository_health_engineer, qa_engineer, producer_system_designer, runtime_engineer, wasm_platform_engineer
+- Review Question: Confirm whether the scoped world-runtime doc patch correctly converges live evidence-sink wording away from centralized `doc/devlog/YYYY-MM-DD.md` / `devlog 记录` semantics and whether it changes any product/system, runtime, WASM, or verification semantics beyond internal task evidence-sink wording.
+- Evidence Available: targeted `rg -n 'doc/devlog/YYYY-MM-DD\.md|devlog 记录' doc/world-runtime/project.md doc/world-runtime/checklists doc/world-runtime/templates` returned no matches; `./scripts/doc-governance-check.sh` passed; `git diff --check` passed.
+- Expected Return Contract: findings or no_findings; scope/spec compliance verdict; role quality/risk verdict; residual_risk.
+- Slice Ledger: `.pm/scratch/task_cec36d733eaa4d418223792f8227c0a6/slice-ledger.jsonl`
+- Formal Sink: `.pm/tasks/task_cec36d733eaa4d418223792f8227c0a6.execution.md`
+
+## 2026-06-26 15:30:00 CST / repository_health_engineer
+- Review Trigger: pre-PR local role review result
+- Review Scope: current local diff for world-runtime live guidance and `.pm` task bookkeeping.
+- Review Result: one P3 non-blocking finding.
+- Finding: `doc/world-runtime/project.md` Done Definition had changed one item from checkbox form to a plain bullet; recommended restoring checkbox shape if doc governance allows it.
+- Scope/Spec Compliance Verdict: pass; patch is scoped to live world-runtime guidance surfaces plus `.pm` task bookkeeping and does not touch historical `doc/world-runtime/runtime/*.project.md` rows or broad historical docs.
+- Role Quality/Risk Verdict: pass with minor cleanup recommended; active `doc/devlog/YYYY-MM-DD.md` / `devlog 记录` evidence-sink wording is converged to `.pm/tasks/task_<32hex>.execution.md`, while `doc/devlog/README.md` remains only as historical archive wording.
+- Residual Risk: low; other historical docs may still mention `doc/devlog`, but this patch intentionally limits itself to current live world-runtime guidance.
+
+## 2026-06-26 15:31:00 CST / qa_engineer
+- Review Trigger: pre-PR local role review result
+- Review Scope: current local diff for documentation-governance verification sufficiency.
+- Review Result: no_findings.
+- Scope/Spec Compliance Verdict: pass; diff only covers `.pm` task/backlog records and specified world-runtime live guidance surfaces, without expanding to historical `runtime/*.project.md` rows or runtime/WASM semantics.
+- Role Quality/Risk Verdict: pass, verification sufficient; targeted `rg` returned no matches, `./scripts/doc-governance-check.sh` returned OK, and `git diff --check` passed. Runtime/browser/playability validation is not required for this docs-only semantic convergence PR.
+- Residual Risk: low; automatic checks do not prove every historical `doc/devlog` phrase is governed, but the PR scope is correctly limited to current live guidance.
+
+## 2026-06-26 15:32:00 CST / producer_system_designer
+- Review Trigger: pre-PR local role review result
+- Review Scope: current local diff for product/system semantics.
+- Review Result: no_findings.
+- Scope/Spec Compliance Verdict: pass; diff only changes `.pm` task/backlog records and three world-runtime live guidance surfaces to move active evidence sink wording from `doc/devlog` to `.pm/tasks/task_<32hex>.execution.md`.
+- Role Quality/Risk Verdict: pass, low risk; no product/system acceptance, priority, world/player promise, runtime P0 boundary semantics, or success criteria changed.
+- Residual Risk: low; Done Definition bullet shape is a documentation-format concern, not a producer/system semantic risk.
+
+## 2026-06-26 15:33:00 CST / runtime_engineer
+- Review Trigger: pre-PR local role review result
+- Review Scope: current local diff for runtime semantics.
+- Review Result: no_findings.
+- Scope/Spec Compliance Verdict: pass; document changes are limited to replacing active `doc/devlog/YYYY-MM-DD.md` / `devlog 记录` evidence-sink wording with `.pm/tasks/task_<32hex>.execution.md`.
+- Role Quality/Risk Verdict: pass, low risk; no runtime behavior expectation, replay/checkpoint/recovery semantics, long-run or soak validation requirement, P0 runtime acceptance, WASM/governance boundary criteria, or required/full runtime test obligation changed.
+- Residual Risk: low; the Done Definition plain bullet is not a runtime semantic issue.
+
+## 2026-06-26 15:34:00 CST / wasm_platform_engineer
+- Review Trigger: pre-PR local role review result
+- Review Scope: current local diff for WASM platform semantics.
+- Review Result: no_findings.
+- Scope/Spec Compliance Verdict: pass; patch is limited to evidence-sink wording in `.pm` task records and specified world-runtime docs.
+- Role Quality/Risk Verdict: pass, low risk; no WASM ABI, wire type, executor/host interface, manifest/hash trust, deterministic build/hash policy, sandbox permission, module lifecycle governance, or security acceptance criterion changed.
+- Residual Risk: low; no additional WASM ABI/platform/hash/determinism tests are required beyond doc governance and diff checks.
+
+## 2026-06-26 15:37:00 CST / tpm
+- 完成内容: Evaluated and dispositioned repository_health P3 checklist-shape finding.
+- 遗留事项: Rerun verification and record Pre-PR Local Role Review passed packet.
+- Action: Tested the suggested checkbox variant for the task evidence line in `doc/world-runtime/project.md`; `./scripts/doc-governance-check.sh` rejects newly added `- [ ]` lines in module `project.md` as project task rows unless they match the task-row template, so the line was kept as a plain completion-condition bullet to satisfy the current governance contract.
+- Validation Command: ./scripts/doc-governance-check.sh
+- Expected Result: Checkbox variant either passes and can be kept, or fails with a governance parser reason.
+- Actual Result: Checkbox variant failed with `adds a project task row that does not match the required topic-slug/PRD-ID/Trace template`; reverted to plain bullet wording to preserve semantic convergence and pass governance.
+- Blocker / Next Action: Rerun targeted `rg`, `./scripts/doc-governance-check.sh`, workflow current lint, and `git diff --check`.
+
+## 2026-06-26 15:41:00 CST / tpm
+- Pre-PR Local Role Review: passed
+- Task UID: task_cec36d733eaa4d418223792f8227c0a6
+- Source Worktree: /Users/scc/ccwork/worktrees/oasis7-engineering-legacy-doc-semantics-convergence-next-2
+- Source Branch: task/engineering-legacy-doc-semantics-convergence-next-2
+- Source Head: c37a886b7bc05b62fe3c87a01554208a1012e097 plus current reviewed working-tree diff; later changes before PR creation are limited to task review evidence and PR metadata.
+- Comparison Ref: refs/remotes/origin/main
+- Reviewed Changed Paths: `.pm/roles/tpm/backlog/committed.yaml`; `.pm/tasks/task_cec36d733eaa4d418223792f8227c0a6.yaml`; `.pm/tasks/task_cec36d733eaa4d418223792f8227c0a6.execution.md`; `doc/world-runtime/project.md`; `doc/world-runtime/checklists/runtime-core-boundary-acceptance-checklist.md`; `doc/world-runtime/templates/runtime-security-numeric-regression-template.md`
+- Review Package: `.pm/scratch/task_cec36d733eaa4d418223792f8227c0a6/review-packages/review-c37a886b7..c37a886b7.diff`; limitation recorded above because the package was generated before local diff commit and is empty, so reviewers used current `git diff` and listed paths.
+- Role Selection Basis: changed paths affect documentation-governance semantics, current world-runtime live guidance, runtime/WASM-labeled validation templates, and verification evidence; included repository_health_engineer for doc/workflow semantic convergence, qa_engineer for verification sufficiency, producer_system_designer for product/system semantics, runtime_engineer for runtime semantics, and wasm_platform_engineer for WASM platform semantics.
+- Review Roles: producer_system_designer, qa_engineer, repository_health_engineer, runtime_engineer, wasm_platform_engineer
+- Review Evidence: repository_health_engineer returned one P3 non-blocking checklist-shape finding with scope/spec pass and repository health pass; qa_engineer returned `no_findings`, verification sufficient; producer_system_designer returned `no_findings`, product/system risk pass; runtime_engineer returned `no_findings`, runtime risk pass; wasm_platform_engineer returned `no_findings`, WASM risk pass.
+- Review Verdicts: repository_health_engineer scope/spec compliance pass and repository health quality/risk pass with minor cleanup evaluated; qa_engineer scope/spec compliance pass and QA quality/risk pass; producer_system_designer scope/spec compliance pass and producer/system quality/risk pass; runtime_engineer scope/spec compliance pass and runtime quality/risk pass; wasm_platform_engineer scope/spec compliance pass and WASM quality/risk pass.
+- Review Findings Disposition: addressed
+- Finding Disposition Evidence: Repository health P3 requested restoring checkbox form for the Done Definition evidence line, but `./scripts/doc-governance-check.sh` rejects newly added `- [ ]` lines in `project.md` as project task rows unless they match the task-row template; the final plain-bullet wording preserves the evidence-sink semantic fix while satisfying doc governance. Other roles returned no findings.
+- Verification Matrix: world-runtime live evidence-sink wording -> targeted `rg` for active devlog terms -> no matches; doc governance contract -> `./scripts/doc-governance-check.sh` -> OK; current task workflow packet -> `./scripts/pm/workflow-lint.sh --task-uid task_cec36d733eaa4d418223792f8227c0a6 --phase current` -> OK; whitespace/diff hygiene -> `git diff --check` -> pass.
+- Visual Evidence: n/a; docs-only wording change with no UI or screenshot surface.
+- WASM Evidence: explicit exemption; wasm_platform_engineer confirmed no WASM ABI/platform/hash/determinism/security semantics changed and no WASM-specific tests are required.
+- Ops Evidence: n/a; no deployment, rollback, node, or operator runbook behavior touched.
+- LiveOps Evidence: explicit exemption; no external messaging, release note, player/community promise, incident communication, channel runbook, or LiveOps follow-up surface touched.
+- Residual Risk: Low; other historical docs may still mention `doc/devlog`, but this patch intentionally converges only current live world-runtime guidance and leaves historical archives untouched.
+- Slice Ledger: `.pm/scratch/task_cec36d733eaa4d418223792f8227c0a6/slice-ledger.jsonl`
+
+## 2026-06-26 15:48:00 CST / tpm
+- 完成内容: Final local verification passed after review integration.
+- 遗留事项: Close task, commit, create PR, and continue PR watch/merge path.
+- Action: Reran targeted evidence-sink search, doc governance, current task workflow lint, and whitespace validation after review integration.
+- Validation Command: rg -n 'doc/devlog/YYYY-MM-DD\.md|devlog 记录' doc/world-runtime/project.md doc/world-runtime/checklists doc/world-runtime/templates; ./scripts/doc-governance-check.sh; ./scripts/pm/workflow-lint.sh --task-uid task_cec36d733eaa4d418223792f8227c0a6 --phase current; git diff --check
+- Expected Result: No active `doc/devlog/YYYY-MM-DD.md` / `devlog 记录` wording remains in targeted live world-runtime docs; doc governance passes; current task workflow lint passes; diff has no whitespace errors.
+- Actual Result: targeted `rg` returned no matches; `./scripts/doc-governance-check.sh` returned OK; current task workflow lint returned OK; `git diff --check` passed.
+- Blocker / Next Action: Run task closeout and PR preparation.
+
+## 2026-06-26 15:54:00 CST / tpm
+- 完成内容: Task closeout status confirmed; engineering project Trace/status updated for this governance pass.
+- 遗留事项: Rerun final verification, claim ready, commit, create PR, and continue PR watch/merge path.
+- Action: Ran `./scripts/pm/task-closeout.sh --role tpm --task-uid task_cec36d733eaa4d418223792f8227c0a6 --verify-command "./scripts/doc-governance-check.sh"`; helper marked the current task `done` with `last_verification_status: verified` and verification exit code `0`, but the helper command exited `1` after hitting unrelated repo-wide historical `.pm` lint debt outside this task.
+- Validation Command: sed -n '1,140p' .pm/tasks/task_cec36d733eaa4d418223792f8227c0a6.yaml
+- Expected Result: Current task closeout state is recorded independently from unrelated repo-wide lint debt.
+- Actual Result: Current task YAML shows `status: done`, `last_claim_type: task_complete`, `last_verify_command: ./scripts/doc-governance-check.sh`, `last_verification_exit_code: 0`, and `last_verification_status: verified`.
+- Blocker / Next Action: None for the current task; rerun scoped workflow/doc/diff verification after project Trace/status update.
+
+## 2026-06-26 15:58:00 CST / tpm
+- 完成内容: Fresh final verification passed after engineering project Trace/status update.
+- 遗留事项: Claim ready, commit, create PR, and continue PR watch/merge path.
+- Action: Reran targeted evidence-sink search, doc governance, current task workflow lint, and whitespace validation after adding the engineering project task row and latest-completed status.
+- Validation Command: rg -n 'doc/devlog/YYYY-MM-DD\.md|devlog 记录' doc/world-runtime/project.md doc/world-runtime/checklists doc/world-runtime/templates; ./scripts/doc-governance-check.sh; ./scripts/pm/workflow-lint.sh --task-uid task_cec36d733eaa4d418223792f8227c0a6 --phase current; git diff --check
+- Expected Result: Targeted active old semantics remain absent; doc governance passes; current workflow lint passes; diff has no whitespace errors.
+- Actual Result: targeted `rg` returned no matches; `./scripts/doc-governance-check.sh` returned OK; workflow current lint returned OK; `git diff --check` passed.
+- Blocker / Next Action: Run `claim-ready` for ready-for-PR evidence.
+
+## 2026-06-26 16:08:00 CST / tpm
+- 完成内容: Ready-for-PR claim verified.
+- 遗留事项: Commit, create PR, and continue PR watch/merge path.
+- Action: Ran claim-ready with the doc governance verification command.
+- Validation Command: ./scripts/pm/claim-ready.sh --claim-type ready_for_pr --verify-command "./scripts/doc-governance-check.sh"
+- Expected Result: Claim verification passes and branch is allowed to claim ready for PR.
+- Actual Result: `doc-governance-check: OK`; claim summary reported `verification_exit_code: 0`, `status: verified`, `allowed_to_claim: true`, and `claim_message: Fresh verification passed; the branch can now be claimed ready for PR.`
+- Blocker / Next Action: Commit the task diff and create PR.

--- a/.pm/tasks/task_cec36d733eaa4d418223792f8227c0a6.yaml
+++ b/.pm/tasks/task_cec36d733eaa4d418223792f8227c0a6.yaml
@@ -1,0 +1,25 @@
+task_uid: task_cec36d733eaa4d418223792f8227c0a6
+title: "Converge next stale legacy document semantics"
+owner_role: tpm
+module: engineering
+worktree_hint: /Users/scc/ccwork/worktrees/oasis7-engineering-legacy-doc-semantics-convergence-next-2
+execution_log_path: .pm/tasks/task_cec36d733eaa4d418223792f8227c0a6.execution.md
+status: done
+priority: P2
+source_signal: null
+source_refs:
+  - doc/engineering/project.md
+doc_refs:
+  - doc/engineering/project.md
+related_prd: []
+acceptance:
+  - "Find one additional current old-document/old-semantics drift point, remediate the live documentation surface without broad historical rewrites, verify doc governance, and close through PR."
+handoff_to: []
+updated_at: 2026-06-26T15:03:25+08:00
+last_started_at: 2026-06-26T14:48:29+08:00
+last_claim_type: task_complete
+last_verify_command: ./scripts/doc-governance-check.sh
+last_verified_at: 2026-06-26T15:03:23+08:00
+last_verification_exit_code: 0
+last_verification_status: verified
+last_closed_at: 2026-06-26T15:03:25+08:00

--- a/doc/engineering/project.md
+++ b/doc/engineering/project.md
@@ -307,6 +307,7 @@
 - [x] world-runtime-prd-legacy-entrypoint-sync (PRD-ENGINEERING-021/025) [test_tier_required]: 收口 doc 层 repository health 巡检发现的 `doc/world-runtime/prd.md` legacy entrypoint 漂移，将 active PRD 接口区中的根级 `doc/world-runtime.project.md` 从“兼容执行入口”改为“兼容跳转互链”，保持当前执行入口唯一指向 `doc/world-runtime/project.md`。 Trace: .pm/tasks/task_bdacd20a0dcb4034b52208123be2c832.yaml
 - [x] root-design-legacy-entrypoint-semantics (PRD-ENGINEERING-021/025) [test_tier_required]: 收口当前模块根 `design.md` 的旧模板语义，删除指向标准 `project.md` 的重复“兼容执行入口”行，并把 legacy 风险改为 redirect 误标注风险，避免读者把当前执行入口误读成历史兼容入口。 Trace: .pm/tasks/task_4d604c693b8249e5aa62f03aa18985a7.yaml
 - [x] headless-runtime-evidence-sink-semantics (PRD-ENGINEERING-021/025) [test_tier_required]: 收口 `headless-runtime` 当前项目页、生命周期/鉴权 checklist 与长稳归档模板中仍把新任务证据导向 `doc/devlog` 的旧语义，将 active evidence sink 改为 `.pm/tasks/task_<32hex>.execution.md`，保留 `doc/devlog/README.md` 仅作为历史归档入口。 Trace: .pm/tasks/task_c1cea810b89f4d668bd4cd189ab7caf3.yaml
+- [x] world-runtime-evidence-sink-semantics (PRD-ENGINEERING-021/025) [test_tier_required]: 收口 `world-runtime` 当前项目页、runtime core boundary checklist 与 runtime security/numeric regression template 中仍把新任务证据导向 `doc/devlog` 的旧语义，将 active evidence sink 改为 `.pm/tasks/task_<32hex>.execution.md`，保留 `doc/devlog/README.md` 仅作为历史归档入口。 Trace: .pm/tasks/task_cec36d733eaa4d418223792f8227c0a6.yaml
 
 ## File Structure / Affected Paths
 
@@ -374,7 +375,7 @@
 - 更新日期: 2026-06-26
 - 当前状态: active
 - 下一任务: 当前 `scripts/doc-inventory-report.sh` 复算显示 near-limit active docs 为 none；后续 repository health 巡检应按 module density / hotspot `action_required` 结果做 bounded 分类判断，先分级再切 focused follow-up，避免回到已收口的 `doc/world-simulator/project.md` / `doc/readme/project.md` 队列。
-- 最新完成: `headless-runtime-evidence-sink-semantics`（已将 `headless-runtime` 活跃项目页、checklist 与模板中的 active evidence sink 从旧 `doc/devlog` 记录口径收敛到 `.pm/tasks/task_<32hex>.execution.md`，并保留 devlog 仅作历史归档入口。）
+- 最新完成: `world-runtime-evidence-sink-semantics`（已将 `world-runtime` 活跃项目页、checklist 与模板中的 active evidence sink 从旧 `doc/devlog` 记录口径收敛到 `.pm/tasks/task_<32hex>.execution.md`，并保留 devlog 仅作历史归档入口。）
 - PRD 质量门状态: strict schema 已对齐（含第 6 章验证与决策记录）。
 - 当前治理重点: P0/P1 技术债首轮优化正在收口，重点是 public_testnet readiness blocker 显式化、hosted access verdict 去半实现口径，以及 Viewer 前端状态模块化。
 - 当前库存判断: 文档债的主矛盾仍是“入口减重之后的存量维护成本”，不是继续扩更多 landing pages。复算入口仍以 `scripts/doc-inventory-report.sh` 为准。

--- a/doc/world-runtime/checklists/runtime-core-boundary-acceptance-checklist.md
+++ b/doc/world-runtime/checklists/runtime-core-boundary-acceptance-checklist.md
@@ -45,5 +45,5 @@
 ## 五、最小审查清单
 - 是否三大边界（确定性 / WASM / 治理）均已填写状态与证据路径。
 - 是否所有 `fail` / `blocked` 项都写明原因。
-- 是否已把结果回写 `doc/world-runtime/project.md` 与 `doc/devlog/YYYY-MM-DD.md`。
+- 是否已把结果回写 `doc/world-runtime/project.md` 与对应 `.pm/tasks/task_<32hex>.execution.md`。
 - 是否已标明哪些项仅完成 `test_tier_required`，哪些需后续 `test_tier_full`。

--- a/doc/world-runtime/project.md
+++ b/doc/world-runtime/project.md
@@ -737,7 +737,7 @@
 - 承接约束: `TASK-WORLD_RUNTIME-002` 完成后方可进入 `TASK-WORLD_RUNTIME-003` 与 `TASK-WORLD_RUNTIME-004`；`TASK-WORLD_RUNTIME-033` 保留为后续联合验证切片。
 - 实施备注: 仅保留 `TASK-WORLD_RUNTIME-043` 的当前阻塞与承接约束；已完成切片不再在状态区展开，统一回看上方任务项、topic project 与 `.pm` execution log。
 - PRD 质量门状态: strict schema 已对齐（含第 6 章验证与决策记录）。
-- 说明: 本文档仅维护 world-runtime 模块设计执行状态；过程记录在 `doc/devlog/README.md`、`doc/devlog/README.md` 与 `doc/devlog/README.md`。
+- 说明: 本文档仅维护 world-runtime 模块设计执行状态；历史过程归档见 `doc/devlog/README.md`，当前任务执行证据以 `.pm/tasks/task_<32hex>.execution.md` 为准。
 
 ## 阶段收口角色交接
 ### Meta
@@ -781,13 +781,13 @@
 - 代码改动：如需，仅限支撑 runtime 验收与指标暴露的必要实现。
 - 文档回写：`doc/world-runtime/project.md` 与相关专题文档。
 - 测试记录：补齐 runtime `test_tier_required`，必要时标注后续 `test_tier_full`。
-- devlog 记录：记录验收项、风险与下一切片。
+- 任务证据记录：在对应 `.pm/tasks/task_<32hex>.execution.md` 记录验收项、风险与下一切片。
 
 ### Done Definition
 - [ ] 输出满足目标与成功标准
 - [ ] 影响面已核对 `producer_system_designer` / `qa_engineer`
 - [ ] 对应 `prd.md` / `project.md` 已回写
-- [ ] 对应 `doc/devlog/YYYY-MM-DD.md` 已记录
+- 任务证据已记录到对应 `.pm/tasks/task_<32hex>.execution.md`
 - [ ] required/full 测试证据已补齐或明确挂起原因
 
 ### Risks / Decisions

--- a/doc/world-runtime/templates/runtime-security-numeric-regression-template.md
+++ b/doc/world-runtime/templates/runtime-security-numeric-regression-template.md
@@ -52,4 +52,4 @@
 - 是否同时覆盖安全与数值两大维度。
 - 是否为每一项填写命令 / 方法、证据路径、结果与失败签名。
 - `fail/blocked` 是否已有问题 ID 与负责人。
-- 是否已将结果回写 `doc/world-runtime/project.md` 与 `doc/devlog/YYYY-MM-DD.md`。
+- 是否已将结果回写 `doc/world-runtime/project.md` 与对应 `.pm/tasks/task_<32hex>.execution.md`。


### PR DESCRIPTION
## Summary
- converge active world-runtime evidence-sink wording from doc/devlog to .pm task execution logs
- update runtime checklist/template evidence wording and engineering project Trace/status metadata
- record local role review, closeout, and ready-for-PR verification evidence

## Verification
- rg -n 'doc/devlog/YYYY-MM-DD\.md|devlog 记录' doc/world-runtime/project.md doc/world-runtime/checklists doc/world-runtime/templates
- ./scripts/doc-governance-check.sh
- ./scripts/pm/workflow-lint.sh --task-uid task_cec36d733eaa4d418223792f8227c0a6 --phase current
- git diff --check
- ./scripts/pm/claim-ready.sh --claim-type ready_for_pr --verify-command ./scripts/doc-governance-check.sh