### PR TITLE
Delete playability manual legacy redirect

### DIFF
--- a/.pm/roles/tpm/backlog/committed.yaml
+++ b/.pm/roles/tpm/backlog/committed.yaml
@@ -99,14 +99,3 @@ tasks:
     handoff_to: []
     status: committed
     task_path: .pm/tasks/task_b442769f7ef74d01894f4b8405c21301.yaml
-  - task_uid: task_21152e953bd14e4195a3f2ec3519a33b
-    title: "Converge and delete next stale legacy document surface"
-    module: engineering
-    priority: P2
-    source_signal: null
-    related_prd: []
-    acceptance:
-      - "Find one additional current old-document/old-semantics drift point with emphasis on removable stale legacy documentation, remediate the live documentation surface, delete obsolete legacy document(s) only when current references are safely repointed, avoid broad historical rewrites, verify doc governance, and close through PR."
-    handoff_to: []
-    status: committed
-    task_path: .pm/tasks/task_21152e953bd14e4195a3f2ec3519a33b.yaml

--- a/.pm/roles/tpm/backlog/committed.yaml
+++ b/.pm/roles/tpm/backlog/committed.yaml
@@ -99,3 +99,14 @@ tasks:
     handoff_to: []
     status: committed
     task_path: .pm/tasks/task_b442769f7ef74d01894f4b8405c21301.yaml
+  - task_uid: task_21152e953bd14e4195a3f2ec3519a33b
+    title: "Converge and delete next stale legacy document surface"
+    module: engineering
+    priority: P2
+    source_signal: null
+    related_prd: []
+    acceptance:
+      - "Find one additional current old-document/old-semantics drift point with emphasis on removable stale legacy documentation, remediate the live documentation surface, delete obsolete legacy document(s) only when current references are safely repointed, avoid broad historical rewrites, verify doc governance, and close through PR."
+    handoff_to: []
+    status: committed
+    task_path: .pm/tasks/task_21152e953bd14e4195a3f2ec3519a33b.yaml

--- a/.pm/tasks/task_21152e953bd14e4195a3f2ec3519a33b.execution.md
+++ b/.pm/tasks/task_21152e953bd14e4195a3f2ec3519a33b.execution.md
@@ -54,3 +54,47 @@ Example:
 - Expected Result: no live doc/governance references to the deleted root manual shell, deleted file absent, canonical manual present, doc governance passes, task workflow lint passes, and diff whitespace check passes.
 - Actual Result: PASS. Exact stale root-path search `rg -n -F "doc/playability_test_manual.md" doc scripts .agents README.md` returned no matches; `test ! -e doc/playability_test_manual.md` passed; `test -e doc/playability_test_result/playability_test_manual.md` passed; `git diff --check` passed; `./scripts/doc-governance-check.sh` returned `doc-governance-check: OK`; `./scripts/pm/workflow-lint.sh --task-uid task_21152e953bd14e4195a3f2ec3519a33b --phase current` returned `workflow-lint: OK`.
 - Blocker / Next Action: Commit implementation and dispatch pre-PR local role review.
