### PR TITLE
Delete root playability card redirect

### DIFF
--- a/.pm/roles/tpm/backlog/committed.yaml
+++ b/.pm/roles/tpm/backlog/committed.yaml
@@ -99,14 +99,3 @@ tasks:
     handoff_to: []
     status: committed
     task_path: .pm/tasks/task_b442769f7ef74d01894f4b8405c21301.yaml
-  - task_uid: task_89ecb9cc79d44cab9cef5e8ae01bd48a
-    title: "Converge and delete next stale legacy document surface"
-    module: engineering
-    priority: P2
-    source_signal: null
-    related_prd: []
-    acceptance:
-      - "Find one additional current old-document/old-semantics drift point with emphasis on removable stale legacy documentation, remediate the live documentation surface, delete obsolete legacy document(s) only when current references are safely repointed or obsolete, avoid broad historical rewrites, verify doc governance, and close through PR."
-    handoff_to: []
-    status: committed
-    task_path: .pm/tasks/task_89ecb9cc79d44cab9cef5e8ae01bd48a.yaml

--- a/.pm/roles/tpm/backlog/committed.yaml
+++ b/.pm/roles/tpm/backlog/committed.yaml
@@ -99,3 +99,14 @@ tasks:
     handoff_to: []
     status: committed
     task_path: .pm/tasks/task_b442769f7ef74d01894f4b8405c21301.yaml
+  - task_uid: task_89ecb9cc79d44cab9cef5e8ae01bd48a
+    title: "Converge and delete next stale legacy document surface"
+    module: engineering
+    priority: P2
+    source_signal: null
+    related_prd: []
+    acceptance:
+      - "Find one additional current old-document/old-semantics drift point with emphasis on removable stale legacy documentation, remediate the live documentation surface, delete obsolete legacy document(s) only when current references are safely repointed or obsolete, avoid broad historical rewrites, verify doc governance, and close through PR."
+    handoff_to: []
+    status: committed
+    task_path: .pm/tasks/task_89ecb9cc79d44cab9cef5e8ae01bd48a.yaml

--- a/.pm/tasks/task_89ecb9cc79d44cab9cef5e8ae01bd48a.execution.md
+++ b/.pm/tasks/task_89ecb9cc79d44cab9cef5e8ae01bd48a.execution.md
@@ -61,3 +61,50 @@ Example:
 - Expected Result: no exact deleted root path remains in current scoped docs; no actionable bare stale root filename remains; deleted root shell absent; canonical card present; governance and workflow checks pass.
 - Actual Result: PASS. Exact deleted root path search returned no matches; bare filename scan showed canonical-path references plus a historical count-only entry, with no actionable old root path; `test ! -e doc/playability_test_card.md` passed by absence; `test -e doc/playability_test_result/playability_test_card.md` passed; `git diff --check` passed; `doc-governance-check: OK`; `workflow-lint: OK`.
 - Blocker / Next Action: Commit implementation, generate review package, then dispatch pre-PR local role review.
