### PR TITLE
Document Darwin Docker evidence closure

### DIFF
--- a/.pm/tasks/task_0a6477b5b6b34b869c8b85c81c554dc0.execution.md
+++ b/.pm/tasks/task_0a6477b5b6b34b869c8b85c81c554dc0.execution.md
@@ -232,3 +232,12 @@ Example:
 - Actual Result: actionlint, bash syntax, YAML load, task workflow lint, and diff hygiene passed; negative stale-digest guard exited `1` before Docker module execution with `canonical wasm builder image has stale digest`, proving the normal strict path remains intact.
 - Review Findings Disposition: addressed
 - Blocker / Next Action: amend/push PR #721 and re-watch checks/comments.
+
+## 2026-06-28 10:19:00 CST / tpm
+- 完成内容: Updated WDBP / world-runtime docs to reflect final Darwin Docker evidence closure.
+- 遗留事项: push documentation follow-up PR and merge after checks/comments are clear.
+- Action: after final main run `28297899706` passed, audited project docs for stale `darwin-arm64` pending / P0-not-closed language. Updated `doc/world-runtime/wasm/wasm-deterministic-build-pipeline.project.md`, `doc/world-runtime/wasm/wasm-deterministic-build-pipeline.design.md`, `doc/world-runtime/wasm/wasm-deterministic-build-pipeline.prd.md`, `doc/world-runtime/prd.md`, and `doc/world-runtime/project.md` to mark WDBP-3.2 cross-host evidence as closed by self-hosted Darwin Docker run evidence while preserving the boundary that GitHub-hosted macOS is still not a Docker evidence producer.
+- Validation Command: `rg -n 'WDBP-3\.2.*(未完成|待真实|待.*到位|剩余阻塞)|真实 Docker-capable `darwin-arm64` evidence 仍需|cross-host report 还未|仍无法产出真实 Docker-capable|当前剩余阻塞仍是|WDBP-3 会被误认为已完成|linux_x86_64|darwin_arm64' doc/world-runtime doc/testing doc/scripts`; `./scripts/doc-governance-check.sh`; `./scripts/pm/workflow-lint.sh --task-uid task_0a6477b5b6b34b869c8b85c81c554dc0`; `git diff --check`.
+- Expected Result: stale WDBP-3.2 pending language is gone from active docs; doc governance, task lint, and diff hygiene pass.
+- Actual Result: stale-doc scan returned no matches; doc-governance-check passed; task workflow lint passed with `phase=pr-ready`; diff hygiene passed.
+- Blocker / Next Action: commit, push, create PR, and watch checks/comments.

--- a/.pm/tasks/task_0a6477b5b6b34b869c8b85c81c554dc0.execution.md
+++ b/.pm/tasks/task_0a6477b5b6b34b869c8b85c81c554dc0.execution.md
@@ -241,3 +241,13 @@ Example:
 - Expected Result: stale WDBP-3.2 pending language is gone from active docs; doc governance, task lint, and diff hygiene pass.
 - Actual Result: stale-doc scan returned no matches; doc-governance-check passed; task workflow lint passed with `phase=pr-ready`; diff hygiene passed.
 - Blocker / Next Action: commit, push, create PR, and watch checks/comments.
+
+## 2026-06-28 10:30:00 CST / tpm
+- 完成内容: Addressed PR #723 automated review findings about evidence-retention wording and root project task-state consistency.
+- 遗留事项: rerun validation, push review fix, resolve/outdate PR threads, then re-check CI/comments/mergeability.
+- Action: replaced wording that implied repo-tracked artifact archival with GitHub Actions run/artifact evidence plus retention-boundary wording; marked root `TASK-WORLD_RUNTIME-043` complete and removed it from the current "next task" / active blocker status.
+- Review Threads: `PRRT_kwDORHhWec6MxN8s`; `PRRT_kwDORHhWec6MxN8v`.
+- Validation Command: `rg -n '仓库内已归档|真实 Linux \+ Docker-capable macOS full-tier 证据已归档|证据归档流程|正式 closure 证据应归档|cross-host 证据已由 self-hosted Darwin Docker workflow 归档|main run `28297899706` 归档' doc/world-runtime doc/testing doc/scripts`; `rg -n 'WDBP-3\.2.*(未完成|待真实|待.*到位|剩余阻塞)|真实 Docker-capable `darwin-arm64` evidence 仍需|cross-host report 还未|仍无法产出真实 Docker-capable|当前剩余阻塞仍是|WDBP-3 会被误认为已完成|linux_x86_64|darwin_arm64' doc/world-runtime doc/testing doc/scripts`; `./scripts/doc-governance-check.sh`; `./scripts/pm/workflow-lint.sh --task-uid task_0a6477b5b6b34b869c8b85c81c554dc0`; `git diff --check`.
+- Expected Result: no stale WDBP-3.2 blocker wording remains, docs pass governance, current task passes workflow lint, and diff hygiene is clean.
+- Actual Result: both stale/bad wording scans returned no matches; doc-governance-check passed; task workflow lint passed with `phase=pr-ready`; diff hygiene passed.
+- Blocker / Next Action: push fix, resolve/outdate PR #723 threads after validation, then re-check CI and mergeability.

--- a/doc/world-runtime/prd.md
+++ b/doc/world-runtime/prd.md
@@ -238,7 +238,7 @@
 - Technical Risks:
   - 风险-1: 运行时复杂度提升导致验证成本增加。
   - 风险-2: ABI/治理策略变更引发兼容性断裂。
