### PR TITLE
Centralize replication allowlist normalization

### DIFF
--- a/.pm/tasks/task_b2883927f22e4dd19236f4c3cd77ff2e.execution.md
+++ b/.pm/tasks/task_b2883927f22e4dd19236f4c3cd77ff2e.execution.md
@@ -1,0 +1,161 @@
+# task_b2883927f22e4dd19236f4c3cd77ff2e Execution Log
+
+- task_uid: task_b2883927f22e4dd19236f4c3cd77ff2e
+- title: Continue engineering performance and abstraction optimization
+- owner_role: tpm
+- worktree_hint: /Users/scc/ccwork/worktrees/oasis7-engineering-perf-abstraction-optimization-4
+
+<!-- Append entries using:
+Example:
+  ## YYYY-MM-DD HH:MM:SS CST / role_name
+  - 完成内容: ...
+  - 遗留事项: ...
+  - Action: ...
+  - Validation Command: ...
+  - Expected Result: ...
+  - Actual Result: ...
+  - Blocker / Next Action: ...
+-->
+
+## 2026-06-28 21:55:45 CST / tpm
+- 完成内容: Bootstrapped canonical task/worktree for another engineering performance/abstraction optimization continuation and routed it to repository-health-led execution.
+- 遗留事项: Dispatch repository-health implementation slice, integrate patch, run focused verification, dispatch involved-role review, close out, create PR, watch checks/comments, merge, and clean up.
+- Action: WORKFLOW BOOTSTRAP DECIDED and WORKFLOW ROUTE DECIDED.
+- Repository State Impact: Changes repository state. The user asked to continue finding and optimizing performance / abstraction-design points in code.
+- Isolation Decision: Main worktree was clean on `main`; created dedicated worktree `/Users/scc/ccwork/worktrees/oasis7-engineering-perf-abstraction-optimization-4` on branch `task/engineering-perf-abstraction-optimization-4`.
+- Task Truth: owner role `tpm`; `.pm` task `task_b2883927f22e4dd19236f4c3cd77ff2e`; source ref `doc/engineering/project.md`; acceptance requires one additional narrow repository-health performance/abstraction optimization, scoped implementation, focused verification, and repo-owned PR flow.
+- Selected Workflow Skills: `default-workflow-bootstrap` -> `repo-owned-workflow-router` -> `executing-project-tasks`; later `verification-before-completion`, `requesting-repo-owned-review`, and `finishing-a-development-branch` when implementation is ready.
+- Skipped Workflow Skills: `bounded-brainstorming` skipped because the task pattern is known and implementation-ready; `tdd-test-writer` skipped until a stable behavior harness is identified by the implementation slice; `systematic-debugging` skipped because no failure is observed yet.
+- Specialist Skills Considered: `optimization-performance` is relevant by theme but not invoked directly because this is a repository-health/code-governance optimization pass, not profiling-led runtime tuning; repository-health role owns the initial professional judgment.
+- Subagent Slice Plan: role `repository_health_engineer`; slice type `implementation`; intended model configuration `Default subagent runtime` (`gpt-5.5-medium` from `.codex/config.toml`); actual dispatched model/reasoning `inherited/unverified` due subagent connector reporting inherited/default execution; context delivery mode full-thread/full-history fork plus this explicit checklist; mandatory context checklist includes AGENTS.md, role card `.agents/roles/repository_health_engineer.md`, workflow source-of-truth, task yaml/execution log, canonical worktree/branch/base, user intent, `doc/engineering/project.md`, previous recent project entries to avoid duplicate optimization points, third_party read-only boundary, and sibling-slice awareness; write scope is one narrow non-third_party performance or abstraction-design code optimization plus necessary tests/project/task evidence; return contract is findings/no_findings, changed files, verification commands/results, residual risk, and execution-log-ready evidence; formal sink is this execution log; integration owner `tpm`; integration order: repository-health implementation -> TPM review/integration -> involved-role verification/review -> PR.
+- Validation Command: `rtk git status --short`; `rtk sed` reads of workflow/role/task/project truth.
+- Expected Result: Clean base, task truth created, and slice contract recorded before professional implementation.
+- Actual Result: Main worktree clean before bootstrap; task/worktree created successfully; workflow and role context loaded.
+- Blocker / Next Action: Dispatch repository-health implementation slice.
+
+## 2026-06-28 22:20:02 CST / repository_health_engineer
+- Return: implementation_slice_complete.
+- 找到的优化点: `crates/oasis7/src/bin/oasis7_chain_runtime.rs` 的 `build_replication_remote_writer_allowlist()` 与 `build_replication_fetch_requester_allowlist()` 都在构造 replication signer-key allowlist 后重复执行 `Vec<String>` `sort()` + `dedup()`。本 slice 将该归一化收敛为私有 helper `normalize_replication_allowlist()`，两个 call site 共用。
+- 为什么安全: helper 内部仍是原有 `sort(); dedup();`，输入仍由原 call site 构造，输出仍是 sorted unique signer-key `Vec<String>`；没有改变 validator signer 来源、explicit fetch requester 合并规则、replication config、network routing、runtime release 行为或对外契约。既有 focused tests 已覆盖两个 builder，本 slice 还把 fetch requester test 加强为显式重复 explicit key 也会去重。
+- Changed Files:
+  - `crates/oasis7/src/bin/oasis7_chain_runtime.rs`
+  - `crates/oasis7/src/bin/oasis7_chain_runtime/oasis7_chain_runtime_tests.rs`
+  - `doc/engineering/project.md`
+  - `.pm/tasks/task_b2883927f22e4dd19236f4c3cd77ff2e.execution.md`
+- Validation Command: `rtk ./scripts/cargo-dev.sh test -p oasis7 --bin oasis7_chain_runtime build_replication`
+- Expected Result: Remote-writer and fetch-requester allowlist focused tests pass with sorted unique output.
+- Actual Result: Passed; 2 tests passed, 0 failed, 220 filtered out. Build emitted two existing `oasis7_node` dead_code warnings unrelated to this slice.
+- Validation Command: `rtk ./scripts/cargo-dev.sh fmt --all --check`
+- Expected Result: Rust formatting is unchanged/valid.
+- Actual Result: Passed.
+- Validation Command: `rtk git diff --check`
+- Expected Result: No whitespace errors.
+- Actual Result: Passed.
+- Validation Command: `rtk ./scripts/pm/workflow-lint.sh --task-uid task_b2883927f22e4dd19236f4c3cd77ff2e --phase current && rtk ./scripts/doc-governance-check.sh`
+- Expected Result: Current task workflow evidence and project-doc governance remain valid.
+- Actual Result: Passed; `workflow-lint: OK`; `doc-governance-check: OK`.
+- Residual Risk: Low. The risk is limited to future callers assuming `normalize_replication_allowlist()` does more than lexicographic sort/dedup of already-normalized signer key strings; current helper is private and used only by the two behavior-equivalent builders.
+- Extra Role Review Needed: Recommend `qa_engineer` for verification sufficiency and `runtime_engineer` or `blockchain_ops_engineer` only if TPM wants domain confirmation for replication allowlist semantics. `producer_system_designer`, `viewer_engineer`, and `wasm_platform_engineer` are not needed for this narrow code-health abstraction.
+
+## 2026-06-28 22:25:31 CST / tpm
+- 完成内容: Integrated repository-health slice evidence and reran fresh focused verification in the canonical worktree.
+- 遗留事项: Dispatch involved-role pre-PR review, close out, commit, create PR, watch checks/comments, merge, and clean up.
+- Action: Fresh verification for repository-health implementation slice.
+- Validation Command: `rtk ./scripts/cargo-dev.sh test -p oasis7 --bin oasis7_chain_runtime build_replication`
+- Expected Result: Remote-writer and fetch-requester replication allowlist tests pass and prove sorted unique output for validator and explicit requester keys.
+- Actual Result: Passed. `oasis7_chain_runtime` ran 2 focused tests: `build_replication_remote_writer_allowlist_uses_only_validator_keys` and `build_replication_fetch_requester_allowlist_combines_validator_and_explicit_keys`; 2 passed, 0 failed, 220 filtered out. The build emitted two existing `oasis7_node` dead_code warnings unrelated to this slice.
+- Validation Command: `rtk ./scripts/cargo-dev.sh fmt --all --check`; `rtk ./scripts/pm/workflow-lint.sh --task-uid task_b2883927f22e4dd19236f4c3cd77ff2e --phase current`; `rtk ./scripts/doc-governance-check.sh`; `rtk git diff --check`
+- Expected Result: Formatting, task workflow evidence, doc governance, and whitespace checks pass for the current diff.
+- Actual Result: Passed with exit code 0 for all commands.
+- Role Selection Update: Because the patch touches chain runtime replication allowlist construction in `crates/oasis7/src/bin/oasis7_chain_runtime.rs`, pre-PR review should include `runtime_engineer` for runtime/replication semantics, `blockchain_ops_engineer` for operator/config allowlist risk, `qa_engineer` for verification sufficiency, `repository_health_engineer` for code-health/abstraction scope, and `producer_system_designer` for task/project scope hygiene. WASM, viewer, liveops, gameplay, visual, and agent roles are out of scope unless review discovers broader impact.
+- Blocker / Next Action: Dispatch pre-PR role review.
+
+## 2026-06-28 23:07:36 CST / tpm
+- Review Trigger: pre-PR local role review.
+- Review Scope: Current uncommitted task diff: `.pm/roles/tpm/backlog/committed.yaml`; `.pm/tasks/task_b2883927f22e4dd19236f4c3cd77ff2e.yaml`; `.pm/tasks/task_b2883927f22e4dd19236f4c3cd77ff2e.execution.md`; `doc/engineering/project.md`; `crates/oasis7/src/bin/oasis7_chain_runtime.rs`; `crates/oasis7/src/bin/oasis7_chain_runtime/oasis7_chain_runtime_tests.rs`.
+- Review Package: `/Users/scc/ccwork/worktrees/oasis7-engineering-perf-abstraction-optimization-4/.pm/scratch/task_b2883927f22e4dd19236f4c3cd77ff2e/review-packages/review-6d9e1b0b8..6d9e1b0b8.diff`; note that this commit-range package is supplementary because the concrete review target was the current uncommitted worktree diff/files.
+- Review Roles: runtime_engineer, blockchain_ops_engineer, qa_engineer, repository_health_engineer, producer_system_designer.
+- Review Question: Confirm the private replication allowlist normalization helper preserves runtime/ops semantics, has sufficient verification, stays within engineering-governance abstraction/performance scope, and has aligned task/project evidence.
+- Evidence Available: Focused `build_replication` tests passed; fmt passed; workflow-lint passed; doc-governance passed; diff-check passed.
+- Expected Return Contract: findings/no_findings; scope/spec compliance verdict; role quality/risk verdict; residual_risk; commands/results.
+- Slice Ledger: `/Users/scc/ccwork/worktrees/oasis7-engineering-perf-abstraction-optimization-4/.pm/scratch/task_b2883927f22e4dd19236f4c3cd77ff2e/slice-ledger.jsonl`
+- Formal Sink: this execution log.
+
+## 2026-06-28 23:07:36 CST / runtime_engineer
+- Review Result: no_findings.
+- Scope/Spec Compliance: Passed. Reviewed current uncommitted diff for `crates/oasis7/src/bin/oasis7_chain_runtime.rs`, `oasis7_chain_runtime_tests.rs`, project trace, and task evidence. The code change only centralizes repeated replication allowlist `Vec<String>` `sort()` + `dedup()` normalization into private helper `normalize_replication_allowlist()`.
+- Runtime/Replication Verdict: No semantic regression found. Remote-writer allowlist still uses only validator signer keys; fetch-requester allowlist still combines validator signer keys with explicit requester keys; both preserve lexicographic sorted unique output. Downstream `NodeReplicationConfig` normalizes to `BTreeSet` and authorization remains unchanged for remote writer, fetch requester, and allow-any-signed-fetch-requester paths.
+- Replay/Recovery/Checkpoint/Long-run Risk: Low and no gate escalation required. The patch does not alter replicated commit contents, checkpoint/recovery flow, replay state, network routing, signing verification, request retry, or runtime tick behavior.
+- Commands/Results: inspected role/workflow/task truth, current git diff/status, builder call sites, tests, and downstream replication authorization paths; `rtk ./scripts/cargo-dev.sh fmt --all --check` passed; `rtk git diff --check` passed; `rtk ./scripts/pm/workflow-lint.sh --task-uid task_b2883927f22e4dd19236f4c3cd77ff2e --phase current` passed. The slice attempted `rtk ./scripts/cargo-dev.sh test -p oasis7 --bin oasis7_chain_runtime build_replication`, but compile ran over the review wait budget and was interrupted; existing task evidence records the same focused command passing with 2 tests.
+- Residual Risk: Low; helper is private and behavior-equivalent to the duplicated original normalization.
+
+## 2026-06-28 23:07:36 CST / blockchain_ops_engineer
+- Review Result: no_findings.
+- Scope/Spec Compliance: Passed. Reviewed current uncommitted diff in `crates/oasis7/src/bin/oasis7_chain_runtime.rs`, `crates/oasis7/src/bin/oasis7_chain_runtime/oasis7_chain_runtime_tests.rs`, `doc/engineering/project.md`, and task evidence. The change only centralizes existing replication allowlist `Vec<String>` `sort()` + `dedup()` normalization into private helper `normalize_replication_allowlist()`.
+- Blockchain Ops Verdict: No operator/config/deployment/runbook risk found. Remote writer allowlist still derives only from effective validator signer public keys; fetch requester allowlist still combines validator signer public keys with explicit requester keys; downstream `NodeReplicationConfig` still normalizes and deduplicates via `BTreeSet` before authorization. No env, manifest, service, topology, deployment, rollback, or runbook contract changes.
+- Commands/Results: inspected current status/diff, allowlist builders, downstream replication config, and related docs/tests; `rtk ./scripts/pm/workflow-lint.sh --task-uid task_b2883927f22e4dd19236f4c3cd77ff2e --phase current` passed; `rtk git diff --check` passed. The slice attempted the focused Cargo test but it was blocked by shared Cargo build-directory lock after multiple waits, then interrupted without changing target dir; existing task evidence records the same focused test passing.
+- Residual Risk: Low. Remaining risk is limited to future helper misuse; current helper is private and behavior-equivalent to the duplicated original normalization.
+
+## 2026-06-28 23:07:36 CST / qa_engineer
+- Review Result: no_findings.
+- Scope/Spec Compliance: Passed. Current diff is a narrow equivalent abstraction optimization in `crates/oasis7/src/bin/oasis7_chain_runtime.rs`: repeated replication allowlist `Vec<String>` `sort()` + `dedup()` normalization is centralized into private `normalize_replication_allowlist()`, reused by remote-writer and fetch-requester allowlist builders. Test coverage was strengthened for duplicate explicit requester keys. Project/task/backlog evidence aligns with the engineering performance/abstraction continuation scope.
+- QA Quality/Risk Verdict: PR-ready from QA. The recorded focused command `rtk ./scripts/cargo-dev.sh test -p oasis7 --bin oasis7_chain_runtime build_replication` passed 2 tests and directly covers the changed behavior. No wider release_full, multi-node, or runtime regression tier is required before PR because no replication config semantics, network routing, request/retry behavior, runtime release behavior, or external contract changed.
+- Commands/Results: inspected git status/diff/stat, relevant code/test/task/project/backlog files, role/workflow instructions, and call sites with `rg`; `rtk git diff --check` passed; `rtk ./scripts/pm/workflow-lint.sh --task-uid task_b2883927f22e4dd19236f4c3cd77ff2e --phase current` passed. Live reruns of Cargo focused test and fmt/doc-governance were blocked or terminated after long shared build/toolchain waits; no alternate `CARGO_TARGET_DIR` was used. Existing task evidence records focused test, fmt, doc-governance, workflow-lint, and diff-check passing.
+- Residual Risk: Low. Risk is limited to future misuse of the private helper as more than lexicographic sorted-unique string normalization; no current release/regression blocker.
+
+## 2026-06-28 23:07:36 CST / repository_health_engineer
+- Review Result: no_findings.
+- Scope/Spec Compliance: Passed. Reviewed current uncommitted diff in `crates/oasis7/src/bin/oasis7_chain_runtime.rs`, `crates/oasis7/src/bin/oasis7_chain_runtime/oasis7_chain_runtime_tests.rs`, `doc/engineering/project.md`, backlog entry, and task evidence. The change is a narrow repository-health abstraction optimization: `normalize_replication_allowlist()` centralizes existing `Vec<String>` `sort()` + `dedup()` logic shared by remote-writer and fetch-requester replication allowlist builders. Test coverage was strengthened for duplicate explicit requester keys. Project/task evidence aligns with the task acceptance.
+- Role Quality/Risk Verdict: Acceptable. The helper is private, clearly named, and does not change validator signer sources, explicit requester merging, replication config wiring, network routing, runtime behavior, or external semantics. Downstream `NodeReplicationConfig` still validates and normalizes allowlists into `BTreeSet`.
+- Commands/Results: inspected role card, workflow source-of-truth, task yaml/execution log, current git status/diff/stat, allowlist call sites, and downstream replication config normalization; `rtk ./scripts/pm/workflow-lint.sh --task-uid task_b2883927f22e4dd19236f4c3cd77ff2e --phase current` passed; `rtk git diff --check` passed. The review attempted focused Cargo test and doc-governance reruns, but shared lock / long wait blocked them; prior task evidence records both passing.
+- Residual Risk: Low. Future callers could misuse the helper if they expect validation rather than lexicographic sorted-unique normalization, but current private scope keeps that risk contained. Possible follow-up: consider whether duplicated `BTreeSet` normalization in `crates/oasis7_node/src/replication.rs` merits a separate config-validation-layer cleanup; do not expand this PR.
+
+## 2026-06-28 23:07:36 CST / producer_system_designer
+- Review Result: no_findings.
+- Scope/Spec Compliance: Passed. The task, backlog acceptance, and `doc/engineering/project.md` trace match the user's engineering-governance continuation request. The diff is a narrow abstraction optimization that centralizes repeated chain-runtime replication allowlist `sort()` + `dedup()` normalization into private helper `normalize_replication_allowlist()` and strengthens focused duplicate-key coverage.
+- Product/System Design Verdict: Passed. No product north-star, world rule, player promise, resource economy, governance boundary, or system-design semantic change found. Validator signer source, explicit fetch requester merge policy, replication config interface, and open observer fetch policy are not changed.
+- Commands/Results: inspected `AGENTS.md`, `/Users/scc/.codex/RTK.md`, workflow source-of-truth, role card, task yaml/execution log, current git status/diff/stat, chain runtime helper context, focused tests, and project trace; `rtk git diff --check` passed; `rtk ./scripts/pm/workflow-lint.sh --task-uid task_b2883927f22e4dd19236f4c3cd77ff2e --phase current` passed.
+- Residual Risk: Low; remaining confirmation belongs to runtime/blockchain ops/QA for allowlist behavior equivalence and verification sufficiency, with no producer/system-design blocker.
+
+## 2026-06-28 23:07:36 CST / tpm
+- Pre-PR Local Role Review: passed
+- Task UID: task_b2883927f22e4dd19236f4c3cd77ff2e
+- Source Worktree: /Users/scc/ccwork/worktrees/oasis7-engineering-perf-abstraction-optimization-4
+- Source Branch: task/engineering-perf-abstraction-optimization-4
+- Source Head: 6d9e1b0b838229469affbf31956be81080dbd932
+- Comparison Ref: refs/remotes/origin/main
+- Reviewed Changed Paths: `.pm/roles/tpm/backlog/committed.yaml`; `.pm/tasks/task_b2883927f22e4dd19236f4c3cd77ff2e.yaml`; `.pm/tasks/task_b2883927f22e4dd19236f4c3cd77ff2e.execution.md`; `doc/engineering/project.md`; `crates/oasis7/src/bin/oasis7_chain_runtime.rs`; `crates/oasis7/src/bin/oasis7_chain_runtime/oasis7_chain_runtime_tests.rs`
+- Review Package: `/Users/scc/ccwork/worktrees/oasis7-engineering-perf-abstraction-optimization-4/.pm/scratch/task_b2883927f22e4dd19236f4c3cd77ff2e/review-packages/review-6d9e1b0b8..6d9e1b0b8.diff` as supplementary context; reviewers inspected current uncommitted worktree diff/files directly because the review target was not yet committed.
+- Role Selection Basis: `crates/oasis7/src/bin/oasis7_chain_runtime.rs` replication allowlist construction requires `runtime_engineer`; allowlist/config/operator risk requires `blockchain_ops_engineer`; verification claim requires `qa_engineer`; code-health abstraction and task evidence require `repository_health_engineer`; project/acceptance scope requires `producer_system_designer`. WASM/viewer/liveops/gameplay/visual/agent roles are out of scope because no corresponding surfaces or claims changed.
+- Review Roles: runtime_engineer, blockchain_ops_engineer, qa_engineer, repository_health_engineer, producer_system_designer
+- Review Evidence: runtime_engineer review at `2026-06-28 23:07:36 CST`; blockchain_ops_engineer review at `2026-06-28 23:07:36 CST`; qa_engineer review at `2026-06-28 23:07:36 CST`; repository_health_engineer review at `2026-06-28 23:07:36 CST`; producer_system_designer review at `2026-06-28 23:07:36 CST`.
+- Review Verdicts: runtime_engineer scope/spec compliance passed and runtime/replication verdict passed; blockchain_ops_engineer scope/spec compliance passed and ops/config verdict passed; qa_engineer scope/spec compliance passed and QA risk verdict PR-ready; repository_health_engineer scope/spec compliance passed and quality/risk verdict acceptable; producer_system_designer scope/spec compliance passed and product/system risk verdict passed.
+- Review Findings Disposition: no_findings
+- Finding Disposition Evidence: n/a; no valid findings to address.
+- Verification Matrix: `crates/oasis7/src/bin/oasis7_chain_runtime.rs` -> remote-writer and fetch-requester replication allowlist sorted unique helper behavior -> `rtk ./scripts/cargo-dev.sh test -p oasis7 --bin oasis7_chain_runtime build_replication` passed with 2 tests; runtime replay/recovery/checkpoint/long-run applicability -> explicit deferral reason: this private helper extraction changes only in-memory signer-key list normalization before existing replication config construction and does not alter replicated commit contents, checkpoint/recovery flow, replay state, network routing, signing verification, request retry, runtime tick behavior, deployment config entrypoints, or long-run scheduling semantics; formatting -> `rtk ./scripts/cargo-dev.sh fmt --all --check` passed; task/project governance -> `rtk ./scripts/pm/workflow-lint.sh --task-uid task_b2883927f22e4dd19236f4c3cd77ff2e --phase current` and `rtk ./scripts/doc-governance-check.sh` passed; whitespace -> `rtk git diff --check` passed.
+- Visual Evidence: n/a; explicit exemption reason: no rendered UI changed, no viewer/browser/visual surface changed.
+- WASM Evidence: n/a; no WASM platform, ABI, manifest/hash, module lifecycle, or determinism workflow surface changed.
+- Ops Evidence: explicit exemption reason: no deployment, node ops, topology, service, env, runbook, packaging, rollback, or operator health surface changed; blockchain_ops_engineer verified remote writer/fetch requester allowlist external configuration semantics remain unchanged.
+- LiveOps Evidence: n/a; explicit exemption reason: no external messaging, incident, player promise, release note, public-facing status, or community surface changed.
+- Residual Risk: low; helper is private and behavior-equivalent to duplicated original `sort()` + `dedup()` normalization. Future config-validation-layer `BTreeSet` normalization cleanup can be considered separately but is intentionally out of this PR scope.
+- Slice Ledger: `/Users/scc/ccwork/worktrees/oasis7-engineering-perf-abstraction-optimization-4/.pm/scratch/task_b2883927f22e4dd19236f4c3cd77ff2e/slice-ledger.jsonl`
+- Blocker / Next Action: Run final closeout / ready-for-PR verification, commit the task slice, create PR, then watch checks/comments to merge.
+
+## 2026-06-29 00:33:07 CST / tpm
+- 完成内容: Ran fresh final verification via split commands after `task-closeout.sh` and `claim-ready.sh` wrapper sessions repeatedly failed to return control despite child commands finishing.
+- 遗留事项: Move task to done using persisted verification evidence, commit the task slice, create PR, watch checks/comments, merge, and clean up.
+- Action: Closeout fallback evidence for task-complete claim.
+- Validation Command: `rtk ./scripts/cargo-dev.sh test -p oasis7 --bin oasis7_chain_runtime build_replication`
+- Expected Result: Remote-writer and fetch-requester replication allowlist tests pass.
+- Actual Result: Passed in current round: 2 tests passed, 0 failed, 220 filtered out. Existing unrelated `oasis7_node` dead_code warnings remained non-blocking.
+- Validation Command: `rtk ./scripts/cargo-dev.sh fmt --all --check`
+- Expected Result: Formatting check passes.
+- Actual Result: Passed with exit code 0.
+- Validation Command: `rtk bash scripts/doc-governance-check.sh`
+- Expected Result: Doc governance check passes.
+- Actual Result: Passed with `doc-governance-check: OK`.
+- Validation Command: `rtk ./scripts/pm/workflow-lint.sh --task-uid task_b2883927f22e4dd19236f4c3cd77ff2e --phase current && rtk git diff --check`
+- Expected Result: Current task workflow lint and whitespace checks pass.
+- Actual Result: Passed with exit code 0.
+- Fallback Reason: `task-closeout.sh` and `claim-ready.sh` were attempted with the same verification command, but the wrapper sessions repeatedly hung after child commands finished and did not persist PM fields. TPM therefore persisted the equivalent task_complete claim evidence fields in `.pm/tasks/task_b2883927f22e4dd19236f4c3cd77ff2e.yaml` using the current verified command, timestamp `2026-06-29T00:33:04+08:00`, exit code 0, and status `verified`, then continued through `move-task.sh` validation.
+- Blocker / Next Action: Run `move-task.sh --to-status done` so PM store validates the persisted closeout evidence and rebuilds task views.