+
+## 2026-06-27 13:18:00 CST / tpm
+- 完成内容: Created implementation commit and prepared local review package for pre-PR role review.
+- Review Scope: commit `618d9a3b6` against `origin/main`; changed paths include `.pm` task truth, `doc/.governance/doc-root-md-allowlist.txt`, `doc/README.md`, `doc/core/reviews/round-003-reviewed-files.md`, `doc/core/reviews/round-004-audit-progress-log.md`, `doc/core/reviews/round-004-reviewed-files.md`, `doc/engineering/project.md`, and deleted `doc/playability_test_card.md`.
+- Review Package: `.pm/scratch/task_89ecb9cc79d44cab9cef5e8ae01bd48a/review-packages/review-origin-main..618d9a3b6.diff`.
+- Role Selection Basis: `repository_health_engineer` for doc-governance deletion/reachability; `qa_engineer` for verification coverage of deleted/canonical paths and governance gates; `producer_system_designer` for playability evidence semantics and reader journey impact.
+- Planned Review Roles:
+  - `repository_health_engineer`
+  - `qa_engineer`
+  - `producer_system_designer`
+- Action: Dispatch bounded local review slices against the review package.
+- Validation Command: `git diff --binary origin/main..HEAD --output=.pm/scratch/task_89ecb9cc79d44cab9cef5e8ae01bd48a/review-packages/review-origin-main..618d9a3b6.diff`.
+- Expected Result: Review package exists and covers all changed paths.
+- Actual Result: PASS.
+- Blocker / Next Action: Wait for role review verdicts, address findings, then record pre-PR local role review packet.
+
+## 2026-06-27 13:28:00 CST / tpm
+- 完成内容: Integrated pre-PR local role review verdicts.
+- Review Evidence: `producer_system_designer` subagent `019f077a-915d-7670-aad0-0d60de19565d` returned `no_findings`, confirming canonical `doc/playability_test_result/playability_test_card.md` was not modified and playability evidence/card semantics and reader journey remain intact. `repository_health_engineer` subagent `019f077a-469f-7931-8ff9-100143ef97e2` returned `no_findings`, confirming doc governance, workflow lint, and diff hygiene are passing. `qa_engineer` subagent `019f077a-6b84-7200-98db-fce71d3a8f18` returned `no_findings`, confirming deleted path, canonical path, exact stale references, bare filename risk, doc-governance, workflow-lint, and diff-check coverage have no blockers.
+- Review Findings Disposition: no_findings.
+- Residual Risk: low. External bookmarks to the deleted root shell no longer receive an in-repo redirect, but current repo reader journeys and scripts converge on canonical `doc/playability_test_result/playability_test_card.md`.
+- Blocker / Next Action: Record formal `Pre-PR Local Role Review: passed` packet and run fresh ready-for-PR verification.
+
+## 2026-06-27 13:30:00 CST / tpm
+Pre-PR Local Role Review: passed
+- Task UID: task_89ecb9cc79d44cab9cef5e8ae01bd48a
+- Source Worktree: `/Users/scc/ccwork/worktrees/oasis7-engineering-legacy-doc-semantics-deletion-next-11`
+- Source Branch: `task/engineering-legacy-doc-semantics-deletion-next-11`
+- Source Head: `618d9a3b6`
+- Comparison Ref: refs/remotes/origin/main
+- Reviewed Changed Paths: `.pm/roles/tpm/backlog/committed.yaml`; `.pm/tasks/task_89ecb9cc79d44cab9cef5e8ae01bd48a.yaml`; `.pm/tasks/task_89ecb9cc79d44cab9cef5e8ae01bd48a.execution.md`; `doc/.governance/doc-root-md-allowlist.txt`; `doc/README.md`; `doc/core/reviews/round-003-reviewed-files.md`; `doc/core/reviews/round-004-audit-progress-log.md`; `doc/core/reviews/round-004-reviewed-files.md`; `doc/engineering/project.md`; deleted `doc/playability_test_card.md`.
+- Review Package: `.pm/scratch/task_89ecb9cc79d44cab9cef5e8ae01bd48a/review-packages/review-origin-main..618d9a3b6.diff`
+- Slice Ledger: n/a; formal review evidence and subagent IDs are recorded in this execution log.
+- Role Selection Basis: `repository_health_engineer` for doc-governance deletion/reachability; `qa_engineer` for verification coverage of deleted/canonical paths and governance gates; `producer_system_designer` for playability evidence/card semantics and reader journey impact.
+- Review Roles: `repository_health_engineer`; `qa_engineer`; `producer_system_designer`.
+- Review Evidence: repository health, QA, and producer/system review all returned `no_findings`.
+- Review Verdicts: `repository_health_engineer`: no_findings; `qa_engineer`: no_findings; `producer_system_designer`: no_findings.
+- Review Findings Disposition: no_findings
+- Finding Disposition Evidence: no review findings required remediation; focused stale-path checks and governance gates already passed before review.
+- Verification Matrix: exact deleted root path -> no matches in `doc README.md scripts .agents`; bare stale filename risk -> only canonical paths or historical count-only context; deleted shell file -> `test ! -e doc/playability_test_card.md` passed; canonical card -> `test -e doc/playability_test_result/playability_test_card.md` passed; doc governance -> `./scripts/doc-governance-check.sh` OK; workflow current phase -> `./scripts/pm/workflow-lint.sh --task-uid task_89ecb9cc79d44cab9cef5e8ae01bd48a --phase current` OK; diff hygiene -> `git diff --check` OK.
+- Visual/WASM/Ops/LiveOps Evidence: not applicable; this is doc-governance deletion of a root playability card redirect shell with no visual UI, WASM runtime, blockchain ops, or external community messaging surface changes.
+- Gameplay/Playability Evidence Semantics: producer/system review confirmed canonical playability card body and evidence semantics were unchanged; deletion only removes the obsolete root redirect shell.
+- Action: Run fresh verification plus ready-for-PR claim.
+- Validation Command: pending fresh `rg`, deleted/canonical file checks, `git diff --check`, `./scripts/doc-governance-check.sh`, `./scripts/pm/workflow-lint.sh --task-uid task_89ecb9cc79d44cab9cef5e8ae01bd48a --phase current`, and `./scripts/pm/claim-ready.sh --claim-type ready_for_pr --verify-command "./scripts/doc-governance-check.sh"`.
+- Expected Result: all checks pass and ready-for-PR claim records evidence.
+- Actual Result: PASS. Exact deleted root path search returned no matches; bare filename scan returned only canonical-path references and a historical count-only row; deleted root shell absent; canonical card present; `git diff --check` passed; `doc-governance-check: OK`; `workflow-lint: OK`; `claim-ready` status `verified`, allowed_to_claim `true`.
+- Blocker / Next Action: Commit review/verification evidence, run task closeout, then create PR.

--- a/.pm/tasks/task_89ecb9cc79d44cab9cef5e8ae01bd48a.execution.md
+++ b/.pm/tasks/task_89ecb9cc79d44cab9cef5e8ae01bd48a.execution.md
@@ -85,7 +85,7 @@ Example:
 - Blocker / Next Action: Record formal `Pre-PR Local Role Review: passed` packet and run fresh ready-for-PR verification.
 
 ## 2026-06-27 13:30:00 CST / tpm
-Pre-PR Local Role Review: passed
+- Pre-PR Local Role Review: passed
 - Task UID: task_89ecb9cc79d44cab9cef5e8ae01bd48a
 - Source Worktree: `/Users/scc/ccwork/worktrees/oasis7-engineering-legacy-doc-semantics-deletion-next-11`
 - Source Branch: `task/engineering-legacy-doc-semantics-deletion-next-11`
@@ -101,7 +101,10 @@ Pre-PR Local Role Review: passed
 - Review Findings Disposition: no_findings
 - Finding Disposition Evidence: no review findings required remediation; focused stale-path checks and governance gates already passed before review.
 - Verification Matrix: exact deleted root path -> no matches in `doc README.md scripts .agents`; bare stale filename risk -> only canonical paths or historical count-only context; deleted shell file -> `test ! -e doc/playability_test_card.md` passed; canonical card -> `test -e doc/playability_test_result/playability_test_card.md` passed; doc governance -> `./scripts/doc-governance-check.sh` OK; workflow current phase -> `./scripts/pm/workflow-lint.sh --task-uid task_89ecb9cc79d44cab9cef5e8ae01bd48a --phase current` OK; diff hygiene -> `git diff --check` OK.
-- Visual/WASM/Ops/LiveOps Evidence: not applicable; this is doc-governance deletion of a root playability card redirect shell with no visual UI, WASM runtime, blockchain ops, or external community messaging surface changes.
+- Visual Evidence: not applicable; this is doc-governance deletion of a root playability card redirect shell with no visual UI surface changes.
+- WASM Evidence: not applicable; no WASM runtime files or behavior changed.
+- Ops Evidence: not applicable; no blockchain ops or deployment files changed.
+- LiveOps Evidence: not applicable; no external community messaging or channel runbook changed.
 - Gameplay/Playability Evidence Semantics: producer/system review confirmed canonical playability card body and evidence semantics were unchanged; deletion only removes the obsolete root redirect shell.
 - Action: Run fresh verification plus ready-for-PR claim.
 - Validation Command: pending fresh `rg`, deleted/canonical file checks, `git diff --check`, `./scripts/doc-governance-check.sh`, `./scripts/pm/workflow-lint.sh --task-uid task_89ecb9cc79d44cab9cef5e8ae01bd48a --phase current`, and `./scripts/pm/claim-ready.sh --claim-type ready_for_pr --verify-command "./scripts/doc-governance-check.sh"`.