-  - 风险-3（2026-03-18 记录，2026-03-31 复核，P0 未收口）: `TASK-WORLD_RUNTIME-043` 当前只有 GitHub-hosted `linux-x86_64` stable gate；本地 `runtime_engineer` 复核环境为 `Linux x86_64 + Docker(linux/x86_64)`，只能验证导入/打包/proof 工具链，仍无法产出真实 Docker-capable `darwin-arm64` full-tier evidence，因此跨宿主 closure 继续保持外部 live 证据阻塞态。
+  - 风险-3（2026-03-18 记录，2026-06-28 已收口）: `TASK-WORLD_RUNTIME-043` 原先只有 GitHub-hosted `linux-x86_64` stable gate，缺少真实 Docker-capable `darwin-arm64` full-tier evidence；现已通过 self-hosted runner `oasis7-Mac-darwin-arm64-docker` 和 `Wasm Darwin Docker Evidence` main run `28297899706` 补齐 Darwin live summary bundle，并完成 Linux cross-host verify，因此跨宿主 closure 不再是 P0 阻塞。
   - 风险-4（2026-03-18 记录，2026-03-31 已收口）: `ReleaseSecurityPolicy` 的生产禁 fallback / 禁本地签名 / 禁 runtime source compile 不再依赖额外 `enable_production_release_policy()` 约定；production-facing `chain runtime execution world` 装载、`reward runtime worker`、`viewer runtime_live` bootstrap 与 `governance_registry_import` 新建/加载路径均已默认绑定 hardened policy。
   - 风险-5（2026-03-31 已收口）: `apply_domain_event_gameplay*` 中 replay / preflight / 恢复链路残留的 panic-style `expect(...)` 已改为结构化 `WorldError`，损坏事件与缺失 actor 回归已补齐，不再把状态漂移故障降级为 panic。
   - 风险-6（2026-03-31 已收口）: runtime 热路径超限文件已按语义边界拆分，`action_to_event_core.rs` 与 `apply_domain_event_main_token.rs` 均已回到治理线内，并通过编译/定向回归验证“拆文件不改语义”。

--- a/doc/world-runtime/project.md
+++ b/doc/world-runtime/project.md
@@ -729,7 +729,7 @@
 - 更新日期: 2026-05-26
 - 当前状态: in_progress
 - 下一任务: `TASK-WORLD_RUNTIME-043`
-- 当前窗口摘要: provider/runtime live traceability、WASM Docker builder image/wrapper、build receipt/canonical token/identity/CI summary、receipt-aware release gate、node-side proof flow 与近期 runtime 技术债 tranche 均已收口；当前剩余阻塞仍是 `TASK-WORLD_RUNTIME-043` 的真实 Docker-capable `darwin-arm64` live evidence。Trace: .pm/tasks/task_dac2a6ab38134923b8573bc74fe5743e.yaml
+- 当前窗口摘要: provider/runtime live traceability、WASM Docker builder image/wrapper、build receipt/canonical token/identity/CI summary、receipt-aware release gate、node-side proof flow、真实 Docker-capable `darwin-arm64` live evidence 与近期 runtime 技术债 tranche 均已收口；Darwin evidence closure 由 `Wasm Darwin Docker Evidence` main run `28297899706` 归档。Trace: .pm/tasks/task_0a6477b5b6b34b869c8b85c81c554dc0.yaml
 - 当前窗口补充（2026-06-27 / hosted macOS Docker probe）: self-hosted Darwin Docker evidence workflow 已可手动触发但仓库级 self-hosted runner inventory 为 0，新增独立 GitHub-hosted macOS ARM64 Docker capability probe workflow 仅采集 Docker/`linux/amd64` container 能力诊断 artifact，显式 `release_evidence=false`，不替代 WDBP-3.2/P0 canonical release evidence。Trace: .pm/tasks/task_fef95d44dbba4048b574d68138431371.yaml
 - 近期收口: viewer-live integration flake、builtin-wasm integer centimeter contract、node observability、wasm timing metrics、fetch-commit / peer-record backoff、traffic/finality/consensus health metrics 与 chain-linked passive world progress 已完成；详情回看对应任务项、topic project 与 `.pm` execution logs。
 - 历史追溯: 更早 `TASK-WORLD_RUNTIME-*` 完成项不再在状态区逐条追加；需要追 WASM builder、runtime storage、release policy、source compile、module release 或 node observability 历史时，先从上方任务项、`doc/world-runtime/prd.index.md`、topic project 与 `.pm/tasks/*.execution.md` 进入。

--- a/doc/world-runtime/project.md
+++ b/doc/world-runtime/project.md
@@ -95,7 +95,7 @@
 - [x] TASK-WORLD_RUNTIME-040 (PRD-WORLD_RUNTIME-001) [test_tier_required]: 为 provider 双轨模式补齐 mode/schema/environment/fixture/replay 元数据透传，并统一 replay/summary traceability。
 - [x] TASK-WORLD_RUNTIME-041 (PRD-WORLD_RUNTIME-020/021/022) [test_tier_required]: 将 `WASM 确定性构建与工件治理管线` 专题修正为 Docker-first canonical builder 目标态，并回写 world-runtime 根 PRD、项目索引、README 与当日 devlog。
 - [x] TASK-WORLD_RUNTIME-042 (PRD-WORLD_RUNTIME-020/021) [test_tier_required]: 新增 pinned WASM builder image 与 host wrapper，固定 `linux-x86_64` container platform 为唯一 publish build 平台；构建入口改为 Docker-only，不再保留 host-native fallback。
