### PR TITLE
Converge playability template evidence semantics

### DIFF
--- a/.pm/roles/tpm/backlog/committed.yaml
+++ b/.pm/roles/tpm/backlog/committed.yaml
@@ -99,3 +99,14 @@ tasks:
     handoff_to: []
     status: committed
     task_path: .pm/tasks/task_b442769f7ef74d01894f4b8405c21301.yaml
+  - task_uid: task_eb93f5de123c49d1a3889855038b6987
+    title: "Converge next stale legacy document semantics"
+    module: engineering
+    priority: P2
+    source_signal: null
+    related_prd: []
+    acceptance:
+      - "Find one additional current old-document/old-semantics drift point, remediate the live documentation surface without broad historical rewrites, verify doc governance, and close through PR."
+    handoff_to: []
+    status: committed
+    task_path: .pm/tasks/task_eb93f5de123c49d1a3889855038b6987.yaml

--- a/.pm/roles/tpm/backlog/committed.yaml
+++ b/.pm/roles/tpm/backlog/committed.yaml
@@ -99,14 +99,3 @@ tasks:
     handoff_to: []
     status: committed
     task_path: .pm/tasks/task_b442769f7ef74d01894f4b8405c21301.yaml
-  - task_uid: task_eb93f5de123c49d1a3889855038b6987
-    title: "Converge next stale legacy document semantics"
-    module: engineering
-    priority: P2
-    source_signal: null
-    related_prd: []
-    acceptance:
-      - "Find one additional current old-document/old-semantics drift point, remediate the live documentation surface without broad historical rewrites, verify doc governance, and close through PR."
-    handoff_to: []
-    status: committed
-    task_path: .pm/tasks/task_eb93f5de123c49d1a3889855038b6987.yaml

--- a/.pm/tasks/task_eb93f5de123c49d1a3889855038b6987.execution.md
+++ b/.pm/tasks/task_eb93f5de123c49d1a3889855038b6987.execution.md
@@ -210,3 +210,15 @@ Example:
 - Expected Result: No valid findings remain before PR creation and PR helper required-role inference is covered.
 - Actual Result: QA P3 finding was addressed; gameplay_designer and all other involved roles returned no_findings / passed verdicts with bounded residual risk.
 - Blocker / Next Action: Commit supplemented review evidence and rerun PR helper.
+
+## 2026-06-27 00:03:54 CST / tpm
+- 完成内容: Addressed the actionable GitHub review finding on PR #675.
+- 遗留事项: Commit and push the review fix, then resolve the PR review thread and re-check PR gates.
+- Review Finding: Codex review reported P2 on `doc/playability_test_result/project.md` line 117: the edited lines sit inside the archived `HO-CORE-20260310-PLAY-001` handoff block, so replacing its original devlog expectation with a generic future `.pm/tasks/task_<32hex>.execution.md` sink retroactively changed a historical closure contract despite the stated boundary of leaving historical handoff/evidence records untouched.
+- Finding Disposition: addressed.
+- Fix Evidence: restored the dated handoff `Expected Outputs` and `Done Definition` lines to their original `devlog` wording while keeping current PM task execution-log guidance in the module status/current-live surfaces and active templates.
+- Action: Preserve the dated handoff record and keep new PM-sink guidance in current template/status text only.
+- Validation Command: ./scripts/doc-governance-check.sh; ./scripts/pm/workflow-lint.sh --task-uid task_eb93f5de123c49d1a3889855038b6987 --phase current; git diff --check
+- Expected Result: Documentation governance remains valid and the historical handoff boundary is restored.
+- Actual Result: `./scripts/doc-governance-check.sh` OK; task `workflow-lint` OK; `git diff --check` OK; scoped legacy grep now shows only the intentionally restored dated handoff lines.
+- Blocker / Next Action: Commit and push review fix.

--- a/.pm/tasks/task_eb93f5de123c49d1a3889855038b6987.execution.md
+++ b/.pm/tasks/task_eb93f5de123c49d1a3889855038b6987.execution.md
@@ -160,3 +160,53 @@ Example:
 - Expected Result: Current task metadata shows verified closeout state.
 - Actual Result: Current task metadata shows `status: done` and `last_verification_status: verified`.
 - Blocker / Next Action: Commit final evidence and create PR.