+
+## 2026-06-27 08:44:00 CST / tpm
+- Review Trigger: pre-PR local role review
+- Review Scope: commit `77a7c8d15969e55dc045a3344d251d031db945b0` against `origin/main`; changed paths include `.pm` task truth, `doc/.governance/doc-root-md-allowlist.txt`, `doc/core/reviews/round-003-reviewed-files.md`, `doc/core/reviews/round-004-reviewed-files.md`, `doc/core/reviews/round-004-audit-progress-log.md`, `doc/engineering/project.md`, and deleted `doc/playability_test_manual.md`.
+- Review Package: `/Users/scc/ccwork/worktrees/oasis7-engineering-legacy-doc-semantics-deletion-next-9/.pm/scratch/task_21152e953bd14e4195a3f2ec3519a33b/review-packages/review-d54c561ec..77a7c8d15.diff`
+- Review Roles: repository_health_engineer, producer_system_designer, qa_engineer
+- Review Question: confirm deletion is limited to the obsolete root playability manual redirect shell, preserves canonical playability reader journey, avoids broad historical rewrites, and has sufficient doc-only verification evidence.
+- Evidence Available: exact stale root-path search returned no live doc/governance matches; deleted-file check passed; canonical manual file exists; `./scripts/doc-governance-check.sh` OK; `./scripts/pm/workflow-lint.sh --task-uid task_21152e953bd14e4195a3f2ec3519a33b --phase current` OK; `git diff --check` OK.
+- Expected Return Contract: findings or explicit no_findings; scope/spec compliance verdict; role quality/risk verdict; residual_risk; concrete file/line or command evidence.
+- Slice Ledger: `/Users/scc/ccwork/worktrees/oasis7-engineering-legacy-doc-semantics-deletion-next-9/.pm/scratch/task_21152e953bd14e4195a3f2ec3519a33b/slice-ledger.jsonl`
+- Formal Sink: `.pm/tasks/task_21152e953bd14e4195a3f2ec3519a33b.execution.md`
+- Actual Dispatch: repository_health_engineer subagent `019f0705-befd-7a20-a4e3-2f2d3cb27d60`; producer_system_designer subagent `019f0705-f675-7cf1-871c-752046561ba9`; qa_engineer subagent `019f0706-3382-75d0-8b6e-353a22271487`.
+
+## 2026-06-27 08:55:00 CST / tpm
+- Pre-PR Local Role Review: passed
+- Task UID: task_21152e953bd14e4195a3f2ec3519a33b
+- Source Worktree: /Users/scc/ccwork/worktrees/oasis7-engineering-legacy-doc-semantics-deletion-next-9
+- Source Branch: task/engineering-legacy-doc-semantics-deletion-next-9
+- Source Head: 77a7c8d15969e55dc045a3344d251d031db945b0
+- Comparison Ref: refs/remotes/origin/main
+- Reviewed Changed Paths: `.pm/roles/tpm/backlog/committed.yaml`; `.pm/tasks/task_21152e953bd14e4195a3f2ec3519a33b.yaml`; `.pm/tasks/task_21152e953bd14e4195a3f2ec3519a33b.execution.md`; `doc/.governance/doc-root-md-allowlist.txt`; `doc/core/reviews/round-003-reviewed-files.md`; `doc/core/reviews/round-004-reviewed-files.md`; `doc/core/reviews/round-004-audit-progress-log.md`; `doc/engineering/project.md`; deleted `doc/playability_test_manual.md`.
+- Review Package: `/Users/scc/ccwork/worktrees/oasis7-engineering-legacy-doc-semantics-deletion-next-9/.pm/scratch/task_21152e953bd14e4195a3f2ec3519a33b/review-packages/review-d54c561ec..77a7c8d15.diff`
+- Role Selection Basis: `repository_health_engineer` selected for cross-cutting doc governance, root markdown allowlist, and deletion boundary review; `producer_system_designer` selected because playability manual entrypoints affect product/system document reader journey; `qa_engineer` selected for verification/test-tier sufficiency. Runtime/viewer/WASM/ops/liveops roles were not selected because no runtime behavior, UI, wasm, ops runbook, or external messaging changed.
+- Review Roles: repository_health_engineer, producer_system_designer, qa_engineer
+- Review Evidence: `repository_health_engineer` subagent `019f0705-befd-7a20-a4e3-2f2d3cb27d60` returned `no_findings`, confirmed the diff only deletes the obsolete root playability manual redirect shell, repoints stale root references to canonical `doc/playability_test_result/playability_test_manual.md`, avoids broad historical rewrites, and keeps doc governance gates passing. `producer_system_designer` subagent `019f0705-f675-7cf1-871c-752046561ba9` returned `no_findings`, confirmed the playability/game-test reader journey remains anchored in canonical module docs and current preferred entrypoints remain clear. `qa_engineer` subagent `019f0706-3382-75d0-8b6e-353a22271487` returned `no_findings`, confirmed `test_tier_required` evidence is sufficient for this pure documentation governance deletion and no release/full-test readiness claim is made.
+- Review Verdicts: repository health scope/spec compliance passed and repository health quality/risk passed; producer/system scope/spec compliance passed and producer/system document quality/risk passed; QA scope/spec compliance passed and QA quality/risk passed.
+- Review Findings Disposition: no_findings
+- Finding Disposition Evidence: n/a; no findings to address.
+- Verification Matrix: stale root manual path -> scoped `rg` no live doc/governance matches; deleted shell file -> `test ! -e` passed; canonical manual -> `test -e doc/playability_test_result/playability_test_manual.md` passed; doc governance -> `./scripts/doc-governance-check.sh` OK; workflow current phase -> `./scripts/pm/workflow-lint.sh --task-uid task_21152e953bd14e4195a3f2ec3519a33b --phase current` OK; diff hygiene -> `git diff --check` OK.
+- Visual Evidence: n/a; documentation governance deletion with no UI or rendered visual surface.
+- WASM Evidence: n/a; no WASM code, ABI, receipt, or determinism surface changed.
+- Ops Evidence: n/a; no deployment, node ops, rollback, or operator runbook surface changed.
+- LiveOps Evidence: n/a; no external messaging, release note, incident, or community runbook changed.
+- Residual Risk: low. External links outside the repository search scope that directly target deleted root `doc/playability_test_manual.md` will no longer resolve, but current repo reader journey is concentrated on canonical module docs and root `.prd` / `.project` compatibility redirects.
+- Slice Ledger: `/Users/scc/ccwork/worktrees/oasis7-engineering-legacy-doc-semantics-deletion-next-9/.pm/scratch/task_21152e953bd14e4195a3f2ec3519a33b/slice-ledger.jsonl` was requested by helper output; formal evidence is retained in this execution log and the review package above.
+
+## 2026-06-27 11:06:00 CST / tpm
+- 完成内容: Ran fresh final verification after pre-PR role review evidence was recorded.
+- 遗留事项: Commit review evidence and run task closeout / PR preparation.
+- Action: Verify final branch state before PR creation.
+- Validation Command: `rg -n -F "doc/playability_test_manual.md" doc scripts .agents README.md`; `test ! -e doc/playability_test_manual.md`; `test -e doc/playability_test_result/playability_test_manual.md`; `git diff --check`; `./scripts/doc-governance-check.sh`; `./scripts/pm/workflow-lint.sh --task-uid task_21152e953bd14e4195a3f2ec3519a33b --phase current`; `./scripts/pm/claim-ready.sh --claim-type ready_for_pr --verify-command "./scripts/doc-governance-check.sh"`.
+- Expected Result: root stale manual path absent from live doc/governance search; deleted file absent; canonical manual present; diff whitespace OK; doc governance OK; workflow current-phase lint OK; claim-ready allows ready_for_pr.
+- Actual Result: PASS. Scoped root-path `rg` returned no matches; deleted-file and canonical-file checks passed; `git diff --check` passed; `doc-governance-check: OK`; `workflow-lint: OK (task_21152e953bd14e4195a3f2ec3519a33b, phase=current)`; `claim-ready` reported `status: verified`, `allowed_to_claim: true`.
+- Blocker / Next Action: Commit review evidence, run task closeout and prepare PR.

