### PR TITLE
Optimize wasm build path ordering

### DIFF
--- a/.pm/tasks/task_f7a74ed95c704c09899a494237e500d7.execution.md
+++ b/.pm/tasks/task_f7a74ed95c704c09899a494237e500d7.execution.md
@@ -1,0 +1,352 @@
+# task_f7a74ed95c704c09899a494237e500d7 Execution Log
+
+- task_uid: task_f7a74ed95c704c09899a494237e500d7
+- title: Optimize more performance and abstractions
+- owner_role: tpm
+- worktree_hint: /Users/scc/ccwork/worktrees/oasis7-engineering-perf-abstraction-optimization-2
+
+<!-- Append entries using:
+Example:
+  ## YYYY-MM-DD HH:MM:SS CST / role_name
+  - 完成内容: ...
+  - 遗留事项: ...
+  - Action: ...
+  - Validation Command: ...
+  - Expected Result: ...
+  - Actual Result: ...
+  - Blocker / Next Action: ...
+-->
+
+## 2026-06-28 19:06:10 CST / tpm
+
+WORKFLOW BOOTSTRAP DECIDED
+
+## Repository State Impact
+- Changes repository state: yes
+- Why: user asked to continue finding code performance and abstraction-design opportunities and optimize them.
+
+## Isolation Decision
+- Current workspace state: source worktree `/Users/scc/ccwork/oasis7` was on `main...origin/main` and clean.
+- Reuse allowed: no explicit reuse requested; create a fresh task worktree because prior task/PR #726 is merged and cleaned up.
+- Worktree action: created `/Users/scc/ccwork/worktrees/oasis7-engineering-perf-abstraction-optimization-2` on branch `task/engineering-perf-abstraction-optimization-2` with shared cargo target symlink.
+
+## Task Truth
+- Owner role: `tpm` as workflow coordinator/integrator only.
+- `.pm` task: `task_f7a74ed95c704c09899a494237e500d7`
+- Formal docs: `AGENTS.md`, `doc/engineering/workflow/source-of-truth.md`, `doc/engineering/project.md`, `doc/engineering/prd.md`.
+
+## Routed Next Phase
+- Selected workflow surface: `repo-owned-workflow-router` -> `executing-project-tasks`
+- Why now: task truth exists and implementation is requested; professional repository-health judgment must identify and validate the next optimization.
+
+## Required Writeback
+- `prd.md`: no initial PRD update expected unless the selected change reveals durable governance requirements.
+- `project.md`: add a completed engineering trace if an optimization lands.
+- `.pm` execution log (mandatory): record route, subagent slice contract, findings, implementation evidence, verification, review, and closeout.
+- handoff (optional supplement): not needed initially.
+
+## Next Action
+- exact next step: dispatch `repository_health_engineer` bounded implementation slice for a new narrow optimization distinct from PR #726.
+
+WORKFLOW ROUTE DECIDED
+
+## Task Phase
+- Current phase: execution
+- Why: scope is clear enough to execute; the task asks for another concrete performance/abstraction optimization.
+
+## Selected Workflow Skills
+1. `executing-project-tasks` - perform a scoped implementation with step evidence.
+2. `systematic-debugging` - use only if scan or verification exposes a concrete failing behavior.
+3. `verification-before-completion` - use before claiming the task is complete or ready for PR.
+4. `finishing-a-development-branch` - use after implementation/review for closeout, PR, CI watch, merge, and cleanup.
+
+## Skipped Workflow Skills
+- `bounded-brainstorming` - no option-heavy planning is needed; repository-health scan can directly choose a low-risk target.
+- `tdd-test-writer` - defer until the concrete target is selected; add or extend focused tests if the selected surface has a stable test harness.
+
+## Subagent Slice Plan
+- role: `repository_health_engineer`
+- slice type: bounded scan plus direct patch if a safe new optimization is found.
+- intended model configuration: workflow source-of-truth `Default subagent runtime`.
+- actual dispatched model/reasoning: inherited/unverified; current subagent tool inherits parent model by default and does not report exact model after dispatch.
+- context delivery mode: full-thread/full-history fork via subagent `fork_context=true`.
+- mandatory context checklist/packet:
+  - identity and authority: `AGENTS.md`, `/Users/scc/.codex/RTK.md`, `.agents/roles/repository_health_engineer.md`
+  - workflow governance: `doc/engineering/workflow/source-of-truth.md`, `default-workflow-bootstrap`, `repo-owned-workflow-router`, `executing-project-tasks`
+  - task truth: `.pm/tasks/task_f7a74ed95c704c09899a494237e500d7.yaml` and this execution log
+  - user intent: "继续找代码里性能和抽象设计相关的点，做优化"
+  - scoped repo context: avoid repeating PR #726's `tools/wasm_module_observe::diff_btree_map`; prioritize new low-risk repeated allocation/sort/clone/parsing or helper-boundary simplification; avoid `third_party`; do not modify unrelated dirty state.
+  - collaboration boundary: repository_health owns findings and code-health/debt classification; TPM integrates, verifies, reviews, and manages PR. Domain-sensitive runtime/viewer/WASM/agent correctness must request the matching role before claiming domain ownership.
+- write scope: one narrow code/test/doc surface selected by evidence; no broad refactor.
+- return contract: scan method and candidates; selected optimization with risk rationale; files changed; verification commands/results; residual risk/follow-up debt; append slice result to this execution log.
+- formal sink / writeback surface: `.pm/tasks/task_f7a74ed95c704c09899a494237e500d7.execution.md` mandatory.
+- integration owner: `tpm`.
+- integration order: repository-health scan/patch -> TPM inspect/integrate -> focused verification -> pre-PR role review -> closeout/PR.
+- context exemption: none.
+
+## 2026-06-28 19:27:44 CST / repository_health_engineer
+
+BOUNDED IMPLEMENTATION SLICE RESULT
+
+## Scope / Role Boundary
+- Task: `task_f7a74ed95c704c09899a494237e500d7`
+- Role: `repository_health_engineer`
+- Boundary: repository-health/code-health implementation slice only; no runtime/viewer/WASM/domain correctness ownership claimed.
+- Read inputs: `AGENTS.md`, `/Users/scc/.codex/RTK.md`, `.agents/roles/repository_health_engineer.md`, `.pm/tasks/task_f7a74ed95c704c09899a494237e500d7.yaml`, this execution log, `doc/engineering/project.md`, `doc/engineering/prd.md`.
+
+## Scan Method / Candidates Considered
+- Scanned Rust sort/collect/clone/parsing hotspots outside `third_party` with:
+  - `rtk rg -n "sort_by\\(|sort_by_key\\(|sort_unstable_by\\(|sort_unstable_by_key\\(" --glob '!third_party/**' --glob '*.rs'`
+  - `rtk rg -n "collect::<Vec<_>>\\(\\)|\\.collect\\(\\).*sort|\\.clone\\(\\).*collect|\\.to_string\\(\\).*sort|\\.parse::<" --glob '!third_party/**' --glob '*.rs'`
+  - `rtk rg -n "BTreeMap|HashMap|HashSet" tools crates scripts --glob '!third_party/**' --glob '*.rs'`
+- Candidate A: `crates/oasis7_wasm_build/src/lib.rs` repeated path sort/dedup logic used `to_string_lossy().cmp(...)` in sort comparators for package dirs and source files. This is private build/source-hash tooling with existing focused tests and does not repeat PR #726's `tools/wasm_module_observe::diff_btree_map` map-diff optimization.
+- Candidate B: several runtime/world paths still contain full materialization/sort or clone-heavy patterns, but those affect domain event ordering or runtime behavior and should be owned/reviewed by `runtime_engineer` before optimization.
+- Candidate C: libp2p/provider/network sorting and parse paths may have opportunities, but many touch network correctness, peer ordering, or production behavior and should be owned by `runtime_engineer`/network-adjacent role rather than this repository-health slice.
+
+## Selected Optimization
+- Selected Candidate A.
+- Change: introduced private `sort_dedup_paths(&mut Vec<PathBuf>)` and reused it in `collect_local_package_dirs` and `collect_source_files_for_hash`.
+- Performance/abstraction effect: avoids repeated path-to-lossy-string conversion inside sort comparators and removes duplicate sort/dedup helper logic; uses native `PathBuf` ordering plus `dedup` for deterministic path ordering.
+- Low-risk rationale: surface is private `oasis7_wasm_build` source-hash tooling; changed behavior is limited to deterministic internal ordering before hashing; existing source-hash tests exercise package-dir and source-file traversal, local path dependencies, lockfile sensitivity, ignored files, and split-workspace handling. Added a focused helper test for stable sort/dedup behavior.
+
+## Files Changed
+- `crates/oasis7_wasm_build/src/lib.rs`
+
+## Verification
+- Command: `rtk ./scripts/cargo-dev.sh fmt --all --check`
+  - Expected: formatting check passes.
+  - Actual: passed.
+- Command: `rtk ./scripts/cargo-dev.sh test -p oasis7_wasm_build`
+  - Expected: `oasis7_wasm_build` unit/doc tests pass.
+  - Actual: passed after waiting for the shared build directory lock; 6 unit tests passed, 0 failed; doc-tests 0 passed/0 failed.
+- Command: `rtk git diff --check`
+  - Expected: no whitespace errors.
+  - Actual: passed.
+
+## Residual Risk / Follow-up Debt
+- Residual risk: native `PathBuf` ordering replaces previous lossy-string comparator ordering. For normal repository paths this should preserve deterministic ordering while avoiding repeated conversion; non-UTF-8 path ordering may differ from lossy display ordering. This crate hashes repo source inputs, which are expected to use normal valid paths.
+- Follow-up debt: runtime/world/viewer/network clone-heavy or full-sort candidates remain out of scope for this repository-health implementation slice and should be routed to the matching domain role before implementation.
+- Action: return to TPM for integration, additional role review, closeout, and PR flow.
+
+- 完成内容: Identified and implemented a new repository-health optimization in `crates/oasis7_wasm_build/src/lib.rs`, distinct from PR #726, by centralizing path sort/dedup and removing repeated lossy-string comparator conversion.
+- 遗留事项: Domain-sensitive runtime/world/viewer/network optimization candidates were intentionally deferred to their matching owner roles; non-UTF-8 path ordering differs theoretically from the old lossy-string comparator but repo source paths are expected to be normal valid paths.
+- Action: Return to TPM for integration, pre-PR role review, closeout, and PR flow.
+- Validation Command: `rtk ./scripts/cargo-dev.sh fmt --all --check`; `rtk ./scripts/cargo-dev.sh test -p oasis7_wasm_build`; `rtk git diff --check`
+- Expected Result: Formatting, focused crate tests, and whitespace checks pass.
+- Actual Result: Passed; `oasis7_wasm_build` reported 6 unit tests passed and 0 failed after waiting for the shared build directory lock; doc-tests reported 0 passed/0 failed.
+- Blocker / Next Action: No implementation blocker; TPM should run integration/review/closeout gates.
+
+## 2026-06-28 19:17:35 CST / tpm
+- Review Trigger: pre-PR local role review
+- Review Scope: current worktree diff for `.pm/tasks/task_f7a74ed95c704c09899a494237e500d7.*`, `.pm/roles/tpm/backlog/committed.yaml`, `doc/engineering/project.md`, and `crates/oasis7_wasm_build/src/lib.rs`.
+- Review Package: n/a; `./scripts/pm/review-package.sh --base origin/main --head HEAD --task-uid task_f7a74ed95c704c09899a494237e500d7` produced an empty commit-range package because the current review target is still an uncommitted worktree diff.
+- Review Roles: `repository_health_engineer`, `wasm_platform_engineer`, `qa_engineer`, `producer_system_designer`
+- Review Question: confirm the path sort/dedup helper optimization is scoped, preserves wasm build/source-hash determinism for normal repo paths, has sufficient verification, and does not create product/system-design scope drift.
+- Evidence Available: repository_health_engineer implementation slice; `rtk ./scripts/cargo-dev.sh fmt --all --check` passed; `rtk ./scripts/cargo-dev.sh test -p oasis7_wasm_build` passed with 6 unit tests; `rtk git diff --check` passed; project trace added.
+- Expected Return Contract: findings | no_findings | scope/spec compliance verdict | role quality/risk verdict | residual_risk
+- Slice Ledger: `/Users/scc/ccwork/worktrees/oasis7-engineering-perf-abstraction-optimization-2/.pm/scratch/task_f7a74ed95c704c09899a494237e500d7/slice-ledger.jsonl`
+- Formal Sink: `.pm/tasks/task_f7a74ed95c704c09899a494237e500d7.execution.md`
+
+## 2026-06-28 19:16:19 CST / tpm
+- 完成内容: Integrated repository_health_engineer wasm build path sort/dedup optimization and added engineering project trace.
+- 遗留事项: Collect fresh pre-PR local role reviews, close out the task, create PR, and watch through merge.
+- Action: Run focused integration verification for the selected wasm build source-hash tooling change.
+- Validation Command: ./scripts/cargo-dev.sh fmt --all --check && ./scripts/cargo-dev.sh test -p oasis7_wasm_build && git diff --check
+- Expected Result: Formatting, focused oasis7_wasm_build tests, and whitespace diff checks pass.
+- Actual Result: Passed: fmt check exit 0; oasis7_wasm_build reported 6 unit tests passed, 0 failed, and 0 doc tests; git diff --check exit 0.
+- Blocker / Next Action: Proceed to pre-PR local role review.
+
+## 2026-06-28 19:27:24 CST / wasm_platform_engineer
+
+PRE-PR LOCAL ROLE REVIEW RESULT
+
+## Review Target / Method
+- Task: `task_f7a74ed95c704c09899a494237e500d7`
+- Role: `wasm_platform_engineer`
+- Scope inspected: current worktree diff/files for `crates/oasis7_wasm_build/src/lib.rs`, `doc/engineering/project.md`, and task evidence because the review package had no committed range diff.
+- Commands/evidence inspected: `rtk git diff -- crates/oasis7_wasm_build/src/lib.rs doc/engineering/project.md .pm/tasks/task_f7a74ed95c704c09899a494237e500d7.execution.md`; `rtk sed -n '240,680p' crates/oasis7_wasm_build/src/lib.rs`; `rtk rg -n "compute_source_hash|source_hash|manifest|abi|collect_source_files_for_hash|collect_local_package_dirs|sort_dedup_paths" crates/oasis7_wasm_build/src/lib.rs crates/oasis7_wasm_build -g '*.rs'`; task YAML and execution log.
+
+## Findings
+- no_findings
+
+## Scope / Spec Compliance Verdict
+- passed. The change is limited to private source-hash path ordering helpers in `crates/oasis7_wasm_build/src/lib.rs` plus engineering/task trace docs. It does not change `compute_source_hash` record labels, manifest-relative hash formatting, cargo metadata arguments, target selection, ABI surface, module manifest contract, or deployment/install/runtime behavior.
+- For normal repo paths, replacing the repeated `to_string_lossy().cmp(...)` sort comparators with `PathBuf` native ordering remains deterministic and stable before `dedup`; the existing hash traversal still sorts package dirs and package files before hashing.
+
+## Role Quality / Risk Verdict
+- passed. This is an appropriate low-risk WASM platform tooling optimization: it removes repeated lossy string conversion during sorting and centralizes duplicated sort/dedup logic without expanding the public API or hash schema.
+- Existing and fresh evidence cover the relevant source-hash behavior: local path dependency changes, workspace ancestor lockfile changes, ignored non-whitelisted files, split workspace/local dependency handling, lockfile lookup, and the new helper ordering/dedup behavior.
+
+## Fresh Verification
+- Command: `rtk ./scripts/cargo-dev.sh test -p oasis7_wasm_build`
+  - Expected Result: focused WASM build/source-hash tests pass.
+  - Actual Result: passed after waiting for the shared cargo package/build lock; 6 unit tests passed, 0 failed; doc-tests 0 passed/0 failed.
+- Command: `rtk git diff --check`
+  - Expected Result: no whitespace errors.
+  - Actual Result: passed.
+- Command: `rtk ./scripts/pm/workflow-lint.sh --task-uid task_f7a74ed95c704c09899a494237e500d7 --phase current`
+  - Expected Result: current task workflow lint passes.
+  - Actual Result: passed.
+
+## Residual Risk
+- Low. The only material semantic difference is theoretical non-UTF-8 path ordering: the old comparator sorted by lossy UTF-8 display strings, while the new helper sorts by native `PathBuf` ordering. Normal repository source paths are expected to be valid paths, so this does not create unsafe source-hash nondeterminism for the intended repo contract.
+- No ABI, manifest, permission, hash label, or runtime execution compatibility risk identified.
+
+- 完成内容: Completed fresh `wasm_platform_engineer` pre-PR local role review with `no_findings`.
+- 遗留事项: None blocking from WASM platform; TPM should continue collecting other role reviews and PR closeout.
+- Action: Return to TPM integration chain.
+- Validation Command: `rtk ./scripts/cargo-dev.sh test -p oasis7_wasm_build`; `rtk git diff --check`; `rtk ./scripts/pm/workflow-lint.sh --task-uid task_f7a74ed95c704c09899a494237e500d7 --phase current`
+- Expected Result: Focused tests, whitespace check, and workflow lint pass.
+- Actual Result: Passed; test reported 6 unit tests passed, 0 failed, doc-tests 0/0.
+- Blocker / Next Action: No WASM-platform blocker.
+
+## 2026-06-28 19:25:39 CST / qa_engineer
+
+PRE-PR LOCAL ROLE REVIEW RESULT
+
+## Review Target
+- Task: `task_f7a74ed95c704c09899a494237e500d7`
+- Role: `qa_engineer`
+- Scope inspected: current worktree diff/files for `crates/oasis7_wasm_build/src/lib.rs`, `doc/engineering/project.md`, `.pm/tasks/task_f7a74ed95c704c09899a494237e500d7.yaml`, `.pm/tasks/task_f7a74ed95c704c09899a494237e500d7.execution.md`, and `.pm/roles/tpm/backlog/committed.yaml`.
+- Review package: n/a; uncommitted worktree diff was inspected directly as requested.
+
+## Findings
+- `no_findings`
+
+## Scope / Spec Compliance Verdict
+- Pass. The implementation matches the accepted task scope: a new repository-health performance/abstraction optimization distinct from PR #726, limited to wasm build source-hash tooling path ordering/deduplication plus project/task trace writeback.
+- No player-facing, release-process, product-system, or runtime semantics were introduced by the code change.
+
+## Role Quality / Risk Verdict
+- Pass with low QA risk. The changed helper keeps deterministic sorting and deduplication for normal repository paths while removing repeated `to_string_lossy()` comparator conversion and duplicated sort/dedup logic.
+- Existing focused crate coverage is appropriate for this tooling-only change: source hash changes for local path dependency changes and lockfile changes, ignores non-whitelisted files, supports split workspace path dependencies, and now includes direct helper sort/dedup coverage.
+
+## Verification Evidence Reviewed / Run
+- Reviewed prior implementation evidence:
+  - `rtk ./scripts/cargo-dev.sh fmt --all --check` passed.
+  - `rtk ./scripts/cargo-dev.sh test -p oasis7_wasm_build` passed with 6 unit tests and 0 doc tests.
+  - `rtk git diff --check` passed.
+- Fresh QA commands:
+  - `rtk ./scripts/cargo-dev.sh fmt --all --check` passed.
+  - `rtk git diff --check` passed.
+  - `rtk ./scripts/pm/workflow-lint.sh --task-uid task_f7a74ed95c704c09899a494237e500d7 --phase current` passed.
+  - `rtk ./scripts/cargo-dev.sh test -p oasis7_wasm_build` was attempted but remained blocked waiting for the shared Cargo package/build-directory lock for several polling intervals and was interrupted with exit 130 to avoid leaving a hanging QA process. This is not a test failure; the review relies on the already-recorded passing focused crate test evidence for this target.
+
+## Residual Risk
+- Low. The main residual risk is theoretical ordering drift for non-UTF-8 paths because native `PathBuf` ordering replaces the previous lossy-string comparator; normal repo source paths are expected to be valid and deterministic under the new helper.
+- No benchmark or full release test was run, but that is acceptable for a narrow private build/source-hash helper optimization with focused crate tests and no runtime/player-facing surface.
+
+## Return Contract
+- findings: `no_findings`
+- scope/spec compliance verdict: pass
+- role quality/risk verdict: pass, low QA risk
+- residual_risk: low; non-UTF-8 path ordering theory only, no release-blocking gap
+
+## 2026-06-28 19:23:52 CST / repository_health_engineer
+
+PRE-PR LOCAL ROLE REVIEW RESULT
+
+## Review Scope
+- Task: `task_f7a74ed95c704c09899a494237e500d7`
+- Role: `repository_health_engineer`
+- Reviewed current uncommitted worktree diff/files for `.pm/tasks/task_f7a74ed95c704c09899a494237e500d7.*`, `.pm/roles/tpm/backlog/committed.yaml`, `doc/engineering/project.md`, and `crates/oasis7_wasm_build/src/lib.rs`.
+- Review package: n/a; current target is uncommitted worktree diff.
+
+## Findings
+- `no_findings`
+
+## Scope / Spec Compliance Verdict
+- Pass. The change is a valid repository-health performance/abstraction improvement: `collect_local_package_dirs` and `collect_source_files_for_hash` now reuse a private `sort_dedup_paths` helper instead of duplicating `sort + dedup` logic and repeatedly converting paths through `to_string_lossy()` inside sort comparators.
+- Pass. Scope remains narrow to `oasis7_wasm_build` source-hash/build tooling plus task/project evidence. This is distinct from PR #726, which optimized `tools/wasm_module_observe::diff_btree_map` by merging ordered `BTreeMap` iterators.
+- Pass. Task evidence is sufficiently recorded: implementation slice documents scan method, rejected domain-sensitive candidates, selected optimization, verification evidence, and residual risk.
+
+## Role Quality / Risk Verdict
+- Pass. The abstraction boundary is appropriate: a private helper removes duplicated local behavior without broadening public API or crossing into runtime/viewer/network domain correctness.
+- Pass. The performance rationale is credible for repository health: native `PathBuf` ordering avoids repeated lossy string allocation/conversion work during comparator calls and keeps deterministic sort/dedup behavior for normal repo paths.
+- Pass. The added helper unit test covers deduplication and ordering; existing crate tests already cover source-hash traversal behavior around local path dependencies, lockfile handling, ignored files, and split-workspace handling.
+
+## Fresh Review Verification
+- Command: `rtk git diff --check`
+  - Result: passed.
+- Command: `rtk ./scripts/pm/workflow-lint.sh --task-uid task_f7a74ed95c704c09899a494237e500d7 --phase current`
+  - Result: passed.
+- Command: `rtk ./scripts/cargo-dev.sh test -p oasis7_wasm_build sort_dedup_paths_uses_stable_path_order`
+  - Result: blocked waiting on shared Cargo build-directory lock for multiple minutes; reviewer cancelled the waiting process with exit 130 to avoid leaving a stale background command. This does not change the verdict because the implementation slice already recorded `rtk ./scripts/cargo-dev.sh test -p oasis7_wasm_build` passing with 6 unit tests and 0 failures for the current patch.
+
+## Residual Risk
+- Low. Non-UTF-8 path ordering may theoretically differ from the old lossy-string comparator ordering; this is already recorded and acceptable for normal repository source paths.
+- Domain-sensitive clone/full-sort candidates remain intentionally out of scope and should be routed to the matching owner role before future optimization.
+
+- 完成内容: Completed repository_health_engineer pre-PR review for the wasm-build path sort/dedup helper optimization.
+- 遗留事项: None blocking from repository health.
+- Action: Return to TPM for remaining role reviews and PR closeout.
+- Validation Command: `rtk git diff --check`; `rtk ./scripts/pm/workflow-lint.sh --task-uid task_f7a74ed95c704c09899a494237e500d7 --phase current`; attempted `rtk ./scripts/cargo-dev.sh test -p oasis7_wasm_build sort_dedup_paths_uses_stable_path_order`.
+- Expected Result: Diff whitespace and workflow lint pass; focused helper test runs when shared Cargo lock is available.
+- Actual Result: Diff whitespace and workflow lint passed; focused helper test was cancelled after waiting on shared Cargo build-directory lock. Prior current-patch full crate test evidence remains passed.
+- Blocker / Next Action: No repository-health blocker; TPM should continue pre-PR review/closeout flow.
+
+## 2026-06-28 19:21:25 CST / producer_system_designer
+
+PRE-PR LOCAL ROLE REVIEW RESULT
+
+## Review Target / Inputs
+- Task: `task_f7a74ed95c704c09899a494237e500d7`
+- Role boundary: `producer_system_designer` review only for task/project trace and product/system-design scope alignment; no code-health ownership claimed.
+- Files inspected: `doc/engineering/project.md`, `.pm/tasks/task_f7a74ed95c704c09899a494237e500d7.yaml`, this execution log, `.pm/roles/tpm/backlog/committed.yaml`, and `crates/oasis7_wasm_build/src/lib.rs`.
+- Review package: n/a; current target is uncommitted worktree diff/files.
+- Evidence used: repository-health implementation slice, project trace, focused wasm-build test evidence, and current diff.
+
+## Findings
+- `no_findings`
+
+## Scope / Spec Compliance Verdict
+- Pass. The task title, acceptance, backlog entry, execution log, and `doc/engineering/project.md` trace align with the user request to continue engineering-governance performance/abstraction optimization.
+- The selected change is a narrow engineering tooling optimization for wasm build source-hash path ordering and helper reuse. It does not introduce or alter product goals, system-design rules, world rules, resource-economy policy, gameplay behavior, player-facing UX, liveops promises, or external messaging.
+- The project trace explicitly scopes the behavior to preserving deterministic source-hash traversal for normal repo paths, which is appropriate for this engineering/governance task.
+
+## Role Quality / Risk Verdict
+- Pass. The implementation quality/code-health conclusion remains attributed to `repository_health_engineer`; this review only confirms product/system-design scope hygiene.
+- No product/system-design owner escalation is required for this tooling-only optimization. The non-UTF-8 path-ordering residual risk is an engineering determinism concern already captured by the implementation slice, not a product/world-rule drift.
+
+## Residual Risk
+- Residual product/system-design risk: low. Future optimization candidates in runtime/world/viewer/network code may cross domain behavior boundaries and should continue to route to the matching owner role before implementation.
+
+- 完成内容: Completed producer/system-design pre-PR review for task/project trace and scope drift.
+- 遗留事项: None for producer_system_designer.
+- Action: Return to TPM for remaining pre-PR reviews and closeout.
+- Validation Command: `rtk git diff -- doc/engineering/project.md .pm/tasks/task_f7a74ed95c704c09899a494237e500d7.yaml .pm/roles/tpm/backlog/committed.yaml crates/oasis7_wasm_build/src/lib.rs`; direct file inspection.
+- Expected Result: Current diff remains scoped to engineering-governance trace plus wasm build tooling optimization with no product/system-design drift.
+- Actual Result: Passed; `no_findings`.
+- Blocker / Next Action: No blocker from producer_system_designer.
+
+## 2026-06-28 19:29:07 CST / tpm
+- Pre-PR Local Role Review: passed
+- Task UID: task_f7a74ed95c704c09899a494237e500d7
+- Source Worktree: /Users/scc/ccwork/worktrees/oasis7-engineering-perf-abstraction-optimization-2
+- Source Branch: task/engineering-perf-abstraction-optimization-2
+- Source Head: de3f71e89fc2259bb5433938133beff83b8244a4
+- Comparison Ref: refs/remotes/origin/main
+- Reviewed Changed Paths: `.pm/roles/tpm/backlog/committed.yaml`; `.pm/tasks/task_f7a74ed95c704c09899a494237e500d7.yaml`; `.pm/tasks/task_f7a74ed95c704c09899a494237e500d7.execution.md`; `doc/engineering/project.md`; `crates/oasis7_wasm_build/src/lib.rs`
+- Review Package: n/a; `./scripts/pm/review-package.sh --base origin/main --head HEAD --task-uid task_f7a74ed95c704c09899a494237e500d7` produced an empty commit-range package because the reviewed target was the uncommitted worktree diff, so reviewers inspected current worktree diff/files directly.
+- Role Selection Basis: changed paths include engineering governance/task evidence and `crates/oasis7_wasm_build`, which triggers repository-health, WASM-platform, QA, and producer/system-design scope review. No runtime/viewer/liveops/player-facing claims were made.
+- Review Roles: repository_health_engineer, wasm_platform_engineer, qa_engineer, producer_system_designer
+- Review Evidence: repository_health_engineer review at `2026-06-28 19:23:52 CST`; wasm_platform_engineer review at `2026-06-28 19:27:24 CST`; qa_engineer review at `2026-06-28 19:25:39 CST`; producer_system_designer review at `2026-06-28 19:21:25 CST`. WASM platform reviewer freshly ran `rtk ./scripts/cargo-dev.sh test -p oasis7_wasm_build`, `rtk git diff --check`, and current task workflow lint; QA and repository-health also ran workflow/diff checks; producer inspected scope/project trace.
+- Review Verdicts: repository_health_engineer scope/spec compliance verdict: pass and role quality/risk verdict: pass; wasm_platform_engineer scope/spec compliance verdict: pass and role quality/risk verdict: pass; qa_engineer scope/spec compliance verdict: pass and role quality/risk verdict: pass; producer_system_designer scope/spec compliance verdict: pass and role quality/risk verdict: pass.
+- Review Findings Disposition: no_findings
+- Finding Disposition Evidence: n/a; no valid findings to address.
+- Verification Matrix: `crates/oasis7_wasm_build/src/lib.rs` -> focused wasm build tests and source-hash behavior -> `rtk ./scripts/cargo-dev.sh test -p oasis7_wasm_build` passed with 6 unit tests; formatting -> `rtk ./scripts/cargo-dev.sh fmt --all --check` passed; task/project evidence -> `rtk ./scripts/pm/workflow-lint.sh --task-uid task_f7a74ed95c704c09899a494237e500d7 --phase current` passed; whitespace -> `rtk git diff --check` passed.
+- Visual Evidence: n/a; no UI or visual surface changed.
+- WASM Evidence: `oasis7_wasm_build` crate tests passed; wasm_platform_engineer confirmed no ABI, manifest, hash label, cargo metadata parameter, target selection, runtime/deploy/install, or module lifecycle contract change.
+- Ops Evidence: n/a; no deployment, node ops, release packaging, rollback, or runbook surface changed.
+- LiveOps Evidence: n/a; no external messaging, release notes, player promise, or community surface changed.
+- Residual Risk: low; native `PathBuf` ordering may theoretically differ from the old lossy-string comparator for non-UTF-8 paths, but normal repository source paths are expected to be valid and deterministic. Runtime/world/viewer/network optimization candidates remain out of scope.
+- Slice Ledger: `/Users/scc/ccwork/worktrees/oasis7-engineering-perf-abstraction-optimization-2/.pm/scratch/task_f7a74ed95c704c09899a494237e500d7/slice-ledger.jsonl`
+
+## 2026-06-28 19:33:53 CST / tpm
+- 完成内容: Closed task after no-findings local role reviews and ran fresh ready_for_pr claim verification.
+- 遗留事项: Commit task slice, prepare PR, watch checks/comments, merge, and clean up.
+- Action: Record claim-ready.sh and task-closeout.sh evidence required by prepare-task-pr preflight.
+- Validation Command: ./scripts/pm/claim-ready.sh --claim-type ready_for_pr --verify-command './scripts/cargo-dev.sh test -p oasis7_wasm_build && ./scripts/doc-governance-check.sh && ./scripts/pm/workflow-lint.sh --task-uid task_f7a74ed95c704c09899a494237e500d7 --phase current && git diff --check'; prior ./scripts/pm/task-closeout.sh --role tpm --task-uid task_f7a74ed95c704c09899a494237e500d7 --verify-command './scripts/cargo-dev.sh test -p oasis7_wasm_build && ./scripts/doc-governance-check.sh && ./scripts/pm/workflow-lint.sh --task-uid task_f7a74ed95c704c09899a494237e500d7 --phase current && git diff --check' --no-lint
+- Expected Result: claim-ready.sh verifies ready_for_pr and task-closeout.sh evidence remains recorded for the done task.
+- Actual Result: claim-ready.sh ready_for_pr passed at 2026-06-28T19:33:38+08:00 with exit code 0; task-closeout.sh completed at 2026-06-28T19:32:15+08:00 with exit code 0 and task status done.
+- Blocker / Next Action: Commit task slice and rerun prepare-task-pr.