@@ -120,7 +123,7 @@ Pre-PR Local Role Review: passed
 - Blocker / Next Action: Commit closeout metadata and create PR.
 
 ## 2026-06-27 13:42:00 CST / tpm
-Pre-PR Local Role Review: passed
+- Pre-PR Local Role Review: passed
 - Task UID: task_89ecb9cc79d44cab9cef5e8ae01bd48a
 - Source Worktree: `/Users/scc/ccwork/worktrees/oasis7-engineering-legacy-doc-semantics-deletion-next-11`
 - Source Branch: `task/engineering-legacy-doc-semantics-deletion-next-11`
@@ -136,7 +139,10 @@ Pre-PR Local Role Review: passed
 - Review Findings Disposition: no_findings
 - Finding Disposition Evidence: no review findings required remediation; final task-scoped gates passed at closeout.
 - Verification Matrix: exact deleted root path -> no matches in `doc README.md scripts .agents`; bare stale filename risk -> only canonical paths or historical count-only context; deleted shell file -> `test ! -e doc/playability_test_card.md` passed; canonical card -> `test -e doc/playability_test_result/playability_test_card.md` passed; doc governance -> `./scripts/doc-governance-check.sh` OK; workflow current phase -> `./scripts/pm/workflow-lint.sh --task-uid task_89ecb9cc79d44cab9cef5e8ae01bd48a --phase current` OK; diff hygiene -> `git diff --check` OK.
-- Visual/WASM/Ops/LiveOps Evidence: not applicable; this is doc-governance deletion of a root playability card redirect shell with no visual UI, WASM runtime, blockchain ops, or external community messaging surface changes.
+- Visual Evidence: not applicable; this is doc-governance deletion of a root playability card redirect shell with no visual UI surface changes.
+- WASM Evidence: not applicable; no WASM runtime files or behavior changed.
+- Ops Evidence: not applicable; no blockchain ops or deployment files changed.
+- LiveOps Evidence: not applicable; no external community messaging or channel runbook changed.
 - Gameplay/Playability Evidence Semantics: producer/system review confirmed canonical playability card body and evidence semantics were unchanged; deletion only removes the obsolete root redirect shell.
 - Action: Retry `prepare-task-pr.sh --create`.
 - Validation Command: `./scripts/prepare-task-pr.sh --create --base main --title "Delete root playability card redirect"`.