+
+## 2026-06-26 23:51:52 CST / tpm
+- 完成内容: Prepared an additional gameplay_designer review required by the PR helper changed-path role matrix.
+- 遗留事项: Integrate gameplay_designer review, update the passed pre-PR packet, commit evidence, and rerun PR helper.
+- PR Helper Gate Evidence: `./scripts/prepare-task-pr.sh --create --title "Converge playability template evidence semantics"` exited 1 because the inferred changed-path role set also required `gameplay_designer` (present roles before this entry: repository_health_engineer, qa_engineer, producer_system_designer, liveops_community; required roles: producer_system_designer, gameplay_designer, liveops_community, qa_engineer).
+- Additional Review Trigger: pre-PR local role review supplement
+- Additional Review Scope: branch diff `origin/main...3549b40cdb8347fd60a2c1315873d0d96091720f`
+- Additional Review Role: gameplay_designer
+- Additional Review Question: Confirm the doc-only evidence-sink convergence does not alter playability issue severity/status semantics, player feedback loop, high-priority issue closure expectations, gameplay smoke / go-no-go meaning, or player-facing closed beta candidate claim boundaries; confirm whether no gameplay walkthrough/balance/playtest evidence is needed for this sink-only change.
+- Evidence Available: scoped legacy grep no-match; doc-governance-check OK; workflow-lint OK; git diff --check OK; repository_health/producer/liveops no_findings; QA P3 addressed.
+- Expected Return Contract: findings or no_findings; scope/spec compliance verdict; gameplay quality/risk verdict; residual_risk.
+- Action: Dispatch gameplay_designer supplemental pre-PR review.
+- Validation Command: multi-agent gameplay_designer review slice.
+- Expected Result: gameplay_designer returns findings/no_findings before PR helper rerun.
+- Actual Result: Pending review result.
+- Blocker / Next Action: Wait for gameplay_designer review.
+
+## 2026-06-26 23:54:35 CST / tpm
+- 完成内容: Integrated the supplemental gameplay_designer pre-PR review required by the PR helper path-role matrix.
+- 遗留事项: Commit supplemented review evidence, rerun PR helper, then create/watch/merge the PR.
+- Additional Review Evidence:
+  - gameplay_designer: no_findings; scope/spec compliance passed; gameplay quality/risk passed; residual risk low.
+  - gameplay_designer rationale: diff is doc-only and limited to active playability project/template evidence-sink wording plus task/trace evidence; it does not alter gameplay rules, test topics, scoring dimensions, severity labels, issue states, release/go-no-go criteria, player feedback loop, or player-facing closed beta candidate claim boundaries.
+  - gameplay evidence exemption: gameplay_designer confirmed no gameplay walkthrough, balance pass, or playtest evidence is required because the patch changes only where evidence is recorded, not what players can do, what counts as playable/balanced, or how gameplay risk is judged.
+- Pre-PR Local Role Review: passed
+- Task UID: task_eb93f5de123c49d1a3889855038b6987
+- Source Worktree: /Users/scc/ccwork/worktrees/oasis7-engineering-legacy-doc-semantics-convergence-next-6
+- Source Branch: task/engineering-legacy-doc-semantics-convergence-next-6
+- Source Head: 3549b40cdb8347fd60a2c1315873d0d96091720f
+- Comparison Ref: refs/remotes/origin/main
+- Reviewed Changed Paths: .pm/roles/tpm/backlog/committed.yaml; .pm/tasks/task_eb93f5de123c49d1a3889855038b6987.execution.md; .pm/tasks/task_eb93f5de123c49d1a3889855038b6987.yaml; doc/engineering/project.md; doc/playability_test_result/project.md; doc/playability_test_result/templates/closed-beta-candidate-incident-templates-2026-03-22.md; doc/playability_test_result/templates/high-priority-issue-closure-template.md
+- Review Package: n/a; review target was branch diff `origin/main...3549b40cdb8347fd60a2c1315873d0d96091720f`.
+- Role Selection Basis: PR helper changed-path inference required producer_system_designer, gameplay_designer, liveops_community, and qa_engineer; repository_health_engineer was also included for old-doc/old-semantics governance and live/historical boundary. The final review set covers documentation governance, QA/playability evidence sufficiency, producer go/no-go and claim boundaries, gameplay severity/status semantics, and LiveOps/community signal flow.
+- Review Roles: repository_health_engineer, qa_engineer, producer_system_designer, liveops_community, gameplay_designer
+- Review Evidence: repository_health_engineer no_findings / passed; qa_engineer P3 finding addressed / otherwise passed; producer_system_designer no_findings / passed; liveops_community no_findings / passed; gameplay_designer no_findings / passed.
+- Review Verdicts: repository_health_engineer scope/spec compliance passed and repository-health quality/risk passed; qa_engineer scope/spec compliance passed with minor finding and QA quality/risk mostly passed after fix; producer_system_designer scope/spec compliance passed and producer/system quality/risk passed; liveops_community scope/spec compliance passed and liveops/community quality/risk passed; gameplay_designer scope/spec compliance passed and gameplay quality/risk passed.
+- Review Findings Disposition: addressed
+- Finding Disposition Evidence: QA P3 checklist finding fixed by restoring the execution-log evidence item as an indented checkbox in `doc/playability_test_result/project.md`; scoped grep no-match, doc-governance-check OK, workflow-lint OK, and git diff --check OK after the fix; gameplay_designer returned no_findings and confirmed no gameplay playtest/balance evidence is required for this evidence-sink-only change.
+- Verification Matrix: playability active project/templates legacy evidence-sink semantics -> scoped rg no `doc/devlog` / `devlog` sink references remain; documentation governance -> doc-governance-check OK; task workflow evidence -> workflow-lint OK; patch hygiene -> git diff --check OK; QA/playability applicability -> high-priority issue closure, retest evidence, release evidence bundle linkage, required-tier evidence, and go/no-go traceability preserved; producer/system applicability -> go/no-go, producer escalation, and closed-beta claim boundary preserved; gameplay applicability -> severity/status semantics, player feedback loop, high-priority closure expectations, gameplay smoke/go-no-go meaning, and claim boundary preserved; LiveOps applicability -> closed beta signal logging, limited playable technical preview / GitHub CTA response boundary, incident escalation, and 3h owner summary preserved.
+- Visual Evidence: explicit exemption; doc-only project/template evidence-sink wording change with no UI/browser/player-facing visual behavior changed.
+- WASM Evidence: n/a; no WASM/platform/ABI/determinism path touched.
+- Ops Evidence: explicit exemption; no deployment/readiness/rollback/node-health/operator-facing chain ops behavior changed.
+- LiveOps Evidence: liveops_community reviewed the closed beta candidate feedback/incident template change and returned no_findings; no external message/release note/status/community artifact was created or changed beyond internal template evidence-sink wording.
+- Residual Risk: Historical `doc/playability_test_result` evidence, dated closures, handoffs, and broader archival docs may still contain legacy `devlog` wording outside the scoped current project/template surfaces; future work should continue by active entrypoint/template slice rather than broad historical rewrite.
+- Slice Ledger: n/a; role dispatch and result integration are recorded in this execution log.
+- Action: Record supplemented passed pre-PR local role review packet including gameplay_designer.
+- Validation Command: multi-agent gameplay_designer review slice plus prior repository_health_engineer, qa_engineer, producer_system_designer, and liveops_community review slices.
+- Expected Result: No valid findings remain before PR creation and PR helper required-role inference is covered.
+- Actual Result: QA P3 finding was addressed; gameplay_designer and all other involved roles returned no_findings / passed verdicts with bounded residual risk.
+- Blocker / Next Action: Commit supplemented review evidence and rerun PR helper.

