### PR TITLE
Optimize module routing payload serialization

### DIFF
--- a/.pm/tasks/task_9e8e6246b4264cda8baf908cd98d8cfd.execution.md
+++ b/.pm/tasks/task_9e8e6246b4264cda8baf908cd98d8cfd.execution.md
@@ -1,0 +1,144 @@
+# task_9e8e6246b4264cda8baf908cd98d8cfd Execution Log
+
+- task_uid: task_9e8e6246b4264cda8baf908cd98d8cfd
+- title: code execution efficiency governance next issue
+- owner_role: tpm
+- worktree_hint: /Users/scc/ccwork/worktrees/oasis7-engineering-code-execution-efficiency-next-7
+
+<!-- Append entries using:
+Example:
+  ## YYYY-MM-DD HH:MM:SS CST / role_name
+  - 完成内容: ...
+  - 遗留事项: ...
+  - Action: ...
+  - Validation Command: ...
+  - Expected Result: ...
+  - Actual Result: ...
+  - Blocker / Next Action: ...
+-->
+
+## 2026-06-27 15:48:59 CST / tpm
+- 完成内容: WORKFLOW BOOTSTRAP DECIDED.
+- 遗留事项: Need route decision and professional discovery slices before implementation.
+- Repository State Impact: Changes repository state; user requested continuing engineering governance and code execution efficiency improvement.
+- Isolation Decision: Created dedicated task worktree `/Users/scc/ccwork/worktrees/oasis7-engineering-code-execution-efficiency-next-7` from `origin/main` on branch `task/engineering-code-execution-efficiency-next-7`.
+- Task Truth: Owner role `tpm`; canonical task `.pm/tasks/task_9e8e6246b4264cda8baf908cd98d8cfd.yaml`; execution log `.pm/tasks/task_9e8e6246b4264cda8baf908cd98d8cfd.execution.md`.
+- Formal Docs: Source ref `doc/engineering/project.md`; no separate PRD doc ref required for this scoped governance follow-up unless selected fix changes a domain contract.
+- Routed Next Phase: `repo-owned-workflow-router` -> discovery slices -> execution. Direction is bounded enough to look for the next code execution efficiency issue, but the professional candidate selection must come from role slices.
+- Required Writeback: task execution log is mandatory; `doc/engineering/project.md` must be updated if a fix lands; other docs only if the selected issue changes a documented contract.
+- Blocker / Next Action: Record route and subagent slice contracts before delegated discovery.
+
+## 2026-06-27 15:49:10 CST / tpm
+- 完成内容: WORKFLOW ROUTE DECIDED.
+- 遗留事项: Need dispatched discovery slices and candidate integration before code edits.
+- Current Phase: Discovery for a scoped implementation task.
+- Selected Workflow Skills: `executing-project-tasks` after discovery; `systematic-debugging` if discovery or verification exposes an unexpected failure; `verification-before-completion`, `requesting-repo-owned-review`, and `finishing-a-development-branch` for closeout/PR.
+- Specialist Skills Considered: `optimization-performance` applies as performance framing; professional conclusions will be owned by `repository_health_engineer` and `runtime_engineer` slices rather than TPM.
+- Skipped Workflow Skills: `bounded-brainstorming` skipped because user requested continuing the established governance loop; `tdd-test-writer` deferred until the selected target has a stable harness.
+- TPM TODO Decomposition:
+  1. Dispatch repository-health discovery slice for next code execution efficiency candidate, avoiding already completed project entries.
+  2. Dispatch runtime-engineer discovery slice for runtime/simulator hot-path candidate with testability.
+  3. Integrate candidate evidence and choose one scoped target.
+  4. Implement minimal fix, add regression/perf-oriented evidence, update engineering project trace.
+  5. Run focused and required validation, local role review, PR watch/fix/merge/cleanup.
+- Subagent Slice Contract: repository_health_engineer discovery
+  - slice type: bounded professional discovery / candidate ranking.
+  - intended model configuration: workflow default subagent runtime.
+  - actual dispatched model/reasoning: inherited/unverified; subagent tool inherits parent model and does not verify actual model in task truth.
+  - context delivery mode: full-thread/full-history fork plus explicit checklist in prompt.
+  - mandatory context checklist/packet: identity `repository_health_engineer`; workflow governance `AGENTS.md` + `doc/engineering/workflow/source-of-truth.md`; task truth `task_9e8e6246b4264cda8baf908cd98d8cfd`; user intent "continue finding next code execution efficiency issue"; scoped repo context `doc/engineering/project.md` completed performance entries and first-party code excluding `third_party/**`; collaboration boundary no edits unless explicitly asked, return findings to TPM.
+  - write scope: read-only discovery; no file edits.
+  - return contract: 1-3 ranked candidates with file paths, suspected inefficiency pattern, expected minimal fix, verification command, risk, and recommendation.
+  - formal sink: this execution log.
+  - integration owner/order: TPM integrates after runtime slice.
+- Subagent Slice Contract: runtime_engineer discovery
+  - slice type: bounded professional runtime/performance discovery.
+  - intended model configuration: workflow default subagent runtime.
+  - actual dispatched model/reasoning: inherited/unverified; subagent tool inherits parent model and does not verify actual model in task truth.
+  - context delivery mode: full-thread/full-history fork plus explicit checklist in prompt.
+  - mandatory context checklist/packet: identity `runtime_engineer`; workflow governance `AGENTS.md` + source-of-truth; task truth `task_9e8e6246b4264cda8baf908cd98d8cfd`; user intent code execution efficiency; scoped repo context runtime/simulator hot paths and completed project entries; collaboration boundary no edits during discovery, return runtime-owned candidate evidence.
+  - write scope: read-only discovery; no file edits.
+  - return contract: one preferred implementable candidate plus alternates, with behavior boundary and test command.
+- formal sink: this execution log.
+- integration owner/order: TPM integrates after repository-health slice.
+- Blocker / Next Action: Dispatch both discovery slices in parallel.
+
+## 2026-06-27 15:56:00 CST / repository_health_engineer
+- 完成内容: Read-only discovery slice completed.
+- 遗留事项: Runtime owner candidate still pending before TPM selects implementation target.
+- Scope: first-party code execution efficiency candidates, excluding `third_party/**` and already completed `doc/engineering/project.md` performance entries.
+- Finding 1 / Recommendation: `crates/oasis7_net/src/provider_selection.rs` full scores/clones/sorts every provider record before dedup/top-N; recommended as repository-health first choice with `./scripts/cargo-dev.sh test -p oasis7_net rank_providers --lib`.
+- Finding 2: `crates/oasis7/src/simulator/kernel/observation.rs` redundantly sorts several vectors derived from BTreeMap-backed snapshots; lower confidence because runtime order semantics need owner confirmation.
+- Finding 3: `crates/oasis7_node/src/libp2p_replication_network.rs` request peer filtering appears to lock score state once per peer; higher concurrency semantics risk than the first candidate.
+- Residual Risk: Findings are discovery-only and do not authorize TPM to claim runtime/network correctness without corresponding owner review.
+- Blocker / Next Action: Wait for runtime_engineer slice and integrate candidate selection.
+
+## 2026-06-27 15:57:00 CST / runtime_engineer
+- 完成内容: Read-only runtime/performance discovery slice completed.
+- 遗留事项: TPM must implement and verify the selected candidate.
+- Preferred Candidate: `crates/oasis7/src/runtime/world/module_runtime.rs` computes canonical event/action payload bytes and `current_manifest_hash()` before confirming any active module subscription matches in `route_event_to_modules` and `route_action_to_modules_with_stage_and_event`.
+- Hot Path Pattern: Active modules can be many while most do not subscribe to a given event/action; old routing paid serialization/hash work even for 0-call or low-hit paths.
+- Minimal Fix: Keep JSON value creation for subscription matching; lazily compute canonical payload bytes and world config hash only on first subscribed module, then reuse cached bytes/hash for subsequent subscribed modules.
+- Behavior Boundary: Non-subscribed modules remain uncalled; subscribed module input bytes/context hash/manifest hash/call order remain equivalent. The intended change is avoiding unused payload/hash work when no matching subscriber exists.
+- Verification Recommendation: `./scripts/cargo-dev.sh test -p oasis7 modules --lib`; `./scripts/cargo-dev.sh test -p oasis7 module_runtime --lib`; optional local ignored perf probe.
+- Blocker / Next Action: TPM to implement runtime preferred candidate; keep provider selection as a future governance candidate.
+
+## 2026-06-27 15:58:49 CST / tpm
+- 完成内容: Integrated discovery and implemented selected runtime efficiency fix.
+- 遗留事项: Need required validation, local role review, task closeout, PR creation, CI/comment watch, merge, and cleanup.
+- Selection Rationale: Chose the runtime_engineer preferred candidate because it is a direct runtime module-routing hot path, has a narrow behavior boundary, and is covered by existing module routing tests. Repository-health provider selection top-N remains a good follow-up candidate but is outside this runtime-focused slice.
+- Action: Updated `route_event_to_modules` to lazily cache `event_bytes` and `world_config_hash` after the first matching subscription instead of before the loop.
+- Action: Updated `route_action_to_modules_with_stage_and_event` to lazily cache `action_bytes`, optional post-action `event_bytes`, and `world_config_hash` after the first matching subscription.
+- Action: Added project trace `module-routing-lazy-payload-serialization-efficiency` in `doc/engineering/project.md`.
+- Validation Command: `./scripts/cargo-dev.sh fmt --check`
+- Expected Result: Formatting remains clean.
+- Actual Result: Passed.
+- Validation Command: `./scripts/cargo-dev.sh test -p oasis7 modules --lib`
+- Expected Result: Module routing behavior remains intact.
+- Actual Result: Passed; 27 passed, 1 ignored.
+- Validation Command: `./scripts/cargo-dev.sh test -p oasis7 module_runtime --lib`
+- Expected Result: Module runtime helper tests remain intact.
+- Actual Result: Passed; 7 passed.
+- Blocker / Next Action: Run broader module surface checks, diff/file-size gates, and required validation before local role review / PR prep.
+
+## 2026-06-27 16:01:00 CST / tpm
+- 完成内容: Ran broader local verification after implementation.
+- 遗留事项: Need fresh claim-ready/closeout after required validation; `prepare-task-pr` currently blocked by dirty worktree until this evidence is committed.
+- Validation Command: `./scripts/cargo-dev.sh test -p oasis7 module --lib`
+- Expected Result: Full module-related lib surface remains green.
+- Actual Result: Passed; 164 passed, 1 ignored.
+- Validation Command: `./scripts/check-rust-file-size.sh`
+- Expected Result: Rust file-size gate remains zero.
+- Actual Result: Passed.
+- Validation Command: `git diff --check`
+- Expected Result: No whitespace errors.
+- Actual Result: Passed.
+- Validation Command: `./scripts/doc-governance-check.sh`
+- Expected Result: Project trace update satisfies doc governance.
+- Actual Result: Passed.
+- Validation Command: `./scripts/pm/workflow-lint.sh --task-uid task_9e8e6246b4264cda8baf908cd98d8cfd --phase pr-ready`
+- Expected Result: Not yet expected to pass before claim-ready and closeout; should only reveal remaining workflow evidence gaps.
+- Actual Result: Failed as expected because claim-ready and closeout evidence are not recorded yet, and because earlier execution entries needed `遗留事项` fields; this entry fixes the structured-field gap.
+- Validation Command: `./scripts/prepare-task-pr.sh --json`
+- Expected Result: Not yet expected to pass before commit/clean worktree and final gates.
+- Actual Result: Failed because the source worktree is dirty.
+- Blocker / Next Action: Run required validation, then claim-ready and closeout before PR prep.
+
+## 2026-06-27 16:11:30 CST / tpm
+- 完成内容: Ran targeted required validation for the runtime/module-routing change.
+- 遗留事项: Need claim-ready, closeout, local role review, commit, PR creation, CI/comment watch, merge, and cleanup.
+- Validation Command: `OASIS7_CI_RUN_OASIS7_REQUIRED_TESTS=true OASIS7_CI_RUN_CONSENSUS_TESTS=false OASIS7_CI_RUN_DISTFS_TESTS=false OASIS7_CI_RUN_OASIS7_NODE_TESTS=false OASIS7_CI_RUN_OASIS7_NET_TESTS=false OASIS7_CI_RUN_OASIS7_NET_LIBP2P_TESTS=false OASIS7_CI_RUN_VIEWER_CONTRACT_TESTS=false OASIS7_CI_RUN_VIEWER_WASM_CHECK=false OASIS7_CI_RUN_VIEWER_PERF_SMOKE=false OASIS7_CI_RUN_LAUNCHER_WEB_BUILD=true OASIS7_CI_RUN_WORKSPACE_SUPPORT_CRATE_TESTS=false ./scripts/ci-tests.sh required`
+- Expected Result: Required local gate passes for the changed runtime/doc surface.
+- Actual Result: Passed. Covered doc governance, skill lint, path/script checks, cargo-dev helper smoke, standalone tool lockfiles, provider bridge smoke, `oasis7_newapi_bridge_service` tests, Rust file-size, `cargo fmt --all -- --check`, RustSec/cargo-deny advisories, `cargo test -p oasis7 --tests --features test_tier_required`, web launcher `trunk build --release`, and clippy correctness/suspicious. Non-selected suites were skipped by scope planner with explicit claim-boundary messages.
+- Blocker / Next Action: Run claim-ready and task closeout.
+
+## 2026-06-27 16:13:38 CST / tpm
+- 完成内容: Ran claim-ready and task closeout for the selected module-routing efficiency fix.
+- 遗留事项: Need pre-PR local role review, commit, PR creation, CI/comment watch, merge, and cleanup.
+- Validation Command: `./scripts/pm/claim-ready.sh --claim-type ready_for_pr --task-uid task_9e8e6246b4264cda8baf908cd98d8cfd --verify-command './scripts/cargo-dev.sh test -p oasis7 module --lib'`
+- Expected Result: Fresh ready-for-PR claim is backed by the module surface verification command.
+- Actual Result: Passed; verification command exited 0 with 164 passed and 1 ignored, and the claim status was `verified`.
+- Validation Command: `./scripts/pm/task-closeout.sh --role tpm --task-uid task_9e8e6246b4264cda8baf908cd98d8cfd --verify-command './scripts/cargo-dev.sh test -p oasis7 module --lib'`
+- Expected Result: Close the task after rerunning the same verification command.
+- Actual Result: Task-local YAML was updated to `status: done`, `last_claim_type: task_complete`, `last_verification_status: verified`, and `last_closed_at: 2026-06-27T16:13:38+08:00`. The helper exited non-zero only after encountering unrelated historical repo-wide `.pm` lint debt outside this task.
+- Blocker / Next Action: Re-run task-local workflow lint, then perform pre-PR local role review.