--- a/.pm/tasks/task_21152e953bd14e4195a3f2ec3519a33b.execution.md
+++ b/.pm/tasks/task_21152e953bd14e4195a3f2ec3519a33b.execution.md
@@ -98,3 +98,12 @@ Example:
 - Expected Result: root stale manual path absent from live doc/governance search; deleted file absent; canonical manual present; diff whitespace OK; doc governance OK; workflow current-phase lint OK; claim-ready allows ready_for_pr.
 - Actual Result: PASS. Scoped root-path `rg` returned no matches; deleted-file and canonical-file checks passed; `git diff --check` passed; `doc-governance-check: OK`; `workflow-lint: OK (task_21152e953bd14e4195a3f2ec3519a33b, phase=current)`; `claim-ready` reported `status: verified`, `allowed_to_claim: true`.
 - Blocker / Next Action: Commit review evidence, run task closeout and prepare PR.
+
+## 2026-06-27 11:07:00 CST / tpm
+- 完成内容: Ran task closeout helper and recorded its boundary.
+- 遗留事项: Repo-wide `.pm` lint still has unrelated historical execution-log debt outside this task; this task's scoped doc governance, workflow current-phase lint, ready-for-PR claim, and closeout verification succeeded.
+- Action: `./scripts/pm/task-closeout.sh --role tpm --task-uid task_21152e953bd14e4195a3f2ec3519a33b --verify-command "./scripts/doc-governance-check.sh"`
+- Validation Command: closeout helper with `./scripts/doc-governance-check.sh` verification.
+- Expected Result: current task marked complete if verification passes; any repo-wide historical lint debt remains attributed separately.
+- Actual Result: helper recorded `last_verification_status: verified`, `last_verification_exit_code: 0`, and moved the task to `done`; final helper exit was non-zero because repo-wide `pm-lint` reported pre-existing failures in many unrelated `.pm/tasks/*.execution.md` files, beginning with `task_04d61dc5778e4b1683a61056daf454e3` and `task_060e9de147ba4757ac29cf0fb7a15210`.
+- Blocker / Next Action: Treat repo-wide `.pm` historical debt as out of scope for this focused doc deletion task; proceed to PR preparation with the current task's scoped gates and review packet.

