### PR TITLE
Add hosted macOS Docker probe workflow

### DIFF
--- a/.github/workflows/wasm-hosted-macos-arm64-docker-probe.yml
+++ b/.github/workflows/wasm-hosted-macos-arm64-docker-probe.yml
@@ -1,0 +1,145 @@
+name: Wasm Hosted macOS ARM64 Docker Probe
+
+on:
+  workflow_dispatch:
+    inputs:
+      runner_image:
+        description: GitHub-hosted macOS runner image to probe.
+        required: true
+        default: macos-15
+        type: choice
+        options:
+          - macos-15
+          - macos-14
+      require_linux_amd64_docker:
+        description: Fail the workflow if Docker cannot run a linux/amd64 container.
+        required: true
+        default: false
+        type: boolean
+
+env:
+  PROBE_ROOT: output/ci/wasm-hosted-macos-arm64-docker-probe
+
+jobs:
+  probe-hosted-macos-arm64-docker:
+    name: hosted-macos-arm64-docker-probe
+    runs-on: ${{ inputs.runner_image }}
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Collect host and Docker probe evidence
+        id: probe
+        shell: bash
+        continue-on-error: true
+        run: |
+          set -u
+
+          mkdir -p "${PROBE_ROOT}"
+
+          {
+            printf 'probe_kind=hosted-macos-arm64-docker-capability\n'
+            printf 'release_evidence=false\n'
+            printf 'runner_image=%s\n' "${{ inputs.runner_image }}"
+            printf 'runner_os=%s\n' "${RUNNER_OS:-}"
+            printf 'runner_arch=%s\n' "${RUNNER_ARCH:-}"
+            printf 'github_run_id=%s\n' "${GITHUB_RUN_ID:-}"
+            printf 'github_sha=%s\n' "${GITHUB_SHA:-}"
+            printf 'host_uname_s=%s\n' "$(uname -s)"
+            printf 'host_uname_m=%s\n' "$(uname -m)"
+            printf 'host_uname_a=%s\n' "$(uname -a)"
+          } | tee "${PROBE_ROOT}/host.txt"
+
+          docker_cli=missing
+          docker_daemon=unknown
+          linux_amd64_container=unknown
+          docker_platform_output=''
+
+          if command -v docker >/dev/null 2>&1; then
+            docker_cli=present
+            command -v docker | tee "${PROBE_ROOT}/docker-path.txt"
+            docker version > "${PROBE_ROOT}/docker-version.txt" 2>&1
+            if docker info > "${PROBE_ROOT}/docker-info.txt" 2>&1; then
+              docker_daemon=available
+            else
+              docker_info_status=$?
+              docker_daemon=unavailable
+              printf 'docker_info_exit=%s\n' "$docker_info_status" | tee "${PROBE_ROOT}/docker-info-exit.txt"
+            fi
+
+            if docker run --rm --platform linux/amd64 alpine:3.20 uname -m \
+                > "${PROBE_ROOT}/docker-linux-amd64-uname.stdout" \
+                2> "${PROBE_ROOT}/docker-linux-amd64-uname.stderr"; then
+              docker_platform_output="$(awk 'NF { value=$0 } END { print value }' "${PROBE_ROOT}/docker-linux-amd64-uname.stdout")"
+              printf '%s\n' "$docker_platform_output" > "${PROBE_ROOT}/docker-linux-amd64-uname.txt"
+              case "$docker_platform_output" in
+                x86_64|amd64)
+                  linux_amd64_container=available
+                  ;;
+                *)
+                  linux_amd64_container=unexpected-output
+                  ;;
+              esac
+            else
+              linux_amd64_container=unavailable
+            fi
+          else
+            printf 'docker CLI not found on PATH\n' | tee "${PROBE_ROOT}/docker-missing.txt"
+          fi
+
+          {
+            printf '{\n'
+            printf '  "probe_kind": "hosted-macos-arm64-docker-capability",\n'
+            printf '  "release_evidence": false,\n'
+            printf '  "runner_image": "%s",\n' "${{ inputs.runner_image }}"
+            printf '  "runner_os": "%s",\n' "${RUNNER_OS:-}"
+            printf '  "runner_arch": "%s",\n' "${RUNNER_ARCH:-}"
+            printf '  "host_uname_s": "%s",\n' "$(uname -s)"
+            printf '  "host_uname_m": "%s",\n' "$(uname -m)"
+            printf '  "docker_cli": "%s",\n' "$docker_cli"
+            printf '  "docker_daemon": "%s",\n' "$docker_daemon"
+            printf '  "linux_amd64_container": "%s",\n' "$linux_amd64_container"
+            printf '  "docker_platform_output": "%s"\n' "$docker_platform_output"
+            printf '}\n'
+          } | tee "${PROBE_ROOT}/probe-summary.json"
+
+          {
+            echo "docker_cli=${docker_cli}"
+            echo "docker_daemon=${docker_daemon}"
+            echo "linux_amd64_container=${linux_amd64_container}"
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Write probe summary
+        if: always()
+        shell: bash
+        run: |
+          summary_json="${PROBE_ROOT}/probe-summary.json"
+          {
+            echo "## Hosted macOS ARM64 Docker Probe"
+            echo
+            echo "This diagnostic is not release evidence and does not close WDBP-3.2 by itself."
+            echo
+            if [[ -f "$summary_json" ]]; then
+              echo '```json'
+              cat "$summary_json"
+              echo '```'
+            else
+              echo "Probe summary was not produced."
+            fi
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: Upload probe evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: hosted-macos-arm64-docker-probe-${{ inputs.runner_image }}-${{ github.run_id }}
+          path: ${{ env.PROBE_ROOT }}
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Enforce linux/amd64 Docker requirement
+        if: ${{ inputs.require_linux_amd64_docker && steps.probe.outputs.linux_amd64_container != 'available' }}
+        shell: bash
+        run: |
+          echo "linux/amd64 Docker container execution is not available on this hosted macOS runner." >&2
+          exit 1

--- a/.pm/tasks/task_fef95d44dbba4048b574d68138431371.execution.md
+++ b/.pm/tasks/task_fef95d44dbba4048b574d68138431371.execution.md
@@ -158,7 +158,7 @@ Example:
 - Task UID: task_fef95d44dbba4048b574d68138431371
 - Source Worktree: /Users/scc/ccwork/worktrees/oasis7-chain-world-state-substrate-darwin-docker-ci-trial
 - Source Branch: task/chain-world-state-substrate-darwin-docker-ci-trial
-- Source Head: 850fdb13b4689edf219a54845eb7354e90a747be
+- Source Head: 334695244a3bcab6cad928c8d7804c17c5ecc3f5
 - Comparison Ref: refs/remotes/origin/main
 - Reviewed Changed Paths: `.github/workflows/wasm-hosted-macos-arm64-docker-probe.yml`; `doc/world-runtime/project.md`; `.pm/roles/tpm/backlog/committed.yaml`; `.pm/tasks/task_fef95d44dbba4048b574d68138431371.execution.md`; `.pm/tasks/task_fef95d44dbba4048b574d68138431371.yaml`.
 - Review Package: `.pm/scratch/task_fef95d44dbba4048b574d68138431371/review-packages/staged-review.diff`

--- a/.pm/tasks/task_fef95d44dbba4048b574d68138431371.execution.md
+++ b/.pm/tasks/task_fef95d44dbba4048b574d68138431371.execution.md
@@ -158,7 +158,7 @@ Example:
 - Task UID: task_fef95d44dbba4048b574d68138431371
 - Source Worktree: /Users/scc/ccwork/worktrees/oasis7-chain-world-state-substrate-darwin-docker-ci-trial
 - Source Branch: task/chain-world-state-substrate-darwin-docker-ci-trial
-- Source Head: 716f937ccbf920f7e281c7ba5b91fde7c0ddea29
+- Source Head: 850fdb13b4689edf219a54845eb7354e90a747be
 - Comparison Ref: refs/remotes/origin/main
 - Reviewed Changed Paths: `.github/workflows/wasm-hosted-macos-arm64-docker-probe.yml`; `.pm/roles/tpm/backlog/committed.yaml`; `.pm/tasks/task_fef95d44dbba4048b574d68138431371.execution.md`; `.pm/tasks/task_fef95d44dbba4048b574d68138431371.yaml`.
 - Review Package: `.pm/scratch/task_fef95d44dbba4048b574d68138431371/review-packages/staged-review.diff`

--- a/.pm/tasks/task_fef95d44dbba4048b574d68138431371.execution.md
+++ b/.pm/tasks/task_fef95d44dbba4048b574d68138431371.execution.md
@@ -176,7 +176,7 @@ Example:
   - `repository_health_engineer`: mostly compliant before P2, acceptable after acceptance clarification.
 - Review Findings Disposition: addressed
 - Finding Disposition Evidence: `.github/workflows/wasm-hosted-macos-arm64-docker-probe.yml` Docker stdout/stderr fix; `.pm/tasks/task_fef95d44dbba4048b574d68138431371.yaml` acceptance rewrite; validation commands below passed.
-- Verification Matrix: hosted probe workflow syntax -> `/opt/homebrew/bin/actionlint` passed; YAML syntax -> Ruby YAML load passed; staged diff hygiene -> `git diff --cached --check` passed; live hosted runner capability -> deferred to manual workflow run after merge because workflow must exist on default branch for dispatch.
+- Verification Matrix: hosted probe workflow syntax -> `/opt/homebrew/bin/actionlint` passed; YAML syntax -> Ruby YAML load passed; staged diff hygiene -> `git diff --cached --check` passed; runtime replay/recovery/checkpoint/long-run applicability -> n/a with explicit deferral because this change is workflow/docs/task evidence only and touches no runtime source, replay, recovery, checkpoint, simulator state, or long-run behavior; live hosted runner capability -> deferred to manual workflow run after merge because workflow must exist on default branch for dispatch.
 - Visual Evidence: n/a; workflow-only CI diagnostic change.
 - WASM Evidence: workflow probe collects host/Docker/linux-amd64 container capability inputs; canonical release evidence remains `.github/workflows/wasm-darwin-docker-evidence.yml` and is not weakened.
 - Ops Evidence: self-hosted run `28278585758` remains queued because repo self-hosted runner inventory was `total_count: 0`; hosted probe is diagnostic only.
@@ -241,3 +241,12 @@ Example:
 - Expected Result: producer review confirms product/system release-contract boundary.
 - Actual Result: `producer_system_designer` returned `no_findings`; scope/spec pass because workflow is diagnostic-only, `workflow_dispatch` only, writes `release_evidence=false`, uploads probe artifacts, and summary/project/task acceptance preserve that it does not close WDBP-3.2 by itself. Residual risk remains that hosted probe success is capability evidence only.
 - Blocker / Next Action: commit evidence and rerun `prepare-task-pr.sh --create`.
+
+## 2026-06-27 14:30:00 CST / tpm
+- 完成内容: Added explicit runtime semantic verification deferral required by PR helper.
+- 遗留事项: commit evidence and rerun PR helper.
+- Action: updated Verification Matrix to state runtime replay/recovery/checkpoint/long-run applicability is n/a because the change touches only workflow/docs/task evidence.
+- Validation Command: `./scripts/prepare-task-pr.sh --create --title "Add hosted macOS Docker probe workflow"`.
+- Expected Result: helper accepts semantic evidence for inferred runtime role.
+- Actual Result: prior helper run required explicit runtime replay/recovery/checkpoint/long-run applicability or deferral; matrix updated.
+- Blocker / Next Action: commit evidence update and rerun PR helper.

--- a/.pm/tasks/task_fef95d44dbba4048b574d68138431371.execution.md
+++ b/.pm/tasks/task_fef95d44dbba4048b574d68138431371.execution.md
@@ -1,0 +1,189 @@
+# task_fef95d44dbba4048b574d68138431371 Execution Log
+
+- task_uid: task_fef95d44dbba4048b574d68138431371
+- title: Trial Darwin Docker CI evidence workflow
+- owner_role: tpm
+- worktree_hint: /Users/scc/ccwork/worktrees/oasis7-chain-world-state-substrate-darwin-docker-ci-trial
+
+<!-- Append entries using:
+Example:
+  ## YYYY-MM-DD HH:MM:SS CST / role_name
+  - 完成内容: ...
+  - 遗留事项: ...
+  - Action: ...
+  - Validation Command: ...
+  - Expected Result: ...
+  - Actual Result: ...
+  - Blocker / Next Action: ...
+-->
+
+## 2026-06-27 13:32:32 CST / tpm
+- 完成内容: WORKFLOW BOOTSTRAP DECIDED for user request "在ci搞个流水线试试吧".
+- 遗留事项: self-hosted workflow status and hosted probe feasibility still need evidence.
+- Repository State Impact: no workflow source edit planned initially; this task records a manual CI trial for the already-merged Darwin Docker evidence workflow.
+- Isolation Decision: created canonical task worktree `/Users/scc/ccwork/worktrees/oasis7-chain-world-state-substrate-darwin-docker-ci-trial` from `origin/main`; source main worktree was clean.
+- Task Truth: owner role `tpm`; `.pm` task `task_fef95d44dbba4048b574d68138431371`; docs `doc/world-runtime/wasm/wasm-deterministic-build-pipeline.project.md` and `doc/world-runtime/wasm/wasm-deterministic-build-pipeline.design.md`.
+- Routed Next Phase: repo-owned workflow router -> mechanical CI trigger/evidence collection; no specialist professional conclusion is being claimed unless workflow behavior needs design/ops judgment after observation.
+- Subagent Slice Plan: not dispatched for the initial mechanical trigger/status capture; if the run fails or requires CI design changes, route to `wasm_platform_engineer`, `qa_engineer`, `repository_health_engineer`, and/or `blockchain_ops_engineer` slices before authoritative technical conclusions.
+- Action: trigger `.github/workflows/wasm-darwin-docker-evidence.yml` on `main` with default Darwin ARM64 Docker runner labels and Linux verification enabled.
+- Validation Command: `gh workflow run .github/workflows/wasm-darwin-docker-evidence.yml --ref main -f runs_on_json='["self-hosted","macOS","ARM64","docker"]' -f verify_with_linux=true`, followed by run/status inspection.
+- Expected Result: a GitHub Actions run is created; if matching runner capacity exists, Darwin evidence collection starts and then feeds Linux verification.
+- Actual Result: bootstrap recorded; workflow trigger/status inspection continued in the next entry.
+- Blocker / Next Action: trigger workflow and record run URL/status.
+
+## 2026-06-27 13:33:09 CST / tpm
+- 完成内容: Recorded current manual workflow trial status.
+- 遗留事项: self-hosted runner capacity is missing; hosted runner capability still unknown.
+- Action: inspected existing workflow run and repo-level self-hosted runner inventory.
+- Validation Command: `gh run list --workflow "Wasm Darwin Docker Evidence" --limit 5 --json databaseId,status,conclusion,createdAt,displayTitle,event,headBranch,url`; `gh run view 28278585758 --json databaseId,status,conclusion,createdAt,updatedAt,url,headBranch,event,displayTitle,jobs`; `gh api repos/eng-cc/oasis7/actions/runners --paginate`.
+- Expected Result: identify whether an existing run can serve as the CI trial and whether runner capacity exists.
+- Actual Result: existing run `28278585758` on `main` is `queued`; job `83789962336` (`Collect darwin-arm64 Docker summaries`) is `queued` with no steps; repository self-hosted runner inventory is `total_count: 0`.
+- Blocker / Next Action: the self-hosted Darwin Docker evidence workflow is created but blocked by missing repo-level self-hosted runner capacity. Add a separate hosted macOS arm64 probe workflow to empirically test GitHub-hosted runner Docker/platform capability without claiming release evidence.
+
+## 2026-06-27 13:36:00 CST / tpm
+- 完成内容: WORKFLOW ROUTE DECIDED for a hosted CI probe workflow addition.
+- 遗留事项: implement probe, verify locally, and collect role review before PR.
+- Action: routed task into minimal execution plus pre-PR review path.
+- Selected Workflow Skills: executing-project-tasks for minimal workflow implementation; verification-before-completion before any done claim; finishing-a-development-branch only after local verification and role review.
+- Skipped Workflow Skills: bounded-brainstorming skipped because scope is narrow; tdd-test-writer skipped because this is a manual diagnostic CI workflow with no stable local behavior harness beyond action lint/YAML checks; systematic-debugging reserved for observed workflow failures.
+- External Primary Source: GitHub-hosted runner reference identifies standard `macos-15` as arm64 and states nested virtualization is unsupported for arm64 macOS runners; this motivates a probe artifact rather than a release-evidence substitution.
+- Subagent Slice Plan:
+  - role: `wasm_platform_engineer`
+  - slice type: bounded implementation/review support for hosted macOS ARM64 Docker capability probe.
+  - intended model configuration: workflow source-of-truth default subagent runtime.
+  - actual dispatched model/reasoning: inherited/unverified by current multi-agent tool.
+  - context delivery mode: full-thread/full-history fork with explicit checklist below.
+  - mandatory context checklist/packet: AGENTS.md workflow rules; `doc/engineering/workflow/source-of-truth.md`; task `task_fef95d44dbba4048b574d68138431371`; user intent "在ci搞个流水线试试吧"; current queued self-hosted run `28278585758`; existing workflow `.github/workflows/wasm-darwin-docker-evidence.yml`; GitHub hosted runner arm64 macOS nested virtualization limitation; write scope limited to a new manual probe workflow plus necessary docs/task evidence.
+  - write scope: prefer `.github/workflows/wasm-hosted-macos-arm64-docker-probe.yml`; do not edit existing release evidence workflow unless necessary.
+  - return contract: changed files, rationale, commands to validate, residual risk; must not claim hosted probe closes P0 evidence unless Docker linux/amd64 execution actually succeeds.
+  - formal sink / writeback surface: this execution log.
+  - integration owner: `tpm`.
+  - integration order: subagent patch/recommendation -> TPM integrate/review -> local validation -> pre-PR review if branch proceeds to PR.
+- Next Action: dispatch bounded worker slice and implement/verify hosted probe workflow.
+- Validation Command: workflow route based on task truth, existing queued run, and GitHub hosted runner reference.
+- Expected Result: a diagnostic-only hosted probe workflow is implemented without weakening canonical release evidence.
+- Actual Result: route and slice contract recorded; worker dispatch attempted next.
+- Blocker / Next Action: dispatch bounded worker slice and implement/verify hosted probe workflow.
+
+## 2026-06-27 13:40:00 CST / tpm
+- 完成内容: Subagent dispatch fallback recorded.
+- 遗留事项: fallback implementation must avoid professional-release conclusions.
+- Action: closed non-returning worker and switched to mechanical TPM fallback.
+- Intended Dispatch: bounded `wasm_platform_engineer` worker slice for hosted macOS ARM64 Docker capability probe implementation.
+- Actual Limitation: multi-agent worker `019f0793-399b-7ea1-ab6f-dd2ef108a560` did not return after repeated waits and was closed to avoid blocking the user-requested CI trial.
+- Fallback Evidence Path: TPM will perform a mechanical single-file workflow addition limited to objective probe collection and artifact upload; any result will be reported as observed CI fact, not as professional release-evidence closure.
+- Attribution Boundary: no `wasm_platform_engineer` professional conclusion was received from the closed subagent; TPM owns only workflow coordination, mechanical implementation, and command-output restatement.
+- Validation Command: `multi_agent_v1.wait_agent` followed by `multi_agent_v1.close_agent`.
+- Expected Result: avoid blocking the user-requested CI trial while preserving attribution boundary.
+- Actual Result: worker did not return and was closed; fallback boundary recorded.
+- Next Action: add `.github/workflows/wasm-hosted-macos-arm64-docker-probe.yml` and validate with `actionlint`, YAML parsing, and `git diff --check`.
+
+## 2026-06-27 13:44:00 CST / tpm
+- 完成内容: Added a separate manual GitHub-hosted macOS ARM64 Docker capability probe workflow via fallback mechanical implementation.
+- 遗留事项: collect pre-PR local role review and run the workflow after merge to default branch.
+- Action: added `.github/workflows/wasm-hosted-macos-arm64-docker-probe.yml`.
+- Files Changed: `.github/workflows/wasm-hosted-macos-arm64-docker-probe.yml`.
+- Key Behavior:
+  - `workflow_dispatch` only; default runner image input is `macos-15`.
+  - Collects host identity, runner metadata, Docker CLI availability, Docker daemon availability, and `docker run --rm --platform linux/amd64 alpine:3.20 uname -m`.
+  - Uploads diagnostics from `output/ci/wasm-hosted-macos-arm64-docker-probe` even when the Docker probe fails.
+  - Writes explicit `release_evidence=false` in probe output and step summary text stating it does not close WDBP-3.2 by itself.
+  - Defaults `require_linux_amd64_docker=false` so Docker absence still yields an artifact; operators can set it to `true` when they want a red CI status for missing capability.
+- Scope Boundary: Did not edit `.github/workflows/wasm-darwin-docker-evidence.yml`; this probe does not weaken or replace the self-hosted Darwin Docker release evidence path.
+- Validation Command: `/opt/homebrew/bin/actionlint .github/workflows/wasm-hosted-macos-arm64-docker-probe.yml`.
+- Actual Result: passed.
+- Validation Command: `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/wasm-hosted-macos-arm64-docker-probe.yml"); puts "yaml ok"'`.
+- Actual Result: passed (`yaml ok`).
+- Validation Command: `git diff --check`.
+- Actual Result: passed for tracked changes; note the new workflow is untracked until staging.
+- Expected Result: workflow syntax and diff hygiene are valid locally.
+- Blocker / Next Action: stage review target and collect pre-PR role review.
+- Residual Risk: Local validation cannot prove hosted `macos-15` Docker daemon availability; the manual workflow must be merged to the default branch and run on GitHub Actions to collect empirical result. A passing probe is diagnostic capability evidence only and must not be treated as WDBP-3.2/P0 closure unless the canonical release evidence path remains separately satisfied.
+
+## 2026-06-27 13:50:00 CST / tpm
+- 完成内容: Recorded pre-PR local role review request.
+- 遗留事项: wait for role review results and address findings.
+- Action: froze staged diff review target and dispatched involved role reviews.
+- Review Trigger: pre-PR local role review.
+- Review Scope: staged diff for `.github/workflows/wasm-hosted-macos-arm64-docker-probe.yml`; `.pm/tasks/task_fef95d44dbba4048b574d68138431371.yaml`; `.pm/tasks/task_fef95d44dbba4048b574d68138431371.execution.md`; `.pm/roles/tpm/backlog/committed.yaml`.
+- Review Package: `.pm/scratch/task_fef95d44dbba4048b574d68138431371/review-packages/staged-review.diff`.
+- Review Roles: `wasm_platform_engineer`, `qa_engineer`, `repository_health_engineer`.
+- Review Question: confirm the hosted macOS ARM64 Docker probe is correctly scoped as diagnostic-only, does not weaken the canonical Darwin Docker evidence workflow, has sufficient artifact/status evidence for a CI trial, and is safe to take to PR.
+- Evidence Available: `/opt/homebrew/bin/actionlint .github/workflows/wasm-hosted-macos-arm64-docker-probe.yml` passed; Ruby YAML load passed; `git diff --check` passed; existing self-hosted workflow run `28278585758` remains queued with repo runner inventory `total_count: 0`.
+- Expected Return Contract: findings or no_findings; scope/spec compliance verdict; role quality/risk verdict; residual_risk.
+- Validation Command: `git diff --cached --binary > .pm/scratch/task_fef95d44dbba4048b574d68138431371/review-packages/staged-review.diff`; multi-agent review dispatch.
+- Expected Result: reviewers inspect a frozen staged diff and return findings/no_findings.
+- Actual Result: review requests recorded and dispatched.
+- Blocker / Next Action: integrate role review results.
+- Slice Ledger: `.pm/scratch/task_fef95d44dbba4048b574d68138431371/slice-ledger.jsonl`.
+- Formal Sink: `.pm/tasks/task_fef95d44dbba4048b574d68138431371.execution.md`.
+
+## 2026-06-27 13:46:54 CST / tpm
+- Review Result Integrated: `wasm_platform_engineer` returned one P1 finding; `qa_engineer` returned `no_findings`.
+- 完成内容: Integrated WASM and QA pre-PR review results.
+- 遗留事项: wait for repository health review and final passed packet.
+- Action: fixed the valid WASM P1 finding and reran local validation.
+- `wasm_platform_engineer` Finding: `docker run` redirected stdout and stderr into one file, so image pull/status output could cause a successful hosted linux/amd64 container probe to be misclassified as `unexpected-output`.
+- Finding Disposition: addressed.
+- Fix Evidence: `.github/workflows/wasm-hosted-macos-arm64-docker-probe.yml` now redirects Docker stdout to `docker-linux-amd64-uname.stdout`, stderr to `docker-linux-amd64-uname.stderr`, extracts the last non-empty stdout line with `awk`, and writes normalized output to `docker-linux-amd64-uname.txt` before matching `x86_64|amd64`.
+- Validation Command: `/opt/homebrew/bin/actionlint .github/workflows/wasm-hosted-macos-arm64-docker-probe.yml`.
+- Actual Result: passed.
+- Validation Command: `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/wasm-hosted-macos-arm64-docker-probe.yml"); puts "yaml ok"'`.
+- Actual Result: passed (`yaml ok`).
+- Validation Command: `git diff --cached --check`.
+- Actual Result: passed.
+- Expected Result: Docker platform probe cannot misclassify successful stdout because of image-pull/status stderr.
+- Review Package: refreshed `.pm/scratch/task_fef95d44dbba4048b574d68138431371/review-packages/staged-review.diff` after the fix.
+- Blocker / Next Action: wait for `repository_health_engineer` review, then record pre-PR review packet.
+
+## 2026-06-27 13:48:30 CST / tpm
+- Review Result Integrated: `repository_health_engineer` returned one P2 finding.
+- 完成内容: Integrated repository health pre-PR review result.
+- 遗留事项: record passed packet after validation.
+- Action: updated task acceptance to match the hosted probe implementation.
+- `repository_health_engineer` Finding: task acceptance still described only the self-hosted Darwin ARM64 Docker workflow trigger, while the staged implementation adds a separate hosted diagnostic probe path.
+- Finding Disposition: addressed.
+- Fix Evidence: `.pm/tasks/task_fef95d44dbba4048b574d68138431371.yaml` acceptance now distinguishes self-hosted workflow status evidence from the new `.github/workflows/wasm-hosted-macos-arm64-docker-probe.yml` diagnostic workflow and explicitly requires `release_evidence=false` / no WDBP-3.2/P0 closure claim.
+- Validation Command: Ruby YAML load, `/opt/homebrew/bin/actionlint`, and `git diff --cached --check`.
+- Expected Result: task acceptance and workflow remain parseable and lint-clean for the changed surface.
+- Actual Result: validation passed.
+- Blocker / Next Action: record pre-PR local role review passed packet.
+- Residual Risk from review: hosted probe success remains capability evidence only and must not be promoted into release closure without the canonical cross-host summary/report path.
+
+## 2026-06-27 13:50:30 CST / tpm
+- 完成内容: Recorded pre-PR local role review passed packet.
+- 遗留事项: closeout, commit, create PR, merge, then trigger hosted probe workflow from default branch.
+- Action: summarized all review evidence, finding dispositions, verification matrix, and residual risk.
+- Pre-PR Local Role Review: passed
+- Task UID: task_fef95d44dbba4048b574d68138431371
+- Source Worktree: /Users/scc/ccwork/worktrees/oasis7-chain-world-state-substrate-darwin-docker-ci-trial
+- Source Branch: task/chain-world-state-substrate-darwin-docker-ci-trial
+- Source Head: 716f937ccbf920f7e281c7ba5b91fde7c0ddea29
+- Comparison Ref: refs/remotes/origin/main
+- Reviewed Changed Paths: `.github/workflows/wasm-hosted-macos-arm64-docker-probe.yml`; `.pm/roles/tpm/backlog/committed.yaml`; `.pm/tasks/task_fef95d44dbba4048b574d68138431371.execution.md`; `.pm/tasks/task_fef95d44dbba4048b574d68138431371.yaml`.
+- Review Package: `.pm/scratch/task_fef95d44dbba4048b574d68138431371/review-packages/staged-review.diff`
+- Role Selection Basis: WASM deterministic-build CI/probe workflow touched (`wasm_platform_engineer`); release/evidence sufficiency and CI diagnostics claim (`qa_engineer`); workflow/task evidence alignment and acceptance semantics (`repository_health_engineer`).
+- Review Roles: `wasm_platform_engineer`, `qa_engineer`, `repository_health_engineer`
+- Review Evidence: wasm_platform_engineer P1 mixed Docker stdout/stderr finding addressed; qa_engineer no_findings; repository_health_engineer P2 acceptance ambiguity addressed.
+- Review Evidence Detail:
+  - `wasm_platform_engineer`: one P1 finding on mixed Docker stdout/stderr misclassification; addressed by separated stdout/stderr capture and last non-empty stdout extraction.
+  - `qa_engineer`: `no_findings`; verdict that workflow is safe/testable for PR as diagnostic-only, with residual risk that hosted runner capability requires real Actions run.
+  - `repository_health_engineer`: one P2 finding on task acceptance ambiguity; addressed by updating acceptance to explicitly cover hosted probe diagnostic workflow and `release_evidence=false` boundary.
+- Review Verdicts: wasm_platform_engineer scope/spec acceptable after fix and role risk diagnostic-only; qa_engineer scope/spec pass for PR and role risk acceptable with empirical run required; repository_health_engineer acceptable after acceptance clarification.
+- Review Verdicts Detail:
+  - `wasm_platform_engineer`: scope/spec partial before P1, acceptable after fix; role risk remains that hosted probe is capability evidence only.
+  - `qa_engineer`: scope/spec pass for PR; role risk acceptable with empirical Actions run still required.
+  - `repository_health_engineer`: mostly compliant before P2, acceptable after acceptance clarification.
+- Review Findings Disposition: addressed
+- Finding Disposition Evidence: `.github/workflows/wasm-hosted-macos-arm64-docker-probe.yml` Docker stdout/stderr fix; `.pm/tasks/task_fef95d44dbba4048b574d68138431371.yaml` acceptance rewrite; validation commands below passed.
+- Verification Matrix: hosted probe workflow syntax -> `/opt/homebrew/bin/actionlint` passed; YAML syntax -> Ruby YAML load passed; staged diff hygiene -> `git diff --cached --check` passed; live hosted runner capability -> deferred to manual workflow run after merge because workflow must exist on default branch for dispatch.
+- Visual Evidence: n/a; workflow-only CI diagnostic change.
+- WASM Evidence: workflow probe collects host/Docker/linux-amd64 container capability inputs; canonical release evidence remains `.github/workflows/wasm-darwin-docker-evidence.yml` and is not weakened.
+- Ops Evidence: self-hosted run `28278585758` remains queued because repo self-hosted runner inventory was `total_count: 0`; hosted probe is diagnostic only.
+- LiveOps Evidence: n/a; no external/player messaging.
+- Validation Command: `/opt/homebrew/bin/actionlint .github/workflows/wasm-hosted-macos-arm64-docker-probe.yml`; Ruby YAML load; `git diff --cached --check`.
+- Expected Result: branch is ready for task closeout and PR creation.
+- Actual Result: validations passed and closeout was attempted; repo-wide `.pm lint` historical debt required `--no-lint` handling.
+- Blocker / Next Action: rerun task closeout with repo-wide lint isolated, then commit and create PR.
+- Residual Risk: hosted `macos-15` Docker capability is unknown until GitHub Actions run executes; even if successful, it is not WDBP-3.2/P0 release closure unless canonical cross-host evidence criteria are separately satisfied or formally redesigned.
+- Slice Ledger: `.pm/scratch/task_fef95d44dbba4048b574d68138431371/slice-ledger.jsonl`

--- a/.pm/tasks/task_fef95d44dbba4048b574d68138431371.execution.md
+++ b/.pm/tasks/task_fef95d44dbba4048b574d68138431371.execution.md
@@ -187,3 +187,12 @@ Example:
 - Blocker / Next Action: rerun task closeout with repo-wide lint isolated, then commit and create PR.
 - Residual Risk: hosted `macos-15` Docker capability is unknown until GitHub Actions run executes; even if successful, it is not WDBP-3.2/P0 release closure unless canonical cross-host evidence criteria are separately satisfied or formally redesigned.
 - Slice Ledger: `.pm/scratch/task_fef95d44dbba4048b574d68138431371/slice-ledger.jsonl`
+
+## 2026-06-27 14:05:00 CST / tpm
+- 完成内容: Recorded closeout and claim-ready evidence for PR preflight.
+- 遗留事项: create PR, watch checks/comments, merge, then trigger the hosted probe workflow from `main`.
+- Action: documented the `task-closeout.sh` closeout run and the embedded `claim-ready.sh` verification record after workflow-lint requested explicit log evidence.
+- Validation Command: `./scripts/pm/task-closeout.sh --role tpm --task-uid task_fef95d44dbba4048b574d68138431371 --claim-type task_complete --verify-command '/opt/homebrew/bin/actionlint .github/workflows/wasm-hosted-macos-arm64-docker-probe.yml && ruby -e '\''require "yaml"; YAML.load_file(".pm/tasks/task_fef95d44dbba4048b574d68138431371.yaml"); YAML.load_file(".github/workflows/wasm-hosted-macos-arm64-docker-probe.yml"); puts "yaml ok"'\'' && git diff --cached --check' --json`; helper-internal `claim-ready.sh --claim-type task_complete` record persisted in task YAML.
+- Expected Result: task closeout records fresh verification, `last_claim_type`, `last_verified_at`, `last_verification_status`, and `last_closed_at` for PR readiness evidence.
+- Actual Result: task status is `done`; `last_claim_type=task_complete`; `last_verification_status=verified`; `last_verification_exit_code=0`; `last_closed_at=2026-06-27T13:49:41+08:00`. A later direct `claim-ready.sh --claim-type ready_for_pr` attempt was rejected because closed task claim evidence is immutable for non-completion claims.
+- Blocker / Next Action: rerun `prepare-task-pr.sh --create` after committing evidence-only updates.

--- a/.pm/tasks/task_fef95d44dbba4048b574d68138431371.execution.md
+++ b/.pm/tasks/task_fef95d44dbba4048b574d68138431371.execution.md
@@ -162,14 +162,14 @@ Example:
 - Comparison Ref: refs/remotes/origin/main
 - Reviewed Changed Paths: `.github/workflows/wasm-hosted-macos-arm64-docker-probe.yml`; `doc/world-runtime/project.md`; `.pm/roles/tpm/backlog/committed.yaml`; `.pm/tasks/task_fef95d44dbba4048b574d68138431371.execution.md`; `.pm/tasks/task_fef95d44dbba4048b574d68138431371.yaml`.
 - Review Package: `.pm/scratch/task_fef95d44dbba4048b574d68138431371/review-packages/staged-review.diff`
-- Role Selection Basis: WASM deterministic-build CI/probe workflow touched (`wasm_platform_engineer`); release/evidence sufficiency and CI diagnostics claim (`qa_engineer`); workflow/task evidence alignment and acceptance semantics (`repository_health_engineer`).
-- Review Roles: wasm_platform_engineer, qa_engineer, repository_health_engineer
-- Review Evidence: wasm_platform_engineer P1 mixed Docker stdout/stderr finding addressed; qa_engineer no_findings; repository_health_engineer P2 acceptance ambiguity addressed; workflow-lint project trace requirement addressed in `doc/world-runtime/project.md`.
+- Role Selection Basis: WASM deterministic-build CI/probe workflow touched (`wasm_platform_engineer`); release/evidence sufficiency and CI diagnostics claim (`qa_engineer`); workflow/task evidence alignment and acceptance semantics (`repository_health_engineer`); module project trace and system release-contract semantics required `producer_system_designer`; world-runtime project trace required `runtime_engineer`.
+- Review Roles: wasm_platform_engineer, qa_engineer, repository_health_engineer, producer_system_designer, runtime_engineer
+- Review Evidence: wasm_platform_engineer P1 mixed Docker stdout/stderr finding addressed; qa_engineer no_findings; repository_health_engineer P2 acceptance ambiguity addressed; producer_system_designer no_findings on diagnostic-only release-contract boundary; runtime_engineer no_findings on runtime/system boundary; workflow-lint project trace requirement addressed in `doc/world-runtime/project.md`.
 - Review Evidence Detail:
   - `wasm_platform_engineer`: one P1 finding on mixed Docker stdout/stderr misclassification; addressed by separated stdout/stderr capture and last non-empty stdout extraction.
   - `qa_engineer`: `no_findings`; verdict that workflow is safe/testable for PR as diagnostic-only, with residual risk that hosted runner capability requires real Actions run.
   - `repository_health_engineer`: one P2 finding on task acceptance ambiguity; addressed by updating acceptance to explicitly cover hosted probe diagnostic workflow and `release_evidence=false` boundary.
-- Review Verdicts: wasm_platform_engineer scope/spec acceptable after fix and role risk diagnostic-only; qa_engineer scope/spec pass for PR and role risk acceptable with empirical run required; repository_health_engineer acceptable after acceptance clarification.
+- Review Verdicts: wasm_platform_engineer scope/spec acceptable after fix and role risk diagnostic-only; qa_engineer scope/spec pass for PR and role risk acceptable with empirical run required; repository_health_engineer acceptable after acceptance clarification; producer_system_designer pass/acceptable because probe does not replace or weaken release evidence; runtime_engineer pass/acceptable because no runtime paths or release activation semantics changed.
 - Review Verdicts Detail:
   - `wasm_platform_engineer`: scope/spec partial before P1, acceptable after fix; role risk remains that hosted probe is capability evidence only.
   - `qa_engineer`: scope/spec pass for PR; role risk acceptable with empirical Actions run still required.
@@ -205,3 +205,39 @@ Example:
 - Expected Result: PR helper should find module project trace for `task_fef95d44dbba4048b574d68138431371`.
 - Actual Result: prior run failed with `project task item lacks Trace`; doc trace was added as the corrective action.
 - Blocker / Next Action: commit trace and update review packet Source Head through an evidence-only follow-up commit.
+
+## 2026-06-27 14:12:00 CST / tpm
+- 完成内容: Recorded supplemental pre-PR role review request required by changed `doc/world-runtime/project.md`.
+- 遗留事项: collect `producer_system_designer` and `runtime_engineer` review results, update passed packet, and rerun PR helper.
+- Action: dispatch supplemental review for roles inferred by `prepare-task-pr.sh` after adding module project trace.
+- Validation Command: `./scripts/prepare-task-pr.sh --create --title "Add hosted macOS Docker probe workflow"`.
+- Expected Result: PR helper reports any remaining required role gaps.
+- Actual Result: helper required supplemental `producer_system_designer` and `runtime_engineer` roles because `doc/world-runtime/project.md` changed.
+- Blocker / Next Action: dispatch supplemental read-only reviews for the hosted probe workflow plus project trace diff.
+
+## 2026-06-27 14:20:00 CST / tpm
+- 完成内容: Integrated supplemental `runtime_engineer` review and tracked pending producer review.
+- 遗留事项: wait for `producer_system_designer` supplemental review, then update pre-PR review packet and rerun PR helper.
+- Action: collected `runtime_engineer` supplemental review result for workflow + project trace diff.
+- Validation Command: `multi_agent_v1.wait_agent` for supplemental review agents.
+- Expected Result: required supplemental roles return findings/no_findings verdicts for PR helper coverage.
+- Actual Result: `runtime_engineer` returned `no_findings`; scope/spec pass because workflow is manual diagnostic-only and does not touch runtime source/replay/checkpoint/recovery/simulator/state paths; role risk acceptable with residual risk that a passing probe is hosted capability evidence only. `producer_system_designer` remained pending after repeated waits and was prompted to return a concise verdict.
+- Blocker / Next Action: wait for `producer_system_designer` result.
+
+## 2026-06-27 14:24:00 CST / tpm
+- 完成内容: Re-dispatched stalled producer review as a narrower supplemental slice.
+- 遗留事项: integrate new `producer_system_designer` result.
+- Action: closed stalled producer agent `019f07a9-3574-7e63-bfec-a8362b4d0bee` after repeated waits and spawned narrow replacement focused only on product/system release-contract semantics.
+- Validation Command: `multi_agent_v1.close_agent`; `multi_agent_v1.spawn_agent`.
+- Expected Result: obtain required `producer_system_designer` verdict without broad exploration.
+- Actual Result: previous producer slice was shut down; replacement producer slice `019f07b6-4bc5-7112-8cd2-b185ce9b582f` dispatched with a narrowed three-file review scope.
+- Blocker / Next Action: wait for replacement producer review result.
+
+## 2026-06-27 14:28:00 CST / tpm
+- 完成内容: Integrated supplemental `producer_system_designer` review and updated pre-PR review packet.
+- 遗留事项: commit evidence update and rerun PR helper.
+- Action: added `producer_system_designer` and `runtime_engineer` coverage to the passed local role review packet.
+- Validation Command: `multi_agent_v1.wait_agent` for replacement producer review.
+- Expected Result: producer review confirms product/system release-contract boundary.
+- Actual Result: `producer_system_designer` returned `no_findings`; scope/spec pass because workflow is diagnostic-only, `workflow_dispatch` only, writes `release_evidence=false`, uploads probe artifacts, and summary/project/task acceptance preserve that it does not close WDBP-3.2 by itself. Residual risk remains that hosted probe success is capability evidence only.
+- Blocker / Next Action: commit evidence and rerun `prepare-task-pr.sh --create`.

--- a/.pm/tasks/task_fef95d44dbba4048b574d68138431371.execution.md
+++ b/.pm/tasks/task_fef95d44dbba4048b574d68138431371.execution.md
@@ -160,11 +160,11 @@ Example:
 - Source Branch: task/chain-world-state-substrate-darwin-docker-ci-trial
 - Source Head: 850fdb13b4689edf219a54845eb7354e90a747be
 - Comparison Ref: refs/remotes/origin/main
-- Reviewed Changed Paths: `.github/workflows/wasm-hosted-macos-arm64-docker-probe.yml`; `.pm/roles/tpm/backlog/committed.yaml`; `.pm/tasks/task_fef95d44dbba4048b574d68138431371.execution.md`; `.pm/tasks/task_fef95d44dbba4048b574d68138431371.yaml`.
+- Reviewed Changed Paths: `.github/workflows/wasm-hosted-macos-arm64-docker-probe.yml`; `doc/world-runtime/project.md`; `.pm/roles/tpm/backlog/committed.yaml`; `.pm/tasks/task_fef95d44dbba4048b574d68138431371.execution.md`; `.pm/tasks/task_fef95d44dbba4048b574d68138431371.yaml`.
 - Review Package: `.pm/scratch/task_fef95d44dbba4048b574d68138431371/review-packages/staged-review.diff`
 - Role Selection Basis: WASM deterministic-build CI/probe workflow touched (`wasm_platform_engineer`); release/evidence sufficiency and CI diagnostics claim (`qa_engineer`); workflow/task evidence alignment and acceptance semantics (`repository_health_engineer`).
 - Review Roles: wasm_platform_engineer, qa_engineer, repository_health_engineer
-- Review Evidence: wasm_platform_engineer P1 mixed Docker stdout/stderr finding addressed; qa_engineer no_findings; repository_health_engineer P2 acceptance ambiguity addressed.
+- Review Evidence: wasm_platform_engineer P1 mixed Docker stdout/stderr finding addressed; qa_engineer no_findings; repository_health_engineer P2 acceptance ambiguity addressed; workflow-lint project trace requirement addressed in `doc/world-runtime/project.md`.
 - Review Evidence Detail:
   - `wasm_platform_engineer`: one P1 finding on mixed Docker stdout/stderr misclassification; addressed by separated stdout/stderr capture and last non-empty stdout extraction.
   - `qa_engineer`: `no_findings`; verdict that workflow is safe/testable for PR as diagnostic-only, with residual risk that hosted runner capability requires real Actions run.
@@ -196,3 +196,12 @@ Example:
 - Expected Result: task closeout records fresh verification, `last_claim_type`, `last_verified_at`, `last_verification_status`, and `last_closed_at` for PR readiness evidence.
 - Actual Result: task status is `done`; `last_claim_type=task_complete`; `last_verification_status=verified`; `last_verification_exit_code=0`; `last_closed_at=2026-06-27T13:49:41+08:00`. A later direct `claim-ready.sh --claim-type ready_for_pr` attempt was rejected because closed task claim evidence is immutable for non-completion claims.
 - Blocker / Next Action: rerun `prepare-task-pr.sh --create` after committing evidence-only updates.
+
+## 2026-06-27 14:08:00 CST / tpm
+- 完成内容: Added module project trace required by PR workflow-lint.
+- 遗留事项: commit doc trace, refresh Source Head evidence, and rerun PR helper.
+- Action: updated `doc/world-runtime/project.md` with a current-window hosted macOS Docker probe trace pointing to this task.
+- Validation Command: `./scripts/prepare-task-pr.sh --create --title "Add hosted macOS Docker probe workflow"`.
+- Expected Result: PR helper should find module project trace for `task_fef95d44dbba4048b574d68138431371`.
+- Actual Result: prior run failed with `project task item lacks Trace`; doc trace was added as the corrective action.
+- Blocker / Next Action: commit trace and update review packet Source Head through an evidence-only follow-up commit.

--- a/.pm/tasks/task_fef95d44dbba4048b574d68138431371.execution.md
+++ b/.pm/tasks/task_fef95d44dbba4048b574d68138431371.execution.md
@@ -163,7 +163,7 @@ Example:
 - Reviewed Changed Paths: `.github/workflows/wasm-hosted-macos-arm64-docker-probe.yml`; `.pm/roles/tpm/backlog/committed.yaml`; `.pm/tasks/task_fef95d44dbba4048b574d68138431371.execution.md`; `.pm/tasks/task_fef95d44dbba4048b574d68138431371.yaml`.
 - Review Package: `.pm/scratch/task_fef95d44dbba4048b574d68138431371/review-packages/staged-review.diff`
 - Role Selection Basis: WASM deterministic-build CI/probe workflow touched (`wasm_platform_engineer`); release/evidence sufficiency and CI diagnostics claim (`qa_engineer`); workflow/task evidence alignment and acceptance semantics (`repository_health_engineer`).
-- Review Roles: `wasm_platform_engineer`, `qa_engineer`, `repository_health_engineer`
+- Review Roles: wasm_platform_engineer, qa_engineer, repository_health_engineer
 - Review Evidence: wasm_platform_engineer P1 mixed Docker stdout/stderr finding addressed; qa_engineer no_findings; repository_health_engineer P2 acceptance ambiguity addressed.
 - Review Evidence Detail:
   - `wasm_platform_engineer`: one P1 finding on mixed Docker stdout/stderr misclassification; addressed by separated stdout/stderr capture and last non-empty stdout extraction.

--- a/.pm/tasks/task_fef95d44dbba4048b574d68138431371.yaml
+++ b/.pm/tasks/task_fef95d44dbba4048b574d68138431371.yaml
@@ -10,6 +10,7 @@ source_signal: null
 source_refs:
   - doc/world-runtime/wasm/wasm-deterministic-build-pipeline.project.md
 doc_refs:
+  - doc/world-runtime/project.md
   - doc/world-runtime/wasm/wasm-deterministic-build-pipeline.project.md
   - doc/world-runtime/wasm/wasm-deterministic-build-pipeline.design.md
 related_prd: []

--- a/.pm/tasks/task_fef95d44dbba4048b574d68138431371.yaml
+++ b/.pm/tasks/task_fef95d44dbba4048b574d68138431371.yaml
@@ -1,0 +1,28 @@
+task_uid: task_fef95d44dbba4048b574d68138431371
+title: "Trial Darwin Docker CI evidence workflow"
+owner_role: tpm
+module: chain-world-state-substrate
+worktree_hint: /Users/scc/ccwork/worktrees/oasis7-chain-world-state-substrate-darwin-docker-ci-trial
+execution_log_path: .pm/tasks/task_fef95d44dbba4048b574d68138431371.execution.md
+status: done
+priority: P0
+source_signal: null
+source_refs:
+  - doc/world-runtime/wasm/wasm-deterministic-build-pipeline.project.md
+doc_refs:
+  - doc/world-runtime/wasm/wasm-deterministic-build-pipeline.project.md
+  - doc/world-runtime/wasm/wasm-deterministic-build-pipeline.design.md
+related_prd: []
+acceptance:
+  - "Self-hosted Darwin ARM64 Docker evidence workflow status and runner availability are recorded in task execution evidence."
+  - "A separate manual `.github/workflows/wasm-hosted-macos-arm64-docker-probe.yml` diagnostic workflow is added for GitHub-hosted macOS ARM64 runner capability probing."
+  - "Hosted probe uploads diagnostic artifacts with `release_evidence=false` and does not claim WDBP-3.2/P0 release closure."
+handoff_to: []
+updated_at: 2026-06-27T13:49:41+08:00
+last_started_at: 2026-06-27T13:32:13+08:00
+last_claim_type: task_complete
+last_verify_command: "/opt/homebrew/bin/actionlint .github/workflows/wasm-hosted-macos-arm64-docker-probe.yml && ruby -e 'require \"yaml\"; YAML.load_file(\".pm/tasks/task_fef95d44dbba4048b574d68138431371.yaml\"); YAML.load_file(\".github/workflows/wasm-hosted-macos-arm64-docker-probe.yml\"); puts \"yaml ok\"' && git diff --cached --check"
+last_verified_at: 2026-06-27T13:49:40+08:00
+last_verification_exit_code: 0
+last_verification_status: verified
+last_closed_at: 2026-06-27T13:49:41+08:00

--- a/doc/world-runtime/project.md
+++ b/doc/world-runtime/project.md
@@ -729,6 +729,7 @@
 - 当前状态: in_progress
 - 下一任务: `TASK-WORLD_RUNTIME-043`
 - 当前窗口摘要: provider/runtime live traceability、WASM Docker builder image/wrapper、build receipt/canonical token/identity/CI summary、receipt-aware release gate、node-side proof flow 与近期 runtime 技术债 tranche 均已收口；当前剩余阻塞仍是 `TASK-WORLD_RUNTIME-043` 的真实 Docker-capable `darwin-arm64` live evidence。Trace: .pm/tasks/task_dac2a6ab38134923b8573bc74fe5743e.yaml
+- 当前窗口补充（2026-06-27 / hosted macOS Docker probe）: self-hosted Darwin Docker evidence workflow 已可手动触发但仓库级 self-hosted runner inventory 为 0，新增独立 GitHub-hosted macOS ARM64 Docker capability probe workflow 仅采集 Docker/`linux/amd64` container 能力诊断 artifact，显式 `release_evidence=false`，不替代 WDBP-3.2/P0 canonical release evidence。Trace: .pm/tasks/task_fef95d44dbba4048b574d68138431371.yaml
 - 近期收口: viewer-live integration flake、builtin-wasm integer centimeter contract、node observability、wasm timing metrics、fetch-commit / peer-record backoff、traffic/finality/consensus health metrics 与 chain-linked passive world progress 已完成；详情回看对应任务项、topic project 与 `.pm` execution logs。
 - 历史追溯: 更早 `TASK-WORLD_RUNTIME-*` 完成项不再在状态区逐条追加；需要追 WASM builder、runtime storage、release policy、source compile、module release 或 node observability 历史时，先从上方任务项、`doc/world-runtime/prd.index.md`、topic project 与 `.pm/tasks/*.execution.md` 进入。
 - 阶段收口优先级: `P0`


### PR DESCRIPTION
## Summary
- add a manual GitHub-hosted macOS ARM64 Docker capability probe workflow
- keep canonical Darwin Docker release evidence workflow unchanged
- record task evidence and world-runtime project trace for diagnostic-only probe scope

## Verification
- /opt/homebrew/bin/actionlint .github/workflows/wasm-hosted-macos-arm64-docker-probe.yml
- ruby YAML load for task and workflow files
- git diff --check

## Scope
This probe uploads diagnostic artifacts with release_evidence=false. It does not close WDBP-3.2/P0 release evidence by itself.