--- a/.pm/tasks/task_9e8e6246b4264cda8baf908cd98d8cfd.execution.md
+++ b/.pm/tasks/task_9e8e6246b4264cda8baf908cd98d8cfd.execution.md
@@ -195,3 +195,11 @@ Example:
 - Expected Result: No whitespace errors.
 - Actual Result: Passed.
 - Blocker / Next Action: Commit post-rebase evidence and run PR helper.
+
+## 2026-06-27 16:50:00 CST / tpm
+- 完成内容: Created GitHub PR for normal CI/comment/merge watch.
+- 遗留事项: Watch required checks, mergeability, PR comments/review threads, fix blockers if any, then merge and clean up worktree/branch.
+- PR: https://github.com/eng-cc/oasis7/pull/699
+- PR Purpose Decision: normal_pr_ci_watch
+- Reason: This is an ordinary runtime efficiency/governance implementation PR, not a manual packaging/release CI hold.
+- Next Action: Push this PR-purpose evidence commit and monitor PR #699 required checks/comments/review threads.

--- a/.pm/tasks/task_9e8e6246b4264cda8baf908cd98d8cfd.execution.md
+++ b/.pm/tasks/task_9e8e6246b4264cda8baf908cd98d8cfd.execution.md
@@ -146,7 +146,7 @@ Example:
 ## 2026-06-27 16:20:00 CST / tpm
 - Review Trigger: pre-PR local role review
 - Review Scope: `crates/oasis7/src/runtime/world/module_runtime.rs`; `doc/engineering/project.md`; `.pm/tasks/task_9e8e6246b4264cda8baf908cd98d8cfd.*`
