### PR TITLE
Optimize wasm observe metric diff

### DIFF
--- a/.pm/tasks/task_abeacd11de97477c91668825da4524b5.execution.md
+++ b/.pm/tasks/task_abeacd11de97477c91668825da4524b5.execution.md
@@ -190,14 +190,14 @@ PRE-PR LOCAL ROLE REVIEW RESULT
 - Task UID: task_abeacd11de97477c91668825da4524b5
 - Source Worktree: /Users/scc/ccwork/worktrees/oasis7-engineering-perf-abstraction-optimization
 - Source Branch: task/engineering-perf-abstraction-optimization
-- Source Head: 55e200d32c3093aa71f0ee8a5946f0a3401d3cb9
+- Source Head: cb88313bef40ddf39514bfd6fcb6029170bce16b
 - Comparison Ref: refs/remotes/origin/main
 - Reviewed Changed Paths: `.pm/roles/tpm/backlog/committed.yaml`; `.pm/tasks/task_abeacd11de97477c91668825da4524b5.yaml`; `.pm/tasks/task_abeacd11de97477c91668825da4524b5.execution.md`; `doc/engineering/project.md`; `tools/wasm_module_observe/src/lib.rs`
 - Review Package: n/a; `./scripts/pm/review-package.sh --base origin/main --head HEAD --task-uid task_abeacd11de97477c91668825da4524b5` generated `/Users/scc/ccwork/worktrees/oasis7-engineering-perf-abstraction-optimization/.pm/scratch/task_abeacd11de97477c91668825da4524b5/review-packages/review-55e71f9b2..4699b2283.diff`, but reviewer found its content did not match the requested target, so the accepted review source was the current worktree target diff and files.
-- Role Selection Basis: changed paths are engineering governance/task evidence plus `tools/wasm_module_observe` helper code; task history includes repository-health scan/implementation; no product/runtime/viewer/liveops claims were made, so only `repository_health_engineer` was required.
-- Review Roles: repository_health_engineer
-- Review Evidence: repository_health_engineer pre-PR review at `2026-06-28 10:49:41 CST`; reviewer ran `rtk ./scripts/cargo-dev.sh test --manifest-path tools/wasm_module_observe/Cargo.toml diff_btree_map_subtracts_counters` and observed the focused test pass; reviewer also noted `rtk git diff --check` still passed.
-- Review Verdicts: repository_health_engineer scope/spec compliance verdict: pass; role quality/risk verdict: pass.
+- Role Selection Basis: changed paths are engineering governance/task evidence plus `tools/wasm_module_observe` helper code; task history includes repository-health scan/implementation; `prepare-task-pr.sh` mechanically inferred `producer_system_designer` and `qa_engineer`, so supplemental reviews were collected for those roles. No product/runtime/viewer/liveops claims were made.
+- Review Roles: repository_health_engineer, producer_system_designer, qa_engineer
+- Review Evidence: repository_health_engineer pre-PR review at `2026-06-28 10:49:41 CST`; producer_system_designer supplemental review at `2026-06-28 10:56:53 CST`; qa_engineer supplemental review at `2026-06-28 10:58:33 CST`. Repository-health reviewer ran `rtk ./scripts/cargo-dev.sh test --manifest-path tools/wasm_module_observe/Cargo.toml diff_btree_map_subtracts_counters`; producer reviewer ran `rtk git diff --check`; QA reviewer ran `rtk ./scripts/cargo-dev.sh test --manifest-path tools/wasm_module_observe/Cargo.toml`, `rtk ./scripts/doc-governance-check.sh`, `rtk ./scripts/pm/workflow-lint.sh --task-uid task_abeacd11de97477c91668825da4524b5 --phase current`, and `rtk git diff --check`.
+- Review Verdicts: repository_health_engineer scope/spec compliance verdict: pass and role quality/risk verdict: pass; producer_system_designer scope/spec compliance verdict: pass and role quality/risk verdict: pass; qa_engineer scope/spec compliance verdict: pass and role quality/risk verdict: pass.
 - Review Findings Disposition: no_findings
 - Finding Disposition Evidence: n/a; no valid findings to address.
 - Verification Matrix: `tools/wasm_module_observe/src/lib.rs` -> focused package tests and diff whitespace -> `rtk ./scripts/cargo-dev.sh test --manifest-path tools/wasm_module_observe/Cargo.toml` passed, reviewer focused test passed, `rtk git diff --check` passed; `doc/engineering/project.md` and `.pm` task evidence -> doc/workflow governance -> `rtk ./scripts/doc-governance-check.sh` passed and `rtk ./scripts/pm/workflow-lint.sh --task-uid task_abeacd11de97477c91668825da4524b5 --phase current` passed; repo-wide `.pm` lint -> observed historical unrelated execution-log debt, not current task paths.
@@ -207,3 +207,64 @@ PRE-PR LOCAL ROLE REVIEW RESULT
 - LiveOps Evidence: n/a; no external messaging, release notes, player promise, or community surface changed.
 - Residual Risk: low; no benchmark was added, but semantic cases for counter deltas are covered and the helper remains private. Runtime clone-heavy paths are explicitly out of scope for a future `runtime_engineer` slice.
 - Slice Ledger: n/a; requested path `/Users/scc/ccwork/worktrees/oasis7-engineering-perf-abstraction-optimization/.pm/scratch/task_abeacd11de97477c91668825da4524b5/slice-ledger.jsonl` was not present during review; formal sink is this execution log.