--- a/.pm/tasks/task_eb93f5de123c49d1a3889855038b6987.execution.md
+++ b/.pm/tasks/task_eb93f5de123c49d1a3889855038b6987.execution.md
@@ -79,3 +79,42 @@ Example:
 - Expected Result: All scoped verification gates pass before pre-PR local role review.
 - Actual Result: All scoped verification gates passed.
 - Blocker / Next Action: Commit implementation and dispatch repository_health_engineer, qa_engineer, producer_system_designer, and liveops_community review slices.
+
+## 2026-06-26 23:41:03 CST / tpm
+- 完成内容: Prepared pre-PR local role review request for the committed playability evidence-sink semantics diff.
+- 遗留事项: Integrate review results, address findings if any, then record passed pre-PR packet.
+- Review Trigger: pre-PR local role review
+- Review Scope: `.pm/roles/tpm/backlog/committed.yaml`; `.pm/tasks/task_eb93f5de123c49d1a3889855038b6987.execution.md`; `.pm/tasks/task_eb93f5de123c49d1a3889855038b6987.yaml`; `doc/engineering/project.md`; `doc/playability_test_result/project.md`; `doc/playability_test_result/templates/closed-beta-candidate-incident-templates-2026-03-22.md`; `doc/playability_test_result/templates/high-priority-issue-closure-template.md`
+- Review Package: n/a; current review target is branch diff `origin/main...c038bdcc0ee7cfdd474632844696357060ca1b95`.
+- Review Roles: repository_health_engineer, qa_engineer, producer_system_designer, liveops_community
+- Review Question: Confirm the playability template evidence-sink semantics convergence is minimal and current/live, does not rewrite historical evidence, preserves QA high-priority issue closure, release evidence bundle, go/no-go / producer escalation, and LiveOps closed beta candidate signal flow, and has sufficient verification for a doc-only PR.
+- Evidence Available: scoped `rg` no-match for legacy devlog sink in target playability project/templates; `./scripts/doc-governance-check.sh` OK; task `workflow-lint` OK; `git diff --check` OK; implementation commit `c038bdcc0ee7cfdd474632844696357060ca1b95`.
+- Expected Return Contract: findings or no_findings; scope/spec compliance verdict; role quality/risk verdict; residual_risk.
+- Slice Ledger: n/a; role dispatch and result integration are recorded in this execution log.
+- Formal Sink: `.pm/tasks/task_eb93f5de123c49d1a3889855038b6987.execution.md`
+- Action: Record pre-PR local role review request.
+- Validation Command: git diff --name-only origin/main...HEAD
+- Expected Result: Review scope includes only task metadata and focused engineering/playability documentation semantics changes.
+- Actual Result: Scope listed above.
+- Blocker / Next Action: Dispatch role reviews.
+
+## 2026-06-26 23:46:04 CST / tpm
+- 完成内容: Integrated pre-PR local role reviews and addressed the QA finding.
+- 遗留事项: Record the passed pre-PR packet, run claim-ready / closeout, commit evidence, then create PR.
+- Review Evidence:
+  - repository_health_engineer: no_findings; scope/spec passed; repository-health quality/risk passed; residual risk low.
+  - qa_engineer: P3 finding that the Done Definition execution-log item had become a plain bullet, weakening QA checklist semantics; scope/spec passed with minor finding; QA quality/risk mostly passed.
+  - producer_system_designer: no_findings; scope/spec passed; producer/system quality/risk passed; go/no-go, release evidence, producer escalation, and closed-beta claim boundaries preserved.
+  - liveops_community: no_findings; scope/spec passed; LiveOps/community quality/risk passed; closed beta signal logging, limited playable technical preview / GitHub CTA response boundary, producer/QA/runtime escalation, and 3h owner summary preserved.
+- Finding Disposition: addressed.
+- Finding Fix Evidence: `doc/playability_test_result/project.md` Done Definition now keeps the evidence-log item as an indented checkbox (`- [ ]`) so QA closure remains checklist-driven while avoiding the top-level project task-row parser false positive.
+- Verification Evidence After Fix:
+  - `rg -n "doc/devlog|devlog|doc/devlog/YYYY-MM-DD\\.md" doc/playability_test_result/project.md doc/playability_test_result/templates`: exit 1, no scoped legacy devlog sink references remain.
+  - `./scripts/doc-governance-check.sh`: OK.
+  - `./scripts/pm/workflow-lint.sh --task-uid task_eb93f5de123c49d1a3889855038b6987 --phase current`: OK.
+  - `git diff --check`: OK.
+- Action: Fix QA P3 finding and rerun scoped verification.
+- Validation Command: rg/doc-governance/workflow-lint/git-diff-check verification matrix above.
+- Expected Result: QA checklist semantics restored and all verification gates remain green.
+- Actual Result: QA finding addressed; all verification gates passed.
+- Blocker / Next Action: Record passed pre-PR local role review packet.