--- a/.pm/tasks/task_21152e953bd14e4195a3f2ec3519a33b.execution.md
+++ b/.pm/tasks/task_21152e953bd14e4195a3f2ec3519a33b.execution.md
@@ -1,0 +1,56 @@
+# task_21152e953bd14e4195a3f2ec3519a33b Execution Log
+
+- task_uid: task_21152e953bd14e4195a3f2ec3519a33b
+- title: Converge and delete next stale legacy document surface
+- owner_role: tpm
+- worktree_hint: /Users/scc/ccwork/worktrees/oasis7-engineering-legacy-doc-semantics-deletion-next-9
+
+<!-- Append entries using:
+Example:
+  ## YYYY-MM-DD HH:MM:SS CST / role_name
+  - 完成内容: ...
+  - 遗留事项: ...
+  - Action: ...
+  - Validation Command: ...
+  - Expected Result: ...
+  - Actual Result: ...
+  - Blocker / Next Action: ...
+-->
+
+## 2026-06-27 08:22:00 CST / tpm
+- 完成内容: Bootstrapped the next legacy-document semantics/deletion governance task and routed it to bounded repository-health discovery before remediation edits.
+- 遗留事项: Dispatch repository_health_engineer discovery, integrate one actionable current/live finding with a deletion candidate, then remediate and verify.
+- Repository State Impact: changes repository state if discovery identifies a stale legacy document that can be safely deleted after current references are repointed or proven obsolete.
+- Isolation Decision: created dedicated task worktree `/Users/scc/ccwork/worktrees/oasis7-engineering-legacy-doc-semantics-deletion-next-9` on branch `task/engineering-legacy-doc-semantics-deletion-next-9`; main worktree remains untouched for edits.
+- Task Truth: owner role `tpm`; `.pm` task `task_21152e953bd14e4195a3f2ec3519a33b`; acceptance is to find one additional current old-document/old-semantics drift point with emphasis on removable stale legacy documentation, remediate live docs, delete obsolete legacy document(s) only when current references are safely repointed, avoid broad historical rewrites, verify doc governance, and close through PR.
+- Route Decision: selected repo-owned workflow path `default-workflow-bootstrap -> repo-owned-workflow-router -> executing-project-tasks -> verification-before-completion -> requesting-repo-owned-review -> finishing-a-development-branch`.
+- Skipped Workflow Skills: `bounded-brainstorming` skipped because the task asks for one concrete governance/deletion point; `tdd-test-writer` skipped because this is doc/governance structure work with doc-governance verification rather than behavior tests.
+- Subagent Slice Plan:
+  - role: repository_health_engineer
+  - slice type: read_only_analysis / governance deletion discovery
+  - intended model configuration: workflow default subagent runtime
+  - actual dispatched model/reasoning: inherited/unverified due subagent tool model-reporting limitation
+  - context delivery mode: full-thread/full-history fork preferred; explicit task context included as delivery supplement
+  - mandatory context checklist/packet: identity and authority = repository_health_engineer role card with tpm integration owner; workflow governance = AGENTS.md and `doc/engineering/workflow/source-of-truth.md`; task truth = current task YAML/execution log, branch, worktree, base `origin/main`; user intent = find next live-doc old-semantics convergence point with deletable stale legacy document emphasis; scoped repo context = prior completed slices converged root design redirect shell deletion for world-runtime/world-simulator and game-test, active evidence sinks, devlog semantics, and current live-doc cleanup boundaries; collaboration boundary = no file edits by discovery slice, return one actionable finding and role-review needs.
+  - write scope: none for discovery slice
+  - return contract: conclusion; severity/category; evidence paths; why current/live or why safely obsolete; deletion/remediation scope; references to repoint/delete; verification commands; residual risk; additional role-review needs
+  - formal sink / writeback surface: `.pm/tasks/task_21152e953bd14e4195a3f2ec3519a33b.execution.md`
+  - integration owner/order: tpm records finding, applies minimal patch/delete if accepted, runs verification, dispatches pre-PR local role review.
+- Action: Create task/worktree and record workflow route plus repository_health_engineer discovery slice contract.
+- Validation Command: `./scripts/new-task-worktree.sh engineering legacy-doc-semantics-deletion-next-9 --pm-owner-role tpm --pm-title "Converge and delete next stale legacy document surface" --pm-priority P2 --pm-source-ref doc/engineering/project.md --pm-doc-ref doc/engineering/project.md --pm-acceptance "..."`
+- Expected Result: Standard task worktree, branch, and `.pm` task are created.
+- Actual Result: Created `task_21152e953bd14e4195a3f2ec3519a33b` on `task/engineering-legacy-doc-semantics-deletion-next-9` at `/Users/scc/ccwork/worktrees/oasis7-engineering-legacy-doc-semantics-deletion-next-9`.
+- Blocker / Next Action: Dispatch repository_health_engineer deletion discovery slice.
+
+## 2026-06-27 08:34:00 CST / tpm
+- 完成内容: Integrated repository_health_engineer discovery and applied the selected legacy-document deletion point.
+- 遗留事项: Run verification and dispatch pre-PR local role review after the patch is validated.
+- Repository Health Finding Integrated: `doc/playability_test_manual.md` was a root-level legacy redirect shell. Canonical current manual content already exists at `doc/playability_test_result/playability_test_manual.md`, and current playability reader journey is anchored in the `playability_test_result` module.
+- Scope Applied: deleted `doc/playability_test_manual.md`, removed it from `doc/.governance/doc-root-md-allowlist.txt`, repointed old root-path references in `doc/core/reviews/round-003-reviewed-files.md`, `doc/core/reviews/round-004-reviewed-files.md`, and `doc/core/reviews/round-004-audit-progress-log.md` to `doc/playability_test_result/playability_test_manual.md`, and added the completed governance trace to `doc/engineering/project.md`.
+- Boundary: retained root `doc/game-test.prd.md` and `doc/game-test.project.md` compatibility redirects, did not rewrite broad historical task/project evidence, and limited historical review edits to stale path references required by deleting the obsolete root manual shell.
+- Attribution: deletion candidate, evidence, and minimal scope came from repository_health_engineer bounded discovery slice; tpm integrated the patch and workflow record.
+- Action: Delete obsolete root playability manual legacy redirect shell and repoint the remaining old root references.
+- Validation Command: pending verification batch: exact stale root-path search, deleted-file and canonical-file checks, `./scripts/doc-governance-check.sh`, `./scripts/pm/workflow-lint.sh --task-uid task_21152e953bd14e4195a3f2ec3519a33b --phase current`, and `git diff --check`.
+- Expected Result: no live doc/governance references to the deleted root manual shell, deleted file absent, canonical manual present, doc governance passes, task workflow lint passes, and diff whitespace check passes.
+- Actual Result: PASS. Exact stale root-path search `rg -n -F "doc/playability_test_manual.md" doc scripts .agents README.md` returned no matches; `test ! -e doc/playability_test_manual.md` passed; `test -e doc/playability_test_result/playability_test_manual.md` passed; `git diff --check` passed; `./scripts/doc-governance-check.sh` returned `doc-governance-check: OK`; `./scripts/pm/workflow-lint.sh --task-uid task_21152e953bd14e4195a3f2ec3519a33b --phase current` returned `workflow-lint: OK`.
+- Blocker / Next Action: Commit implementation and dispatch pre-PR local role review.