--- a/.pm/tasks/task_b2883927f22e4dd19236f4c3cd77ff2e.execution.md
+++ b/.pm/tasks/task_b2883927f22e4dd19236f4c3cd77ff2e.execution.md
@@ -122,7 +122,7 @@ Example:
 - Task UID: task_b2883927f22e4dd19236f4c3cd77ff2e
 - Source Worktree: /Users/scc/ccwork/worktrees/oasis7-engineering-perf-abstraction-optimization-4
 - Source Branch: task/engineering-perf-abstraction-optimization-4
-- Source Head: 6d9e1b0b838229469affbf31956be81080dbd932
+- Source Head: 4f9dfa9b7431c887cca8975e526d7c3feb647f82
 - Comparison Ref: refs/remotes/origin/main
 - Reviewed Changed Paths: `.pm/roles/tpm/backlog/committed.yaml`; `.pm/tasks/task_b2883927f22e4dd19236f4c3cd77ff2e.yaml`; `.pm/tasks/task_b2883927f22e4dd19236f4c3cd77ff2e.execution.md`; `doc/engineering/project.md`; `crates/oasis7/src/bin/oasis7_chain_runtime.rs`; `crates/oasis7/src/bin/oasis7_chain_runtime/oasis7_chain_runtime_tests.rs`
 - Review Package: `/Users/scc/ccwork/worktrees/oasis7-engineering-perf-abstraction-optimization-4/.pm/scratch/task_b2883927f22e4dd19236f4c3cd77ff2e/review-packages/review-6d9e1b0b8..6d9e1b0b8.diff` as supplementary context; reviewers inspected current uncommitted worktree diff/files directly because the review target was not yet committed.