--- a/.pm/tasks/task_eb93f5de123c49d1a3889855038b6987.execution.md
+++ b/.pm/tasks/task_eb93f5de123c49d1a3889855038b6987.execution.md
@@ -1,0 +1,81 @@
+# task_eb93f5de123c49d1a3889855038b6987 Execution Log
+
+- task_uid: task_eb93f5de123c49d1a3889855038b6987
+- title: Converge next stale legacy document semantics
+- owner_role: tpm
+- worktree_hint: /Users/scc/ccwork/worktrees/oasis7-engineering-legacy-doc-semantics-convergence-next-6
+
+<!-- Append entries using:
+Example:
+  ## YYYY-MM-DD HH:MM:SS CST / role_name
+  - 完成内容: ...
+  - 遗留事项: ...
+  - Action: ...
+  - Validation Command: ...
+  - Expected Result: ...
+  - Actual Result: ...
+  - Blocker / Next Action: ...
+-->
+
+## 2026-06-26 23:32:29 CST / tpm
+- 完成内容: Bootstrapped the next stale legacy document semantics convergence task and routed it to bounded repository-health discovery before any remediation edits.
+- 遗留事项: Dispatch repository_health_engineer discovery, integrate one actionable current/live finding, then remediate and verify.
+- Repository State Impact: changes repository state if discovery identifies a current/live old-semantics surface worth converging.
+- Isolation Decision: created dedicated task worktree `/Users/scc/ccwork/worktrees/oasis7-engineering-legacy-doc-semantics-convergence-next-6` on branch `task/engineering-legacy-doc-semantics-convergence-next-6`; main worktree remains untouched for edits.
+- Task Truth: owner role `tpm`; `.pm` task `task_eb93f5de123c49d1a3889855038b6987`; acceptance is to find one additional current old-document/old-semantics drift point, remediate the live documentation surface without broad historical rewrites, verify doc governance, and close through PR.
+- Route Decision: selected repo-owned workflow path `default-workflow-bootstrap -> repo-owned-workflow-router -> executing-project-tasks -> verification-before-completion -> requesting-repo-owned-review -> finishing-a-development-branch`.
+- Skipped Workflow Skills: `bounded-brainstorming` skipped because the next-action pattern is established and the task asks for one concrete governance point; `tdd-test-writer` skipped because this is doc/governance semantics work with no behavior harness.
+- Subagent Slice Plan:
+  - role: repository_health_engineer
+  - slice type: read_only_analysis / governance discovery
+  - intended model configuration: workflow default subagent runtime
+  - actual dispatched model/reasoning: inherited/unverified due subagent tool model-reporting limitation
+  - context delivery mode: full-thread/full-history fork preferred; explicit task context included as delivery supplement
+  - mandatory context checklist/packet: identity and authority = repository_health_engineer role card with tpm integration owner; workflow governance = AGENTS.md and `doc/engineering/workflow/source-of-truth.md`; task truth = current task YAML/execution log, branch, worktree, base `origin/main`; user intent = find next live-doc old-semantics convergence point; scoped repo context = prior completed slices converged workflow bootstrap docs, evidence-template execution-log sink, and readme LiveOps devlog sink, so exclude those exact completed surfaces; collaboration boundary = no file edits by discovery slice, return one actionable finding and role-review needs.
+  - write scope: none for discovery slice
+  - return contract: conclusion; severity/category; evidence paths; why current/live; minimal remediation scope; verification commands; residual risk; additional role-review needs
+  - formal sink / writeback surface: `.pm/tasks/task_eb93f5de123c49d1a3889855038b6987.execution.md`
+  - integration owner/order: tpm records finding, applies minimal patch if accepted, runs verification, dispatches pre-PR local role review.
+- Action: Create task/worktree and record workflow route plus repository_health_engineer discovery slice contract.
+- Validation Command: ./scripts/new-task-worktree.sh engineering legacy-doc-semantics-convergence-next-6 --pm-owner-role tpm --pm-title "Converge next stale legacy document semantics" --pm-priority P2 --pm-source-ref doc/engineering/project.md --pm-doc-ref doc/engineering/project.md --pm-acceptance "Find one additional current old-document/old-semantics drift point, remediate the live documentation surface without broad historical rewrites, verify doc governance, and close through PR." --json
+- Expected Result: Standard task worktree, branch, and `.pm` task are created.
+- Actual Result: Created `task_eb93f5de123c49d1a3889855038b6987` on `task/engineering-legacy-doc-semantics-convergence-next-6` at `/Users/scc/ccwork/worktrees/oasis7-engineering-legacy-doc-semantics-convergence-next-6`.
+- Blocker / Next Action: Dispatch repository_health_engineer discovery slice.
+
+## 2026-06-26 23:37:14 CST / tpm
+- 完成内容: Integrated repository_health_engineer discovery and applied the minimal playability live-template evidence-sink remediation.
+- 遗留事项: Run fresh verification, then dispatch pre-PR local role review for the involved roles.
+- repository_health_engineer finding: `doc/playability_test_result` current project / template surfaces still routed new playability issues and closed beta candidate signals into legacy `doc/devlog` evidence sinks, while the current evidence model uses `.pm/tasks/task_<32hex>.execution.md` plus formal evidence bundles.
+- Finding Severity / Category: P2 / doc governance semantic drift.
+- Why Current/Live: `doc/playability_test_result/README.md` points at `templates/` as a current key-doc entry; `doc/playability_test_result/project.md` still lists the high-priority issue closure template and release evidence bundle as module capabilities. The affected templates are reused for new playability issues, closed beta candidate feedback, QA triage, producer escalation, and release evidence.
+- Integration Decision: accepted the finding and limited the patch to the current module project wording plus two live templates. Historical evidence, dated closure records, and old handoff artifacts remain untouched.
+- Files Changed: `doc/playability_test_result/project.md`; `doc/playability_test_result/templates/closed-beta-candidate-incident-templates-2026-03-22.md`; `doc/playability_test_result/templates/high-priority-issue-closure-template.md`; `doc/engineering/project.md`; this task execution log.
+- Action: Replace active playability project/template `doc/devlog` evidence-sink wording with corresponding `.pm/tasks/task_<32hex>.execution.md` wording while preserving project/prd writeback, release evidence bundle, QA triage, producer escalation, and LiveOps signal flow.
+- Validation Command: rg -n "doc/devlog|devlog|doc/devlog/YYYY-MM-DD\\.md" doc/playability_test_result/project.md doc/playability_test_result/templates
+- Expected Result: No active scoped playability project/template references to legacy devlog evidence sinks remain.
+- Actual Result: Pending verification.
+- Blocker / Next Action: Run scoped grep, doc governance, workflow lint, and diff hygiene checks.
+
+## 2026-06-26 23:38:55 CST / tpm
+- 完成内容: Fixed doc-governance parser compatibility for the playability project Done Definition wording.
+- 遗留事项: Rerun fresh verification.
+- Issue: `./scripts/doc-governance-check.sh` treated the Done Definition checkbox `- [ ] 对应 .pm/tasks/task_<32hex>.execution.md 已记录` as a project task row and rejected it for not matching the topic-slug / PRD-ID / Trace template.
+- Action: Converted that Done Definition item to a plain bullet while preserving the evidence-sink semantics.
+- Validation Command: ./scripts/doc-governance-check.sh
+- Expected Result: Doc governance no longer treats the Done Definition evidence line as a project task row.
+- Actual Result: Pending rerun.
+- Blocker / Next Action: Rerun verification.
+
+## 2026-06-26 23:39:55 CST / tpm
+- 完成内容: Fresh verification passed for the scoped playability template evidence-sink convergence.
+- 遗留事项: Commit implementation, then dispatch required pre-PR local role reviews.
+- Verification Evidence:
+  - `rg -n "doc/devlog|devlog|doc/devlog/YYYY-MM-DD\\.md" doc/playability_test_result/project.md doc/playability_test_result/templates`: exit 1, no scoped active playability project/template legacy devlog sink references remain.
+  - `./scripts/doc-governance-check.sh`: OK.
+  - `./scripts/pm/workflow-lint.sh --task-uid task_eb93f5de123c49d1a3889855038b6987 --phase current`: OK.
+  - `git diff --check`: OK.
+- Action: Verify scoped documentation semantics and governance hygiene.
+- Validation Command: rg/doc-governance/workflow-lint/git-diff-check verification matrix above.
+- Expected Result: All scoped verification gates pass before pre-PR local role review.
+- Actual Result: All scoped verification gates passed.
+- Blocker / Next Action: Commit implementation and dispatch repository_health_engineer, qa_engineer, producer_system_designer, and liveops_community review slices.