--- a/.pm/tasks/task_21152e953bd14e4195a3f2ec3519a33b.execution.md
+++ b/.pm/tasks/task_21152e953bd14e4195a3f2ec3519a33b.execution.md
@@ -107,3 +107,14 @@ Example:
 - Expected Result: current task marked complete if verification passes; any repo-wide historical lint debt remains attributed separately.
 - Actual Result: helper recorded `last_verification_status: verified`, `last_verification_exit_code: 0`, and moved the task to `done`; final helper exit was non-zero because repo-wide `pm-lint` reported pre-existing failures in many unrelated `.pm/tasks/*.execution.md` files, beginning with `task_04d61dc5778e4b1683a61056daf454e3` and `task_060e9de147ba4757ac29cf0fb7a15210`.
 - Blocker / Next Action: Treat repo-wide `.pm` historical debt as out of scope for this focused doc deletion task; proceed to PR preparation with the current task's scoped gates and review packet.
+
+## 2026-06-27 11:18:00 CST / tpm
+- 完成内容: Addressed PR review feedback about duplicate historical review inventory/progress-log entries.
+- 遗留事项: Re-run scoped verification, push the fix, and re-check PR threads/checks before merge.
+- Feedback Source: GitHub Codex review on PR #682.
+- Action: Removed the duplicate canonical `doc/playability_test_result/playability_test_manual.md` entries that were introduced by retargeting the deleted root redirect row in `doc/core/reviews/round-003-reviewed-files.md`, `doc/core/reviews/round-004-reviewed-files.md`, and `doc/core/reviews/round-004-audit-progress-log.md`.
+- Boundary: kept the deleted root path absent rather than reintroducing it as historical text; retained the existing canonical review entries that already covered `doc/playability_test_result/playability_test_manual.md`.
+- Validation Command: pending rerun of exact stale path search, duplicate canonical path search, `git diff --check`, `./scripts/doc-governance-check.sh`, and task workflow lint.
+- Expected Result: no deleted root path references, no duplicate canonical playability manual entries in the touched review ledgers, and doc/task gates remain green.
+- Actual Result: PASS. Exact stale root-path search returned no matches; canonical path search showed one retained entry in each touched ledger (`round-003-reviewed-files.md`, `round-004-reviewed-files.md`, `round-004-audit-progress-log.md`); `git diff --check` passed; `doc-governance-check: OK`; `workflow-lint: OK`.
+- Blocker / Next Action: Commit and push review-fix commit.