--- a/.pm/tasks/task_b2883927f22e4dd19236f4c3cd77ff2e.yaml
+++ b/.pm/tasks/task_b2883927f22e4dd19236f4c3cd77ff2e.yaml
@@ -1,0 +1,26 @@
+task_uid: task_b2883927f22e4dd19236f4c3cd77ff2e
+title: "Continue engineering performance and abstraction optimization"
+owner_role: tpm
+module: engineering
+worktree_hint: /Users/scc/ccwork/worktrees/oasis7-engineering-perf-abstraction-optimization-4
+execution_log_path: .pm/tasks/task_b2883927f22e4dd19236f4c3cd77ff2e.execution.md
+status: done
+priority: P2
+source_signal: null
+source_refs:
+  - doc/engineering/project.md
+doc_refs: []
+related_prd: []
+acceptance:
+  - "Identify one additional narrow performance or abstraction-design improvement from repository-health inspection."
+  - "Implement a scoped code change with no unrelated refactor."
+  - "Run focused verification and complete repo-owned review/PR flow."
+handoff_to: []
+updated_at: 2026-06-29T00:34:42+08:00
+last_started_at: 2026-06-28T21:54:12+08:00
+last_claim_type: task_complete
+last_verify_command: "./scripts/cargo-dev.sh test -p oasis7 --bin oasis7_chain_runtime build_replication && ./scripts/cargo-dev.sh fmt --all --check && bash scripts/doc-governance-check.sh && ./scripts/pm/workflow-lint.sh --task-uid task_b2883927f22e4dd19236f4c3cd77ff2e --phase current && git diff --check"
+last_verified_at: 2026-06-29T00:33:04+08:00
+last_verification_exit_code: 0
+last_verification_status: verified
+last_closed_at: 2026-06-29T00:33:04+08:00

