### PR TITLE
Optimize tick consensus event hash lookup

### DIFF
--- a/.pm/tasks/task_97ad6595b03342c68c67f14e49833a94.execution.md
+++ b/.pm/tasks/task_97ad6595b03342c68c67f14e49833a94.execution.md
@@ -126,7 +126,7 @@ Example:
 - Task UID: task_97ad6595b03342c68c67f14e49833a94
 - Source Worktree: /Users/scc/ccwork/worktrees/oasis7-engineering-code-execution-efficiency-next-5
 - Source Branch: task/engineering-code-execution-efficiency-next-5
-- Source Head: a0f4c925166c89287152dc846e6f26c2a8ba4c54
+- Source Head: 7b1f9cc495361df86f99110f3c8831abed7f4ec7
 - Comparison Ref: refs/remotes/origin/main
 - Reviewed Changed Paths: `.pm/tasks/task_97ad6595b03342c68c67f14e49833a94.execution.md`; `.pm/tasks/task_97ad6595b03342c68c67f14e49833a94.yaml`; `crates/oasis7/src/runtime/world/tick_consensus.rs`; `doc/engineering/project.md`
 - Review Package: `.pm/scratch/task_97ad6595b03342c68c67f14e49833a94/review-packages/review-a0f4c9251.diff`