+
+## 2026-06-28 10:53:43 CST / tpm
+- Review Trigger: supplemental pre-PR local role review after `prepare-task-pr.sh --create --title "Optimize wasm observe metric diff"` inferred missing roles.
+- Review Scope: current branch diff through `cb88313bef40ddf39514bfd6fcb6029170bce16b`; engineering project trace, `.pm` task evidence, and `tools/wasm_module_observe/src/lib.rs`.
+- Review Package: n/a; previous review-package helper output was found mismatched, so reviewers must inspect current worktree diff/files directly.
+- Review Roles: `producer_system_designer`, `qa_engineer`
+- Review Question: `producer_system_designer` should confirm project/task trace and scope alignment without making code-health claims; `qa_engineer` should confirm verification sufficiency and residual release/test risk for this tooling-only optimization.
+- Evidence Available: repository_health_engineer implementation slice and pre-PR review no_findings; `rtk ./scripts/cargo-dev.sh test --manifest-path tools/wasm_module_observe/Cargo.toml` passed; reviewer focused `diff_btree_map_subtracts_counters` test passed; `rtk ./scripts/cargo-dev.sh fmt --all --check` passed; `rtk ./scripts/doc-governance-check.sh` passed; `rtk git diff --check` passed; current task `workflow-lint` passed; repo-wide `pm/lint` has unrelated historical task-log debt.
+- Expected Return Contract: findings | no_findings | scope/spec compliance verdict | role quality/risk verdict | residual_risk
+- Slice Ledger: n/a; slice ledger path was not materialized by helper.
+- Formal Sink: `.pm/tasks/task_abeacd11de97477c91668825da4524b5.execution.md`
+
+## 2026-06-28 10:56:53 CST / producer_system_designer
+
+SUPPLEMENTAL PRE-PR LOCAL ROLE REVIEW RESULT
+
+## Review Outcome
+- Return contract: no_findings.
+- Scope/spec compliance verdict: pass. The task truth frames the request as an engineering governance optimization, with `tpm` as coordinator and `repository_health_engineer` as the professional slice owner for identifying and validating the performance/abstraction point. The selected `tools/wasm_module_observe` helper change and `doc/engineering/project.md` trace stay inside that scope and do not introduce product, gameplay, world-rule, player-facing, or external-promise semantics.
+- Role quality/risk verdict: pass. The project trace is narrow and auditable: `wasm-module-observe-btreemap-diff-merge-efficiency` points to this `.pm` task, names the concrete helper-level optimization, and preserves the attribution boundary by relying on repository-health evidence for the code-health conclusion rather than claiming product/system-design ownership.
+
+## Evidence Reviewed
+- Current branch/task files in `/Users/scc/ccwork/worktrees/oasis7-engineering-perf-abstraction-optimization`.
+- `doc/engineering/project.md` entry `wasm-module-observe-btreemap-diff-merge-efficiency`, traced to `.pm/tasks/task_abeacd11de97477c91668825da4524b5.yaml`.
+- `.pm/tasks/task_abeacd11de97477c91668825da4524b5.yaml` acceptance criteria: repository-health slice identifies a concrete performance/abstraction opportunity, and the implementation is scoped, verified, and recorded.
+- Execution log repository_health_engineer implementation slice and pre-PR review `no_findings`, including focused test evidence and the explicit exclusion of runtime clone-heavy paths.
+- Local review commands: `rtk git diff refs/remotes/origin/main...HEAD -- doc/engineering/project.md .pm/tasks/task_abeacd11de97477c91668825da4524b5.yaml tools/wasm_module_observe/src/lib.rs`; `rtk git diff --check`.
+
+## Scope / Spec Notes
+- The project/task trace satisfies the requested "engineering governance colleague finds performance/abstraction points and optimizes" scope: it records one concrete low-risk optimization instead of broadening into a platform refactor.
+- No producer/system-design escalation is required because no PRD acceptance, player capability, resource economy, world rule, progression, governance rule, or release promise changes.
+- The previous review-package mismatch is already documented and does not affect this role verdict because the current worktree diff/files and execution-log evidence were inspected directly.
+
+## Residual Risk
+- Residual risk: low. This review does not validate the code-health implementation itself; that remains owned by `repository_health_engineer`. Runtime clone-heavy paths remain explicitly out of scope and would need a separate `runtime_engineer` slice before any product/system-level claim about runtime performance or ownership model simplification.
+
+## 2026-06-28 10:58:33 CST / qa_engineer
+
+SUPPLEMENTAL PRE-PR LOCAL ROLE REVIEW RESULT
+
+## Review Outcome
+- Return contract: no_findings.
+- Scope/spec compliance verdict: pass. The current branch diff through `cb88313bef40ddf39514bfd6fcb6029170bce16b` is limited to `tools/wasm_module_observe/src/lib.rs`, `doc/engineering/project.md`, and task evidence; this is a tooling-only optimization with no UI, runtime protocol, wasm ABI/schema, ops, release packaging, or player-facing behavior surface.
+- Role quality/risk verdict: pass. Existing repository-health review owns the code-health conclusion, and QA evidence is sufficient for PR readiness for this scope: the changed package tests pass, the focused counter-delta unit test is covered by the package run, doc/task governance gates pass, and whitespace diff check passes.
+
+## Evidence Reviewed
+- Current worktree diff/files directly, because the earlier review-package helper output was documented as mismatched.
+- Execution-log evidence from repository_health_engineer and TPM: full package test passed, focused `diff_btree_map_subtracts_counters` reviewer test passed, `fmt --all --check` passed, doc governance passed, workflow-lint passed, and `git diff --check` passed.
+- Fresh QA verification command: `rtk ./scripts/cargo-dev.sh test --manifest-path tools/wasm_module_observe/Cargo.toml`.
+- Fresh QA verification result: passed; observed 6 lib tests, 2 CLI arg tests, 1 `m1_rule_move` integration fixture, and 0 doc tests.
+- Fresh QA verification command: `rtk ./scripts/doc-governance-check.sh`.
+- Fresh QA verification result: passed; `doc-governance-check: OK`.
+- Fresh QA verification command: `rtk ./scripts/pm/workflow-lint.sh --task-uid task_abeacd11de97477c91668825da4524b5 --phase current`.
+- Fresh QA verification result: passed; `workflow-lint: OK`.
+- Fresh QA verification command: `rtk git diff --check`.
+- Fresh QA verification result: passed with exit code 0 and no whitespace output.
+
+## Residual Risk
+- Residual risk: low. There is no benchmark or end-to-end release test for `tools/wasm_module_observe`, so QA can only confirm semantic/regression evidence rather than measured performance gain. That is acceptable for this private helper optimization because package-level tests include the changed unit test and fixture integration coverage.
+- Repo-wide `rtk ./scripts/pm/lint.sh` remains a known unrelated historical `.pm/tasks/*` execution-log debt according to the task evidence; it should not block this tooling-only PR unless PR policy requires repo-wide PM cleanup in the same change.
+- Runtime clone-heavy paths are out of scope and should not be described as optimized or release-validated by this PR.