--- a/.pm/tasks/task_21152e953bd14e4195a3f2ec3519a33b.yaml
+++ b/.pm/tasks/task_21152e953bd14e4195a3f2ec3519a33b.yaml
@@ -1,0 +1,19 @@
+task_uid: task_21152e953bd14e4195a3f2ec3519a33b
+title: "Converge and delete next stale legacy document surface"
+owner_role: tpm
+module: engineering
+worktree_hint: /Users/scc/ccwork/worktrees/oasis7-engineering-legacy-doc-semantics-deletion-next-9
+execution_log_path: .pm/tasks/task_21152e953bd14e4195a3f2ec3519a33b.execution.md
+status: committed
+priority: P2
+source_signal: null
+source_refs:
+  - doc/engineering/project.md
+doc_refs:
+  - doc/engineering/project.md
+related_prd: []
+acceptance:
+  - "Find one additional current old-document/old-semantics drift point with emphasis on removable stale legacy documentation, remediate the live documentation surface, delete obsolete legacy document(s) only when current references are safely repointed, avoid broad historical rewrites, verify doc governance, and close through PR."
+handoff_to: []
+updated_at: 2026-06-27T10:53:05+08:00
+last_started_at: 2026-06-27T10:53:05+08:00

--- a/.pm/tasks/task_21152e953bd14e4195a3f2ec3519a33b.yaml
+++ b/.pm/tasks/task_21152e953bd14e4195a3f2ec3519a33b.yaml
@@ -4,7 +4,7 @@ owner_role: tpm
 module: engineering
 worktree_hint: /Users/scc/ccwork/worktrees/oasis7-engineering-legacy-doc-semantics-deletion-next-9
 execution_log_path: .pm/tasks/task_21152e953bd14e4195a3f2ec3519a33b.execution.md
-status: committed
+status: done
 priority: P2
 source_signal: null
 source_refs:
@@ -15,5 +15,11 @@ related_prd: []
 acceptance:
   - "Find one additional current old-document/old-semantics drift point with emphasis on removable stale legacy documentation, remediate the live documentation surface, delete obsolete legacy document(s) only when current references are safely repointed, avoid broad historical rewrites, verify doc governance, and close through PR."
 handoff_to: []
-updated_at: 2026-06-27T10:53:05+08:00
+updated_at: 2026-06-27T11:06:31+08:00
 last_started_at: 2026-06-27T10:53:05+08:00
+last_claim_type: task_complete
+last_verify_command: ./scripts/doc-governance-check.sh
+last_verified_at: 2026-06-27T11:06:29+08:00
+last_verification_exit_code: 0
+last_verification_status: verified
+last_closed_at: 2026-06-27T11:06:30+08:00

--- a/doc/.governance/doc-root-md-allowlist.txt
+++ b/doc/.governance/doc-root-md-allowlist.txt
@@ -2,7 +2,6 @@ doc/README.md
 doc/game-test.prd.md
 doc/game-test.project.md
 doc/playability_test_card.md
-doc/playability_test_manual.md
 doc/viewer-manual.md
 doc/world-runtime.prd.md
 doc/world-runtime.project.md

--- a/doc/core/reviews/round-003-reviewed-files.md
+++ b/doc/core/reviews/round-003-reviewed-files.md
@@ -226,7 +226,7 @@
 - `doc/p2p/viewer-live/oasis7-viewer-live-release-locked-launch-2026-02-23.prd.md`
 - `doc/p2p/viewer-live/oasis7-viewer-live-release-locked-launch-2026-02-23.project.md`
 - `doc/playability_test_card.md`
-- `doc/playability_test_manual.md`
+- `doc/playability_test_result/playability_test_manual.md`
 - `doc/playability_test_result/README.md`
 - `doc/playability_test_result/card_2026_02_28_19_22_20.md`
 - `doc/playability_test_result/card_2026_02_28_21_22_51.md`

--- a/doc/core/reviews/round-003-reviewed-files.md
+++ b/doc/core/reviews/round-003-reviewed-files.md
@@ -226,7 +226,6 @@
 - `doc/p2p/viewer-live/oasis7-viewer-live-release-locked-launch-2026-02-23.prd.md`
 - `doc/p2p/viewer-live/oasis7-viewer-live-release-locked-launch-2026-02-23.project.md`
 - `doc/playability_test_card.md`
-- `doc/playability_test_result/playability_test_manual.md`
 - `doc/playability_test_result/README.md`
 - `doc/playability_test_result/card_2026_02_28_19_22_20.md`
 - `doc/playability_test_result/card_2026_02_28_21_22_51.md`

--- a/doc/core/reviews/round-004-audit-progress-log.md
+++ b/doc/core/reviews/round-004-audit-progress-log.md
@@ -45,7 +45,6 @@
 | 2026-03-06 11:54:15 +0800 | codex | `doc/README.md` | pass | - | 总入口路径矩阵与 legacy redirect 说明完整，未发现 D4-001~D4-008 新增问题。 |
 | 2026-03-06 11:54:44 +0800 | codex | `doc/game-test.prd.md` | pass | - | redirect 角色边界与主入口指向清晰，未见多入口冲突。 |
 | 2026-03-06 11:55:15 +0800 | codex | `doc/game-test.project.md` | issue_open | I4-021 | Project 文档未维护 PRD-ID 映射与验收命令字段，redirect 任务可追溯性不足。 |