--- a/.pm/tasks/task_f7a74ed95c704c09899a494237e500d7.execution.md
+++ b/.pm/tasks/task_f7a74ed95c704c09899a494237e500d7.execution.md
@@ -324,7 +324,7 @@ PRE-PR LOCAL ROLE REVIEW RESULT
 - Task UID: task_f7a74ed95c704c09899a494237e500d7
 - Source Worktree: /Users/scc/ccwork/worktrees/oasis7-engineering-perf-abstraction-optimization-2
 - Source Branch: task/engineering-perf-abstraction-optimization-2
-- Source Head: de3f71e89fc2259bb5433938133beff83b8244a4
+- Source Head: b4e9022df0d6cadffa5efc348922f5332eb895b7
 - Comparison Ref: refs/remotes/origin/main
 - Reviewed Changed Paths: `.pm/roles/tpm/backlog/committed.yaml`; `.pm/tasks/task_f7a74ed95c704c09899a494237e500d7.yaml`; `.pm/tasks/task_f7a74ed95c704c09899a494237e500d7.execution.md`; `doc/engineering/project.md`; `crates/oasis7_wasm_build/src/lib.rs`
 - Review Package: n/a; `./scripts/pm/review-package.sh --base origin/main --head HEAD --task-uid task_f7a74ed95c704c09899a494237e500d7` produced an empty commit-range package because the reviewed target was the uncommitted worktree diff, so reviewers inspected current worktree diff/files directly.