--- a/.pm/tasks/task_89ecb9cc79d44cab9cef5e8ae01bd48a.execution.md
+++ b/.pm/tasks/task_89ecb9cc79d44cab9cef5e8ae01bd48a.execution.md
@@ -1,0 +1,63 @@
+# task_89ecb9cc79d44cab9cef5e8ae01bd48a Execution Log
+
+- task_uid: task_89ecb9cc79d44cab9cef5e8ae01bd48a
+- title: Converge and delete next stale legacy document surface
+- owner_role: tpm
+- worktree_hint: /Users/scc/ccwork/worktrees/oasis7-engineering-legacy-doc-semantics-deletion-next-11
+
+<!-- Append entries using:
+Example:
+  ## YYYY-MM-DD HH:MM:SS CST / role_name
+  - 完成内容: ...
+  - 遗留事项: ...
+  - Action: ...
+  - Validation Command: ...
+  - Expected Result: ...
+  - Actual Result: ...
+  - Blocker / Next Action: ...
+-->
+
+## 2026-06-27 12:20:00 CST / tpm
+- 完成内容: Bootstrapped the next legacy-document semantics/deletion governance task and routed it to bounded repository-health discovery before remediation edits.
+- 遗留事项: Dispatch repository_health_engineer discovery, integrate one actionable current/live finding with a deletion candidate, then remediate and verify.
+- Repository State Impact: changes repository state if discovery identifies a stale legacy document that can be safely deleted after current references are repointed or proven obsolete.
+- Isolation Decision: created dedicated task worktree `/Users/scc/ccwork/worktrees/oasis7-engineering-legacy-doc-semantics-deletion-next-11` on branch `task/engineering-legacy-doc-semantics-deletion-next-11`; main worktree remains untouched for edits.
+- Task Truth: owner role `tpm`; `.pm` task `task_89ecb9cc79d44cab9cef5e8ae01bd48a`; acceptance is to find one additional current old-document/old-semantics drift point with emphasis on removable stale legacy documentation, remediate live docs, delete obsolete legacy document(s) only when current references are safely repointed or obsolete, avoid broad historical rewrites, verify doc governance, and close through PR.
+- Route Decision: selected repo-owned workflow path `default-workflow-bootstrap -> repo-owned-workflow-router -> executing-project-tasks -> verification-before-completion -> requesting-repo-owned-review -> finishing-a-development-branch`.
+- Skipped Workflow Skills: `bounded-brainstorming` skipped because the task asks for one concrete governance/deletion point; `tdd-test-writer` skipped because this is doc/governance structure work with doc-governance verification rather than behavior tests.
+- Subagent Slice Plan:
+  - role: repository_health_engineer
+  - slice type: read_only_analysis / governance deletion discovery
+  - intended model configuration: workflow default subagent runtime
+  - actual dispatched model/reasoning: inherited/unverified due subagent tool model-reporting limitation
+  - context delivery mode: full-thread/full-history fork preferred; explicit task context included as delivery supplement
+  - mandatory context checklist/packet: identity and authority = repository_health_engineer role card with tpm integration owner; workflow governance = AGENTS.md and `doc/engineering/workflow/source-of-truth.md`; task truth = current task YAML/execution log, branch, worktree, base `origin/main`; user intent = find next live-doc old-semantics convergence point with deletable stale legacy document emphasis; scoped repo context = prior completed slices converged root redirects plus playability and Viewer manual legacy redirect shells; current live-doc cleanup boundaries; doc-governance path reachability behavior; collaboration boundary = no file edits by discovery slice, return one actionable finding and role-review needs.
+  - write scope: none for discovery slice
+  - return contract: conclusion; severity/category; evidence paths; why current/live or why safely obsolete; deletion/remediation scope; references to repoint/delete; verification commands; residual risk; additional role-review needs
+  - formal sink / writeback surface: `.pm/tasks/task_89ecb9cc79d44cab9cef5e8ae01bd48a.execution.md`
+  - integration owner/order: tpm records finding, applies minimal patch/delete if accepted, runs verification, dispatches pre-PR local role review.
+- Action: Create task/worktree and record workflow route plus repository_health_engineer discovery slice contract.
+- Validation Command: `./scripts/new-task-worktree.sh engineering legacy-doc-semantics-deletion-next-11 --pm-owner-role tpm --pm-title "Converge and delete next stale legacy document surface" --pm-priority P2 --pm-source-ref doc/engineering/project.md --pm-doc-ref doc/engineering/project.md --pm-acceptance "..."`
+- Expected Result: Standard task worktree, branch, and `.pm` task are created.
+- Actual Result: Created `task_89ecb9cc79d44cab9cef5e8ae01bd48a` on `task/engineering-legacy-doc-semantics-deletion-next-11` at `/Users/scc/ccwork/worktrees/oasis7-engineering-legacy-doc-semantics-deletion-next-11`.
+- Blocker / Next Action: Dispatch repository_health_engineer deletion discovery slice.
+
+## 2026-06-27 13:06:00 CST / repository_health_engineer
+- 完成内容: Completed read-only deletion discovery slice for the next legacy-document governance point.
+- Finding: P2 doc-governance debt. Root `doc/playability_test_card.md` is only a 2026-03-03 legacy redirect shell to `doc/playability_test_result/playability_test_card.md`; canonical card content, module README/project, and live scripts already use the canonical module path.
+- Evidence: `doc/playability_test_card.md` contains only redirect metadata; `doc/playability_test_result/playability_test_card.md` is the real card template; `doc/.governance/doc-root-md-allowlist.txt` still allowed the root shell; `doc/README.md` still listed the root shell as a high-frequency compatibility example; exact root-path references were limited to `doc/README.md`, `doc/core/reviews/round-003-reviewed-files.md`, `doc/core/reviews/round-004-reviewed-files.md`, and `doc/core/reviews/round-004-audit-progress-log.md`; `scripts/prepare-playability-l4-review.sh` already uses canonical `doc/playability_test_result/playability_test_card.md`.
+- Recommended Scope: delete `doc/playability_test_card.md`; remove it from root markdown allowlist; update `doc/README.md` to avoid presenting the deleted root shell as a live compatibility entry; convert historical review exact-path entries to non-path historical descriptions only where required by missing-path governance; avoid broad historical rewrites.
+- Residual Risk: low; external bookmarks to the root shell lose the in-repo redirect, but live repo reader journeys and scripts converge on the canonical card.
+- Additional Role Review Needs: repository_health_engineer and qa_engineer required; producer_system_designer recommended because playability-card semantics are user-facing evidence semantics even though canonical template body is unchanged.
+- Subagent Evidence: `repository_health_engineer` subagent `019f0774-20fb-7261-a417-283c99160fbb`.
+- Blocker / Next Action: TPM integrate minimal deletion patch and run doc governance verification.
+
+## 2026-06-27 13:12:00 CST / tpm
+- 完成内容: Integrated the repository-health finding by deleting the root playability card redirect shell and converging live/current references.
+- Scope Applied: deleted `doc/playability_test_card.md`; removed it from `doc/.governance/doc-root-md-allowlist.txt`; changed `doc/README.md` to point only at canonical `doc/playability_test_result/playability_test_card.md`; converted the three historical review exact-path references to non-path historical descriptions; added the completed governance trace to `doc/engineering/project.md`.
+- Boundary: did not change canonical `doc/playability_test_result/playability_test_card.md`; did not rewrite broad historical task/project evidence beyond exact deleted-path cleanup required for doc-governance reachability.
+- Action: Run focused stale-path checks, deleted/canonical file checks, diff hygiene, doc governance, and workflow lint.
+- Validation Command: `rg -n -F "doc/playability_test_card.md" doc README.md scripts .agents`; `rg -n "playability_test_card\\.md" doc README.md scripts .agents`; `test ! -e doc/playability_test_card.md`; `test -e doc/playability_test_result/playability_test_card.md`; `git diff --check`; `./scripts/doc-governance-check.sh`; `./scripts/pm/workflow-lint.sh --task-uid task_89ecb9cc79d44cab9cef5e8ae01bd48a --phase current`.
+- Expected Result: no exact deleted root path remains in current scoped docs; no actionable bare stale root filename remains; deleted root shell absent; canonical card present; governance and workflow checks pass.
+- Actual Result: PASS. Exact deleted root path search returned no matches; bare filename scan showed canonical-path references plus a historical count-only entry, with no actionable old root path; `test ! -e doc/playability_test_card.md` passed by absence; `test -e doc/playability_test_result/playability_test_card.md` passed; `git diff --check` passed; `doc-governance-check: OK`; `workflow-lint: OK`.
+- Blocker / Next Action: Commit implementation, generate review package, then dispatch pre-PR local role review.

--- a/.pm/tasks/task_89ecb9cc79d44cab9cef5e8ae01bd48a.execution.md
+++ b/.pm/tasks/task_89ecb9cc79d44cab9cef5e8ae01bd48a.execution.md
@@ -118,3 +118,28 @@ Pre-PR Local Role Review: passed
 - Actual Result: `task-closeout.sh` exited 1 after closeout because repo-wide `.pm lint` reported unrelated historical execution-log formatting failures such as `task_04d61dc5778e4b1683a61056daf454e3` and `task_060e9de147ba4757ac29cf0fb7a15210`; current task YAML now shows `status: done`, `last_claim_type: task_complete`, `last_verify_command: ./scripts/doc-governance-check.sh`, `last_verification_status: verified`, and `last_closed_at: 2026-06-27T13:13:58+08:00`.
 - Task-Scoped Gate Rerun: PASS. `doc-governance-check: OK`; `workflow-lint: OK`; `git diff --check` passed.
 - Blocker / Next Action: Commit closeout metadata and create PR.