-- [ ] TASK-WORLD_RUNTIME-043 (PRD-WORLD_RUNTIME-021/022) [test_tier_required + test_tier_full]: 将 manifest / identity / CI summary / release evidence 切换为 Docker canonical hash，对不同宿主只比较容器输出，不再比较 host-native 发布 hash。
+- [x] TASK-WORLD_RUNTIME-043 (PRD-WORLD_RUNTIME-021/022) [test_tier_required + test_tier_full]: 将 manifest / identity / CI summary / release evidence 切换为 Docker canonical hash，对不同宿主只比较容器输出，不再比较 host-native 发布 hash。
   - 2026-03-29 drift repair: GitHub-hosted `Wasm Determinism Gate` 已暴露 `m1` tracked canonical hash 继续漂移；本轮按 runner log 回写 `m1` builtin `sha256`/identity hash token，并同步修正 `builtin_wasm_identity.rs` 中残留的旧 `m1/m5` hardcoded canonical hash，避免 required gate 继续因 stale manifest / stale test constant 双重阻断。
 - [x] wasm-darwin-docker-self-hosted-runner (PRD-WORLD_RUNTIME-021/022) [test_tier_required] + [test_tier_full]: 建立本机 Darwin ARM64 Docker-capable self-hosted runner，修正 Darwin Docker evidence workflow 与本地 WASM builder 默认 digest，使 `Wasm Darwin Docker Evidence` 可从 `main` 重新触发并产出跨平台 release evidence。 Trace: .pm/tasks/task_0a6477b5b6b34b869c8b85c81c554dc0.yaml
 - [x] TASK-WORLD_RUNTIME-044 (PRD-WORLD_RUNTIME-022) [test_tier_required]: 将 `compile_module_artifact_from_source` 的生产路径外移到 external Docker builder 或 production 默认禁用，runtime 仅消费 binary + receipt。
@@ -728,8 +728,8 @@
 ## 状态
 - 更新日期: 2026-05-26
 - 当前状态: in_progress
-- 下一任务: `TASK-WORLD_RUNTIME-043`
-- 当前窗口摘要: provider/runtime live traceability、WASM Docker builder image/wrapper、build receipt/canonical token/identity/CI summary、receipt-aware release gate、node-side proof flow、真实 Docker-capable `darwin-arm64` live evidence 与近期 runtime 技术债 tranche 均已收口；Darwin evidence closure 由 `Wasm Darwin Docker Evidence` main run `28297899706` 归档。Trace: .pm/tasks/task_0a6477b5b6b34b869c8b85c81c554dc0.yaml
+- 下一任务: 无 WDBP-3.2/P0 后续阻塞；后续按 `TASK-WORLD_RUNTIME-002/003/004` 承接。
+- 当前窗口摘要: provider/runtime live traceability、WASM Docker builder image/wrapper、build receipt/canonical token/identity/CI summary、receipt-aware release gate、node-side proof flow、真实 Docker-capable `darwin-arm64` live evidence 与近期 runtime 技术债 tranche 均已收口；Darwin evidence closure 由 `Wasm Darwin Docker Evidence` main run `28297899706` 的 GitHub Actions artifact/run evidence 记录，后续长期复核以 run URL、job id 与 `.pm` evidence log 为索引。Trace: .pm/tasks/task_0a6477b5b6b34b869c8b85c81c554dc0.yaml
 - 当前窗口补充（2026-06-27 / hosted macOS Docker probe）: self-hosted Darwin Docker evidence workflow 已可手动触发但仓库级 self-hosted runner inventory 为 0，新增独立 GitHub-hosted macOS ARM64 Docker capability probe workflow 仅采集 Docker/`linux/amd64` container 能力诊断 artifact，显式 `release_evidence=false`，不替代 WDBP-3.2/P0 canonical release evidence。Trace: .pm/tasks/task_fef95d44dbba4048b574d68138431371.yaml
 - 近期收口: viewer-live integration flake、builtin-wasm integer centimeter contract、node observability、wasm timing metrics、fetch-commit / peer-record backoff、traffic/finality/consensus health metrics 与 chain-linked passive world progress 已完成；详情回看对应任务项、topic project 与 `.pm` execution logs。
 - 历史追溯: 更早 `TASK-WORLD_RUNTIME-*` 完成项不再在状态区逐条追加；需要追 WASM builder、runtime storage、release policy、source compile、module release 或 node observability 历史时，先从上方任务项、`doc/world-runtime/prd.index.md`、topic project 与 `.pm/tasks/*.execution.md` 进入。
@@ -737,7 +737,7 @@
 - 阶段 owner: `wasm_platform_engineer`（联审：`producer_system_designer`、`runtime_engineer`；验证：`qa_engineer`）
 - 阻断条件: 在 `TASK-WORLD_RUNTIME-002/003/004` 完成前，`TASK-WORLD_RUNTIME-033` 不再作为当前版本的首要发布驱动项。
 - 承接约束: `TASK-WORLD_RUNTIME-002` 完成后方可进入 `TASK-WORLD_RUNTIME-003` 与 `TASK-WORLD_RUNTIME-004`；`TASK-WORLD_RUNTIME-033` 保留为后续联合验证切片。
-- 实施备注: 仅保留 `TASK-WORLD_RUNTIME-043` 的当前阻塞与承接约束；已完成切片不再在状态区展开，统一回看上方任务项、topic project 与 `.pm` execution log。
+- 实施备注: `TASK-WORLD_RUNTIME-043` 已完成；当前状态区仅保留后续 `TASK-WORLD_RUNTIME-002/003/004` 承接约束，已完成切片统一回看上方任务项、topic project 与 `.pm` execution log。
 - PRD 质量门状态: strict schema 已对齐（含第 6 章验证与决策记录）。
 - 说明: 本文档仅维护 world-runtime 模块设计执行状态；历史过程归档见 `doc/devlog/README.md`，当前任务执行证据以 `.pm/tasks/task_<32hex>.execution.md` 为准。
 