-- Review Package: `/Users/scc/ccwork/worktrees/oasis7-engineering-code-execution-efficiency-next-7/.pm/scratch/task_9e8e6246b4264cda8baf908cd98d8cfd/review-packages/review-458ed286f..2c1c209f8.diff`
+- Review Package: `/Users/scc/ccwork/worktrees/oasis7-engineering-code-execution-efficiency-next-7/.pm/scratch/task_9e8e6246b4264cda8baf908cd98d8cfd/review-packages/review-70a8b1d84..29d5f856a.diff`
 - Review Roles: runtime_engineer, wasm_platform_engineer, qa_engineer, repository_health_engineer, producer_system_designer
 - Review Question: Confirm the lazy module-routing payload/hash computation preserves module call input semantics, WASM/module-platform compatibility, verification sufficiency, and governance trace quality before PR creation.
 - Evidence Available: `./scripts/cargo-dev.sh fmt --check`; `./scripts/cargo-dev.sh test -p oasis7 modules --lib`; `./scripts/cargo-dev.sh test -p oasis7 module_runtime --lib`; `./scripts/cargo-dev.sh test -p oasis7 module --lib`; targeted `./scripts/ci-tests.sh required`; `./scripts/check-rust-file-size.sh`; `git diff --check`; `./scripts/doc-governance-check.sh`; task-local `./scripts/pm/workflow-lint.sh --task-uid task_9e8e6246b4264cda8baf908cd98d8cfd --phase pr-ready`.