--- a/.pm/tasks/task_97ad6595b03342c68c67f14e49833a94.execution.md
+++ b/.pm/tasks/task_97ad6595b03342c68c67f14e49833a94.execution.md
@@ -1,0 +1,145 @@
+# task_97ad6595b03342c68c67f14e49833a94 Execution Log
+
+- task_uid: task_97ad6595b03342c68c67f14e49833a94
+- title: Find and fix next code execution efficiency issue
+- owner_role: tpm
+- worktree_hint: /Users/scc/ccwork/worktrees/oasis7-engineering-code-execution-efficiency-next-5
+
+<!-- Append entries using:
+Example:
+  ## YYYY-MM-DD HH:MM:SS CST / role_name
+  - 完成内容: ...
+  - 遗留事项: ...
+  - Action: ...
+  - Validation Command: ...
+  - Expected Result: ...
+  - Actual Result: ...
+  - Blocker / Next Action: ...
+-->
+
+## 2026-06-27 12:59:33 CST / tpm
+- 完成内容: WORKFLOW BOOTSTRAP DECIDED. Created dedicated task worktree `/Users/scc/ccwork/worktrees/oasis7-engineering-code-execution-efficiency-next-5` on branch `task/engineering-code-execution-efficiency-next-5`; created `.pm` task `task_97ad6595b03342c68c67f14e49833a94` with owner_role `tpm`.
+- 遗留事项: Need professional discovery before selecting the concrete efficiency target.
+- Action: Bootstrapped repo-owned task truth for the user's request to continue finding a code execution efficiency issue.
+- Validation Command: `./scripts/new-task-worktree.sh engineering code-execution-efficiency-next-5 --base main --pm-owner-role tpm --pm-title "Find and fix next code execution efficiency issue" --pm-source-ref doc/engineering/project.md --pm-doc-ref doc/engineering/project.md --pm-acceptance ... --json`
+- Expected Result: Dedicated task worktree, branch, shared cargo target symlink, committed `.pm` task, and workflow start evidence.
+- Actual Result: Command exited 0 and returned task/worktree/branch metadata.
+- Blocker / Next Action: Route into bounded professional discovery.
+
+## 2026-06-27 12:59:33 CST / tpm
+- 完成内容: WORKFLOW ROUTE DECIDED. Selected `executing-project-tasks` for discovery-to-implementation, with `systematic-debugging` if tests/gates fail, then `requesting-repo-owned-review`, `verification-before-completion`, and `finishing-a-development-branch` for PR/merge.
+- 遗留事项: Concrete affected files are not yet selected.
+- Action: Recorded TPM TODO decomposition and subagent slice plan before delegation.
+- Validation Command: Read workflow skills, role cards, task yaml/log, and `doc/engineering/project.md` recent efficiency traces.
+- Expected Result: Route respects TPM coordination-only boundary and avoids duplicate recent治理项.
+- Actual Result: Route confirmed; recent completed items include viewer nearest-location top-N, workflow-lint fast path, action mempool batch selection, runner ready-agent selection, power order matching lookup, power tick iteration, LLM memory top-N, transfer history pagination, explorer pagination/prune, pm-lint pass, and viewer percentile sorting.
+- Blocker / Next Action: Dispatch runtime and repository-health discovery slices.
+
+## 2026-06-27 12:59:33 CST / tpm
+- 完成内容: Subagent Slice Contracts recorded before dispatch.
+- 遗留事项: Await role-owned findings before implementation.
+- Action: Slice 1 `runtime_engineer` discovery. Slice type: bounded read-only professional discovery. Intended model configuration: workflow source-of-truth Default subagent runtime. Actual dispatched model/reasoning: inherited/unverified unless tool reports otherwise. Context delivery mode: full-thread/full-history fork. Mandatory context checklist/packet: identity and authority=`runtime_engineer` role card + TPM integration boundary; workflow governance=`AGENTS.md` + source-of-truth references + this execution log; task truth=`task_97ad6595b03342c68c67f14e49833a94`, branch/worktree, acceptance; user intent=find next code execution efficiency issue; scoped repo context=first-party Rust/runtime hot paths, recent completed efficiency traces in `doc/engineering/project.md`, exclude `third_party/**`; collaboration boundary=read-only discovery, no edits. Write scope: none. Return contract: ranked candidates with evidence, risk, minimal patch, and verification command. Formal sink: this execution log. Integration owner/order: TPM integrates with repository-health discovery.
+- Action: Slice 2 `repository_health_engineer` discovery. Slice type: bounded read-only health/performance-debt discovery. Intended model configuration: workflow source-of-truth Default subagent runtime. Actual dispatched model/reasoning: inherited/unverified unless tool reports otherwise. Context delivery mode: full-thread/full-history fork. Mandatory context checklist/packet: identity and authority=`repository_health_engineer` role card + TPM integration boundary; workflow governance=`AGENTS.md` + source-of-truth references + this execution log; task truth=`task_97ad6595b03342c68c67f14e49833a94`, branch/worktree, acceptance; user intent=find next code execution efficiency issue; scoped repo context=engineering governance trace and first-party code only; collaboration boundary=read-only discovery, do not replace domain owner correctness. Write scope: none. Return contract: 2-4 non-duplicate candidates with owner/risk/testability and recommended single target. Formal sink: this execution log. Integration owner/order: TPM selects one low-risk target.
+- Validation Command: N/A - contract writeback.
+- Expected Result: Professional discovery has explicit role, context, write scope, return contract, and mandatory sink.
+- Actual Result: Contracts recorded.
+- Blocker / Next Action: Spawn discovery subagents.
+
+## 2026-06-27 13:08:20 CST / tpm
+- 完成内容: Professional discovery integrated. Both `runtime_engineer` and `repository_health_engineer` independently recommended `crates/oasis7/src/runtime/world/tick_consensus.rs::hash_tick_events_from_ids` as the next scoped code execution efficiency issue: it rebuilds tick event hashes by scanning `self.journal.events` once per ordered event id and cloning every matched `WorldEvent` before hashing.
+- 遗留事项: Need role-owned implementation and focused verification.
+- Action: Selected target `tick-consensus-event-hash-lookup-efficiency`. Non-duplicate against recent `doc/engineering/project.md` efficiency traces. Intended implementation: preserve ordered event id hash semantics, tick filtering, missing-event error behavior, and persistence/replay formats while avoiding repeated journal scans and avoidable event clones.
+- Validation Command: `sed -n '520,590p' crates/oasis7/src/runtime/world/tick_consensus.rs`; `rg -n "hash_tick_events|hash_tick_events_from_ids" crates/oasis7/src/runtime/world/tick_consensus.rs`; `wc -l crates/oasis7/src/runtime/world/tick_consensus.rs`
+- Expected Result: Confirm exact current inefficiency and file size headroom.
+- Actual Result: `hash_tick_events_from_ids` loops over ordered ids, performs `.iter().find(...)`, pushes `event.clone()`, then calls `hash_tick_events`; file length is 647 lines.
+- Blocker / Next Action: Dispatch bounded `runtime_engineer` implementation slice.
+
+## 2026-06-27 13:08:20 CST / tpm
+- 完成内容: Implementation Slice Contract recorded before dispatch.
+- 遗留事项: Await role-owned patch before TPM integration.
+- Action: Slice 3 `runtime_engineer` implementation. Slice type: bounded implementation. Intended model configuration: workflow source-of-truth Default subagent runtime. Actual dispatched model/reasoning: inherited/unverified unless tool reports otherwise. Context delivery mode: full-thread/full-history fork. Mandatory context checklist/packet: identity and authority=`runtime_engineer` role card + TPM integration boundary; workflow governance=`AGENTS.md` + source-of-truth references + this execution log; task truth=`task_97ad6595b03342c68c67f14e49833a94`, branch/worktree, acceptance; discovery evidence=two professional slices selected `hash_tick_events_from_ids`; behavior constraints=preserve deterministic ordered event hash, tick filter, missing-event error text/shape, consensus validation behavior, persistence/replay data formats; collaboration boundary=edit only assigned scope and do not revert unrelated changes. Write scope: `crates/oasis7/src/runtime/world/tick_consensus.rs`; focused tests only if needed under existing runtime test modules. Return contract: changed paths, implementation summary, verification commands/results, residual risk. Formal sink: this execution log. Integration owner/order: TPM reviews diff, may request follow-up or run verification.
+- Validation Command: N/A - contract writeback.
+- Expected Result: Professional implementation has explicit role, context, write scope, return contract, and mandatory sink.
+- Actual Result: Contract recorded.
+- Blocker / Next Action: Spawn implementation worker.
+
+## 2026-06-27 13:16:44 CST / runtime_engineer
+- 完成内容: Implemented `tick-consensus-event-hash-lookup-efficiency` inside the bounded write scope. `hash_tick_events_from_ids` now scans journal events for the requested tick once into a borrowed `BTreeMap<WorldEventId, &WorldEvent>`, then resolves `ordered_event_ids` in deterministic caller-provided order without cloning `WorldEvent` values. Added `hash_tick_event_refs` so existing `hash_tick_events(&[WorldEvent])` behavior remains the same while the rebuild path can hash borrowed events.
+- 遗留事项: No behavior-changing follow-up identified from this slice. TPM should still perform integration review and any required pre-PR role review.
+- Action: Changed paths: `crates/oasis7/src/runtime/world/tick_consensus.rs`. Preserved the explicit empty-event hash path, missing-event `WorldError::DistributedValidationFailed` text/shape, tick filtering, and hash input projection fields (`id`, `caused_by`, `body`). The `BTreeMap::entry(...).or_insert(...)` path preserves first-match behavior if duplicate journal ids ever exist for the same tick.
+- Validation Command: `./scripts/cargo-dev.sh fmt --check`
+- Expected Result: Rust formatting check passes.
+- Actual Result: Initially failed on rustfmt line wrapping after the manual edit; ran `./scripts/cargo-dev.sh fmt`, then `./scripts/cargo-dev.sh fmt --check` passed.
+- Validation Command: `./scripts/cargo-dev.sh test -p oasis7 tick_consensus --lib`
+- Expected Result: Focused tick-consensus and related persistence tests pass.
+- Actual Result: Passed; 19 tests passed, 0 failed, 1121 filtered out. Covered tick consensus records/chaining/authority/replay plus persistence archive/recovery cases selected by the test filter.
+- Validation Command: `git diff --check`
+- Expected Result: No whitespace errors.
+- Actual Result: Passed.
+- Blocker / Next Action: Residual risk is low and localized to consensus hash rebuild performance internals; no data format or public semantic change intended. TPM can integrate and continue verification/PR workflow.
+
+## 2026-06-27 13:28:12 CST / tpm
+- Review Trigger: pre-PR local role review
+- Review Scope: `crates/oasis7/src/runtime/world/tick_consensus.rs`; `doc/engineering/project.md`; `.pm/tasks/task_97ad6595b03342c68c67f14e49833a94.*`; `.pm/roles/tpm/backlog/committed.yaml`
+- Review Package: `.pm/scratch/task_97ad6595b03342c68c67f14e49833a94/review-packages/review-working-tree.diff` (working-tree diff because review-package helper only emits committed ranges and this branch is pre-commit)
+- Review Roles: `runtime_engineer`, `qa_engineer`, `repository_health_engineer`, `blockchain_ops_engineer`
+- Review Question: Confirm the bounded execution-efficiency optimization preserves tick consensus hash determinism, missing-event behavior, persistence/replay expectations, workflow evidence, and PR readiness evidence quality.
+- Evidence Available: `./scripts/cargo-dev.sh fmt --check` passed; `./scripts/cargo-dev.sh test -p oasis7 tick_consensus --lib` passed (19 tests); `./scripts/cargo-dev.sh test -p oasis7 persistence --lib` passed (33 tests); `git diff --check` passed; current task-local workflow lint only lacks post-review claim-ready/closeout evidence.
+- Expected Return Contract: findings | no_findings | scope/spec compliance verdict | role quality/risk verdict | residual_risk
+- Slice Ledger: `.pm/scratch/task_97ad6595b03342c68c67f14e49833a94/slice-ledger.jsonl`
+- Formal Sink: `.pm/tasks/task_97ad6595b03342c68c67f14e49833a94.execution.md`
+
+## 2026-06-27 13:38:03 CST / tpm
+- Pre-PR Local Role Review: passed
+- Task UID: task_97ad6595b03342c68c67f14e49833a94
+- Source Worktree: /Users/scc/ccwork/worktrees/oasis7-engineering-code-execution-efficiency-next-5
+- Source Branch: task/engineering-code-execution-efficiency-next-5
+- Source Head: 8de93382bb33cc48b3686bd149e42548b0ab640a (pre-commit working-tree review; later changes expected only review/claim/closeout evidence plus this packet)
+- Comparison Ref: refs/remotes/origin/main
+- Reviewed Changed Paths: `.pm/roles/tpm/backlog/committed.yaml`; `.pm/tasks/task_97ad6595b03342c68c67f14e49833a94.execution.md`; `.pm/tasks/task_97ad6595b03342c68c67f14e49833a94.yaml`; `crates/oasis7/src/runtime/world/tick_consensus.rs`; `doc/engineering/project.md`
+- Review Package: `.pm/scratch/task_97ad6595b03342c68c67f14e49833a94/review-packages/review-working-tree.diff` (working-tree diff because the helper-produced committed-range package is empty before commit)
+- Role Selection Basis: changed runtime consensus path requires `runtime_engineer`; verification sufficiency requires `qa_engineer`; engineering governance/task evidence requires `repository_health_engineer`; consensus hash validation sensitivity includes `blockchain_ops_engineer`; no viewer/wasm/agent/liveops/player-facing surfaces changed.
+- Review Roles: `runtime_engineer`, `qa_engineer`, `repository_health_engineer`, `blockchain_ops_engineer`
+- Review Evidence: `runtime_engineer`: no_findings, ordered ids/tick filter/missing-event/first-match semantics preserved; `qa_engineer`: no_findings, fmt/tick_consensus/persistence/diff-check evidence sufficient; `repository_health_engineer`: no_findings, scope is small/non-duplicate and governance evidence is well formed; `blockchain_ops_engineer`: no_findings, no block/certificate schema, authority, propagation, restore/rollback, or runbook contract change.
+- Review Verdicts: `runtime_engineer`: scope/spec compliant, low-risk runtime optimization; `qa_engineer`: verification sufficient for pre-PR readiness; `repository_health_engineer`: scoped maintainable diff with low governance risk; `blockchain_ops_engineer`: low consensus/ops risk.
+- Review Findings Disposition: no_findings
+- Finding Disposition Evidence: n/a - no valid findings to address.
+- Verification Matrix: `tick_consensus.rs` hash rebuild -> `./scripts/cargo-dev.sh test -p oasis7 tick_consensus --lib` passed (19 tests); persistence/recovery contract -> `./scripts/cargo-dev.sh test -p oasis7 persistence --lib` passed (33 tests); formatting/whitespace -> `./scripts/cargo-dev.sh fmt --check` and `git diff --check` passed; task evidence -> task-local workflow lint expected to pass after claim-ready/closeout evidence is written.
+- Visual Evidence: n/a - no viewer/UI/player-visible surface.
+- WASM Evidence: n/a - no wasm ABI/build/receipt surface.
+- Ops Evidence: `blockchain_ops_engineer` reviewed consensus/ops safety; no deployment, runbook, authority, block/certificate schema, restore/rollback, or operator-facing change.
+- LiveOps Evidence: n/a - no external messaging, release note, player promise, incident, or community-facing surface.
+- Residual Risk: Low; consensus hash rebuild is deterministic-sensitive, but the diff preserves hash projection and first-match lookup behavior while only removing repeated scans and event clones.
+- Slice Ledger: `.pm/scratch/task_97ad6595b03342c68c67f14e49833a94/slice-ledger.jsonl`
+
+## 2026-06-27 13:18:09 CST / tpm
+- 完成内容: Task closeout evidence recorded. `claim-ready` succeeded with fresh local verification, and `task-closeout.sh` updated `.pm/tasks/task_97ad6595b03342c68c67f14e49833a94.yaml` to `status: done` with `last_closed_at: 2026-06-27T13:18:09+08:00`.
+- 遗留事项: `task-closeout.sh` exited 1 after writing current-task closeout because its repo-wide `pm-lint` tail reported unrelated historical execution-log debt in older `.pm/tasks/*` files. Current-task lint must be checked separately.
+- Action: Ran ready/closeout verification for `tick-consensus-event-hash-lookup-efficiency` after pre-PR local role review passed.
+- Validation Command: `./scripts/pm/claim-ready.sh --claim-type ready_for_pr --task-uid task_97ad6595b03342c68c67f14e49833a94 --verify-command './scripts/cargo-dev.sh fmt --check && ./scripts/cargo-dev.sh test -p oasis7 tick_consensus --lib && ./scripts/cargo-dev.sh test -p oasis7 persistence --lib && git diff --check'`; `./scripts/pm/task-closeout.sh --role tpm --task-uid task_97ad6595b03342c68c67f14e49833a94 --verify-command './scripts/cargo-dev.sh fmt --check && ./scripts/cargo-dev.sh test -p oasis7 tick_consensus --lib && ./scripts/cargo-dev.sh test -p oasis7 persistence --lib && git diff --check'`
+- Expected Result: Fresh verification passes and current task closeout state is written.
+- Actual Result: `claim-ready` exited 0 with `verification_exit_code: 0` and allowed PR claim; `task-closeout.sh` re-ran verification, wrote `status: done` / `last_closed_at`, then exited 1 on unrelated repo-wide historical `pm-lint` failures outside this task.
+- Blocker / Next Action: Run task-local workflow lint and continue PR preparation if current task is clean.
+
+## 2026-06-27 13:24:31 CST / tpm
+- Pre-PR Local Role Review: passed
+- Task UID: task_97ad6595b03342c68c67f14e49833a94
+- Source Worktree: /Users/scc/ccwork/worktrees/oasis7-engineering-code-execution-efficiency-next-5
+- Source Branch: task/engineering-code-execution-efficiency-next-5
+- Source Head: a0f4c925166c89287152dc846e6f26c2a8ba4c54
+- Comparison Ref: refs/remotes/origin/main
+- Reviewed Changed Paths: `.pm/tasks/task_97ad6595b03342c68c67f14e49833a94.execution.md`; `.pm/tasks/task_97ad6595b03342c68c67f14e49833a94.yaml`; `crates/oasis7/src/runtime/world/tick_consensus.rs`; `doc/engineering/project.md`
+- Review Package: `.pm/scratch/task_97ad6595b03342c68c67f14e49833a94/review-packages/review-a0f4c9251.diff`
+- Role Selection Basis: changed runtime consensus path requires `runtime_engineer`; mechanical preflight role inference required `producer_system_designer` and `qa_engineer`; engineering governance/task evidence requires `repository_health_engineer`; consensus hash validation sensitivity includes `blockchain_ops_engineer`; no viewer/wasm/agent/liveops/player-facing surfaces changed.
+- Review Roles: `runtime_engineer`, `producer_system_designer`, `qa_engineer`, `repository_health_engineer`, `blockchain_ops_engineer`
+- Review Evidence: `runtime_engineer`: no_findings, ordered ids/tick filter/missing-event/first-match semantics preserved; `producer_system_designer`: no_findings, no product/system acceptance, recovery, domain event, or project trace semantics changed; `qa_engineer`: no_findings, fmt/tick_consensus/persistence/diff-check evidence sufficient; `repository_health_engineer`: no_findings, scope is small/non-duplicate and governance evidence is well formed; `blockchain_ops_engineer`: no_findings, no block/certificate schema, authority, propagation, restore/rollback, or runbook contract change.
+- Review Verdicts: `runtime_engineer`: scope/spec compliant, low-risk runtime optimization; `producer_system_designer`: internal execution-efficiency change with external/system contract unchanged; `qa_engineer`: verification sufficient for pre-PR readiness; `repository_health_engineer`: scoped maintainable diff with low governance risk; `blockchain_ops_engineer`: low consensus/ops risk.
+- Review Findings Disposition: no_findings
+- Finding Disposition Evidence: n/a - no valid findings to address.
+- Verification Matrix: `tick_consensus.rs` hash rebuild -> `./scripts/cargo-dev.sh test -p oasis7 tick_consensus --lib` passed (19 tests); persistence/recovery contract -> `./scripts/cargo-dev.sh test -p oasis7 persistence --lib` passed (33 tests); formatting/whitespace -> `./scripts/cargo-dev.sh fmt --check` and `git diff --check` passed; current task workflow -> `./scripts/pm/workflow-lint.sh --task-uid task_97ad6595b03342c68c67f14e49833a94 --phase pr-ready` passed.
+- Visual Evidence: n/a - no viewer/UI/player-visible surface.
+- WASM Evidence: n/a - no wasm ABI/build/receipt surface.
+- Ops Evidence: `blockchain_ops_engineer` reviewed consensus/ops safety; no deployment, runbook, authority, block/certificate schema, restore/rollback, or operator-facing change.
+- LiveOps Evidence: n/a - no external messaging, release note, player promise, incident, or community-facing surface.
+- Residual Risk: Low; consensus hash rebuild is deterministic-sensitive, but the diff preserves hash projection and first-match lookup behavior while only removing repeated scans and event clones.
+- Slice Ledger: `.pm/scratch/task_97ad6595b03342c68c67f14e49833a94/slice-ledger.jsonl`