--- a/doc/world-runtime/wasm/wasm-deterministic-build-pipeline.design.md
+++ b/doc/world-runtime/wasm/wasm-deterministic-build-pipeline.design.md
@@ -12,12 +12,12 @@
 
 | 层级 | 当前实现事实（2026-03-18） | 与 Docker-first 目标的差距 |
 | --- | --- | --- |
-| 容器基础设施 | `docker/wasm-builder/Dockerfile`、`scripts/build-wasm-module.sh` 与 canonical builder digest 已落地。 | canonical builder 已存在，但跨宿主证据仍未完整归档。 |
+| 容器基础设施 | `docker/wasm-builder/Dockerfile`、`scripts/build-wasm-module.sh` 与 canonical builder digest 已落地。 | canonical builder 已存在，跨宿主证据已由 self-hosted Darwin Docker workflow 归档。 |
 | 构建入口 | `scripts/build-wasm-module.sh` 已强制 `docker run --platform linux/amd64`，且显式拒绝 host-native fallback。 | 入口已收敛，但仍需把“stable gate”和“cross-host full closure”严格区分。 |
 | 构建工具 | `tools/wasm_build_suite` 已在容器内输出 `build receipt`、`source_hash`、`build_manifest_hash`、`builder_image_digest` 与 `container_platform`。 | receipt 语义基本完成，剩余重点在 evidence 汇总与 release gate 结论。 |
-| manifest 策略 | builtin hash manifest 已改为单 canonical token `linux-x86_64=<sha256>`；identity 生成已切换为 receipt 驱动。 | 写路径已收敛，但 cross-host report 还未拿到真实 `darwin-arm64` Docker evidence。 |
+| manifest 策略 | builtin hash manifest 已改为单 canonical token `linux-x86_64=<sha256>`；identity 生成已切换为 receipt 驱动。 | 写路径已收敛，cross-host report 已拿到真实 `darwin-arm64` Docker evidence。 |
 | source compile | `compile_module_artifact_from_source` 仍保留源码包编译能力，但 production `ReleaseSecurityPolicy` 已默认拒绝该 action；仅 dev/test 可显式使用。 | external builder worker 仍未落地，当前以 production default-disable 先收敛 runtime 权限面。 |
-| CI 校验 | `.github/workflows/wasm-determinism-gate.yml` 当前已收敛为 GitHub-hosted `linux-x86_64` stable gate，并支持导入外部 summaries。 | 真实 Docker-capable `darwin-arm64` summary 仍未进入正式 evidence 报告，`WDBP-3` 未完成。 |
+| CI 校验 | `.github/workflows/wasm-determinism-gate.yml` 当前已收敛为 GitHub-hosted `linux-x86_64` stable gate，并支持导入外部 summaries；`.github/workflows/wasm-darwin-docker-evidence.yml` 可手动调度 self-hosted Darwin Docker runner 产出真实 `darwin-arm64` bundle 并触发 Linux cross-host verify。 | `WDBP-3` 的真实 `linux-x86_64 + darwin-arm64` evidence 已在 main run `28297899706` 归档；GitHub-hosted macOS 仍不作为 Docker evidence producer。 |
 | runtime 消费策略 | runtime 侧已支持 production policy 关闭 source compile / local signing / builtin fallback，但主要通过显式启用 production policy 进入。 | 主运行入口尚缺“默认 hardened policy”绑定证据，binary-only 仍未完全提升为产品默认事实。 |
 
 ## 3. 设计原则