--- a/.pm/tasks/task_eb93f5de123c49d1a3889855038b6987.execution.md
+++ b/.pm/tasks/task_eb93f5de123c49d1a3889855038b6987.execution.md
@@ -118,3 +118,45 @@ Example:
 - Expected Result: QA checklist semantics restored and all verification gates remain green.
 - Actual Result: QA finding addressed; all verification gates passed.
 - Blocker / Next Action: Record passed pre-PR local role review packet.
+
+## 2026-06-26 23:47:12 CST / tpm
+- 完成内容: Recorded the passed pre-PR local role review packet for the playability template evidence-sink semantics diff.
+- 遗留事项: Run claim-ready and closeout, commit final evidence, create PR, then watch checks/comments/mergeability.
+- Pre-PR Local Role Review: passed
+- Task UID: task_eb93f5de123c49d1a3889855038b6987
+- Source Worktree: /Users/scc/ccwork/worktrees/oasis7-engineering-legacy-doc-semantics-convergence-next-6
+- Source Branch: task/engineering-legacy-doc-semantics-convergence-next-6
+- Source Head: c1c38a8e555c668519b174e98f8ce749771c63aa
+- Comparison Ref: refs/remotes/origin/main
+- Reviewed Changed Paths: .pm/roles/tpm/backlog/committed.yaml; .pm/tasks/task_eb93f5de123c49d1a3889855038b6987.execution.md; .pm/tasks/task_eb93f5de123c49d1a3889855038b6987.yaml; doc/engineering/project.md; doc/playability_test_result/project.md; doc/playability_test_result/templates/closed-beta-candidate-incident-templates-2026-03-22.md; doc/playability_test_result/templates/high-priority-issue-closure-template.md
+- Review Package: n/a; review target was branch diff `origin/main...c038bdcc0ee7cfdd474632844696357060ca1b95`, then QA P3 finding fix committed in `c1c38a8e555c668519b174e98f8ce749771c63aa`.
+- Role Selection Basis: changed paths include cross-cutting engineering trace/task evidence and `doc/playability_test_result` current project/templates; repository_health_engineer required for old-doc/old-semantics governance and live/historical boundary; qa_engineer required because playability closure and release evidence expectations are QA-owned; producer_system_designer required for go/no-go, release evidence, producer escalation, and closed-beta claim boundaries; liveops_community required because the closed beta candidate feedback/incident template touches community signal logging and response boundaries.
+- Review Roles: repository_health_engineer, qa_engineer, producer_system_designer, liveops_community
+- Review Evidence: repository_health_engineer no_findings / passed; qa_engineer P3 finding addressed / otherwise passed; producer_system_designer no_findings / passed; liveops_community no_findings / passed.
+- Review Verdicts: repository_health_engineer scope/spec compliance passed and repository-health quality/risk passed; qa_engineer scope/spec compliance passed with minor finding and QA quality/risk mostly passed after fix; producer_system_designer scope/spec compliance passed and producer/system quality/risk passed; liveops_community scope/spec compliance passed and liveops/community quality/risk passed.
+- Review Findings Disposition: addressed
+- Finding Disposition Evidence: QA P3 checklist finding fixed by restoring the execution-log evidence item as an indented checkbox in `doc/playability_test_result/project.md`; scoped grep no-match, doc-governance-check OK, workflow-lint OK, and git diff --check OK after the fix.
+- Verification Matrix: playability active project/templates legacy evidence-sink semantics -> scoped rg no `doc/devlog` / `devlog` sink references remain; documentation governance -> doc-governance-check OK; task workflow evidence -> workflow-lint OK; patch hygiene -> git diff --check OK; QA/playability applicability -> high-priority issue closure, retest evidence, release evidence bundle linkage, required-tier evidence, and go/no-go traceability preserved; producer/system applicability -> go/no-go, producer escalation, and closed-beta claim boundary preserved; LiveOps applicability -> closed beta signal logging, limited playable technical preview / GitHub CTA response boundary, incident escalation, and 3h owner summary preserved.
+- Visual Evidence: explicit exemption; doc-only project/template evidence-sink wording change with no UI/browser/player-facing visual behavior changed.
+- WASM Evidence: n/a; no WASM/platform/ABI/determinism path touched.
+- Ops Evidence: explicit exemption; no deployment/readiness/rollback/node-health/operator-facing chain ops behavior changed.
+- LiveOps Evidence: liveops_community reviewed the closed beta candidate feedback/incident template change and returned no_findings; no external message/release note/status/community artifact was created or changed beyond internal template evidence-sink wording.
+- Residual Risk: Historical `doc/playability_test_result` evidence, dated closures, handoffs, and broader archival docs may still contain legacy `devlog` wording outside the scoped current project/template surfaces; future work should continue by active entrypoint/template slice rather than broad historical rewrite.
+- Slice Ledger: n/a; role dispatch and result integration are recorded in this execution log.
+- Action: Record passed pre-PR local role review packet.
+- Validation Command: multi-agent repository_health_engineer, qa_engineer, producer_system_designer, and liveops_community review slices.
+- Expected Result: No valid findings remain before PR creation.
+- Actual Result: QA P3 finding was addressed and all other involved roles returned no_findings with bounded residual risk.
+- Blocker / Next Action: Run claim-ready and closeout.
+
+## 2026-06-26 23:50:21 CST / tpm
+- 完成内容: Closeout metadata was written for the current task after fresh doc-governance verification.
+- 遗留事项: Commit closeout / review evidence, create PR, then watch required checks, comments, review threads, and mergeability.
+- Closeout Evidence: task YAML is now `status: done`, `last_claim_type: task_complete`, `last_verify_command: ./scripts/doc-governance-check.sh`, `last_verification_status: verified`, and `last_closed_at: 2026-06-26T23:49:48+08:00`.
+- Helper Limitation: `./scripts/pm/task-closeout.sh --role tpm --task-uid task_eb93f5de123c49d1a3889855038b6987 --verify-command "./scripts/doc-governance-check.sh"` exited 1 after writing current-task closeout metadata because the final repository-wide `.pm` lint surface still includes unrelated historical debt outside this task scope.
+- Attribution Boundary: this limitation is recorded as workflow-helper / historical-repo-lint evidence; it is not used as a professional role conclusion and does not change the repository_health_engineer / qa_engineer / producer_system_designer / liveops_community review verdicts.
+- Action: Record closeout helper limitation and current-task verified/done status.
+- Validation Command: sed -n '1,90p' .pm/tasks/task_eb93f5de123c49d1a3889855038b6987.yaml
+- Expected Result: Current task metadata shows verified closeout state.
+- Actual Result: Current task metadata shows `status: done` and `last_verification_status: verified`.
+- Blocker / Next Action: Commit final evidence and create PR.