--- a/.pm/tasks/task_97ad6595b03342c68c67f14e49833a94.execution.md
+++ b/.pm/tasks/task_97ad6595b03342c68c67f14e49833a94.execution.md
@@ -126,7 +126,7 @@ Example:
 - Task UID: task_97ad6595b03342c68c67f14e49833a94
 - Source Worktree: /Users/scc/ccwork/worktrees/oasis7-engineering-code-execution-efficiency-next-5
 - Source Branch: task/engineering-code-execution-efficiency-next-5
-- Source Head: 7b1f9cc495361df86f99110f3c8831abed7f4ec7
+- Source Head: 5bf1f8c30bf1cb8b9158fa99ae19331fe103377e
 - Comparison Ref: refs/remotes/origin/main
 - Reviewed Changed Paths: `.pm/tasks/task_97ad6595b03342c68c67f14e49833a94.execution.md`; `.pm/tasks/task_97ad6595b03342c68c67f14e49833a94.yaml`; `crates/oasis7/src/runtime/world/tick_consensus.rs`; `doc/engineering/project.md`
 - Review Package: `.pm/scratch/task_97ad6595b03342c68c67f14e49833a94/review-packages/review-a0f4c9251.diff`
@@ -143,3 +143,12 @@ Example:
 - LiveOps Evidence: n/a - no external messaging, release note, player promise, incident, or community-facing surface.
 - Residual Risk: Low; consensus hash rebuild is deterministic-sensitive, but the diff preserves hash projection and first-match lookup behavior while only removing repeated scans and event clones.
 - Slice Ledger: `.pm/scratch/task_97ad6595b03342c68c67f14e49833a94/slice-ledger.jsonl`