@@ -253,15 +253,15 @@ report 聚合时必须输出：
 {
   "module_set": "m1",
   "stable_gate_passed": true,
-  "cross_host_evidence_pending": true,
+  "cross_host_evidence_pending": false,
   "expected_runners": ["linux-x86_64", "darwin-arm64"],
-  "received_runners": ["linux-x86_64"],
-  "gate_result": "conditional-go"
+  "received_runners": ["linux-x86_64", "darwin-arm64"],
+  "gate_result": "cross-host-closed"
 }
 ```
 
 #### 5.8.3 External Evidence Dispatch Runbook
-当真实 Docker-capable `darwin-arm64` runner 可用后，full-tier 证据归档流程固定为：
+真实 Docker-capable `darwin-arm64` runner 可用后，full-tier 证据归档流程固定为：
 
 优先使用手动 CI 路径：
 
@@ -270,6 +270,8 @@ report 聚合时必须输出：
 3. `collect-darwin-docker-summaries` job 会做 `Darwin arm64 + docker linux/amd64` preflight，并产出 `darwin-arm64-wasm-summary-bundle` artifact。
 4. `verify-with-linux-summaries` job 会下载该 artifact、收集 `linux-x86_64` summaries、导入 darwin bundle，并产出 `darwin-arm64-wasm-release-evidence-report` artifact。
 5. 该 report 的 `summary.json` 满足下方 closure 条件后，才可把 `WDBP-3.2` 视为完成。
+
+当前正式收口证据：`Wasm Darwin Docker Evidence` main run `28297899706` 已通过；`collect-darwin-docker-summaries` job `83840926310` 在 self-hosted Darwin runner 上产出 bundle，`verify-with-linux-summaries` job `83843884654` 完成 Linux summary 收集、Darwin bundle 导入与 cross-host report 上传。
 
 如果 self-hosted runner 不能直接接入仓库 workflow，则使用外部 dispatch 路径：
 

--- a/doc/world-runtime/wasm/wasm-deterministic-build-pipeline.design.md
+++ b/doc/world-runtime/wasm/wasm-deterministic-build-pipeline.design.md
@@ -12,12 +12,12 @@
 
 | 层级 | 当前实现事实（2026-03-18） | 与 Docker-first 目标的差距 |
 | --- | --- | --- |
-| 容器基础设施 | `docker/wasm-builder/Dockerfile`、`scripts/build-wasm-module.sh` 与 canonical builder digest 已落地。 | canonical builder 已存在，跨宿主证据已由 self-hosted Darwin Docker workflow 归档。 |
+| 容器基础设施 | `docker/wasm-builder/Dockerfile`、`scripts/build-wasm-module.sh` 与 canonical builder digest 已落地。 | canonical builder 已存在，跨宿主证据已由 self-hosted Darwin Docker workflow 产出；repo 内保留 run/job 索引，不提交 workflow artifact 二进制。 |
 | 构建入口 | `scripts/build-wasm-module.sh` 已强制 `docker run --platform linux/amd64`，且显式拒绝 host-native fallback。 | 入口已收敛，但仍需把“stable gate”和“cross-host full closure”严格区分。 |
 | 构建工具 | `tools/wasm_build_suite` 已在容器内输出 `build receipt`、`source_hash`、`build_manifest_hash`、`builder_image_digest` 与 `container_platform`。 | receipt 语义基本完成，剩余重点在 evidence 汇总与 release gate 结论。 |
 | manifest 策略 | builtin hash manifest 已改为单 canonical token `linux-x86_64=<sha256>`；identity 生成已切换为 receipt 驱动。 | 写路径已收敛，cross-host report 已拿到真实 `darwin-arm64` Docker evidence。 |
 | source compile | `compile_module_artifact_from_source` 仍保留源码包编译能力，但 production `ReleaseSecurityPolicy` 已默认拒绝该 action；仅 dev/test 可显式使用。 | external builder worker 仍未落地，当前以 production default-disable 先收敛 runtime 权限面。 |
-| CI 校验 | `.github/workflows/wasm-determinism-gate.yml` 当前已收敛为 GitHub-hosted `linux-x86_64` stable gate，并支持导入外部 summaries；`.github/workflows/wasm-darwin-docker-evidence.yml` 可手动调度 self-hosted Darwin Docker runner 产出真实 `darwin-arm64` bundle 并触发 Linux cross-host verify。 | `WDBP-3` 的真实 `linux-x86_64 + darwin-arm64` evidence 已在 main run `28297899706` 归档；GitHub-hosted macOS 仍不作为 Docker evidence producer。 |
+| CI 校验 | `.github/workflows/wasm-determinism-gate.yml` 当前已收敛为 GitHub-hosted `linux-x86_64` stable gate，并支持导入外部 summaries；`.github/workflows/wasm-darwin-docker-evidence.yml` 可手动调度 self-hosted Darwin Docker runner 产出真实 `darwin-arm64` bundle 并触发 Linux cross-host verify。 | `WDBP-3` 的真实 `linux-x86_64 + darwin-arm64` evidence 已在 main run `28297899706` 产出；GitHub-hosted macOS 仍不作为 Docker evidence producer。 |
 | runtime 消费策略 | runtime 侧已支持 production policy 关闭 source compile / local signing / builtin fallback，但主要通过显式启用 production policy 进入。 | 主运行入口尚缺“默认 hardened policy”绑定证据，binary-only 仍未完全提升为产品默认事实。 |
 
 ## 3. 设计原则
@@ -261,7 +261,7 @@ report 聚合时必须输出：
 ```
 
 #### 5.8.3 External Evidence Dispatch Runbook
-真实 Docker-capable `darwin-arm64` runner 可用后，full-tier 证据归档流程固定为：
+真实 Docker-capable `darwin-arm64` runner 可用后，full-tier 证据产出流程固定为：
 
 优先使用手动 CI 路径：
 
@@ -294,7 +294,7 @@ report 聚合时必须输出：
 交付约束：
 - bundle URL 必须可被 GitHub-hosted verify job 直接下载。
 - 外部 runner 必须实际跑 Docker canonical builder，不能只转存 host-native 结果。
-- 正式 closure 证据应归档 workflow run URL 与对应 report artifact，供 `qa_engineer` 回归复核。
+- 正式 closure 证据应记录 workflow run URL、job id 与对应 report artifact 名称；workflow artifacts 受 GitHub Actions retention 管理，不作为 repo-tracked binary 长期归档。
 
 #### 5.8.4 证据来源分层
 为避免把开发回归、CI 回归、生产候选证据混写，evidence source 需要分层：

--- a/doc/world-runtime/wasm/wasm-deterministic-build-pipeline.prd.md
+++ b/doc/world-runtime/wasm/wasm-deterministic-build-pipeline.prd.md
@@ -132,7 +132,7 @@
   - 风险-1: Docker builder image 维护成本上升，需要明确镜像版本、digest 与升级节奏。
   - 风险-2: 现有 keyed manifest / runtime loader / source compile 路径存在兼容债务，迁移时需要过渡窗口。
   - 风险-3: macOS 开发机在 `linux-x86_64` 容器上构建会更慢，但这是为换取 canonical publish hash 的必要代价。