--- a/.pm/tasks/task_abeacd11de97477c91668825da4524b5.execution.md
+++ b/.pm/tasks/task_abeacd11de97477c91668825da4524b5.execution.md
@@ -190,7 +190,7 @@ PRE-PR LOCAL ROLE REVIEW RESULT
 - Task UID: task_abeacd11de97477c91668825da4524b5
 - Source Worktree: /Users/scc/ccwork/worktrees/oasis7-engineering-perf-abstraction-optimization
 - Source Branch: task/engineering-perf-abstraction-optimization
-- Source Head: 0d8eb132ded35a2e548b09232eca0109182e5a1e
+- Source Head: 55e200d32c3093aa71f0ee8a5946f0a3401d3cb9
 - Comparison Ref: refs/remotes/origin/main
 - Reviewed Changed Paths: `.pm/roles/tpm/backlog/committed.yaml`; `.pm/tasks/task_abeacd11de97477c91668825da4524b5.yaml`; `.pm/tasks/task_abeacd11de97477c91668825da4524b5.execution.md`; `doc/engineering/project.md`; `tools/wasm_module_observe/src/lib.rs`
 - Review Package: n/a; `./scripts/pm/review-package.sh --base origin/main --head HEAD --task-uid task_abeacd11de97477c91668825da4524b5` generated `/Users/scc/ccwork/worktrees/oasis7-engineering-perf-abstraction-optimization/.pm/scratch/task_abeacd11de97477c91668825da4524b5/review-packages/review-55e71f9b2..4699b2283.diff`, but reviewer found its content did not match the requested target, so the accepted review source was the current worktree target diff and files.