-| 2026-03-06 11:55:44 +0800 | codex | `doc/playability_test_result/playability_test_manual.md` | pass | - | redirect 声明与主入口指向明确，未发现新增冲突。 |
 | 2026-03-06 11:56:15 +0800 | codex | `doc/playability_test_card.md` | pass | - | redirect 声明与主入口指向明确，未发现新增冲突。 |
 | 2026-03-06 11:56:43 +0800 | codex | `doc/headless-runtime/nonviewer/nonviewer-onchain-auth-protocol-hardening.prd.md` | issue_open | I4-014 | Traceability 表沿用 `PRD-ENGINEERING-006 + 文档内既有任务条目`，未建立本专题 PRD-ID 与任务/命令/证据链。 |
 | 2026-03-06 11:57:17 +0800 | codex | `doc/headless-runtime/nonviewer/nonviewer-onchain-auth-protocol-hardening.project.md` | issue_open | I4-015 | “含 PRD-ID 映射”仅迁移任务带 PRD-ID，T0~T3 未显式映射需求与验收命令。 |

--- a/doc/core/reviews/round-004-audit-progress-log.md
+++ b/doc/core/reviews/round-004-audit-progress-log.md
@@ -45,7 +45,7 @@
 | 2026-03-06 11:54:15 +0800 | codex | `doc/README.md` | pass | - | 总入口路径矩阵与 legacy redirect 说明完整，未发现 D4-001~D4-008 新增问题。 |
 | 2026-03-06 11:54:44 +0800 | codex | `doc/game-test.prd.md` | pass | - | redirect 角色边界与主入口指向清晰，未见多入口冲突。 |
 | 2026-03-06 11:55:15 +0800 | codex | `doc/game-test.project.md` | issue_open | I4-021 | Project 文档未维护 PRD-ID 映射与验收命令字段，redirect 任务可追溯性不足。 |
-| 2026-03-06 11:55:44 +0800 | codex | `doc/playability_test_manual.md` | pass | - | redirect 声明与主入口指向明确，未发现新增冲突。 |
+| 2026-03-06 11:55:44 +0800 | codex | `doc/playability_test_result/playability_test_manual.md` | pass | - | redirect 声明与主入口指向明确，未发现新增冲突。 |
 | 2026-03-06 11:56:15 +0800 | codex | `doc/playability_test_card.md` | pass | - | redirect 声明与主入口指向明确，未发现新增冲突。 |
 | 2026-03-06 11:56:43 +0800 | codex | `doc/headless-runtime/nonviewer/nonviewer-onchain-auth-protocol-hardening.prd.md` | issue_open | I4-014 | Traceability 表沿用 `PRD-ENGINEERING-006 + 文档内既有任务条目`，未建立本专题 PRD-ID 与任务/命令/证据链。 |
 | 2026-03-06 11:57:17 +0800 | codex | `doc/headless-runtime/nonviewer/nonviewer-onchain-auth-protocol-hardening.project.md` | issue_open | I4-015 | “含 PRD-ID 映射”仅迁移任务带 PRD-ID，T0~T3 未显式映射需求与验收命令。 |

--- a/doc/core/reviews/round-004-reviewed-files.md
+++ b/doc/core/reviews/round-004-reviewed-files.md
@@ -242,7 +242,6 @@
 - `doc/p2p/viewer-live/oasis7-viewer-live-release-locked-launch-2026-02-23.prd.md`
 - `doc/p2p/viewer-live/oasis7-viewer-live-release-locked-launch-2026-02-23.project.md`
 - `doc/playability_test_card.md`
-- `doc/playability_test_result/playability_test_manual.md`
 - `doc/playability_test_result/README.md`
 - `doc/playability_test_result/card_2026_02_28_19_22_20.md`
 - `doc/playability_test_result/card_2026_02_28_21_22_51.md`

--- a/doc/core/reviews/round-004-reviewed-files.md
+++ b/doc/core/reviews/round-004-reviewed-files.md
@@ -242,7 +242,7 @@
 - `doc/p2p/viewer-live/oasis7-viewer-live-release-locked-launch-2026-02-23.prd.md`
 - `doc/p2p/viewer-live/oasis7-viewer-live-release-locked-launch-2026-02-23.project.md`
 - `doc/playability_test_card.md`
-- `doc/playability_test_manual.md`
+- `doc/playability_test_result/playability_test_manual.md`
 - `doc/playability_test_result/README.md`
 - `doc/playability_test_result/card_2026_02_28_19_22_20.md`
 - `doc/playability_test_result/card_2026_02_28_21_22_51.md`