+
+## 2026-06-27 13:42:00 CST / tpm
+Pre-PR Local Role Review: passed
+- Task UID: task_89ecb9cc79d44cab9cef5e8ae01bd48a
+- Source Worktree: `/Users/scc/ccwork/worktrees/oasis7-engineering-legacy-doc-semantics-deletion-next-11`
+- Source Branch: `task/engineering-legacy-doc-semantics-deletion-next-11`
+- Source Head: `f8c777f0c9617bc84cc39f3895a3850e4b3c89b7`
+- Comparison Ref: refs/remotes/origin/main
+- Reviewed Changed Paths: `.pm/roles/tpm/backlog/committed.yaml`; `.pm/tasks/task_89ecb9cc79d44cab9cef5e8ae01bd48a.yaml`; `.pm/tasks/task_89ecb9cc79d44cab9cef5e8ae01bd48a.execution.md`; `doc/.governance/doc-root-md-allowlist.txt`; `doc/README.md`; `doc/core/reviews/round-003-reviewed-files.md`; `doc/core/reviews/round-004-audit-progress-log.md`; `doc/core/reviews/round-004-reviewed-files.md`; `doc/engineering/project.md`; deleted `doc/playability_test_card.md`.
+- Review Package: `.pm/scratch/task_89ecb9cc79d44cab9cef5e8ae01bd48a/review-packages/review-origin-main..618d9a3b6.diff`
+- Slice Ledger: n/a; formal review evidence and subagent IDs are recorded in this execution log.
+- Role Selection Basis: final head only adds review evidence and closeout metadata after the reviewed implementation; no product/doc-governance implementation surface changed after review. `repository_health_engineer`, `qa_engineer`, and `producer_system_designer` remain the required/relevant roles.
+- Review Roles: `repository_health_engineer`; `qa_engineer`; `producer_system_designer`.
+- Review Evidence: repository health, QA, and producer/system review all returned `no_findings` for the implementation scope; subsequent commits only recorded review evidence and closeout metadata.
+- Review Verdicts: `repository_health_engineer`: no_findings; `qa_engineer`: no_findings; `producer_system_designer`: no_findings.
+- Review Findings Disposition: no_findings
+- Finding Disposition Evidence: no review findings required remediation; final task-scoped gates passed at closeout.
+- Verification Matrix: exact deleted root path -> no matches in `doc README.md scripts .agents`; bare stale filename risk -> only canonical paths or historical count-only context; deleted shell file -> `test ! -e doc/playability_test_card.md` passed; canonical card -> `test -e doc/playability_test_result/playability_test_card.md` passed; doc governance -> `./scripts/doc-governance-check.sh` OK; workflow current phase -> `./scripts/pm/workflow-lint.sh --task-uid task_89ecb9cc79d44cab9cef5e8ae01bd48a --phase current` OK; diff hygiene -> `git diff --check` OK.
+- Visual/WASM/Ops/LiveOps Evidence: not applicable; this is doc-governance deletion of a root playability card redirect shell with no visual UI, WASM runtime, blockchain ops, or external community messaging surface changes.
+- Gameplay/Playability Evidence Semantics: producer/system review confirmed canonical playability card body and evidence semantics were unchanged; deletion only removes the obsolete root redirect shell.
+- Action: Retry `prepare-task-pr.sh --create`.
+- Validation Command: `./scripts/prepare-task-pr.sh --create --base main --title "Delete root playability card redirect"`.
+- Expected Result: PR helper accepts the current-head pre-PR review packet.
+- Actual Result: pending.
+- Blocker / Next Action: Commit this current-head packet and retry PR helper.

--- a/.pm/tasks/task_89ecb9cc79d44cab9cef5e8ae01bd48a.execution.md
+++ b/.pm/tasks/task_89ecb9cc79d44cab9cef5e8ae01bd48a.execution.md
@@ -127,13 +127,13 @@ Example:
 - Task UID: task_89ecb9cc79d44cab9cef5e8ae01bd48a
 - Source Worktree: /Users/scc/ccwork/worktrees/oasis7-engineering-legacy-doc-semantics-deletion-next-11
 - Source Branch: task/engineering-legacy-doc-semantics-deletion-next-11
-- Source Head: 197c6531cac71e903190e0d84ad993301c964369
+- Source Head: 4343c5be1acc874f03205da8f0491387f7fad938
 - Comparison Ref: refs/remotes/origin/main
 - Reviewed Changed Paths: `.pm/roles/tpm/backlog/committed.yaml`; `.pm/tasks/task_89ecb9cc79d44cab9cef5e8ae01bd48a.yaml`; `.pm/tasks/task_89ecb9cc79d44cab9cef5e8ae01bd48a.execution.md`; `doc/.governance/doc-root-md-allowlist.txt`; `doc/README.md`; `doc/core/reviews/round-003-reviewed-files.md`; `doc/core/reviews/round-004-audit-progress-log.md`; `doc/core/reviews/round-004-reviewed-files.md`; `doc/engineering/project.md`; deleted `doc/playability_test_card.md`.
 - Review Package: `.pm/scratch/task_89ecb9cc79d44cab9cef5e8ae01bd48a/review-packages/review-origin-main..618d9a3b6.diff`
 - Slice Ledger: n/a; formal review evidence and subagent IDs are recorded in this execution log.
 - Role Selection Basis: final head only adds review evidence and closeout metadata after the reviewed implementation; no product/doc-governance implementation surface changed after review. `repository_health_engineer`, `qa_engineer`, and `producer_system_designer` remain the required/relevant roles.
-- Review Roles: `repository_health_engineer`; `qa_engineer`; `producer_system_designer`.
+- Review Roles: repository_health_engineer,qa_engineer,producer_system_designer
 - Review Evidence: repository health, QA, and producer/system review all returned `no_findings` for the implementation scope; subsequent commits only recorded review evidence and closeout metadata.
 - Review Verdicts: `repository_health_engineer`: no_findings; `qa_engineer`: no_findings; `producer_system_designer`: no_findings.
 - Residual Risk: low; external bookmarks to the deleted root shell no longer receive an in-repo redirect, but current repo reader journeys and scripts converge on canonical `doc/playability_test_result/playability_test_card.md`.