--- a/.pm/tasks/task_abeacd11de97477c91668825da4524b5.execution.md
+++ b/.pm/tasks/task_abeacd11de97477c91668825da4524b5.execution.md
@@ -1,0 +1,209 @@
+# task_abeacd11de97477c91668825da4524b5 Execution Log
+
+- task_uid: task_abeacd11de97477c91668825da4524b5
+- title: Optimize performance and abstractions
+- owner_role: tpm
+- worktree_hint: /Users/scc/ccwork/worktrees/oasis7-engineering-perf-abstraction-optimization
+
+<!-- Append entries using:
+Example:
+  ## YYYY-MM-DD HH:MM:SS CST / role_name
+  - 完成内容: ...
+  - 遗留事项: ...
+  - Action: ...
+  - Validation Command: ...
+  - Expected Result: ...
+  - Actual Result: ...
+  - Blocker / Next Action: ...
+-->
+
+## 2026-06-28 10:36:44 CST / tpm
+
+WORKFLOW BOOTSTRAP DECIDED
+
+## Repository State Impact
+- Changes repository state: yes
+- Why: user requested engineering governance colleague to find performance and abstraction design points in code and optimize them.
+
+## Isolation Decision
+- Current workspace state: source worktree `/Users/scc/ccwork/oasis7` was on `main...origin/main` and clean.
+- Reuse allowed: no explicit reuse requested; standard isolated task worktree required.
+- Worktree action: created `/Users/scc/ccwork/worktrees/oasis7-engineering-perf-abstraction-optimization` on branch `task/engineering-perf-abstraction-optimization` with shared cargo target symlink.
+
+## Task Truth
+- Owner role: `tpm` as workflow coordinator/integrator only.
+- `.pm` task: `task_abeacd11de97477c91668825da4524b5`
+- Formal docs: `AGENTS.md`, `doc/engineering/workflow/source-of-truth.md`, `doc/engineering/project.md`, `doc/engineering/prd.md`.
+
+## Routed Next Phase
+- Selected workflow surface: `repo-owned-workflow-router` -> `executing-project-tasks`
+- Why now: task truth exists and implementation is requested; professional repository-health judgment is required before TPM integrates any code changes.
+
+## Required Writeback
+- `prd.md`: no initial PRD change expected unless scope discovers a durable governance requirement.
+- `project.md`: add trace only if the implemented optimization should be promoted to completed engineering project truth.
+- `.pm` execution log (mandatory): record route, subagent slice contract, findings, implementation evidence, and verification.
+- handoff (optional supplement): not needed initially.
+
+## Next Action
+- exact next step: record repository_health_engineer bounded slice contract, dispatch the slice, then integrate a narrow verified optimization.
+
+WORKFLOW ROUTE DECIDED
+
+## Task Phase
+- Current phase: execution
+- Why: acceptance is explicit enough to start by scanning for low-risk performance/abstraction design debt and implementing one scoped improvement.
+
+## Selected Workflow Skills
+1. `executing-project-tasks` - execute a scoped repo-health optimization with step-level evidence.
+2. `systematic-debugging` - use only if scan or verification exposes a concrete failing behavior.
+3. `verification-before-completion` - use before claiming the optimization is complete.
+
+## Skipped Workflow Skills
+- `bounded-brainstorming` - direction is already actionable: identify and optimize concrete code-level performance/abstraction debt.
+- `tdd-test-writer` - defer until a stable target is selected; add or run focused tests once the target is known.
+
+## Subagent Slice Plan
+- role: `repository_health_engineer`
+- slice type: bounded code-health scan plus, if safe, direct patch proposal within a narrow write scope.
+- intended model configuration: workflow source-of-truth `Default subagent runtime`.
+- actual dispatched model/reasoning: inherited/unverified; current subagent tool inherits parent model by default and does not report exact model after dispatch.
+- context delivery mode: full-thread/full-history fork via subagent `fork_context=true`.
+- mandatory context checklist/packet:
+  - identity and authority: `AGENTS.md`, `@/Users/scc/.codex/RTK.md`, `.agents/roles/repository_health_engineer.md`
+  - workflow governance: `doc/engineering/workflow/source-of-truth.md`, `default-workflow-bootstrap`, `repo-owned-workflow-router`, `executing-project-tasks`
+  - task truth: `.pm/tasks/task_abeacd11de97477c91668825da4524b5.yaml` and this execution log
+  - user intent: "让工程治理同事，找找代码里性能和抽象设计相关的点，做优化"
+  - scoped repo context: prioritize code paths with obvious repeated allocation/sort/clone or duplicated abstraction seams; avoid `third_party`; do not touch unrelated dirty state.
+  - collaboration boundary: repository_health owns findings and debt classification; TPM integrates and records; domain correctness findings must request the relevant domain role instead of asserting final domain ownership.
+- write scope: prefer one narrow code/test/doc surface chosen by repository-health evidence; no broad refactor.
+- return contract: findings with severity/type/evidence, chosen optimization, changed files, verification commands/results, residual risk, and any follow-up debt.
+- formal sink / writeback surface: `.pm/tasks/task_abeacd11de97477c91668825da4524b5.execution.md` mandatory.
+- integration owner: `tpm`.
+- integration order: repository-health scan -> TPM inspect/integrate patch -> focused verification -> closeout/review path.
+- context exemption: none.
+
+## 2026-06-28 10:43:12 CST / repository_health_engineer
+
+BOUNDED SLICE RESULT
+
+## Scope / Method
+- Read: `AGENTS.md`, `/Users/scc/.codex/RTK.md`, `.agents/roles/repository_health_engineer.md`, `.pm/tasks/task_abeacd11de97477c91668825da4524b5.yaml`, and this execution log.
+- Scan method: searched non-`third_party` code for repeated clones, vector collection, sorting, parsing, and map helper patterns; then narrowed to small helpers with existing tests and low domain-correctness risk.
+
+## Candidates Considered
+- `tools/wasm_module_observe/src/lib.rs::diff_btree_map`: private helper diffing metric bucket maps; inputs are already sorted `BTreeMap`s, but implementation cloned keys into a `Vec`, sorted, deduped, then looked values up again.
+- `tools/wasm_module_observe/src/report.rs::PerfStats::from_samples`: sorts sample copies to compute percentiles; behavior is appropriate for percentile calculation and less obviously replaceable without changing semantics.
+- `crates/oasis7/src/bin/oasis7_chain_runtime/execution_bridge/driver.rs`: contains clones around execution snapshots/actions; those are runtime/domain-sensitive and should be owned by runtime_engineer before changing.
+
+## Selected Optimization
+- Changed `diff_btree_map` to merge two ordered `BTreeMap` iterators directly.
+- Why low risk: helper is private, output type remains `BTreeMap<String, u64>`, existing saturating subtraction semantics are preserved, before-only keys still produce `0`, after-only keys still produce their after value, and existing tests cover the helper.
+- Performance/abstraction effect: removes intermediate `Vec<String>` allocation, explicit sort/dedup, and repeated map lookups; uses the map abstraction's natural ordering instead.
+
+## Files Changed
+- `tools/wasm_module_observe/src/lib.rs`: optimized `diff_btree_map`; extended `diff_btree_map_subtracts_counters` to cover before-only keys.
+
+## Verification
+- `rtk ./scripts/cargo-dev.sh fmt --all --check`
+  - Actual Result: passed with exit code 0.
+- `rtk ./scripts/cargo-dev.sh test --manifest-path tools/wasm_module_observe/Cargo.toml`
+  - Actual Result: passed with exit code 0.
+  - Observed tests: 6 lib tests passed, 2 CLI arg tests passed, 1 `m1_rule_move` integration fixture passed, 0 doc tests.
+
+## Findings / Residual Risk
+- Finding: `diff_btree_map` had avoidable allocation/sort/relookup overhead in a metrics aggregation path. Severity: low; category: performance/abstraction debt; owner recommendation: repository_health_engineer/tooling maintainer.
+- Residual risk: no runtime/viewer/domain correctness claim is made. Chain runtime clone-heavy paths were intentionally not changed in this slice because they require `runtime_engineer` ownership to assess snapshot/action semantics.
+- Follow-up debt: if this task continues, a runtime_engineer slice could inspect execution bridge snapshot/action clone sites for safe borrow/ownership improvements, but that should be a separate domain-owned change.
+
+## 2026-06-28 10:45:08 CST / tpm
+
+INTEGRATION RECORD
+
+- Action: reviewed `repository_health_engineer` patch and accepted the selected `tools/wasm_module_observe/src/lib.rs::diff_btree_map` optimization as the scoped task implementation.
+- Integration adjustment: changed before-only key handling from `0_u64.saturating_sub(value)` to explicit `0` in the new merge iterator path, preserving behavior while making the saturating counter-delta semantics easier to read.
+- Project trace: added `wasm-module-observe-btreemap-diff-merge-efficiency` to `doc/engineering/project.md` with trace to this `.pm` task.
+- Validation Command: `rtk ./scripts/cargo-dev.sh fmt --all --check`
+- Expected Result: formatting is unchanged and command exits 0.
+- Actual Result: passed, exit code 0.
+- Validation Command: `rtk ./scripts/cargo-dev.sh test --manifest-path tools/wasm_module_observe/Cargo.toml`
+- Expected Result: wasm_module_observe focused tests pass.
+- Actual Result: passed, exit code 0; observed 6 lib tests, 2 CLI arg tests, 1 integration fixture, and 0 doc tests.
+- Validation Command: `rtk git diff --check`
+- Expected Result: no whitespace errors.
+- Actual Result: passed, exit code 0.
+- Blocker / Next Action: run repo governance gates and then enter pre-PR local role review/closeout path.
+
+## 2026-06-28 10:46:37 CST / tpm
+- Review Trigger: pre-PR local role review
+- Review Scope: `tools/wasm_module_observe/src/lib.rs`; `doc/engineering/project.md`; `.pm/tasks/task_abeacd11de97477c91668825da4524b5.*`; `.pm/roles/tpm/backlog/committed.yaml`
+- Review Package: `/Users/scc/ccwork/worktrees/oasis7-engineering-perf-abstraction-optimization/.pm/scratch/task_abeacd11de97477c91668825da4524b5/review-packages/review-55e71f9b2..4699b2283.diff`
+- Review Roles: `repository_health_engineer`
+- Review Question: confirm the BTreeMap merge iterator optimization preserves saturating counter-delta semantics, is scoped appropriately, and has sufficient focused verification/project evidence for PR creation.
+- Evidence Available: `rtk ./scripts/cargo-dev.sh fmt --all --check` passed; `rtk ./scripts/cargo-dev.sh test --manifest-path tools/wasm_module_observe/Cargo.toml` passed; `rtk git diff --check` passed; `rtk ./scripts/doc-governance-check.sh` passed; `rtk ./scripts/pm/lint.sh` failed on unrelated historical `.pm/tasks/*` execution log debt.
+- Expected Return Contract: findings | no_findings | scope/spec compliance verdict | role quality/risk verdict | residual_risk
+- Slice Ledger: `/Users/scc/ccwork/worktrees/oasis7-engineering-perf-abstraction-optimization/.pm/scratch/task_abeacd11de97477c91668825da4524b5/slice-ledger.jsonl`
+- Formal Sink: `.pm/tasks/task_abeacd11de97477c91668825da4524b5.execution.md`
+
+## 2026-06-28 10:47:39 CST / tpm
+- 完成内容: Integrated repository_health_engineer optimization, refreshed engineering project trace, and started pre-PR local role review.
+- 遗留事项: Await repository_health_engineer pre-PR review result, then record passed packet and close out.
+- Action: Run current task workflow lint after structured execution-log completion.
+- Validation Command: ./scripts/pm/workflow-lint.sh --task-uid task_abeacd11de97477c91668825da4524b5 --phase current
+- Expected Result: Current task execution log has at least one complete structured entry and task-local workflow lint passes.
+- Actual Result: Initial run failed because execution log lacked a complete structured entry; this helper entry was appended to satisfy the current task format contract.
+- Blocker / Next Action: Rerun workflow-lint after this append.
+
+## 2026-06-28 10:49:41 CST / repository_health_engineer
+
+PRE-PR LOCAL ROLE REVIEW RESULT
+
+## Review Outcome
+- Return contract: no_findings.
+- Scope/spec compliance verdict: pass. The implemented `diff_btree_map` change is private to `tools/wasm_module_observe/src/lib.rs`, stays within the requested repository-health performance/abstraction scope, and does not expand into runtime/domain-sensitive clone paths.
+- Role quality/risk verdict: pass. The patch uses the existing `BTreeMap` ordering abstraction directly and reduces temporary allocation, sorting, deduplication, and repeated lookup work without adding a new abstraction surface.
+
+## Semantics Review
+- Old behavior: build the union of before/after keys, then emit `after_value.unwrap_or(0).saturating_sub(before_value.unwrap_or(0))`.
+- New behavior: merge ordered `before.iter()` and `after.iter()`:
+  - before-only key -> `0`, equivalent to `0_u64.saturating_sub(before_value)`.
+  - after-only key -> `after_value`, equivalent to `after_value.saturating_sub(0)`.
+  - key in both maps -> `after_value.saturating_sub(before_value)`.
+- Verdict: saturating counter-delta semantics are preserved, including non-decreasing counters, unchanged counters, after-only counters, and reset/decrease/before-only counters yielding `0`.
+
+## Evidence Reviewed
+- Current worktree target diff for `tools/wasm_module_observe/src/lib.rs`, `doc/engineering/project.md`, `.pm/tasks/task_abeacd11de97477c91668825da4524b5.*`, and `.pm/roles/tpm/backlog/committed.yaml`.
+- Existing TPM evidence: `rtk ./scripts/cargo-dev.sh fmt --all --check` passed; `rtk ./scripts/cargo-dev.sh test --manifest-path tools/wasm_module_observe/Cargo.toml` passed; `rtk git diff --check` passed; `rtk ./scripts/doc-governance-check.sh` passed; `rtk ./scripts/pm/lint.sh` failed on unrelated historical `.pm/tasks/*` execution log debt, not current task paths.
+- Fresh reviewer verification command: `rtk ./scripts/cargo-dev.sh test --manifest-path tools/wasm_module_observe/Cargo.toml diff_btree_map_subtracts_counters`.
+- Fresh reviewer verification result: passed; 1 focused lib test passed, 0 failed; related binary/integration targets had matching filters and ran 0 tests.
+
+## Process Note
+- The specified review package `.pm/scratch/task_abeacd11de97477c91668825da4524b5/review-packages/review-55e71f9b2..4699b2283.diff` did not match the requested review target; it showed unrelated world-runtime documentation diff content. This did not block the review because the current worktree target diff and files were available and were used as the review source.
+- The specified slice ledger path was not present during this review; the formal sink remains this execution log.
+
+## Residual Risk
+- Residual risk: low. The helper remains tested only through focused unit coverage and package tests, not a synthetic benchmark; however the change is a straightforward ordered-map merge and the semantic cases that matter for counter deltas are covered.
+- Follow-up: runtime clone-heavy paths remain intentionally out of scope and should require a `runtime_engineer` slice before any future changes.
+
+## 2026-06-28 10:51:04 CST / tpm
+- Pre-PR Local Role Review: passed
+- Task UID: task_abeacd11de97477c91668825da4524b5
+- Source Worktree: /Users/scc/ccwork/worktrees/oasis7-engineering-perf-abstraction-optimization
+- Source Branch: task/engineering-perf-abstraction-optimization
+- Source Head: 0d8eb132ded35a2e548b09232eca0109182e5a1e
+- Comparison Ref: refs/remotes/origin/main
+- Reviewed Changed Paths: `.pm/roles/tpm/backlog/committed.yaml`; `.pm/tasks/task_abeacd11de97477c91668825da4524b5.yaml`; `.pm/tasks/task_abeacd11de97477c91668825da4524b5.execution.md`; `doc/engineering/project.md`; `tools/wasm_module_observe/src/lib.rs`
+- Review Package: n/a; `./scripts/pm/review-package.sh --base origin/main --head HEAD --task-uid task_abeacd11de97477c91668825da4524b5` generated `/Users/scc/ccwork/worktrees/oasis7-engineering-perf-abstraction-optimization/.pm/scratch/task_abeacd11de97477c91668825da4524b5/review-packages/review-55e71f9b2..4699b2283.diff`, but reviewer found its content did not match the requested target, so the accepted review source was the current worktree target diff and files.
+- Role Selection Basis: changed paths are engineering governance/task evidence plus `tools/wasm_module_observe` helper code; task history includes repository-health scan/implementation; no product/runtime/viewer/liveops claims were made, so only `repository_health_engineer` was required.
+- Review Roles: repository_health_engineer
+- Review Evidence: repository_health_engineer pre-PR review at `2026-06-28 10:49:41 CST`; reviewer ran `rtk ./scripts/cargo-dev.sh test --manifest-path tools/wasm_module_observe/Cargo.toml diff_btree_map_subtracts_counters` and observed the focused test pass; reviewer also noted `rtk git diff --check` still passed.
+- Review Verdicts: repository_health_engineer scope/spec compliance verdict: pass; role quality/risk verdict: pass.
+- Review Findings Disposition: no_findings
+- Finding Disposition Evidence: n/a; no valid findings to address.
+- Verification Matrix: `tools/wasm_module_observe/src/lib.rs` -> focused package tests and diff whitespace -> `rtk ./scripts/cargo-dev.sh test --manifest-path tools/wasm_module_observe/Cargo.toml` passed, reviewer focused test passed, `rtk git diff --check` passed; `doc/engineering/project.md` and `.pm` task evidence -> doc/workflow governance -> `rtk ./scripts/doc-governance-check.sh` passed and `rtk ./scripts/pm/workflow-lint.sh --task-uid task_abeacd11de97477c91668825da4524b5 --phase current` passed; repo-wide `.pm` lint -> observed historical unrelated execution-log debt, not current task paths.
+- Visual Evidence: n/a; no UI or visual surface changed.
+- WASM Evidence: support tooling evidence only; `tools/wasm_module_observe` package tests passed, no wasm ABI/schema/determinism behavior changed.
+- Ops Evidence: n/a; no deployment, node ops, release packaging, rollback, or runbook surface changed.
+- LiveOps Evidence: n/a; no external messaging, release notes, player promise, or community surface changed.
+- Residual Risk: low; no benchmark was added, but semantic cases for counter deltas are covered and the helper remains private. Runtime clone-heavy paths are explicitly out of scope for a future `runtime_engineer` slice.
+- Slice Ledger: n/a; requested path `/Users/scc/ccwork/worktrees/oasis7-engineering-perf-abstraction-optimization/.pm/scratch/task_abeacd11de97477c91668825da4524b5/slice-ledger.jsonl` was not present during review; formal sink is this execution log.