--- a/.pm/tasks/task_eb93f5de123c49d1a3889855038b6987.yaml
+++ b/.pm/tasks/task_eb93f5de123c49d1a3889855038b6987.yaml
@@ -4,7 +4,7 @@ owner_role: tpm
 module: engineering
 worktree_hint: /Users/scc/ccwork/worktrees/oasis7-engineering-legacy-doc-semantics-convergence-next-6
 execution_log_path: .pm/tasks/task_eb93f5de123c49d1a3889855038b6987.execution.md
-status: committed
+status: done
 priority: P2
 source_signal: null
 source_refs:
@@ -15,5 +15,11 @@ related_prd: []
 acceptance:
   - "Find one additional current old-document/old-semantics drift point, remediate the live documentation surface without broad historical rewrites, verify doc governance, and close through PR."
 handoff_to: []
-updated_at: 2026-06-26T23:32:08+08:00
+updated_at: 2026-06-26T23:49:49+08:00
 last_started_at: 2026-06-26T23:32:08+08:00
+last_claim_type: task_complete
+last_verify_command: ./scripts/doc-governance-check.sh
+last_verified_at: 2026-06-26T23:49:45+08:00
+last_verification_exit_code: 0
+last_verification_status: verified
+last_closed_at: 2026-06-26T23:49:48+08:00