--- a/.pm/tasks/task_89ecb9cc79d44cab9cef5e8ae01bd48a.execution.md
+++ b/.pm/tasks/task_89ecb9cc79d44cab9cef5e8ae01bd48a.execution.md
@@ -108,3 +108,13 @@ Pre-PR Local Role Review: passed
 - Expected Result: all checks pass and ready-for-PR claim records evidence.
 - Actual Result: PASS. Exact deleted root path search returned no matches; bare filename scan returned only canonical-path references and a historical count-only row; deleted root shell absent; canonical card present; `git diff --check` passed; `doc-governance-check: OK`; `workflow-lint: OK`; `claim-ready` status `verified`, allowed_to_claim `true`.
 - Blocker / Next Action: Commit review/verification evidence, run task closeout, then create PR.
+
+## 2026-06-27 13:36:00 CST / tpm
+- 完成内容: Ran task closeout; task-scoped closeout metadata was written and the task is marked `done`.
+- 遗留事项: Repo-wide historical `.pm lint` debt still causes `task-closeout.sh` to exit nonzero after the current task is closed; this is outside the current task scope and was not introduced by this branch.
+- Action: Record closeout boundary and rerun task-scoped gates before PR creation.
+- Validation Command: `./scripts/pm/task-closeout.sh --role tpm --task-uid task_89ecb9cc79d44cab9cef5e8ae01bd48a --verify-command "./scripts/doc-governance-check.sh"`; then rerun `./scripts/doc-governance-check.sh`, `./scripts/pm/workflow-lint.sh --task-uid task_89ecb9cc79d44cab9cef5e8ae01bd48a --phase current`, and `git diff --check`.
+- Expected Result: task YAML shows `status: done` with verified closeout metadata; task-scoped gates remain green; repo-wide historical lint debt is recorded as non-blocking boundary.
+- Actual Result: `task-closeout.sh` exited 1 after closeout because repo-wide `.pm lint` reported unrelated historical execution-log formatting failures such as `task_04d61dc5778e4b1683a61056daf454e3` and `task_060e9de147ba4757ac29cf0fb7a15210`; current task YAML now shows `status: done`, `last_claim_type: task_complete`, `last_verify_command: ./scripts/doc-governance-check.sh`, `last_verification_status: verified`, and `last_closed_at: 2026-06-27T13:13:58+08:00`.
+- Task-Scoped Gate Rerun: PASS. `doc-governance-check: OK`; `workflow-lint: OK`; `git diff --check` passed.
+- Blocker / Next Action: Commit closeout metadata and create PR.

--- a/.pm/tasks/task_89ecb9cc79d44cab9cef5e8ae01bd48a.execution.md
+++ b/.pm/tasks/task_89ecb9cc79d44cab9cef5e8ae01bd48a.execution.md
@@ -125,9 +125,9 @@ Example:
 ## 2026-06-27 13:42:00 CST / tpm
 - Pre-PR Local Role Review: passed
 - Task UID: task_89ecb9cc79d44cab9cef5e8ae01bd48a
-- Source Worktree: `/Users/scc/ccwork/worktrees/oasis7-engineering-legacy-doc-semantics-deletion-next-11`
-- Source Branch: `task/engineering-legacy-doc-semantics-deletion-next-11`
-- Source Head: `f8c777f0c9617bc84cc39f3895a3850e4b3c89b7`
+- Source Worktree: /Users/scc/ccwork/worktrees/oasis7-engineering-legacy-doc-semantics-deletion-next-11
+- Source Branch: task/engineering-legacy-doc-semantics-deletion-next-11
+- Source Head: 197c6531cac71e903190e0d84ad993301c964369
 - Comparison Ref: refs/remotes/origin/main
 - Reviewed Changed Paths: `.pm/roles/tpm/backlog/committed.yaml`; `.pm/tasks/task_89ecb9cc79d44cab9cef5e8ae01bd48a.yaml`; `.pm/tasks/task_89ecb9cc79d44cab9cef5e8ae01bd48a.execution.md`; `doc/.governance/doc-root-md-allowlist.txt`; `doc/README.md`; `doc/core/reviews/round-003-reviewed-files.md`; `doc/core/reviews/round-004-audit-progress-log.md`; `doc/core/reviews/round-004-reviewed-files.md`; `doc/engineering/project.md`; deleted `doc/playability_test_card.md`.
 - Review Package: `.pm/scratch/task_89ecb9cc79d44cab9cef5e8ae01bd48a/review-packages/review-origin-main..618d9a3b6.diff`
@@ -136,6 +136,7 @@ Example:
 - Review Roles: `repository_health_engineer`; `qa_engineer`; `producer_system_designer`.
 - Review Evidence: repository health, QA, and producer/system review all returned `no_findings` for the implementation scope; subsequent commits only recorded review evidence and closeout metadata.
 - Review Verdicts: `repository_health_engineer`: no_findings; `qa_engineer`: no_findings; `producer_system_designer`: no_findings.
+- Residual Risk: low; external bookmarks to the deleted root shell no longer receive an in-repo redirect, but current repo reader journeys and scripts converge on canonical `doc/playability_test_result/playability_test_card.md`.
 - Review Findings Disposition: no_findings
 - Finding Disposition Evidence: no review findings required remediation; final task-scoped gates passed at closeout.
 - Verification Matrix: exact deleted root path -> no matches in `doc README.md scripts .agents`; bare stale filename risk -> only canonical paths or historical count-only context; deleted shell file -> `test ! -e doc/playability_test_card.md` passed; canonical card -> `test -e doc/playability_test_result/playability_test_card.md` passed; doc governance -> `./scripts/doc-governance-check.sh` OK; workflow current phase -> `./scripts/pm/workflow-lint.sh --task-uid task_89ecb9cc79d44cab9cef5e8ae01bd48a --phase current` OK; diff hygiene -> `git diff --check` OK.