--- a/.pm/tasks/task_abeacd11de97477c91668825da4524b5.execution.md
+++ b/.pm/tasks/task_abeacd11de97477c91668825da4524b5.execution.md
@@ -268,3 +268,12 @@ SUPPLEMENTAL PRE-PR LOCAL ROLE REVIEW RESULT
 - Residual risk: low. There is no benchmark or end-to-end release test for `tools/wasm_module_observe`, so QA can only confirm semantic/regression evidence rather than measured performance gain. That is acceptable for this private helper optimization because package-level tests include the changed unit test and fixture integration coverage.
 - Repo-wide `rtk ./scripts/pm/lint.sh` remains a known unrelated historical `.pm/tasks/*` execution-log debt according to the task evidence; it should not block this tooling-only PR unless PR policy requires repo-wide PM cleanup in the same change.
 - Runtime clone-heavy paths are out of scope and should not be described as optimized or release-validated by this PR.
+
+## 2026-06-28 11:01:49 CST / tpm
+- 完成内容: Completed supplemental local reviews, added project.md doc_ref, and ran fresh ready_for_pr claim verification.
+- 遗留事项: Rerun prepare-task-pr create after committing evidence updates.
+- Action: Record claim-ready and task-closeout evidence required by prepare-task-pr preflight.
+- Validation Command: ./scripts/pm/claim-ready.sh --claim-type ready_for_pr --verify-command './scripts/cargo-dev.sh test --manifest-path tools/wasm_module_observe/Cargo.toml && ./scripts/doc-governance-check.sh && ./scripts/pm/workflow-lint.sh --task-uid task_abeacd11de97477c91668825da4524b5 --phase current && git diff --check'; prior ./scripts/pm/task-closeout.sh --role tpm --task-uid task_abeacd11de97477c91668825da4524b5 --verify-command './scripts/cargo-dev.sh test --manifest-path tools/wasm_module_observe/Cargo.toml && ./scripts/pm/workflow-lint.sh --task-uid task_abeacd11de97477c91668825da4524b5 --phase current' --no-lint
+- Expected Result: claim-ready.sh verifies ready_for_pr and task-closeout.sh evidence remains recorded for the done task.
+- Actual Result: claim-ready.sh ready_for_pr passed at 2026-06-28T11:01:34+08:00 with exit code 0; task-closeout.sh completed earlier at 2026-06-28T10:51:44+08:00 with exit code 0 and task status done.
+- Blocker / Next Action: Commit evidence-only updates and rerun prepare-task-pr.