--- a/.pm/tasks/task_f7a74ed95c704c09899a494237e500d7.execution.md
+++ b/.pm/tasks/task_f7a74ed95c704c09899a494237e500d7.execution.md
@@ -350,3 +350,14 @@ PRE-PR LOCAL ROLE REVIEW RESULT
 - Expected Result: claim-ready.sh verifies ready_for_pr and task-closeout.sh evidence remains recorded for the done task.
 - Actual Result: claim-ready.sh ready_for_pr passed at 2026-06-28T19:33:38+08:00 with exit code 0; task-closeout.sh completed at 2026-06-28T19:32:15+08:00 with exit code 0 and task status done.
 - Blocker / Next Action: Commit task slice and rerun prepare-task-pr.
+
+## 2026-06-28 19:45:38 CST / tpm
+- 完成内容: Addressed PR #728 Codex review thread `PRRT_kwDORHhWec6My51g`.
+- 遗留事项: Commit and push review-fix update, resolve the GitHub review thread after push, then re-check PR gates and mergeability.
+- Action: Classify and fix actionable review feedback.
+- Review Comment Classification: correctness/regression risk. The comment correctly observed that replacing the prior lossy-string comparator with native `PathBuf::sort()` could change source-hash record ordering for normal UTF-8 paths with file/directory common prefixes such as `src/foo.rs` and `src/foo/bar.rs`.
+- Fix: Updated `sort_dedup_paths` to use `sort_by_cached_key(|path| path.to_string_lossy().into_owned())` before `dedup()`, preserving the prior source-hash label ordering while avoiding repeated comparator-time lossy string conversion. Expanded the unit test to cover the file/directory common-prefix order.
+- Validation Command: `rtk ./scripts/cargo-dev.sh fmt --all --check`; `rtk ./scripts/cargo-dev.sh test -p oasis7_wasm_build`; `rtk git diff --check`.
+- Expected Result: Formatting passes; wasm build crate tests pass including the source-hash label-order regression case; no whitespace errors.
+- Actual Result: Passed. `oasis7_wasm_build` tests passed with 6 tests, including `sort_dedup_paths_preserves_source_hash_label_order`; formatting and diff whitespace checks passed.
+- Blocker / Next Action: Push review fix and resolve the reviewed GitHub thread.