--- a/.pm/tasks/task_eb93f5de123c49d1a3889855038b6987.yaml
+++ b/.pm/tasks/task_eb93f5de123c49d1a3889855038b6987.yaml
@@ -1,0 +1,19 @@
+task_uid: task_eb93f5de123c49d1a3889855038b6987
+title: "Converge next stale legacy document semantics"
+owner_role: tpm
+module: engineering
+worktree_hint: /Users/scc/ccwork/worktrees/oasis7-engineering-legacy-doc-semantics-convergence-next-6
+execution_log_path: .pm/tasks/task_eb93f5de123c49d1a3889855038b6987.execution.md
+status: committed
+priority: P2
+source_signal: null
+source_refs:
+  - doc/engineering/project.md
+doc_refs:
+  - doc/engineering/project.md
+related_prd: []
+acceptance:
+  - "Find one additional current old-document/old-semantics drift point, remediate the live documentation surface without broad historical rewrites, verify doc governance, and close through PR."
+handoff_to: []
+updated_at: 2026-06-26T23:32:08+08:00
+last_started_at: 2026-06-26T23:32:08+08:00

--- a/doc/engineering/project.md
+++ b/doc/engineering/project.md
@@ -321,6 +321,7 @@
 - [x] scripts-bootstrap-devlog-semantics (PRD-ENGINEERING-021/025) [test_tier_required]: 收口 `doc/scripts` 当前 README / PRD 与 task-worktree-bootstrap 专题中仍把 `--init-docs` 绑定到“当日 devlog” / `today_devlog` 的旧语义，将 active bootstrap docs 对齐为模块 PRD/project 检查与 PM task execution log evidence。 Trace: .pm/tasks/task_e53e6c9884ec4f27a45e99f54b7075ba.yaml
 - [x] evidence-template-execution-log-semantics (PRD-ENGINEERING-021/025) [test_tier_required]: 收口 `doc/testing`、`doc/playability_test_result` 与 `doc/core` 活证据/门禁模板中仍把新任务结论导向 `doc/devlog/YYYY-MM-DD.md` 的旧语义，将 active evidence sink 改为对应 `.pm/tasks/task_<32hex>.execution.md`，保留模块 project/evidence bundle 回写要求。 Trace: .pm/tasks/task_cb0f1e08aa594e42a08f9393347fb8e7.yaml
 - [x] readme-liveops-runbook-execution-log-semantics (PRD-ENGINEERING-021/025) [test_tier_required]: 收口 Moltbook / 小红书持续运营 runbook 与 readme PRD 当前 flow / AC 中仍把渠道动作和信号回流导向 `doc/devlog` 的旧语义，将 active evidence sink 改为对应 `.pm/tasks/task_<32hex>.execution.md`，保留 runbook、issue / PR 与 producer summary 等正式回流面。 Trace: .pm/tasks/task_cd72186645e746dd8d12ed5cfc730f50.yaml
+- [x] playability-template-execution-log-semantics (PRD-ENGINEERING-021/025) [test_tier_required]: 收口 `doc/playability_test_result` 当前项目交接与 closed beta / 高优问题闭环活模板中仍把新可玩性信号导向 `doc/devlog` 的旧语义，将 active evidence sink 改为对应 `.pm/tasks/task_<32hex>.execution.md`，保留模块 project/prd、发布证据包、QA triage、producer escalation 与 LiveOps 回流面。 Trace: .pm/tasks/task_eb93f5de123c49d1a3889855038b6987.yaml
 
 ## File Structure / Affected Paths
 
@@ -388,7 +389,7 @@
 - 更新日期: 2026-06-26
 - 当前状态: active
 - 下一任务: 当前 `scripts/doc-inventory-report.sh` 复算显示 near-limit active docs 为 none；后续 repository health 巡检应按 module density / hotspot `action_required` 结果做 bounded 分类判断，先分级再切 focused follow-up，避免回到已收口的 `doc/world-simulator/project.md` / `doc/readme/project.md` 队列。
-- 最新完成: `readme-liveops-runbook-execution-log-semantics`（已将 Moltbook / 小红书持续运营 runbook 与 readme PRD 当前 flow / AC 中的旧 devlog 回写语义收敛到 PM task execution log evidence。）
+- 最新完成: `playability-template-execution-log-semantics`（已将 playability 当前项目交接与 closed beta / 高优问题闭环活模板中的旧 devlog 回写语义收敛到 PM task execution log evidence，同时保留发布证据包、QA/producer/liveops 回流面。）
 - PRD 质量门状态: strict schema 已对齐（含第 6 章验证与决策记录）。
 - 当前治理重点: P0/P1 技术债首轮优化正在收口，重点是 public_testnet readiness blocker 显式化、hosted access verdict 去半实现口径，以及 Viewer 前端状态模块化。
 - 当前库存判断: 文档债的主矛盾仍是“入口减重之后的存量维护成本”，不是继续扩更多 landing pages。复算入口仍以 `scripts/doc-inventory-report.sh` 为准。

--- a/doc/playability_test_result/project.md
+++ b/doc/playability_test_result/project.md
@@ -70,7 +70,7 @@
 - 专题入口状态: `game-test`/`playability_test_card`/`playability_test_manual` 已收敛到模块目录。
 - PRD 质量门状态: strict schema 已对齐（含第 6 章验证与决策记录）。
 - ROUND-010 入口治理状态: 已为 evidence-first 消费者补齐轻量入口，当前模块无需再做更重的根 README 拆分。