--- a/.pm/tasks/task_abeacd11de97477c91668825da4524b5.yaml
+++ b/.pm/tasks/task_abeacd11de97477c91668825da4524b5.yaml
@@ -11,6 +11,7 @@ source_refs:
   - AGENTS.md
 doc_refs:
   - doc/engineering/workflow/source-of-truth.md
+  - doc/engineering/project.md
 related_prd: []
 acceptance:
   - "Repository-health slice identifies concrete performance or abstraction improvement opportunities."

--- a/.pm/tasks/task_abeacd11de97477c91668825da4524b5.yaml
+++ b/.pm/tasks/task_abeacd11de97477c91668825da4524b5.yaml
@@ -1,0 +1,27 @@
+task_uid: task_abeacd11de97477c91668825da4524b5
+title: "Optimize performance and abstractions"
+owner_role: tpm
+module: engineering
+worktree_hint: /Users/scc/ccwork/worktrees/oasis7-engineering-perf-abstraction-optimization
+execution_log_path: .pm/tasks/task_abeacd11de97477c91668825da4524b5.execution.md
+status: done
+priority: P2
+source_signal: null
+source_refs:
+  - AGENTS.md
+doc_refs:
+  - doc/engineering/workflow/source-of-truth.md
+related_prd: []
+acceptance:
+  - "Repository-health slice identifies concrete performance or abstraction improvement opportunities."
+  - "Implementation is scoped, verified, and recorded in the task execution log."
+handoff_to:
+  - repository_health_engineer
+updated_at: 2026-06-28T10:51:44+08:00
+last_started_at: 2026-06-28T10:36:21+08:00
+last_claim_type: task_complete
+last_verify_command: "./scripts/cargo-dev.sh test --manifest-path tools/wasm_module_observe/Cargo.toml && ./scripts/pm/workflow-lint.sh --task-uid task_abeacd11de97477c91668825da4524b5 --phase current"
+last_verified_at: 2026-06-28T10:51:43+08:00
+last_verification_exit_code: 0
+last_verification_status: verified
+last_closed_at: 2026-06-28T10:51:44+08:00