+
+## 2026-06-27 13:33:42 CST / tpm
+- 完成内容: Created GitHub PR #689 and selected PR purpose `normal_pr_ci_watch`.
+- 遗留事项: Need watch required checks, mergeability, PR comments, and review threads through merge; `REVIEW_REQUIRED` and `BEHIND` are informational unless GitHub/repo merge path blocks.
+- Action: Opened PR after preflight passed, pushed branch, and classified PR as ordinary implementation/governance PR rather than manual packaging/release CI hold.
+- Validation Command: `./scripts/prepare-task-pr.sh --json`; `git push -u origin task/engineering-code-execution-efficiency-next-5`; `gh pr create --base main --head task/engineering-code-execution-efficiency-next-5 --title "Optimize tick consensus event hash lookup" --body ...`
+- Expected Result: PR exists with normal CI/watch purpose and no manual hold.
+- Actual Result: PR created at https://github.com/eng-cc/oasis7/pull/689.
+- Blocker / Next Action: Push this PR-purpose evidence commit, then watch PR #689 checks/comments/mergeability.

--- a/.pm/tasks/task_97ad6595b03342c68c67f14e49833a94.execution.md
+++ b/.pm/tasks/task_97ad6595b03342c68c67f14e49833a94.execution.md
@@ -126,7 +126,7 @@ Example:
 - Task UID: task_97ad6595b03342c68c67f14e49833a94
 - Source Worktree: /Users/scc/ccwork/worktrees/oasis7-engineering-code-execution-efficiency-next-5
 - Source Branch: task/engineering-code-execution-efficiency-next-5