--- a/.pm/tasks/task_f7a74ed95c704c09899a494237e500d7.yaml
+++ b/.pm/tasks/task_f7a74ed95c704c09899a494237e500d7.yaml
@@ -1,0 +1,28 @@
+task_uid: task_f7a74ed95c704c09899a494237e500d7
+title: "Optimize more performance and abstractions"
+owner_role: tpm
+module: engineering
+worktree_hint: /Users/scc/ccwork/worktrees/oasis7-engineering-perf-abstraction-optimization-2
+execution_log_path: .pm/tasks/task_f7a74ed95c704c09899a494237e500d7.execution.md
+status: done
+priority: P2
+source_signal: null
+source_refs:
+  - AGENTS.md
+doc_refs:
+  - doc/engineering/workflow/source-of-truth.md
+  - doc/engineering/project.md
+related_prd: []
+acceptance:
+  - "Repository-health slice identifies a new concrete performance or abstraction improvement opportunity distinct from the prior wasm_module_observe diff optimization."
+  - "Implementation is narrow, verified, reviewed, and recorded in the task execution log."
+handoff_to:
+  - repository_health_engineer
+updated_at: 2026-06-28T19:32:18+08:00
+last_started_at: 2026-06-28T19:05:41+08:00
+last_claim_type: task_complete
+last_verify_command: "./scripts/cargo-dev.sh test -p oasis7_wasm_build && ./scripts/doc-governance-check.sh && ./scripts/pm/workflow-lint.sh --task-uid task_f7a74ed95c704c09899a494237e500d7 --phase current && git diff --check"
+last_verified_at: 2026-06-28T19:32:11+08:00
+last_verification_exit_code: 0
+last_verification_status: verified
+last_closed_at: 2026-06-28T19:32:15+08:00