@@ -160,10 +160,10 @@ Example:
 - Task UID: task_9e8e6246b4264cda8baf908cd98d8cfd
 - Source Worktree: /Users/scc/ccwork/worktrees/oasis7-engineering-code-execution-efficiency-next-7
 - Source Branch: task/engineering-code-execution-efficiency-next-7
-- Source Head: 2c1c209f85e0728108eb5a173acdf472dfcf0b75
+- Source Head: 29d5f856acbb36f30bcb7e0b203ed4e6abdcf466
 - Comparison Ref: refs/remotes/origin/main
 - Reviewed Changed Paths: `crates/oasis7/src/runtime/world/module_runtime.rs`; `doc/engineering/project.md`; `.pm/tasks/task_9e8e6246b4264cda8baf908cd98d8cfd.execution.md`; `.pm/tasks/task_9e8e6246b4264cda8baf908cd98d8cfd.yaml`
-- Review Package: `/Users/scc/ccwork/worktrees/oasis7-engineering-code-execution-efficiency-next-7/.pm/scratch/task_9e8e6246b4264cda8baf908cd98d8cfd/review-packages/review-458ed286f..2c1c209f8.diff`
+- Review Package: `/Users/scc/ccwork/worktrees/oasis7-engineering-code-execution-efficiency-next-7/.pm/scratch/task_9e8e6246b4264cda8baf908cd98d8cfd/review-packages/review-70a8b1d84..29d5f856a.diff`
 - Role Selection Basis: changed `crates/oasis7` runtime module-routing code and module call input semantics -> runtime_engineer; module ABI/input/hash compatibility -> wasm_platform_engineer; PR readiness and test-tier sufficiency -> qa_engineer; governance trace and technical-debt separation -> repository_health_engineer; prepare-task-pr changed-path inference and system-level module contract confirmation -> producer_system_designer. Skipped gameplay/visual/agent/viewer/blockchain/liveops roles because this PR changes no gameplay rule, visible UI, agent behavior, viewer path, operator runbook, deployment artifact, or external/player messaging.
 - Review Roles: runtime_engineer, wasm_platform_engineer, qa_engineer, repository_health_engineer, producer_system_designer
 - Review Evidence: runtime_engineer no_findings; wasm_platform_engineer no_findings; qa_engineer no_findings; repository_health_engineer no_findings; producer_system_designer no_findings.
@@ -178,3 +178,20 @@ Example:
 - Residual Risk: Low. No dedicated benchmark asserts the no-subscriber path avoids serialization/hash work; benefit is supported by code structure and owner review. Existing behavior regressions cover module input semantics for subscribed paths.
 - Slice Ledger: `/Users/scc/ccwork/worktrees/oasis7-engineering-code-execution-efficiency-next-7/.pm/scratch/task_9e8e6246b4264cda8baf908cd98d8cfd/slice-ledger.jsonl`
 - 遗留事项: Commit review evidence and run PR preflight/create.
+
+## 2026-06-27 16:43:00 CST / tpm
+- 完成内容: Rebasing completed cleanly after `origin/main` advanced.
+- 遗留事项: Need fresh post-rebase verification, evidence commit, PR creation, CI/comment watch, merge, and cleanup.
+- Action: Rebased `task/engineering-code-execution-efficiency-next-7` onto `origin/main` at `70a8b1d8460c861708aeb921dc7363a77d505d0a`; no conflicts occurred.
+- Action: Refreshed review package to `/Users/scc/ccwork/worktrees/oasis7-engineering-code-execution-efficiency-next-7/.pm/scratch/task_9e8e6246b4264cda8baf908cd98d8cfd/review-packages/review-70a8b1d84..29d5f856a.diff`.
+- Action: Updated pre-PR review packet `Source Head` to current rebased head `29d5f856acbb36f30bcb7e0b203ed4e6abdcf466`; review findings remain applicable because the rebase was conflict-free and changed only commit ancestry/package metadata.
+- Validation Command: `./scripts/cargo-dev.sh test -p oasis7 module --lib`
+- Expected Result: Module surface remains green after rebase.
+- Actual Result: Passed; 164 passed, 1 ignored.
+- Validation Command: `./scripts/pm/workflow-lint.sh --task-uid task_9e8e6246b4264cda8baf908cd98d8cfd --phase pr-ready`
+- Expected Result: Task-local workflow evidence remains PR-ready after packet/head refresh.
+- Actual Result: Passed.
+- Validation Command: `git diff --check`
+- Expected Result: No whitespace errors.
+- Actual Result: Passed.
+- Blocker / Next Action: Commit post-rebase evidence and run PR helper.