--- a/doc/engineering/project.md
+++ b/doc/engineering/project.md
@@ -335,6 +335,7 @@
 - [x] playability-template-execution-log-semantics (PRD-ENGINEERING-021/025) [test_tier_required]: 收口 `doc/playability_test_result` 当前项目交接与 closed beta / 高优问题闭环活模板中仍把新可玩性信号导向 `doc/devlog` 的旧语义，将 active evidence sink 改为对应 `.pm/tasks/task_<32hex>.execution.md`，保留模块 project/prd、发布证据包、QA triage、producer escalation 与 LiveOps 回流面。 Trace: .pm/tasks/task_eb93f5de123c49d1a3889855038b6987.yaml
 - [x] root-design-redirect-shell-deletion (PRD-ENGINEERING-021/025) [test_tier_required]: 删除 world-runtime / world-simulator 根级 legacy design redirect 壳，将仅存索引引用收敛到模块内 canonical design 文档，并同步收紧 root markdown allowlist。 Trace: .pm/tasks/task_a99b0850527b4c1e935e3276a5338b57.yaml
 - [x] game-test-root-design-redirect-deletion (PRD-ENGINEERING-021/025) [test_tier_required]: 删除 game-test 根级 legacy design redirect 壳，将 root project 兼容壳与 review 索引引用收敛到 `playability_test_result` canonical 专题 design，并同步收紧 root markdown allowlist。 Trace: .pm/tasks/task_c1ac55b06cd7455b9c92b914aa131026.yaml
+- [x] playability-manual-root-redirect-deletion (PRD-ENGINEERING-021/025) [test_tier_required]: 删除 playability test manual 根级 legacy redirect 壳，将旧 root 路径 review 索引/日志引用收敛到 `playability_test_result` canonical manual，并同步收紧 root markdown allowlist。 Trace: .pm/tasks/task_21152e953bd14e4195a3f2ec3519a33b.yaml
 
 ## File Structure / Affected Paths
 
@@ -402,7 +403,7 @@
 - 更新日期: 2026-06-27
 - 当前状态: active
 - 下一任务: 当前 `scripts/doc-inventory-report.sh` 复算显示 near-limit active docs 为 none；后续 repository health 巡检应按 module density / hotspot `action_required` 结果做 bounded 分类判断，先分级再切 focused follow-up，避免回到已收口的 `doc/world-simulator/project.md` / `doc/readme/project.md` 队列。
-- 最新完成: `game-test-root-design-redirect-deletion`（已删除 game-test 根级 legacy design redirect 壳，将 root project 兼容壳与 review 索引引用收敛到 `playability_test_result` canonical 专题 design，并同步收紧 root markdown allowlist。）
+- 最新完成: `playability-manual-root-redirect-deletion`（已删除 playability test manual 根级 legacy redirect 壳，将旧 root 路径 review 索引/日志引用收敛到 `playability_test_result` canonical manual，并同步收紧 root markdown allowlist。）
 - PRD 质量门状态: strict schema 已对齐（含第 6 章验证与决策记录）。
 - 当前治理重点: P0/P1 技术债首轮优化正在收口，重点是 public_testnet readiness blocker 显式化、hosted access verdict 去半实现口径，以及 Viewer 前端状态模块化。
 - 当前库存判断: 文档债的主矛盾仍是“入口减重之后的存量维护成本”，不是继续扩更多 landing pages。复算入口仍以 `scripts/doc-inventory-report.sh` 为准。

--- a/doc/playability_test_manual.md
+++ b/doc/playability_test_manual.md
@@ -1,6 +1,0 @@
-# Legacy Redirect: playability_test_manual
-
-本文件自 2026-03-03 起仅保留兼容跳转，不再作为活跃入口。
-
-- 当前主入口：`doc/playability_test_result/playability_test_manual.md`
-- 相关入口：`doc/playability_test_result/project.md`


### PR DESCRIPTION
## Summary
- Delete the root-level legacy redirect shell for the playability test manual.
- Repoint stale root-path review/index references to the canonical playability test result manual.
- Remove the obsolete root manual shell from the root markdown allowlist and update engineering task truth.

## Verification
- `rg -n -F "doc/playability_test_manual.md" doc scripts .agents README.md` returned no matches.
- `test ! -e doc/playability_test_manual.md`
- `test -e doc/playability_test_result/playability_test_manual.md`
- `./scripts/doc-governance-check.sh`
- `./scripts/pm/workflow-lint.sh --task-uid task_21152e953bd14e4195a3f2ec3519a33b --phase current`
- `git diff --check`

## Reviews
- repository_health_engineer: no findings
- producer_system_designer: no findings
- qa_engineer: no findings

## Notes
- `./scripts/pm/task-closeout.sh` marked the task verification as passed, then failed on unrelated historical repo-wide `.pm` lint debt in older task logs. This task's scoped gates passed.