--- a/crates/oasis7_wasm_build/src/lib.rs
+++ b/crates/oasis7_wasm_build/src/lib.rs
@@ -311,8 +311,7 @@ fn collect_local_package_dirs(
         }
     }
 
-    ordered_dirs.sort_by(|left, right| left.to_string_lossy().cmp(&right.to_string_lossy()));
-    ordered_dirs.dedup();
+    sort_dedup_paths(&mut ordered_dirs);
     Ok(ordered_dirs)
 }
 
@@ -327,12 +326,16 @@ fn collect_source_files_for_hash(package_dir: &Path) -> Result<Vec<PathBuf>, Sou
     for root in ["src", "wit", ".cargo", "assets"] {
         collect_files_recursively(package_dir.join(root).as_path(), &mut files)?;
     }
-    files.sort_by(|left, right| left.to_string_lossy().cmp(&right.to_string_lossy()));
-    files.dedup();
+    sort_dedup_paths(&mut files);
     if files.is_empty() {
         return Err(SourceHashError::NoTrackedFiles(package_dir.to_path_buf()));
     }
     Ok(files)
+}
+
+fn sort_dedup_paths(paths: &mut Vec<PathBuf>) {
+    paths.sort();
+    paths.dedup();
 }
 
 fn common_ancestor(paths: &[PathBuf]) -> Option<PathBuf> {
@@ -576,5 +579,24 @@ mod tests {
         assert_eq!(found.as_deref(), Some(workspace_lock.as_path()));
 
         let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn sort_dedup_paths_uses_stable_path_order() {
+        let mut paths = vec![
+            PathBuf::from("/tmp/workspace/zeta/src/lib.rs"),
+            PathBuf::from("/tmp/workspace/alpha/Cargo.toml"),
+            PathBuf::from("/tmp/workspace/zeta/src/lib.rs"),
+        ];
+
+        sort_dedup_paths(&mut paths);
+
+        assert_eq!(
+            paths,
+            vec![
+                PathBuf::from("/tmp/workspace/alpha/Cargo.toml"),
+                PathBuf::from("/tmp/workspace/zeta/src/lib.rs"),
+            ]
+        );
     }
 }

--- a/crates/oasis7_wasm_build/src/lib.rs
+++ b/crates/oasis7_wasm_build/src/lib.rs
@@ -334,7 +334,7 @@ fn collect_source_files_for_hash(package_dir: &Path) -> Result<Vec<PathBuf>, Sou
 }
 
 fn sort_dedup_paths(paths: &mut Vec<PathBuf>) {
-    paths.sort();
+    paths.sort_by_cached_key(|path| path.to_string_lossy().into_owned());
     paths.dedup();
 }
 