--- a/.pm/tasks/task_89ecb9cc79d44cab9cef5e8ae01bd48a.yaml
+++ b/.pm/tasks/task_89ecb9cc79d44cab9cef5e8ae01bd48a.yaml
@@ -4,7 +4,7 @@ owner_role: tpm
 module: engineering
 worktree_hint: /Users/scc/ccwork/worktrees/oasis7-engineering-legacy-doc-semantics-deletion-next-11
 execution_log_path: .pm/tasks/task_89ecb9cc79d44cab9cef5e8ae01bd48a.execution.md
-status: committed
+status: done
 priority: P2
 source_signal: null
 source_refs:
@@ -15,5 +15,11 @@ related_prd: []
 acceptance:
   - "Find one additional current old-document/old-semantics drift point with emphasis on removable stale legacy documentation, remediate the live documentation surface, delete obsolete legacy document(s) only when current references are safely repointed or obsolete, avoid broad historical rewrites, verify doc governance, and close through PR."
 handoff_to: []
-updated_at: 2026-06-27T12:59:27+08:00
+updated_at: 2026-06-27T13:13:58+08:00
 last_started_at: 2026-06-27T12:59:27+08:00
+last_claim_type: task_complete
+last_verify_command: ./scripts/doc-governance-check.sh
+last_verified_at: 2026-06-27T13:13:57+08:00
+last_verification_exit_code: 0
+last_verification_status: verified
+last_closed_at: 2026-06-27T13:13:58+08:00

--- a/.pm/tasks/task_89ecb9cc79d44cab9cef5e8ae01bd48a.yaml
+++ b/.pm/tasks/task_89ecb9cc79d44cab9cef5e8ae01bd48a.yaml
@@ -1,0 +1,19 @@
+task_uid: task_89ecb9cc79d44cab9cef5e8ae01bd48a
+title: "Converge and delete next stale legacy document surface"
+owner_role: tpm
+module: engineering
+worktree_hint: /Users/scc/ccwork/worktrees/oasis7-engineering-legacy-doc-semantics-deletion-next-11
+execution_log_path: .pm/tasks/task_89ecb9cc79d44cab9cef5e8ae01bd48a.execution.md
+status: committed
+priority: P2
+source_signal: null
+source_refs:
+  - doc/engineering/project.md
+doc_refs:
+  - doc/engineering/project.md
+related_prd: []
+acceptance:
+  - "Find one additional current old-document/old-semantics drift point with emphasis on removable stale legacy documentation, remediate the live documentation surface, delete obsolete legacy document(s) only when current references are safely repointed or obsolete, avoid broad historical rewrites, verify doc governance, and close through PR."
+handoff_to: []
+updated_at: 2026-06-27T12:59:27+08:00
+last_started_at: 2026-06-27T12:59:27+08:00

--- a/doc/.governance/doc-root-md-allowlist.txt
+++ b/doc/.governance/doc-root-md-allowlist.txt
@@ -1,7 +1,6 @@
 doc/README.md
 doc/game-test.prd.md
 doc/game-test.project.md
-doc/playability_test_card.md
 doc/viewer-manual.md
 doc/world-runtime.prd.md
 doc/world-runtime.project.md

--- a/doc/README.md
+++ b/doc/README.md
@@ -33,7 +33,7 @@
 - 高频兼容入口示例：
   - `doc/viewer-manual.md` -> `doc/world-simulator/viewer/viewer-manual.manual.md`
   - `doc/game-test.prd.md` -> `doc/playability_test_result/game-test.prd.md`
-  - `doc/playability_test_card.md` -> `doc/playability_test_result/playability_test_card.md`
+- 已删除的历史根入口示例：root playability card shell；当前只使用 `doc/playability_test_result/playability_test_card.md`。
 
 ## 模块入口矩阵
 | 模块 | PRD 主文档 | 设计主文档 | 项目管理文档 | 设计关注点 |

--- a/doc/core/reviews/round-003-reviewed-files.md
+++ b/doc/core/reviews/round-003-reviewed-files.md
@@ -225,7 +225,7 @@
 - `doc/p2p/viewer-live/oasis7-viewer-live-no-llm-flag-2026-02-23.project.md`
 - `doc/p2p/viewer-live/oasis7-viewer-live-release-locked-launch-2026-02-23.prd.md`
 - `doc/p2p/viewer-live/oasis7-viewer-live-release-locked-launch-2026-02-23.project.md`
-- `doc/playability_test_card.md`
+- historical deleted root playability card shell
 - `doc/playability_test_result/README.md`
 - `doc/playability_test_result/card_2026_02_28_19_22_20.md`
 - `doc/playability_test_result/card_2026_02_28_21_22_51.md`

--- a/doc/core/reviews/round-004-audit-progress-log.md
+++ b/doc/core/reviews/round-004-audit-progress-log.md
@@ -45,7 +45,7 @@
 | 2026-03-06 11:54:15 +0800 | codex | `doc/README.md` | pass | - | 总入口路径矩阵与 legacy redirect 说明完整，未发现 D4-001~D4-008 新增问题。 |
 | 2026-03-06 11:54:44 +0800 | codex | `doc/game-test.prd.md` | pass | - | redirect 角色边界与主入口指向清晰，未见多入口冲突。 |
 | 2026-03-06 11:55:15 +0800 | codex | `doc/game-test.project.md` | issue_open | I4-021 | Project 文档未维护 PRD-ID 映射与验收命令字段，redirect 任务可追溯性不足。 |
-| 2026-03-06 11:56:15 +0800 | codex | `doc/playability_test_card.md` | pass | - | redirect 声明与主入口指向明确，未发现新增冲突。 |
+| 2026-03-06 11:56:15 +0800 | codex | historical deleted root playability card shell | pass | - | 当时 redirect 声明与主入口指向明确；该历史根入口后续已删除。 |
 | 2026-03-06 11:56:43 +0800 | codex | `doc/headless-runtime/nonviewer/nonviewer-onchain-auth-protocol-hardening.prd.md` | issue_open | I4-014 | Traceability 表沿用 `PRD-ENGINEERING-006 + 文档内既有任务条目`，未建立本专题 PRD-ID 与任务/命令/证据链。 |
 | 2026-03-06 11:57:17 +0800 | codex | `doc/headless-runtime/nonviewer/nonviewer-onchain-auth-protocol-hardening.project.md` | issue_open | I4-015 | “含 PRD-ID 映射”仅迁移任务带 PRD-ID，T0~T3 未显式映射需求与验收命令。 |
 | 2026-03-06 11:48:11 +0800 | codex | `doc/site/github-pages/github-pages-release-download-pipeline-2026-03-01.project.md` | issue_open | I4-003,I4-006 | 同文并存 `审计轮次: 4` 与 `- 审计轮次: 2`；状态仍写“进行中/等待回归”且最近更新停在 2026-03-01，时效状态失真。 |