--- a/.pm/tasks/task_9e8e6246b4264cda8baf908cd98d8cfd.execution.md
+++ b/.pm/tasks/task_9e8e6246b4264cda8baf908cd98d8cfd.execution.md
@@ -142,3 +142,39 @@ Example:
 - Expected Result: Close the task after rerunning the same verification command.
 - Actual Result: Task-local YAML was updated to `status: done`, `last_claim_type: task_complete`, `last_verification_status: verified`, and `last_closed_at: 2026-06-27T16:13:38+08:00`. The helper exited non-zero only after encountering unrelated historical repo-wide `.pm` lint debt outside this task.
 - Blocker / Next Action: Re-run task-local workflow lint, then perform pre-PR local role review.
+
+## 2026-06-27 16:20:00 CST / tpm
+- Review Trigger: pre-PR local role review
+- Review Scope: `crates/oasis7/src/runtime/world/module_runtime.rs`; `doc/engineering/project.md`; `.pm/tasks/task_9e8e6246b4264cda8baf908cd98d8cfd.*`
+- Review Package: `/Users/scc/ccwork/worktrees/oasis7-engineering-code-execution-efficiency-next-7/.pm/scratch/task_9e8e6246b4264cda8baf908cd98d8cfd/review-packages/review-458ed286f..2c1c209f8.diff`
+- Review Roles: runtime_engineer, wasm_platform_engineer, qa_engineer, repository_health_engineer
+- Review Question: Confirm the lazy module-routing payload/hash computation preserves module call input semantics, WASM/module-platform compatibility, verification sufficiency, and governance trace quality before PR creation.
+- Evidence Available: `./scripts/cargo-dev.sh fmt --check`; `./scripts/cargo-dev.sh test -p oasis7 modules --lib`; `./scripts/cargo-dev.sh test -p oasis7 module_runtime --lib`; `./scripts/cargo-dev.sh test -p oasis7 module --lib`; targeted `./scripts/ci-tests.sh required`; `./scripts/check-rust-file-size.sh`; `git diff --check`; `./scripts/doc-governance-check.sh`; task-local `./scripts/pm/workflow-lint.sh --task-uid task_9e8e6246b4264cda8baf908cd98d8cfd --phase pr-ready`.
+- Expected Return Contract: findings or no_findings; scope/spec compliance verdict; role quality/risk verdict; residual_risk.
+- Slice Ledger: `/Users/scc/ccwork/worktrees/oasis7-engineering-code-execution-efficiency-next-7/.pm/scratch/task_9e8e6246b4264cda8baf908cd98d8cfd/slice-ledger.jsonl`
+- Formal Sink: `.pm/tasks/task_9e8e6246b4264cda8baf908cd98d8cfd.execution.md`
+- 遗留事项: Await review slices and address any valid findings before recording the passed review packet.
+
+## 2026-06-27 16:27:00 CST / tpm
+- Pre-PR Local Role Review: passed
+- Task UID: task_9e8e6246b4264cda8baf908cd98d8cfd
+- Source Worktree: `/Users/scc/ccwork/worktrees/oasis7-engineering-code-execution-efficiency-next-7`
+- Source Branch: `task/engineering-code-execution-efficiency-next-7`
+- Source Head: `2c1c209f85e0728108eb5a173acdf472dfcf0b75`
+- Comparison Ref: refs/remotes/origin/main
+- Reviewed Changed Paths: `crates/oasis7/src/runtime/world/module_runtime.rs`; `doc/engineering/project.md`; `.pm/tasks/task_9e8e6246b4264cda8baf908cd98d8cfd.execution.md`; `.pm/tasks/task_9e8e6246b4264cda8baf908cd98d8cfd.yaml`
+- Review Package: `/Users/scc/ccwork/worktrees/oasis7-engineering-code-execution-efficiency-next-7/.pm/scratch/task_9e8e6246b4264cda8baf908cd98d8cfd/review-packages/review-458ed286f..2c1c209f8.diff`
+- Role Selection Basis: changed `crates/oasis7` runtime module-routing code and module call input semantics -> runtime_engineer; module ABI/input/hash compatibility -> wasm_platform_engineer; PR readiness and test-tier sufficiency -> qa_engineer; governance trace and technical-debt separation -> repository_health_engineer. Skipped producer/gameplay/visual/agent/viewer/blockchain/liveops roles because this PR changes no product contract, gameplay rule, visible UI, agent behavior, viewer path, operator runbook, deployment artifact, or external/player messaging.
+- Review Roles: runtime_engineer, wasm_platform_engineer, qa_engineer, repository_health_engineer
+- Review Evidence: runtime_engineer no_findings; wasm_platform_engineer no_findings; qa_engineer no_findings; repository_health_engineer no_findings.
+- Review Verdicts: runtime_engineer scope/spec passed and runtime quality/risk passed; wasm_platform_engineer scope/spec passed and module-platform quality/risk passed; qa_engineer scope/spec passed and QA quality/risk permits PR with no extra blocking full/release gate; repository_health_engineer scope/spec passed and repository-health quality/risk acceptable for PR.
+- Review Findings Disposition: no_findings
+- Finding Disposition Evidence: n/a; no valid findings required code or documentation changes.
+- Verification Matrix: module-routing behavior -> `./scripts/cargo-dev.sh test -p oasis7 modules --lib` passed and `./scripts/cargo-dev.sh test -p oasis7 module_runtime --lib` passed; module surface -> `./scripts/cargo-dev.sh test -p oasis7 module --lib` passed; required-gate confidence -> targeted `./scripts/ci-tests.sh required` passed; formatting/lint/governance -> `./scripts/cargo-dev.sh fmt --check`, `./scripts/check-rust-file-size.sh`, `git diff --check`, `./scripts/doc-governance-check.sh`, and task-local `./scripts/pm/workflow-lint.sh --task-uid task_9e8e6246b4264cda8baf908cd98d8cfd --phase pr-ready` passed.
+- Visual Evidence: n/a; no visible UI/viewer/game presentation changes.
+- WASM Evidence: wasm_platform_engineer reviewed module input/hash compatibility; no ABI/schema/manifest format changes; behavior covered by module tests listed above.
+- Ops Evidence: n/a; no deployment, node ops, packaging, rollback, or operator runbook changes.
+- LiveOps Evidence: n/a; no external messaging, release note, status, community, or player-promise changes.
+- Residual Risk: Low. No dedicated benchmark asserts the no-subscriber path avoids serialization/hash work; benefit is supported by code structure and owner review. Existing behavior regressions cover module input semantics for subscribed paths.
+- Slice Ledger: `/Users/scc/ccwork/worktrees/oasis7-engineering-code-execution-efficiency-next-7/.pm/scratch/task_9e8e6246b4264cda8baf908cd98d8cfd/slice-ledger.jsonl`
+- 遗留事项: Commit review evidence and run PR preflight/create.