@@ -582,9 +582,11 @@ mod tests {
     }
 
     #[test]
-    fn sort_dedup_paths_uses_stable_path_order() {
+    fn sort_dedup_paths_preserves_source_hash_label_order() {
         let mut paths = vec![
             PathBuf::from("/tmp/workspace/zeta/src/lib.rs"),
+            PathBuf::from("/tmp/workspace/zeta/src/foo/bar.rs"),
+            PathBuf::from("/tmp/workspace/zeta/src/foo.rs"),
             PathBuf::from("/tmp/workspace/alpha/Cargo.toml"),
             PathBuf::from("/tmp/workspace/zeta/src/lib.rs"),
         ];
@@ -595,6 +597,8 @@ mod tests {
             paths,
             vec![
                 PathBuf::from("/tmp/workspace/alpha/Cargo.toml"),
+                PathBuf::from("/tmp/workspace/zeta/src/foo.rs"),
+                PathBuf::from("/tmp/workspace/zeta/src/foo/bar.rs"),
                 PathBuf::from("/tmp/workspace/zeta/src/lib.rs"),
             ]
         );

--- a/doc/engineering/project.md
+++ b/doc/engineering/project.md
@@ -6,6 +6,8 @@
 > 说明：本页既有 `TASK-*` 顺序编号条目作为历史追踪保留，不做批量迁移；自该规则冻结后，新增任务项默认改用小写 kebab-case 的 `topic-slug (PRD-ID)` 稳定标识，并固定追加 `Trace: .pm/tasks/task_<32hex>.yaml`（或等价 `task_uid`）追溯运行态 task。项目页 slug 只用于人类检索与规划，不替代 `.pm` 的 canonical `task_uid`。
 > 模板：`- [ ] agents-workflow-single-source (PRD-ENGINEERING-021) [test_tier_required]: 对齐项目任务标识口径。 Trace: .pm/tasks/task_<32hex>.yaml`
 
+- [x] wasm-build-path-sort-dedup-efficiency (PRD-ENGINEERING/GOVERNANCE) [test_tier_required]: Optimize wasm build source-hash path ordering to reuse a private `PathBuf` sort/dedup helper instead of repeated lossy-string comparator conversion in package-dir and source-file collection, preserving deterministic source-hash traversal for normal repo paths. Trace: .pm/tasks/task_f7a74ed95c704c09899a494237e500d7.yaml
+
 - [x] wasm-module-observe-btreemap-diff-merge-efficiency (PRD-ENGINEERING/GOVERNANCE) [test_tier_required]: Optimize wasm module observe metric bucket diffing to merge ordered `BTreeMap` iterators directly instead of cloning keys into a temporary vector, sorting, deduping, and re-looking up values, preserving saturating counter-delta semantics. Trace: .pm/tasks/task_abeacd11de97477c91668825da4524b5.yaml
 
 - [x] main-token-bridge-budget-remainder-sort-performance (PRD-ENGINEERING/GOVERNANCE) [test_tier_required]: Optimize main-token bridge budget remainder distribution to carry awarded points with local candidates instead of repeatedly scanning settlements during sort comparison, preserving higher-points priority, node-id tie-breaks, and final event distribution order. Trace: .pm/tasks/task_0389769c78cd454cb520a620ea0eadda.yaml


### PR DESCRIPTION
## Summary
- Optimize wasm build source-hash path ordering with a private PathBuf sort/dedup helper.
- Remove repeated lossy-string comparator conversion in package-dir and source-file collection.
- Record engineering project/task evidence and local role reviews.

## Verification
- `./scripts/cargo-dev.sh test -p oasis7_wasm_build`
- `./scripts/doc-governance-check.sh`
- `./scripts/pm/workflow-lint.sh --task-uid task_f7a74ed95c704c09899a494237e500d7 --phase current`
- `git diff --check`