--- a/doc/core/reviews/round-004-reviewed-files.md
+++ b/doc/core/reviews/round-004-reviewed-files.md
@@ -241,7 +241,7 @@
 - `doc/p2p/viewer-live/oasis7-viewer-live-no-llm-flag-2026-02-23.project.md`
 - `doc/p2p/viewer-live/oasis7-viewer-live-release-locked-launch-2026-02-23.prd.md`
 - `doc/p2p/viewer-live/oasis7-viewer-live-release-locked-launch-2026-02-23.project.md`
-- `doc/playability_test_card.md`
+- historical deleted root playability card shell
 - `doc/playability_test_result/README.md`
 - `doc/playability_test_result/card_2026_02_28_19_22_20.md`
 - `doc/playability_test_result/card_2026_02_28_21_22_51.md`

--- a/doc/engineering/project.md
+++ b/doc/engineering/project.md
@@ -342,6 +342,7 @@
 - [x] root-design-redirect-shell-deletion (PRD-ENGINEERING-021/025) [test_tier_required]: 删除 world-runtime / world-simulator 根级 legacy design redirect 壳，将仅存索引引用收敛到模块内 canonical design 文档，并同步收紧 root markdown allowlist。 Trace: .pm/tasks/task_a99b0850527b4c1e935e3276a5338b57.yaml
 - [x] game-test-root-design-redirect-deletion (PRD-ENGINEERING-021/025) [test_tier_required]: 删除 game-test 根级 legacy design redirect 壳，将 root project 兼容壳与 review 索引引用收敛到 `playability_test_result` canonical 专题 design，并同步收紧 root markdown allowlist。 Trace: .pm/tasks/task_c1ac55b06cd7455b9c92b914aa131026.yaml
 - [x] playability-manual-root-redirect-deletion (PRD-ENGINEERING-021/025) [test_tier_required]: 删除 playability test manual 根级 legacy redirect 壳，将旧 root 路径 review 索引/日志引用收敛到 `playability_test_result` canonical manual，并同步收紧 root markdown allowlist。 Trace: .pm/tasks/task_21152e953bd14e4195a3f2ec3519a33b.yaml
+- [x] playability-card-root-redirect-deletion (PRD-ENGINEERING-021/025) [test_tier_required]: 删除 playability test card 根级 legacy redirect 壳，将旧 root 路径 review 索引/日志引用收敛为非路径历史描述，并以 `playability_test_result` canonical card 作为唯一卡片入口。 Trace: .pm/tasks/task_89ecb9cc79d44cab9cef5e8ae01bd48a.yaml
 
 ## File Structure / Affected Paths
 
@@ -409,7 +410,7 @@
 - 更新日期: 2026-06-27
 - 当前状态: active
 - 下一任务: 当前 `scripts/doc-inventory-report.sh` 复算显示 near-limit active docs 为 none；后续 repository health 巡检应按 module density / hotspot `action_required` 结果做 bounded 分类判断，先分级再切 focused follow-up，避免回到已收口的 `doc/world-simulator/project.md` / `doc/readme/project.md` 队列。
-- 最新完成: `viewer-manual-legacy-redirect-deletion`（已删除 Viewer manual legacy redirect 壳，将当前/半当前引用收敛到 `viewer-manual.manual.md` canonical manual。）
+- 最新完成: `playability-card-root-redirect-deletion`（已删除 playability test card 根级 legacy redirect 壳，将当前入口唯一收敛到 `doc/playability_test_result/playability_test_card.md`。）
 - PRD 质量门状态: strict schema 已对齐（含第 6 章验证与决策记录）。
 - 当前治理重点: P0/P1 技术债首轮优化正在收口，重点是 public_testnet readiness blocker 显式化、hosted access verdict 去半实现口径，以及 Viewer 前端状态模块化。
 - 当前库存判断: 文档债的主矛盾仍是“入口减重之后的存量维护成本”，不是继续扩更多 landing pages。复算入口仍以 `scripts/doc-inventory-report.sh` 为准。

--- a/doc/playability_test_card.md
+++ b/doc/playability_test_card.md
@@ -1,6 +1,0 @@
-# Legacy Redirect: playability_test_card
-
-本文件自 2026-03-03 起仅保留兼容跳转，不再作为活跃入口。
-
-- 当前主入口：`doc/playability_test_result/playability_test_card.md`
-- 相关入口：`doc/playability_test_result/project.md`


### PR DESCRIPTION
## Summary
- Delete the obsolete root `doc/playability_test_card.md` legacy redirect shell.
- Remove the root shell from the root markdown allowlist and keep the canonical card at `doc/playability_test_result/playability_test_card.md`.
- Convert the few historical exact root-path references to non-path historical descriptions so doc governance no longer tracks a deleted live path.

## Verification
- `rg -n -F "doc/playability_test_card.md" doc README.md scripts .agents`
- `test ! -e doc/playability_test_card.md`
- `test -e doc/playability_test_result/playability_test_card.md`
- `git diff --check`
- `./scripts/doc-governance-check.sh`
- `./scripts/pm/workflow-lint.sh --task-uid task_89ecb9cc79d44cab9cef5e8ae01bd48a --phase current`
- `./scripts/pm/claim-ready.sh --claim-type ready_for_pr --verify-command "./scripts/doc-governance-check.sh"`

## Review
- repository_health_engineer: no_findings
- qa_engineer: no_findings
- producer_system_designer: no_findings

## Closeout Note
- `task-closeout.sh` wrote current task closeout metadata and marked the task done, then exited nonzero on unrelated historical repo-wide `.pm lint` debt. Task-scoped gates remained green.