-- 说明: 本文档仅维护可玩性结果模块设计执行状态；过程记录在 `doc/devlog/README.md`。
+- 说明: 本文档仅维护可玩性结果模块设计执行状态；当前任务过程记录以对应 `.pm/tasks/task_<32hex>.execution.md` 为准，正式发布/可玩性证据继续回写 evidence bundle 与模块 project/prd。
 
 ## 阶段收口角色交接
 ### Meta
@@ -114,13 +114,13 @@
 - 代码改动：通常无需代码；如需，仅限卡片生成支撑脚本。
 - 文档回写：`doc/playability_test_result/project.md` 与相关模板文档。
 - 测试记录：补齐 `test_tier_required` 的字段抽样与模板引用验证。
-- devlog 记录：记录评分口径、模板与未决风险。
+- 任务证据记录：在对应 `.pm/tasks/task_<32hex>.execution.md` 记录评分口径、模板与未决风险，并按需回写正式 evidence bundle。
 
 ### Done Definition
 - [ ] 输出满足目标与成功标准
 - [ ] 影响面已核对 `producer_system_designer` / `qa_engineer` / `viewer_engineer`
 - [ ] 对应 `prd.md` / `project.md` 已回写
-- [ ] 对应 `doc/devlog/YYYY-MM-DD.md` 已记录
+- 对应 `.pm/tasks/task_<32hex>.execution.md` 已记录
 - [ ] required 证据已补齐
 
 ### Risks / Decisions

--- a/doc/playability_test_result/project.md
+++ b/doc/playability_test_result/project.md
@@ -120,7 +120,7 @@
 - [ ] 输出满足目标与成功标准
 - [ ] 影响面已核对 `producer_system_designer` / `qa_engineer` / `viewer_engineer`
 - [ ] 对应 `prd.md` / `project.md` 已回写
-- 对应 `.pm/tasks/task_<32hex>.execution.md` 已记录
+  - [ ] 对应 `.pm/tasks/task_<32hex>.execution.md` 已记录
 - [ ] required 证据已补齐
 
 ### Risks / Decisions

--- a/doc/playability_test_result/project.md
+++ b/doc/playability_test_result/project.md
@@ -114,13 +114,13 @@
 - 代码改动：通常无需代码；如需，仅限卡片生成支撑脚本。
 - 文档回写：`doc/playability_test_result/project.md` 与相关模板文档。
 - 测试记录：补齐 `test_tier_required` 的字段抽样与模板引用验证。
-- 任务证据记录：在对应 `.pm/tasks/task_<32hex>.execution.md` 记录评分口径、模板与未决风险，并按需回写正式 evidence bundle。
+- devlog 记录：记录评分口径、模板与未决风险。
 
 ### Done Definition
 - [ ] 输出满足目标与成功标准
 - [ ] 影响面已核对 `producer_system_designer` / `qa_engineer` / `viewer_engineer`
 - [ ] 对应 `prd.md` / `project.md` 已回写
-  - [ ] 对应 `.pm/tasks/task_<32hex>.execution.md` 已记录
+- [ ] 对应 `doc/devlog/YYYY-MM-DD.md` 已记录
 - [ ] required 证据已补齐
 
 ### Risks / Decisions

--- a/doc/playability_test_result/templates/closed-beta-candidate-incident-templates-2026-03-22.md
+++ b/doc/playability_test_result/templates/closed-beta-candidate-incident-templates-2026-03-22.md
@@ -15,7 +15,7 @@
 | Next Action | e.g., `issue created, awaiting QA triage` |
 | Response | Short text referencing “limited playable technical preview” & GitHub CTA |
 
-Use the above table to log every closed beta candidate signal before moving it into `doc/devlog/README.md`.
+Use the above table to log every closed beta candidate signal before moving it into the corresponding `.pm/tasks/task_<32hex>.execution.md` and any formal QA / LiveOps evidence bundle required by the release gate.
 
 ## Incident Template
 

--- a/doc/playability_test_result/templates/high-priority-issue-closure-template.md
+++ b/doc/playability_test_result/templates/high-priority-issue-closure-template.md
@@ -70,4 +70,4 @@
 - 是否填写 owner、修复任务、归因标签和证据路径。
 - `verified/closed` 是否具备复测记录。
 - `waived` 是否具备批准人与复审时间。
-- 是否已同步回写对应模块 `project.md`、`doc/devlog/YYYY-MM-DD.md` 与发布证据包。
+- 是否已同步回写对应模块 `project.md`、对应 `.pm/tasks/task_<32hex>.execution.md` 与发布证据包。


### PR DESCRIPTION
## Summary
- Replace legacy devlog evidence-sink wording in active playability project handoff and closed beta / high-priority issue templates with PM task execution log evidence wording.
- Preserve project/prd writeback, release evidence bundles, QA triage, producer escalation, LiveOps signal handling, and gameplay severity/status semantics.
- Keep historical playability evidence and handoff records untouched.

## Verification
- scoped rg for legacy devlog sink returned no matches in target playability project/templates
- ./scripts/doc-governance-check.sh
- ./scripts/pm/workflow-lint.sh --task-uid task_eb93f5de123c49d1a3889855038b6987 --phase current
- git diff --check
- ./scripts/pm/claim-ready.sh --claim-type ready_for_pr --verify-command "./scripts/doc-governance-check.sh"
- pre-PR role reviews: repository_health_engineer, qa_engineer, producer_system_designer, liveops_community, gameplay_designer