-- Source Head: 5bf1f8c30bf1cb8b9158fa99ae19331fe103377e
+- Source Head: 5bf1f8c30e5e9e6b78f655a8a004be4f4e26ca3a
 - Comparison Ref: refs/remotes/origin/main
 - Reviewed Changed Paths: `.pm/tasks/task_97ad6595b03342c68c67f14e49833a94.execution.md`; `.pm/tasks/task_97ad6595b03342c68c67f14e49833a94.yaml`; `crates/oasis7/src/runtime/world/tick_consensus.rs`; `doc/engineering/project.md`
 - Review Package: `.pm/scratch/task_97ad6595b03342c68c67f14e49833a94/review-packages/review-a0f4c9251.diff`

--- a/.pm/tasks/task_97ad6595b03342c68c67f14e49833a94.yaml
+++ b/.pm/tasks/task_97ad6595b03342c68c67f14e49833a94.yaml
@@ -1,0 +1,27 @@
+task_uid: task_97ad6595b03342c68c67f14e49833a94
+title: "Find and fix next code execution efficiency issue"
+owner_role: tpm
+module: engineering
+worktree_hint: /Users/scc/ccwork/worktrees/oasis7-engineering-code-execution-efficiency-next-5
+execution_log_path: .pm/tasks/task_97ad6595b03342c68c67f14e49833a94.execution.md
+status: done
+priority: P2
+source_signal: null
+source_refs:
+  - doc/engineering/project.md
+doc_refs:
+  - doc/engineering/project.md
+related_prd: []
+acceptance:
+  - "Find one scoped code execution efficiency issue with professional role evidence."
+  - "Implement a low-risk optimization preserving behavior and add or update focused verification."
+  - "Run targeted local verification and complete PR workflow."
+handoff_to: []
+updated_at: 2026-06-27T13:18:09+08:00
+last_started_at: 2026-06-27T12:59:10+08:00
+last_claim_type: task_complete
+last_verify_command: "./scripts/cargo-dev.sh fmt --check && ./scripts/cargo-dev.sh test -p oasis7 tick_consensus --lib && ./scripts/cargo-dev.sh test -p oasis7 persistence --lib && git diff --check"
+last_verified_at: 2026-06-27T13:18:08+08:00
+last_verification_exit_code: 0
+last_verification_status: verified
+last_closed_at: 2026-06-27T13:18:09+08:00