--- a/doc/engineering/project.md
+++ b/doc/engineering/project.md
@@ -6,6 +6,8 @@
 > 说明：本页既有 `TASK-*` 顺序编号条目作为历史追踪保留，不做批量迁移；自该规则冻结后，新增任务项默认改用小写 kebab-case 的 `topic-slug (PRD-ID)` 稳定标识，并固定追加 `Trace: .pm/tasks/task_<32hex>.yaml`（或等价 `task_uid`）追溯运行态 task。项目页 slug 只用于人类检索与规划，不替代 `.pm` 的 canonical `task_uid`。
 > 模板：`- [ ] agents-workflow-single-source (PRD-ENGINEERING-021) [test_tier_required]: 对齐项目任务标识口径。 Trace: .pm/tasks/task_<32hex>.yaml`
 
+- [x] wasm-module-observe-btreemap-diff-merge-efficiency (PRD-ENGINEERING/GOVERNANCE) [test_tier_required]: Optimize wasm module observe metric bucket diffing to merge ordered `BTreeMap` iterators directly instead of cloning keys into a temporary vector, sorting, deduping, and re-looking up values, preserving saturating counter-delta semantics. Trace: .pm/tasks/task_abeacd11de97477c91668825da4524b5.yaml
+
 - [x] main-token-bridge-budget-remainder-sort-performance (PRD-ENGINEERING/GOVERNANCE) [test_tier_required]: Optimize main-token bridge budget remainder distribution to carry awarded points with local candidates instead of repeatedly scanning settlements during sort comparison, preserving higher-points priority, node-id tie-breaks, and final event distribution order. Trace: .pm/tasks/task_0389769c78cd454cb520a620ea0eadda.yaml
 
 - [x] code-execution-efficiency-governance (PRD-ENGINEERING/GOVERNANCE) [test_tier_required]: Apply low-risk Rust code execution efficiency improvements across prompt/memory assembly, mempool selection, feedback/provider ordering, DHT progress payloads, and transfer latency summarization while preserving runtime/product semantics. Trace: .pm/tasks/task_c85925c7cfed4946b461883d94aa35be.yaml