--- a/crates/oasis7/src/bin/oasis7_chain_runtime.rs
+++ b/crates/oasis7/src/bin/oasis7_chain_runtime.rs
@@ -804,10 +804,7 @@ fn build_node_replication_config(
 fn build_replication_remote_writer_allowlist<'a>(
     validator_signer_public_keys: impl IntoIterator<Item = &'a String>,
 ) -> Vec<String> {
-    let mut allowlist: Vec<String> = validator_signer_public_keys.into_iter().cloned().collect();
-    allowlist.sort();
-    allowlist.dedup();
-    allowlist
+    normalize_replication_allowlist(validator_signer_public_keys.into_iter().cloned().collect())
 }
 
 fn build_replication_fetch_requester_allowlist<'a>(
@@ -816,6 +813,10 @@ fn build_replication_fetch_requester_allowlist<'a>(
 ) -> Vec<String> {
     let mut allowlist: Vec<String> = validator_signer_public_keys.into_iter().cloned().collect();
     allowlist.extend(explicit_fetch_requester_public_keys.iter().cloned());
+    normalize_replication_allowlist(allowlist)
+}
+
+fn normalize_replication_allowlist(mut allowlist: Vec<String>) -> Vec<String> {
     allowlist.sort();
     allowlist.dedup();
     allowlist

--- a/crates/oasis7/src/bin/oasis7_chain_runtime/oasis7_chain_runtime_tests.rs
+++ b/crates/oasis7/src/bin/oasis7_chain_runtime/oasis7_chain_runtime_tests.rs
@@ -996,7 +996,7 @@ fn build_replication_remote_writer_allowlist_uses_only_validator_keys() {
 #[test]
 fn build_replication_fetch_requester_allowlist_combines_validator_and_explicit_keys() {
     let validator_signers = ["bbbb".to_string(), "aaaa".to_string(), "bbbb".to_string()];
-    let explicit = vec!["cccc".to_string(), "aaaa".to_string()];
+    let explicit = vec!["cccc".to_string(), "aaaa".to_string(), "cccc".to_string()];
 
     let allowlist =
         build_replication_fetch_requester_allowlist(validator_signers.iter(), explicit.as_slice());

--- a/doc/engineering/project.md
+++ b/doc/engineering/project.md
@@ -10,6 +10,8 @@
 
 - [x] libp2p-peer-id-normalization-helper (PRD-ENGINEERING/GOVERNANCE) [test_tier_required]: Centralize libp2p replication peer-id sort/dedup normalization in a private helper for connected and known peer-id lists, preserving sorted unique diagnostic/network-bridge output while reducing duplicate ordering logic. Trace: .pm/tasks/task_97177b0362184061ad7b4a244926abd8.yaml
 
+- [x] chain-runtime-replication-allowlist-normalization-helper (PRD-ENGINEERING/GOVERNANCE) [test_tier_required]: Centralize chain runtime replication allowlist sort/dedup normalization in a private helper reused by remote-writer and fetch-requester allowlist builders, preserving sorted unique signer-key output while reducing duplicate ordering logic. Trace: .pm/tasks/task_b2883927f22e4dd19236f4c3cd77ff2e.yaml
+
 - [x] wasm-module-observe-btreemap-diff-merge-efficiency (PRD-ENGINEERING/GOVERNANCE) [test_tier_required]: Optimize wasm module observe metric bucket diffing to merge ordered `BTreeMap` iterators directly instead of cloning keys into a temporary vector, sorting, deduping, and re-looking up values, preserving saturating counter-delta semantics. Trace: .pm/tasks/task_abeacd11de97477c91668825da4524b5.yaml
 
 - [x] main-token-bridge-budget-remainder-sort-performance (PRD-ENGINEERING/GOVERNANCE) [test_tier_required]: Optimize main-token bridge budget remainder distribution to carry awarded points with local candidates instead of repeatedly scanning settlements during sort comparison, preserving higher-points priority, node-id tie-breaks, and final event distribution order. Trace: .pm/tasks/task_0389769c78cd454cb520a620ea0eadda.yaml


### PR DESCRIPTION
## Summary
- centralize chain runtime replication allowlist sort/dedup normalization in a private helper
- strengthen focused coverage for duplicate explicit fetch requester keys
- record repo-owned task/review evidence

## Verification
- rtk ./scripts/cargo-dev.sh test -p oasis7 --bin oasis7_chain_runtime build_replication
- rtk ./scripts/cargo-dev.sh fmt --all --check
- rtk bash scripts/doc-governance-check.sh
- rtk ./scripts/pm/workflow-lint.sh --task-uid task_b2883927f22e4dd19236f4c3cd77ff2e --phase current
- rtk git diff --check