-  - 风险-4（2026-03-18，P0 未收口）: GitHub-hosted workflow 当前仅稳定覆盖 `linux-x86_64`，真实 Docker-capable `darwin-arm64` evidence 仍需外部补证；如果不持续显式追踪，WDBP-3 会被误认为已完成。
+  - 风险-4（2026-03-18 记录，2026-06-28 已收口）: GitHub-hosted workflow 仍只能直接稳定覆盖 `linux-x86_64`，但真实 Docker-capable `darwin-arm64` evidence 已由 self-hosted runner workflow 补齐；`Wasm Darwin Docker Evidence` main run `28297899706` 产出 Darwin bundle 并完成 Linux cross-host verify。后续风险转为 runner 可用性与 artifact 保留期治理，而非 WDBP-3 P0 阻塞。
   - 风险-5（2026-03-18，P0 未收口）: runtime 生产入口尚未形成“默认 hardened release policy”证据闭环；若只在测试中显式启用生产策略，会让 binary-only / no-fallback 契约停留在文档层。
 
 ## 6. Validation & Decision Record

--- a/doc/world-runtime/wasm/wasm-deterministic-build-pipeline.project.md
+++ b/doc/world-runtime/wasm/wasm-deterministic-build-pipeline.project.md
@@ -41,7 +41,7 @@
 - 联审角色: `producer_system_designer`、`runtime_engineer`
 - 验证角色: `qa_engineer`
 - 阻塞项:
-  - 无 WDBP-3.2 P0 阻塞；真实 Linux + Docker-capable macOS full-tier 证据已归档。
+  - 无 WDBP-3.2 P0 阻塞；真实 Linux + Docker-capable macOS full-tier 证据已由 GitHub Actions run `28297899706` 产出并上传为 workflow artifacts。该证据不作为 repo-tracked binary 长期归档，长期复核索引用 run URL、job id 与 `.pm` execution log 保留。
   - GitHub-hosted `macos-14` runner 仍不能被当作 Docker-capable `darwin-arm64` producer；该能力边界由 self-hosted runner workflow 承接。
 - 实施备注:
   - `docker/wasm-builder/Dockerfile` 与 `scripts/build-wasm-module.sh` 已落地，当前 canonical build 已收敛为 Docker-only path，不再提供 host-native fallback。
@@ -68,4 +68,4 @@
   - `oasis7_chain_runtime` 现已把 `release_default` storage profile 绑定到 hardened `ReleaseSecurityPolicy`，并通过 `/v1/chain/status` 输出 effective policy；`NodeRuntimeExecutionDriver::new_with_storage_profile` 会在装载 execution world 时同步应用该 policy。
   - `scripts/module-release-node-acceptance.sh` 现已新增 `required_release_policy` 步骤，并在 `.tmp/module_release_node_acceptance/20260318-134705/summary.json` 留下 production policy binding/status 证据。
   - `2026-03-31` 已补完 `WDBP-3.3` 的 runtime 侧余量审计：`viewer runtime_live` bootstrap、`governance_registry_import` 新建/加载 world、`reward_runtime_worker` 以及 `execution_bridge::load_execution_world` 的缺档案/旧样本装载路径现也统一切到 hardened `ReleaseSecurityPolicy`，避免 binary-only 语义只停留在 chain runtime 主入口。
-  - `2026-06-28` 复核确认，`WDBP-3.2` 原阻塞已由 self-hosted Darwin Docker runner 与 main run `28297899706` 收口；仓库内已归档真实 Docker-capable `darwin-arm64` live summary bundle 与 `linux-x86_64 + darwin-arm64` cross-host evidence report。
+  - `2026-06-28` 复核确认，`WDBP-3.2` 原阻塞已由 self-hosted Darwin Docker runner 与 main run `28297899706` 收口；真实 Docker-capable `darwin-arm64` live summary bundle 与 `linux-x86_64 + darwin-arm64` cross-host evidence report 由该 GitHub Actions run 产出并上传为 artifacts，repo 内保留 run/job 索引和 `.pm` evidence log。

--- a/doc/world-runtime/wasm/wasm-deterministic-build-pipeline.project.md
+++ b/doc/world-runtime/wasm/wasm-deterministic-build-pipeline.project.md
@@ -11,9 +11,9 @@
 - [x] WDBP-2 (PRD-WORLD_RUNTIME-020/021) [test_tier_required]: 将现有 `tools/wasm_build_suite` 收敛到容器内执行，输出 build receipt，并把 manifest 从多宿主 keyed token 迁移为单 canonical token `linux-x86_64=<sha256>`。
 - [x] WDBP-2.1 (PRD-WORLD_RUNTIME-020/021) [test_tier_required]: 将 host wrapper、builder image、sync/check、CI summary 与 build suite 的 operator env key 收口到 `OASIS7_WASM_*` 当前入口，并移除旧品牌 wasm 运行入口。
 - [x] wasm-source-hash-dependency-closure (PRD-WORLD_RUNTIME-021) [test_tier_required]: 将 `source_hash` 从“模块目录白名单”收紧为“模块源码 + 本地 `path` 依赖闭包”，并让 `tools/wasm_build_suite` 与 `sync_builtin_wasm_identity` 共用同一计算逻辑。 Trace: .pm/tasks/task_075b812172914487a06a93bda125bc9f.yaml
-- [ ] WDBP-3 (PRD-WORLD_RUNTIME-021/022) [test_tier_required + test_tier_full]: 将 identity / release evidence / CI summary / release gate 全面切换为 Docker canonical hash，对 macOS/Linux 只比较容器输出，不再比较 host-native 输出。
+- [x] WDBP-3 (PRD-WORLD_RUNTIME-021/022) [test_tier_required + test_tier_full]: 将 identity / release evidence / CI summary / release gate 全面切换为 Docker canonical hash，对 macOS/Linux 只比较容器输出，不再比较 host-native 输出。
   - [x] WDBP-3.1 (PRD-WORLD_RUNTIME-021) [test_tier_required]: 固化 stable gate / full-tier cross-host evidence 的双层结论模型，并让 `wasm-release-evidence-report` 输出 `expected_runners/received_runners/cross_host_evidence_pending`。