--- a/tools/wasm_module_observe/src/lib.rs
+++ b/tools/wasm_module_observe/src/lib.rs
@@ -645,21 +645,41 @@ fn diff_btree_map(
     before: &BTreeMap<String, u64>,
     after: &BTreeMap<String, u64>,
 ) -> BTreeMap<String, u64> {
-    let mut keys = before.keys().cloned().collect::<Vec<_>>();
-    for key in after.keys() {
-        if !before.contains_key(key) {
-            keys.push(key.clone());
+    let mut diff = BTreeMap::new();
+    let mut before_iter = before.iter().peekable();
+    let mut after_iter = after.iter().peekable();
+
+    while let (Some((before_key, before_value)), Some((after_key, after_value))) =
+        (before_iter.peek(), after_iter.peek())
+    {
+        match before_key.cmp(after_key) {
+            std::cmp::Ordering::Less => {
+                diff.insert((*before_key).clone(), 0);
+                before_iter.next();
+            }
+            std::cmp::Ordering::Equal => {
+                diff.insert(
+                    (*before_key).clone(),
+                    (*after_value).saturating_sub(**before_value),
+                );
+                before_iter.next();
+                after_iter.next();
+            }
+            std::cmp::Ordering::Greater => {
+                diff.insert((*after_key).clone(), **after_value);
+                after_iter.next();
+            }
         }
     }
-    keys.sort();
-    keys.dedup();
-    keys.into_iter()
-        .map(|key| {
-            let before_value = before.get(&key).copied().unwrap_or_default();
-            let after_value = after.get(&key).copied().unwrap_or_default();
-            (key, after_value.saturating_sub(before_value))
-        })
-        .collect()
+
+    for (key, _) in before_iter {
+        diff.insert(key.clone(), 0);
+    }
+    for (key, value) in after_iter {
+        diff.insert(key.clone(), *value);
+    }
+
+    diff
 }
 
 fn module_call_failure_code_label(code: &oasis7_wasm_abi::ModuleCallErrorCode) -> &'static str {
@@ -713,7 +733,11 @@ mod tests {
 
     #[test]
     fn diff_btree_map_subtracts_counters() {
-        let before = BTreeMap::from([("a".to_string(), 1), ("b".to_string(), 2)]);
+        let before = BTreeMap::from([
+            ("a".to_string(), 1),
+            ("b".to_string(), 2),
+            ("d".to_string(), 9),
+        ]);
         let after = BTreeMap::from([
             ("a".to_string(), 3),
             ("b".to_string(), 2),
@@ -723,6 +747,7 @@ mod tests {
         assert_eq!(diff.get("a"), Some(&2));
         assert_eq!(diff.get("b"), Some(&0));
         assert_eq!(diff.get("c"), Some(&5));
+        assert_eq!(diff.get("d"), Some(&0));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Optimize `wasm_module_observe` metric bucket diffing by merging ordered `BTreeMap` iterators directly.
- Preserve saturating counter-delta semantics and add before-only key coverage.
- Record engineering project/task evidence and local role reviews.

## Verification
- `./scripts/cargo-dev.sh test --manifest-path tools/wasm_module_observe/Cargo.toml`
- `./scripts/doc-governance-check.sh`
- `./scripts/pm/workflow-lint.sh --task-uid task_abeacd11de97477c91668825da4524b5 --phase current`
- `git diff --check`

## Notes
- `./scripts/pm/lint.sh` still reports unrelated historical `.pm/tasks/*` execution-log debt; current task workflow lint passes.