--- a/.pm/tasks/task_9e8e6246b4264cda8baf908cd98d8cfd.execution.md
+++ b/.pm/tasks/task_9e8e6246b4264cda8baf908cd98d8cfd.execution.md
@@ -147,7 +147,7 @@ Example:
 - Review Trigger: pre-PR local role review
 - Review Scope: `crates/oasis7/src/runtime/world/module_runtime.rs`; `doc/engineering/project.md`; `.pm/tasks/task_9e8e6246b4264cda8baf908cd98d8cfd.*`
 - Review Package: `/Users/scc/ccwork/worktrees/oasis7-engineering-code-execution-efficiency-next-7/.pm/scratch/task_9e8e6246b4264cda8baf908cd98d8cfd/review-packages/review-458ed286f..2c1c209f8.diff`
-- Review Roles: runtime_engineer, wasm_platform_engineer, qa_engineer, repository_health_engineer
+- Review Roles: runtime_engineer, wasm_platform_engineer, qa_engineer, repository_health_engineer, producer_system_designer
 - Review Question: Confirm the lazy module-routing payload/hash computation preserves module call input semantics, WASM/module-platform compatibility, verification sufficiency, and governance trace quality before PR creation.
 - Evidence Available: `./scripts/cargo-dev.sh fmt --check`; `./scripts/cargo-dev.sh test -p oasis7 modules --lib`; `./scripts/cargo-dev.sh test -p oasis7 module_runtime --lib`; `./scripts/cargo-dev.sh test -p oasis7 module --lib`; targeted `./scripts/ci-tests.sh required`; `./scripts/check-rust-file-size.sh`; `git diff --check`; `./scripts/doc-governance-check.sh`; task-local `./scripts/pm/workflow-lint.sh --task-uid task_9e8e6246b4264cda8baf908cd98d8cfd --phase pr-ready`.
 - Expected Return Contract: findings or no_findings; scope/spec compliance verdict; role quality/risk verdict; residual_risk.
@@ -158,16 +158,16 @@ Example:
 ## 2026-06-27 16:27:00 CST / tpm
 - Pre-PR Local Role Review: passed
 - Task UID: task_9e8e6246b4264cda8baf908cd98d8cfd
-- Source Worktree: `/Users/scc/ccwork/worktrees/oasis7-engineering-code-execution-efficiency-next-7`
-- Source Branch: `task/engineering-code-execution-efficiency-next-7`
-- Source Head: `2c1c209f85e0728108eb5a173acdf472dfcf0b75`
+- Source Worktree: /Users/scc/ccwork/worktrees/oasis7-engineering-code-execution-efficiency-next-7
+- Source Branch: task/engineering-code-execution-efficiency-next-7
+- Source Head: 2c1c209f85e0728108eb5a173acdf472dfcf0b75
 - Comparison Ref: refs/remotes/origin/main
 - Reviewed Changed Paths: `crates/oasis7/src/runtime/world/module_runtime.rs`; `doc/engineering/project.md`; `.pm/tasks/task_9e8e6246b4264cda8baf908cd98d8cfd.execution.md`; `.pm/tasks/task_9e8e6246b4264cda8baf908cd98d8cfd.yaml`
 - Review Package: `/Users/scc/ccwork/worktrees/oasis7-engineering-code-execution-efficiency-next-7/.pm/scratch/task_9e8e6246b4264cda8baf908cd98d8cfd/review-packages/review-458ed286f..2c1c209f8.diff`