-  - [ ] WDBP-3.2 (PRD-WORLD_RUNTIME-021/022) [test_tier_full]: 补齐真实 Docker-capable `darwin-arm64` summary 导入链路，使 release evidence 至少包含 `linux-x86_64 + darwin-arm64` 两类 runner 输入。
+  - [x] WDBP-3.2 (PRD-WORLD_RUNTIME-021/022) [test_tier_full]: 补齐真实 Docker-capable `darwin-arm64` summary 导入链路，使 release evidence 至少包含 `linux-x86_64 + darwin-arm64` 两类 runner 输入。Trace: .pm/tasks/task_0a6477b5b6b34b869c8b85c81c554dc0.yaml
     - [x] WDBP-3.2a (PRD-WORLD_RUNTIME-021/022) [test_tier_required]: 加固 external summary bundle 导入验真，拒绝 `host_platform` 或 `canonical_platform` 与 `darwin-arm64 + linux-x86_64 canonical builder` 目标态不一致的伪装证据。
   - [x] WDBP-3.3 (PRD-WORLD_RUNTIME-022) [test_tier_required]: 在 production runtime / node 主入口绑定 hardened `ReleaseSecurityPolicy`，并把 effective policy 写入 status / acceptance evidence。
 - [x] WDBP-4 (PRD-WORLD_RUNTIME-022) [test_tier_required]: 把 `compile_module_artifact_from_source` 的生产路径外移到 external Docker builder 或 production 默认禁用，runtime 只消费 binary + build receipt。
@@ -33,16 +33,16 @@
 - `crates/oasis7/src/runtime/world/release_manifest.rs`
 
 ## 状态
-- 更新日期: 2026-03-31
-- 当前阶段: WDBP-3 跨宿主 evidence 收口中（WDBP-3.1 / WDBP-3.3 已完成，WDBP-4 已完成）
-- WDBP-3 剩余设计切片:
-  - `WDBP-3.2`: 需要一条真实 Docker-capable `darwin-arm64` summary/evidence 输入，并通过节点侧固定入口生成正式 proof payload / attestation；当前剩余的是 live 证据本身，不是导入、打包或提交工具。 Trace: .pm/tasks/task_dac2a6ab38134923b8573bc74fe5743e.yaml
+- 更新日期: 2026-06-28
+- 当前阶段: WDBP-3 跨宿主 evidence 已收口（WDBP-3.1 / WDBP-3.2 / WDBP-3.3 已完成，WDBP-4 已完成）
+- WDBP-3 收口证据:
+  - `WDBP-3.2`: 真实 Docker-capable `darwin-arm64` summary/evidence 已由本机 self-hosted runner `oasis7-Mac-darwin-arm64-docker` 产出，并在 `Wasm Darwin Docker Evidence` main run `28297899706` 中与 GitHub-hosted `linux-x86_64` summaries 完成 cross-host report；Darwin job `83840926310` 与 Linux verify job `83843884654` 均通过。Trace: .pm/tasks/task_0a6477b5b6b34b869c8b85c81c554dc0.yaml
 - owner role: `wasm_platform_engineer`
 - 联审角色: `producer_system_designer`、`runtime_engineer`
 - 验证角色: `qa_engineer`
 - 阻塞项:
-  - GitHub-hosted `macos-14` runner 当前无 Docker daemon，release evidence / release gate 仍需补齐真实 Linux + Docker-capable macOS full-tier 证据归档。
-  - 当前 `.github/workflows/wasm-determinism-gate.yml` 只能验证 / 导入 external `darwin-arm64` bundle；即使 workflow_dispatch 成功，也不代表 GitHub-hosted CI 已自行产出 `darwin-arm64` live evidence。
+  - 无 WDBP-3.2 P0 阻塞；真实 Linux + Docker-capable macOS full-tier 证据已归档。
+  - GitHub-hosted `macos-14` runner 仍不能被当作 Docker-capable `darwin-arm64` producer；该能力边界由 self-hosted runner workflow 承接。
 - 实施备注:
   - `docker/wasm-builder/Dockerfile` 与 `scripts/build-wasm-module.sh` 已落地，当前 canonical build 已收敛为 Docker-only path，不再提供 host-native fallback。
   - `scripts/build-wasm-module.sh`、`scripts/sync-m1-builtin-wasm-artifacts.sh`、`scripts/ci-m1-wasm-summary.sh`、`tools/wasm_build_suite` 与 `docker/wasm-builder/Dockerfile` 现已只读取/写入 `OASIS7_WASM_*` 当前入口，避免 operator 脚本与容器镜像继续扩散旧前缀。
@@ -57,9 +57,9 @@
   - `scripts/ci-verify-m1-wasm-summaries.py` 与 `scripts/wasm-release-evidence-report.sh` 现已把 `required_runners`（stable gate）与 `expected_runners`（full-tier cross-host evidence）拆开；GitHub-hosted workflow 当前以 `linux-x86_64` 作为 required runner，但 summary/report 会显式输出 `received_runners + missing_runners + cross_host_evidence_pending + gate_result=conditional-go`。
   - `WDBP-3.2` 的导入链路现已落地：`scripts/package-wasm-summary-bundle.sh` 可把外部 Docker-capable runner 的 `m1/m4/m5` summary 打成标准 bundle，`scripts/stage-wasm-summary-imports.sh` 可在 verify 前把 GitHub-hosted Linux summary 与外部 bundle 合并到同一 import dir；`workflow_dispatch` 也新增了 `external_summary_bundle_url` / `external_summary_runner_label` 入口。
   - `2026-06-27` 新增 `.github/workflows/wasm-darwin-docker-evidence.yml` 作为手动 Docker evidence workflow：第一段在 Docker-capable `darwin-arm64` self-hosted runner 上直接产出 summary bundle artifact，第二段可在 `ubuntu-24.04` 下载该 artifact、收集 `linux-x86_64` summaries，并通过既有 `stage-wasm-summary-imports.sh` + `wasm-release-evidence-report.sh` 生成 cross-host report。