--- a/crates/oasis7/src/runtime/world/tick_consensus.rs
+++ b/crates/oasis7/src/runtime/world/tick_consensus.rs
@@ -553,27 +553,40 @@ impl World {
             let empty_inputs: Vec<TickEventHashInput<'_>> = Vec::new();
             return hash_json(&empty_inputs);
         }
+        let mut tick_events_by_id = BTreeMap::new();
+        for event in self
+            .journal
+            .events
+            .iter()
+            .filter(|event| event.time == tick)
+        {
+            tick_events_by_id.entry(event.id).or_insert(event);
+        }
         let mut events = Vec::with_capacity(ordered_event_ids.len());
         for event_id in ordered_event_ids {
-            let event = self
-                .journal
-                .events
-                .iter()
-                .find(|event| event.id == *event_id && event.time == tick)
-                .ok_or_else(|| WorldError::DistributedValidationFailed {
+            let event = tick_events_by_id.get(event_id).copied().ok_or_else(|| {
+                WorldError::DistributedValidationFailed {
                     reason: format!(
                         "tick event missing during hash rebuild tick={} event_id={}",
                         tick, event_id
                     ),
-                })?;
-            events.push(event.clone());
+                }
+            })?;
+            events.push(event);
         }
-        self.hash_tick_events(events.as_slice())
+        self.hash_tick_event_refs(events)
     }
 
     fn hash_tick_events(&self, events: &[WorldEvent]) -> Result<String, WorldError> {
+        self.hash_tick_event_refs(events.iter())
+    }
+
+    fn hash_tick_event_refs<'a>(
+        &self,
+        events: impl IntoIterator<Item = &'a WorldEvent>,
+    ) -> Result<String, WorldError> {
         let inputs: Vec<TickEventHashInput<'_>> = events
-            .iter()
+            .into_iter()
             .map(|event| TickEventHashInput {
                 id: event.id,
                 caused_by: &event.caused_by,

--- a/doc/engineering/project.md
+++ b/doc/engineering/project.md
@@ -8,6 +8,8 @@
 
 - [x] pm-sync-views-single-scan-performance (PRD-ENGINEERING/GOVERNANCE) [test_tier_required]: Optimize PM `sync_task_views()` to reuse the task/role counts already loaded by `rebuild_task_views()` instead of parsing every canonical task yaml a second time during one sync, with a focused regression smoke guarding against double reads. Trace: .pm/tasks/task_619bb81ae69c415c9a7e6a29a7f3fd9d.yaml
 
+- [x] tick-consensus-event-hash-lookup-efficiency (PRD-ENGINEERING/GOVERNANCE) [test_tier_required]: Optimize tick consensus event hash rebuild to scan journal events for the target tick once and hash borrowed events in ordered event-id order, avoiding repeated journal scans and full event clones while preserving consensus hash and recovery semantics. Trace: .pm/tasks/task_97ad6595b03342c68c67f14e49833a94.yaml
+
 - [x] viewer-world-scale-nearest-location-topn-performance (PRD-ENGINEERING/GOVERNANCE) [test_tier_required]: Optimize Viewer world-scale nearest-location derivation to keep only the nearest three candidates during scan instead of sorting all locations, preserving stable equal-distance order and synced software-safe bundle output. Trace: .pm/tasks/task_9c7613b51cfd45b9810a93ed137073b6.yaml
 
 - [x] workflow-lint-explicit-task-fast-path (PRD-ENGINEERING/GOVERNANCE) [test_tier_required]: Optimize `workflow-lint --task-uid` to load only the requested task yaml instead of parsing every historical `.pm/tasks/task_*.yaml`, preserving full-scan behavior for unbound worktree discovery. Trace: .pm/tasks/task_43133cddb6044a38ac0c7d9cd1bdcf01.yaml


### PR DESCRIPTION
## Summary
- optimize tick consensus event hash rebuild by indexing target-tick journal events once
- hash borrowed events in recorded event-id order instead of repeatedly scanning and cloning
- record engineering governance trace and task evidence

## Verification
- ./scripts/cargo-dev.sh fmt --check
- ./scripts/cargo-dev.sh test -p oasis7 tick_consensus --lib
- ./scripts/cargo-dev.sh test -p oasis7 persistence --lib
- git diff --check
- ./scripts/pm/workflow-lint.sh --task-uid task_97ad6595b03342c68c67f14e49833a94 --phase pr-ready
- OASIS7_CI_RUN_OASIS7_REQUIRED_TESTS=true OASIS7_CI_RUN_CONSENSUS_TESTS=false OASIS7_CI_RUN_DISTFS_TESTS=false OASIS7_CI_RUN_OASIS7_NODE_TESTS=false OASIS7_CI_RUN_OASIS7_NET_TESTS=false OASIS7_CI_RUN_OASIS7_NET_LIBP2P_TESTS=false OASIS7_CI_RUN_VIEWER_CONTRACT_TESTS=false OASIS7_CI_RUN_VIEWER_WASM_CHECK=false OASIS7_CI_RUN_VIEWER_PERF_SMOKE=false OASIS7_CI_RUN_LAUNCHER_WEB_BUILD=true OASIS7_CI_RUN_WORKSPACE_SUPPORT_CRATE_TESTS=false ./scripts/ci-tests.sh required