-- Role Selection Basis: changed `crates/oasis7` runtime module-routing code and module call input semantics -> runtime_engineer; module ABI/input/hash compatibility -> wasm_platform_engineer; PR readiness and test-tier sufficiency -> qa_engineer; governance trace and technical-debt separation -> repository_health_engineer. Skipped producer/gameplay/visual/agent/viewer/blockchain/liveops roles because this PR changes no product contract, gameplay rule, visible UI, agent behavior, viewer path, operator runbook, deployment artifact, or external/player messaging.
-- Review Roles: runtime_engineer, wasm_platform_engineer, qa_engineer, repository_health_engineer
-- Review Evidence: runtime_engineer no_findings; wasm_platform_engineer no_findings; qa_engineer no_findings; repository_health_engineer no_findings.
-- Review Verdicts: runtime_engineer scope/spec passed and runtime quality/risk passed; wasm_platform_engineer scope/spec passed and module-platform quality/risk passed; qa_engineer scope/spec passed and QA quality/risk permits PR with no extra blocking full/release gate; repository_health_engineer scope/spec passed and repository-health quality/risk acceptable for PR.
+- Role Selection Basis: changed `crates/oasis7` runtime module-routing code and module call input semantics -> runtime_engineer; module ABI/input/hash compatibility -> wasm_platform_engineer; PR readiness and test-tier sufficiency -> qa_engineer; governance trace and technical-debt separation -> repository_health_engineer; prepare-task-pr changed-path inference and system-level module contract confirmation -> producer_system_designer. Skipped gameplay/visual/agent/viewer/blockchain/liveops roles because this PR changes no gameplay rule, visible UI, agent behavior, viewer path, operator runbook, deployment artifact, or external/player messaging.
+- Review Roles: runtime_engineer, wasm_platform_engineer, qa_engineer, repository_health_engineer, producer_system_designer
+- Review Evidence: runtime_engineer no_findings; wasm_platform_engineer no_findings; qa_engineer no_findings; repository_health_engineer no_findings; producer_system_designer no_findings.
+- Review Verdicts: runtime_engineer scope/spec passed and runtime quality/risk passed; wasm_platform_engineer scope/spec passed and module-platform quality/risk passed; qa_engineer scope/spec passed and QA quality/risk permits PR with no extra blocking full/release gate; repository_health_engineer scope/spec passed and repository-health quality/risk acceptable for PR; producer_system_designer scope/spec passed and producer/system-design quality/risk passed with no product/system contract or verification-tier escalation.
 - Review Findings Disposition: no_findings
 - Finding Disposition Evidence: n/a; no valid findings required code or documentation changes.
 - Verification Matrix: module-routing behavior -> `./scripts/cargo-dev.sh test -p oasis7 modules --lib` passed and `./scripts/cargo-dev.sh test -p oasis7 module_runtime --lib` passed; module surface -> `./scripts/cargo-dev.sh test -p oasis7 module --lib` passed; required-gate confidence -> targeted `./scripts/ci-tests.sh required` passed; formatting/lint/governance -> `./scripts/cargo-dev.sh fmt --check`, `./scripts/check-rust-file-size.sh`, `git diff --check`, `./scripts/doc-governance-check.sh`, and task-local `./scripts/pm/workflow-lint.sh --task-uid task_9e8e6246b4264cda8baf908cd98d8cfd --phase pr-ready` passed.

--- a/.pm/tasks/task_9e8e6246b4264cda8baf908cd98d8cfd.yaml
+++ b/.pm/tasks/task_9e8e6246b4264cda8baf908cd98d8cfd.yaml
@@ -1,0 +1,26 @@
+task_uid: task_9e8e6246b4264cda8baf908cd98d8cfd
+title: "code execution efficiency governance next issue"
+owner_role: tpm
+module: engineering
+worktree_hint: /Users/scc/ccwork/worktrees/oasis7-engineering-code-execution-efficiency-next-7
+execution_log_path: .pm/tasks/task_9e8e6246b4264cda8baf908cd98d8cfd.execution.md
+status: done
+priority: P2
+source_signal: null
+source_refs:
+  - doc/engineering/project.md
+doc_refs: []
+related_prd: []
+acceptance:
+  - "Discover the next code execution efficiency issue through repository-health/runtime slices."
+  - "Implement a scoped fix with regression coverage or equivalent verification."
+  - "Run required local verification and carry the normal PR watch/merge path."
+handoff_to: []
+updated_at: 2026-06-27T16:13:38+08:00
+last_started_at: 2026-06-27T15:48:16+08:00
+last_claim_type: task_complete
+last_verify_command: "./scripts/cargo-dev.sh test -p oasis7 module --lib"
+last_verified_at: 2026-06-27T16:13:38+08:00
+last_verification_exit_code: 0
+last_verification_status: verified
+last_closed_at: 2026-06-27T16:13:38+08:00