-  - 口径约束：`workflow_dispatch + external_summary_bundle_url` 代表“CI verify ready / external evidence import ready”，不代表 GitHub-hosted CI 已获得 `darwin-arm64` 产出能力；只有真实 external runner 提供 live summary/proof 后，才可宣称 `WDBP-3.2` / cross-host closure 完成。
+  - 口径约束：`workflow_dispatch + external_summary_bundle_url` 代表“CI verify ready / external evidence import ready”，不代表 GitHub-hosted CI 已获得 `darwin-arm64` 产出能力；`WDBP-3.2` / cross-host closure 只有在真实 Docker-capable `darwin-arm64` runner 提供 live summary/proof 后才可宣称完成。当前完成证据为 `Wasm Darwin Docker Evidence` main run `28297899706`。
   - `WDBP-3.2a` 已继续加固 external bundle 验真：`package/stage/verify/report` 链路现在会强校验 summary/bundle 的 `host_platform` 与 `canonical_platform=linux-x86_64`，并通过 `scripts/wasm-summary-bundle-smoke.sh` 固定覆盖“真实 darwin bundle 可导入、伪装 darwin 的 linux bundle 必须失败”。
-  - 仓库内已补 `scripts/dispatch-wasm-determinism-gate.sh` 作为 operator 入口，用于以 `gh workflow run` 触发带外部 bundle URL 的 full-tier evidence run；待真实 `darwin-arm64` bundle 到位后即可直接归档正式 closure artifact。
+  - 仓库内已补 `scripts/dispatch-wasm-determinism-gate.sh` 作为 operator 入口，用于以 `gh workflow run` 触发带外部 bundle URL 的 full-tier evidence run；当前优先闭环路径为 `.github/workflows/wasm-darwin-docker-evidence.yml` 在 self-hosted Darwin runner 上直接产出 bundle，再由 Linux verify job 归档 cross-host report。
   - 节点侧 proof 收口已落地：`scripts/module-release-node-attestation-flow.sh` 现可在发布节点本地执行 `summary collect/import -> evidence verify -> canonical proof inputs -> proof payload -> attestation submit`，并刻意剥离 summary/report 中的时间戳与本地路径，避免把非语义字段写入 `proof_cid`。
   - `scripts/module-release-node-acceptance.sh` 现已新增 `required_attestation_flow` smoke，基于合成 `linux-x86_64 + darwin-arm64` summary 验证节点侧固定入口可以稳定生成 `proof_payload.json + submit_request.json`。
   - GitHub-hosted `macos-14` runner 当前不提供 Docker daemon，而 canonical build 已变为 Docker-only path；因此 workflow 已临时收敛为 Linux-only gate，跨宿主对账继续通过导入外部 Docker-capable macOS summary 的方式完成。
@@ -68,4 +68,4 @@
   - `oasis7_chain_runtime` 现已把 `release_default` storage profile 绑定到 hardened `ReleaseSecurityPolicy`，并通过 `/v1/chain/status` 输出 effective policy；`NodeRuntimeExecutionDriver::new_with_storage_profile` 会在装载 execution world 时同步应用该 policy。
   - `scripts/module-release-node-acceptance.sh` 现已新增 `required_release_policy` 步骤，并在 `.tmp/module_release_node_acceptance/20260318-134705/summary.json` 留下 production policy binding/status 证据。
   - `2026-03-31` 已补完 `WDBP-3.3` 的 runtime 侧余量审计：`viewer runtime_live` bootstrap、`governance_registry_import` 新建/加载 world、`reward_runtime_worker` 以及 `execution_bridge::load_execution_world` 的缺档案/旧样本装载路径现也统一切到 hardened `ReleaseSecurityPolicy`，避免 binary-only 语义只停留在 chain runtime 主入口。
-  - `2026-03-31` 在当前 `Linux x86_64 + Docker(linux/x86_64)` 工位复核后确认，仓库内已不存在缺失的 `darwin-arm64` 导入/打包/attestation tooling；`WDBP-3.2` 剩余阻塞仅是真实 Docker-capable `darwin-arm64` live summary / proof 输入本身。
+  - `2026-06-28` 复核确认，`WDBP-3.2` 原阻塞已由 self-hosted Darwin Docker runner 与 main run `28297899706` 收口；仓库内已归档真实 Docker-capable `darwin-arm64` live summary bundle 与 `linux-x86_64 + darwin-arm64` cross-host evidence report。


### PR DESCRIPTION
## Summary
- mark WDBP-3 / WDBP-3.2 cross-host evidence as closed by the self-hosted Darwin Docker workflow
- update world-runtime risk/status docs to reference main run 28297899706 and jobs 83840926310 / 83843884654
- keep the boundary that GitHub-hosted macOS is not a Docker-capable darwin-arm64 evidence producer

## Validation
- rg stale WDBP-3.2 pending phrases across doc/world-runtime doc/testing doc/scripts
- ./scripts/doc-governance-check.sh
- ./scripts/pm/workflow-lint.sh --task-uid task_0a6477b5b6b34b869c8b85c81c554dc0
- git diff --check