--- a/crates/oasis7/src/runtime/world/module_runtime.rs
+++ b/crates/oasis7/src/runtime/world/module_runtime.rs
@@ -325,8 +325,8 @@ impl World {
         let event_kind = event_kind_label(&event.body);
         let event_value = serde_json::to_value(event)?;
         let invocations = self.collect_active_module_invocations()?;
-        let event_bytes = to_canonical_cbor(event)?;
-        let world_config_hash = self.current_manifest_hash()?;
+        let mut event_bytes = None;
+        let mut world_config_hash = None;
         let mut invoked = 0;
         for invocation in invocations {
             let manifest = invocation.manifest;
@@ -337,6 +337,13 @@ impl World {
                 prepared_module_subscribes_to_event(prepared.as_ref(), event_kind, &event_value);
             if !subscribed {
                 continue;
+            }
+
+            if event_bytes.is_none() {
+                event_bytes = Some(to_canonical_cbor(event)?);
+            }
+            if world_config_hash.is_none() {
+                world_config_hash = Some(self.current_manifest_hash()?);
             }
 
             let trace_id = format!("event-{}-{}", event.id, instance_id);
@@ -352,7 +359,7 @@ impl World {
                 },
                 limits: manifest.limits.clone(),
                 stage: Some("post_event".to_string()),
-                world_config_hash: Some(world_config_hash.clone()),
+                world_config_hash: world_config_hash.clone(),
                 manifest_hash: Some(module_manifest_hash),
                 journal_height: Some(event.id),
                 module_version: Some(manifest.version.clone()),
@@ -371,7 +378,7 @@ impl World {
             };
             let input = ModuleCallInput {
                 ctx,
-                event: Some(event_bytes.clone()),
+                event: event_bytes.clone(),
                 action: None,
                 state,
             };
@@ -420,13 +427,9 @@ impl World {
         let action_kind = action_kind_label(&envelope.action);
         let action_value = serde_json::to_value(envelope)?;
         let invocations = self.collect_active_module_invocations()?;
-        let action_bytes = to_canonical_cbor(envelope)?;
-        let event_bytes = if stage == ModuleSubscriptionStage::PostAction {
-            result_event.map(to_canonical_cbor).transpose()?
-        } else {
-            None
-        };
-        let world_config_hash = self.current_manifest_hash()?;
+        let mut action_bytes = None;
+        let mut event_bytes = None;
+        let mut world_config_hash = None;
         let mut invoked = 0;
 
         for invocation in invocations {
@@ -444,6 +447,19 @@ impl World {
                 continue;
             }
 
+            if action_bytes.is_none() {
+                action_bytes = Some(to_canonical_cbor(envelope)?);
+            }
+            if stage == ModuleSubscriptionStage::PostAction
+                && event_bytes.is_none()
+                && let Some(event) = result_event
+            {
+                event_bytes = Some(to_canonical_cbor(event)?);
+            }
+            if world_config_hash.is_none() {
+                world_config_hash = Some(self.current_manifest_hash()?);
+            }
+
             let trace_id = format!("action-{}-{}", envelope.id, instance_id);
             let module_manifest_hash = hash_json(&manifest)?;
             let ctx = ModuleContext {
@@ -457,7 +473,7 @@ impl World {
                 },
                 limits: manifest.limits.clone(),
                 stage: Some(subscription_stage_label(stage).to_string()),
-                world_config_hash: Some(world_config_hash.clone()),
+                world_config_hash: world_config_hash.clone(),
                 manifest_hash: Some(module_manifest_hash),
                 journal_height: Some(self.journal.events.len() as u64),
                 module_version: Some(manifest.version.clone()),
@@ -477,7 +493,7 @@ impl World {
             let input = ModuleCallInput {
                 ctx,
                 event: event_bytes.clone(),
-                action: Some(action_bytes.clone()),
+                action: action_bytes.clone(),
                 state,
             };
             let input_bytes = to_canonical_cbor(&input)?;

--- a/doc/engineering/project.md
+++ b/doc/engineering/project.md
@@ -14,6 +14,8 @@
 
 - [x] module-tick-invocation-lookup-efficiency (PRD-ENGINEERING/GOVERNANCE) [test_tier_required]: Optimize module tick routing to resolve only due invocation ids instead of materializing all active module invocations, preserving retry semantics for due missing-record errors and existing tick lifecycle behavior. Trace: .pm/tasks/task_b5b4afa8686b46d58856252de9cea35e.yaml
 
+- [x] module-routing-lazy-payload-serialization-efficiency (PRD-ENGINEERING/GOVERNANCE) [test_tier_required]: Optimize module event/action routing to compute canonical payload bytes and world config hash only after a matching subscription is found, preserving module call input semantics while avoiding unused serialization work on no-match paths. Trace: .pm/tasks/task_9e8e6246b4264cda8baf908cd98d8cfd.yaml
+
 - [x] pm-sync-views-single-scan-performance (PRD-ENGINEERING/GOVERNANCE) [test_tier_required]: Optimize PM `sync_task_views()` to reuse the task/role counts already loaded by `rebuild_task_views()` instead of parsing every canonical task yaml a second time during one sync, with a focused regression smoke guarding against double reads. Trace: .pm/tasks/task_619bb81ae69c415c9a7e6a29a7f3fd9d.yaml
 
 - [x] tick-consensus-event-hash-lookup-efficiency (PRD-ENGINEERING/GOVERNANCE) [test_tier_required]: Optimize tick consensus event hash rebuild to scan journal events for the target tick once and hash borrowed events in ordered event-id order, avoiding repeated journal scans and full event clones while preserving consensus hash and recovery semantics. Trace: .pm/tasks/task_97ad6595b03342c68c67f14e49833a94.yaml


### PR DESCRIPTION
## Summary
- Lazily compute module-routing event/action canonical payload bytes only after a subscription matches.
- Lazily compute and reuse the world config hash only for actual module calls.
- Add engineering project/task evidence for the code execution efficiency governance slice.

## Verification
- ./scripts/cargo-dev.sh fmt --check
- ./scripts/cargo-dev.sh test -p oasis7 modules --lib
- ./scripts/cargo-dev.sh test -p oasis7 module_runtime --lib
- ./scripts/cargo-dev.sh test -p oasis7 module --lib
- targeted ./scripts/ci-tests.sh required
- ./scripts/check-rust-file-size.sh
- git diff --check
- ./scripts/doc-governance-check.sh
- ./scripts/pm/workflow-lint.sh --task-uid task_9e8e6246b4264cda8baf908cd98d8cfd --phase pr-ready

## PR Purpose
normal_pr_ci_watch