### PR TITLE
Optimize gameplay tick emit filtering

### DIFF
--- a/.pm/roles/tpm/backlog/committed.yaml
+++ b/.pm/roles/tpm/backlog/committed.yaml
@@ -99,17 +99,3 @@ tasks:
     handoff_to: []
     status: committed
     task_path: .pm/tasks/task_b442769f7ef74d01894f4b8405c21301.yaml
-  - task_uid: task_3fa598816b3d4ffda8f44105433a032f
-    title: "Continue engineering performance and abstraction optimization"
-    module: engineering
-    priority: P2
-    source_signal: null
-    related_prd:
-      - PRD-ENGINEERING
-    acceptance:
-      - "Repository-health/performance slice identifies one concrete non-duplicate performance or abstraction improvement opportunity."
-      - "Implement the selected bounded optimization with behavior-preserving tests or focused verification."
-      - "Update task/project trace evidence and pass focused verification, formatting, workflow, doc-governance, and diff hygiene checks."
-    handoff_to: []
-    status: committed
-    task_path: .pm/tasks/task_3fa598816b3d4ffda8f44105433a032f.yaml

--- a/.pm/roles/tpm/backlog/committed.yaml
+++ b/.pm/roles/tpm/backlog/committed.yaml
@@ -99,3 +99,17 @@ tasks:
     handoff_to: []
     status: committed
     task_path: .pm/tasks/task_b442769f7ef74d01894f4b8405c21301.yaml
+  - task_uid: task_3fa598816b3d4ffda8f44105433a032f
+    title: "Continue engineering performance and abstraction optimization"
+    module: engineering
+    priority: P2
+    source_signal: null
+    related_prd:
+      - PRD-ENGINEERING
+    acceptance:
+      - "Repository-health/performance slice identifies one concrete non-duplicate performance or abstraction improvement opportunity."
+      - "Implement the selected bounded optimization with behavior-preserving tests or focused verification."
+      - "Update task/project trace evidence and pass focused verification, formatting, workflow, doc-governance, and diff hygiene checks."
+    handoff_to: []
+    status: committed
+    task_path: .pm/tasks/task_3fa598816b3d4ffda8f44105433a032f.yaml

--- a/.pm/tasks/task_3fa598816b3d4ffda8f44105433a032f.execution.md
+++ b/.pm/tasks/task_3fa598816b3d4ffda8f44105433a032f.execution.md
@@ -133,3 +133,21 @@ Example:
 - LiveOps Evidence: n/a; no external messaging, community, release-note, incident, or player promise surface changed.
 - Residual Risk: Low to moderate. Focused helper behavior is covered locally; broader wasm/module integration confidence remains with CI or a clean deterministic wasm test environment because local full wasm paths were environment-heavy.
 - Slice Ledger: /Users/scc/ccwork/worktrees/oasis7-engineering-perf-abstraction-optimization-7/.pm/scratch/task_3fa598816b3d4ffda8f44105433a032f/slice-ledger.jsonl
+
+## 2026-06-29 17:32:06 CST / tpm
+- 完成内容: Fresh ready-for-PR claim verification passed.
+- 遗留事项: None for local PR readiness; GitHub required checks and PR review/comment/mergeability gates remain pending after PR creation.
+- Action: Claim-ready verification.
+- Validation Command: `rtk ./scripts/pm/claim-ready.sh --claim-type ready_for_pr --verify-command "./scripts/pm/workflow-lint.sh --task-uid task_3fa598816b3d4ffda8f44105433a032f --phase current"`
+- Expected Result: `allowed_to_claim: true`.
+- Actual Result: PASS. `workflow-lint: OK`; `verification_exit_code: 0`; `status: verified`; `allowed_to_claim: true`.
+- Blocker / Next Action: Run task closeout and prepare PR.
+
+## 2026-06-29 17:32:37 CST / tpm
+- 完成内容: Task closeout completed for current task. Task yaml status is `done`; `last_claim_type: task_complete`; `last_verification_status: verified`; `last_closed_at: 2026-06-29T17:32:37+08:00`.
+- 遗留事项: `task-closeout.sh` exited nonzero because its repo-wide PM lint post-check reported unrelated historical `.pm/tasks/*` execution-log debt. The current task remains closed and current-task workflow lint passes.
+- Action: Task closeout and boundary recording.
+- Validation Command: `rtk ./scripts/pm/task-closeout.sh --role tpm --task-uid task_3fa598816b3d4ffda8f44105433a032f --verify-command "./scripts/cargo-dev.sh test -p oasis7 --no-default-features runtime::world::gameplay_loop::tests::collect_gameplay_tick_emits_filters_before_returning_events -- --exact --nocapture"`; `rtk ./scripts/pm/workflow-lint.sh --task-uid task_3fa598816b3d4ffda8f44105433a032f --phase current`.
+- Expected Result: Current task is marked done with fresh verification, or any unrelated repo-wide lint debt is separated from current task truth.
+- Actual Result: PARTIAL PASS. `task-closeout.sh` printed `task: ok` and updated this task to `done`; post-closeout repo-wide PM lint failed on unrelated historical task logs. Fresh current-task workflow lint passed: `workflow-lint: OK`.
+- Blocker / Next Action: Commit closeout evidence and run prepare-task-pr.

--- a/.pm/tasks/task_3fa598816b3d4ffda8f44105433a032f.execution.md
+++ b/.pm/tasks/task_3fa598816b3d4ffda8f44105433a032f.execution.md
@@ -90,3 +90,46 @@ Example:
 - Expected Result: Formatting, workflow lint, and whitespace checks pass; doc governance either passes or records a clear local boundary.
 - Actual Result: PASS: `fmt --all --check`; PASS: `workflow-lint: OK`; PASS: `git diff --check`. Boundary: doc governance did not complete locally before interruption.
 - Blocker / Next Action: Commit implementation snapshot, regenerate review package against the implementation commit, and dispatch pre-PR local role review.
+
+## 2026-06-29 17:01:00 CST / tpm
+- Review Trigger: pre-PR local role review
+- Review Scope: `crates/oasis7/src/runtime/world/gameplay_loop.rs`; `doc/engineering/project.md`; `.pm/tasks/task_3fa598816b3d4ffda8f44105433a032f.{yaml,execution.md}`; `.pm/roles/tpm/backlog/committed.yaml`
+- Review Package: `/Users/scc/ccwork/worktrees/oasis7-engineering-perf-abstraction-optimization-7/.pm/scratch/task_3fa598816b3d4ffda8f44105433a032f/review-packages/review-566f597bc..48e2b3379.diff`
+- Review Roles: runtime_engineer, qa_engineer, repository_health_engineer, producer_system_designer
+- Review Question: Confirm whether implementation commit `48e2b33797978e7addf3d3ee77f012d92e5413f2` safely moves gameplay lifecycle/active-module filtering into `collect_gameplay_tick_emits()` before cloning, preserves module-driven directive semantics, and has sufficient evidence/residual-risk recording for PR creation.
+- Evidence Available: `fmt --all --check` passed; `workflow-lint --phase current` passed; `git diff --check` passed; focused test attempts and doc-governance local boundaries recorded in this execution log.
+- Expected Return Contract: findings | no_findings | scope/spec compliance verdict | role quality/risk verdict | residual_risk
+- Slice Ledger: `/Users/scc/ccwork/worktrees/oasis7-engineering-perf-abstraction-optimization-7/.pm/scratch/task_3fa598816b3d4ffda8f44105433a032f/slice-ledger.jsonl`
+- Formal Sink: `.pm/tasks/task_3fa598816b3d4ffda8f44105433a032f.execution.md`
+
+## 2026-06-29 17:33:00 CST / tpm
+- 完成内容: Integrated pre-PR local role review results. `runtime_engineer` and `producer_system_designer` returned no findings. `qa_engineer` and `repository_health_engineer` returned P1/must-fix findings for polluted comparison range/review package and incomplete focused behavior/doc-governance pass evidence.
+- 遗留事项: Full wasm/module integration regression remains deferred to CI or a clean deterministic wasm environment; local focused wasm attempts are recorded above as environment-heavy boundaries.
+- Action: Address review findings.
+- Validation Command: `rtk git rebase origin/main`; `rtk ./scripts/pm/review-package.sh --base origin/main --head HEAD --task-uid task_3fa598816b3d4ffda8f44105433a032f`; `rtk git diff --name-only origin/main...HEAD`; `rtk ./scripts/cargo-dev.sh test -p oasis7 --no-default-features runtime::world::gameplay_loop::tests::collect_gameplay_tick_emits_filters_before_returning_events -- --exact --nocapture`; `rtk bash scripts/doc-governance-check.sh`.
+- Expected Result: PR/review package is limited to current task scope; focused helper behavior test passes; doc governance passes.
+- Actual Result: PASS. Rebased branch onto current `origin/main`; regenerated review package `/Users/scc/ccwork/worktrees/oasis7-engineering-perf-abstraction-optimization-7/.pm/scratch/task_3fa598816b3d4ffda8f44105433a032f/review-packages/review-566f597bc..48e2b3379.diff` with 1 commit and 27,549 bytes; PR diff files are `.pm/roles/tpm/backlog/committed.yaml`, `.pm/tasks/task_3fa598816b3d4ffda8f44105433a032f.execution.md`, `.pm/tasks/task_3fa598816b3d4ffda8f44105433a032f.yaml`, `crates/oasis7/src/runtime/world/gameplay_loop.rs`, and `doc/engineering/project.md`. Focused helper test passed: 1 passed, 0 failed. `doc-governance-check: OK`.
+- Blocker / Next Action: Request QA/repository_health confirmation that findings are resolved, then record passed Pre-PR Local Role Review packet.
+
+## 2026-06-29 17:39:00 CST / tpm
+- Pre-PR Local Role Review: passed
+- Task UID: task_3fa598816b3d4ffda8f44105433a032f
+- Source Worktree: /Users/scc/ccwork/worktrees/oasis7-engineering-perf-abstraction-optimization-7
+- Source Branch: task/engineering-perf-abstraction-optimization-7
+- Source Head: 48e2b33797978e7addf3d3ee77f012d92e5413f2
+- Comparison Ref: refs/remotes/origin/main
+- Reviewed Changed Paths: `.pm/roles/tpm/backlog/committed.yaml`; `.pm/tasks/task_3fa598816b3d4ffda8f44105433a032f.execution.md`; `.pm/tasks/task_3fa598816b3d4ffda8f44105433a032f.yaml`; `crates/oasis7/src/runtime/world/gameplay_loop.rs`; `doc/engineering/project.md`
+- Review Package: /Users/scc/ccwork/worktrees/oasis7-engineering-perf-abstraction-optimization-7/.pm/scratch/task_3fa598816b3d4ffda8f44105433a032f/review-packages/review-566f597bc..48e2b3379.diff
+- Role Selection Basis: changed paths touched runtime gameplay event collection plus task/project trace; prior discovery included `runtime_engineer` and `repository_health_engineer`; `qa_engineer` included because verification sufficiency was a review blocker; `producer_system_designer` included to confirm no module-driven gameplay directive/product contract change. Skipped `gameplay_designer` because no gameplay rules/progression/balance/player verb semantics changed; skipped `wasm_platform_engineer` because no ABI, wasm executor, builtin module, manifest/hash, or wasm build logic changed.
+- Review Roles: runtime_engineer, qa_engineer, repository_health_engineer, producer_system_designer
+- Review Evidence: runtime_engineer no findings, semantic/determinism pass with CI/full-wasm residual risk; producer_system_designer no findings, module-driven gameplay directive contract preserved; qa_engineer initially found P1 package-scope and behavior-evidence blockers, then confirmed prior P1 findings resolved after rebase/scope-clean package/focused test/doc governance pass; repository_health_engineer initially found the same must-fix blockers, then confirmed resolved with no findings.
+- Review Verdicts: runtime_engineer scope/spec PASS and runtime risk PASS with verification caveat; qa_engineer compliant for PR creation after fixes and verification quality acceptable; repository_health_engineer compliant and maintainability acceptable; producer_system_designer PASS and product/system-design risk acceptable.
+- Review Findings Disposition: addressed
+- Finding Disposition Evidence: rebased onto `origin/main`; regenerated scope-clean review package `review-566f597bc..48e2b3379.diff`; focused behavior test passed with 1 passed, 0 failed; `doc-governance-check: OK`; QA and repository_health follow-up reviews confirmed resolved.
+- Verification Matrix: gameplay tick emit helper behavior -> `rtk ./scripts/cargo-dev.sh test -p oasis7 --no-default-features runtime::world::gameplay_loop::tests::collect_gameplay_tick_emits_filters_before_returning_events -- --exact --nocapture` -> PASS, 1 passed; formatting -> `rtk ./scripts/cargo-dev.sh fmt --all --check` -> PASS; workflow -> `rtk ./scripts/pm/workflow-lint.sh --task-uid task_3fa598816b3d4ffda8f44105433a032f --phase current` -> PASS; doc governance -> `rtk bash scripts/doc-governance-check.sh` -> PASS; diff hygiene -> `rtk git diff --check` -> PASS; wasm/module integration -> deferred to CI/clean deterministic wasm environment due local heavy wasm fallback boundary.
+- Visual Evidence: n/a; runtime helper optimization has no visual/player-facing UI surface.
+- WASM Evidence: n/a for implementation scope; no ABI/wasm executor/builtin module/build logic changed. Full gameplay wasm regression remains residual CI/clean-env coverage.
+- Ops Evidence: n/a; no deployment, node ops, runbook, rollback, topology, or operator surface changed.
+- LiveOps Evidence: n/a; no external messaging, community, release-note, incident, or player promise surface changed.
+- Residual Risk: Low to moderate. Focused helper behavior is covered locally; broader wasm/module integration confidence remains with CI or a clean deterministic wasm test environment because local full wasm paths were environment-heavy.
+- Slice Ledger: /Users/scc/ccwork/worktrees/oasis7-engineering-perf-abstraction-optimization-7/.pm/scratch/task_3fa598816b3d4ffda8f44105433a032f/slice-ledger.jsonl

--- a/.pm/tasks/task_3fa598816b3d4ffda8f44105433a032f.execution.md
+++ b/.pm/tasks/task_3fa598816b3d4ffda8f44105433a032f.execution.md
@@ -1,0 +1,92 @@
+# task_3fa598816b3d4ffda8f44105433a032f Execution Log
+
+- task_uid: task_3fa598816b3d4ffda8f44105433a032f
+- title: Continue engineering performance and abstraction optimization
+- owner_role: tpm
+- worktree_hint: /Users/scc/ccwork/worktrees/oasis7-engineering-perf-abstraction-optimization-7
+
+<!-- Append entries using:
+Example:
+  ## YYYY-MM-DD HH:MM:SS CST / role_name
+  - 完成内容: ...
+  - 遗留事项: ...
+  - Action: ...
+  - Validation Command: ...
+  - Expected Result: ...
+  - Actual Result: ...
+  - Blocker / Next Action: ...
+-->
+
+## 2026-06-29 14:17:00 CST / tpm
+- 完成内容: WORKFLOW BOOTSTRAP DECIDED. Repository state impact: code/docs/task truth will change because the user asked to continue finding performance and abstraction design points, optimize them, and merge. Isolation decision: created dedicated task worktree `/Users/scc/ccwork/worktrees/oasis7-engineering-perf-abstraction-optimization-7` on branch `task/engineering-perf-abstraction-optimization-7` from `origin/main`. Task truth: owner role `tpm`; `.pm` task `task_3fa598816b3d4ffda8f44105433a032f`; formal docs `doc/engineering/project.md`. Routed next phase: professional candidate discovery/confirmation -> focused implementation -> verification -> pre-PR local role review -> closeout -> PR watch/fix/merge.
+- 遗留事项: None. Bootstrap script completed normally and recorded workflow start.
+- Action: Bootstrap user request into repo-owned workflow.
+- Validation Command: `rtk ./scripts/new-task-worktree.sh engineering perf-abstraction-optimization-7 --base origin/main --branch task/engineering-perf-abstraction-optimization-7 --pm-owner-role tpm --pm-title "Continue engineering performance and abstraction optimization" --pm-source-ref doc/engineering/project.md ... --json`; `rtk sed -n '1,180p' .pm/tasks/task_3fa598816b3d4ffda8f44105433a032f.yaml`; `rtk git status --short`
+- Expected Result: Dedicated worktree, branch, and `.pm` task are created from current `origin/main`.
+- Actual Result: PASS. Worktree `/Users/scc/ccwork/worktrees/oasis7-engineering-perf-abstraction-optimization-7`, branch `task/engineering-perf-abstraction-optimization-7`, task `task_3fa598816b3d4ffda8f44105433a032f`, yaml status `committed`, `last_started_at` present.
+- Blocker / Next Action: Record route and dispatch professional bounded slices.
+
+## 2026-06-29 14:18:00 CST / tpm
+- 完成内容: WORKFLOW ROUTE DECIDED. Current phase: specialist candidate discovery/confirmation, then executing-project-tasks. Selected workflow surfaces: `optimization-performance` as method guidance, `executing-project-tasks` for focused implementation once a candidate is selected, then `verification-before-completion`, `requesting-repo-owned-review`, and `finishing-a-development-branch`.
+- 遗留事项: Candidate must not duplicate recent completed project entries such as wasm path sort/dedup, libp2p peer-id normalization, chain runtime replication allowlist normalization, restricted grant expiry BTreeMap ordering, wasm observe diff merge, bridge budget remainder sorting, provider/replica/DHT rankings, simulator observation sorting, social evidence lookup, DistFS audit skip, runtime factory depreciation, module tick/routing laziness, PM sync/lint fast paths, tick consensus hash lookup, viewer nearest-location/percentile optimizations, consensus mempool selection, runner ready-agent selection, power order/tick iteration, LLM top-N, transfer history, Explorer pagination, or libp2p request peer candidate filtering.
+- Action: TPM TODO decomposition and subagent slice contracts.
+- Validation Command: Read `AGENTS.md` instructions in thread context, `default-workflow-bootstrap`, `repo-owned-workflow-router`, `optimization-performance`, task yaml/execution log, and `doc/engineering/project.md` recent completed performance inventory.
+- Expected Result: Route and subagent contracts are recorded before professional work starts.
+- Actual Result: PASS. Route is recorded in this execution log.
+- Blocker / Next Action: Dispatch bounded discovery slices and integrate one concrete candidate.
+
+### Subagent Slice Contracts
+- Slice A role: `repository_health_engineer`.
+- Slice A type: bounded professional discovery/confirmation for repository-health, scripts/tooling, and code-abstraction performance opportunities.
+- Slice A model configuration: intended default subagent runtime per workflow source-of-truth; actual dispatched model/reasoning: inherited/unverified due tool limitation.
+- Slice A context delivery mode: full-thread/full-history fork plus this mandatory checklist.
+- Slice A mandatory context checklist/packet: identity and authority = `AGENTS.md`, `/Users/scc/.codex/RTK.md`, and `.agents/roles/repository_health_engineer.md`; workflow governance = `doc/engineering/workflow/source-of-truth.md` plus bootstrap/router skills; task truth = `.pm/tasks/task_3fa598816b3d4ffda8f44105433a032f.{yaml,execution.md}`; user intent = continue finding performance/abstraction design points, optimize, and merge; scoped repo context = first-party code only, `third_party/**` read-only, avoid completed `doc/engineering/project.md` performance rows; collaboration boundary = no edits, return 1-3 candidates with file/function evidence, expected benefit, risk, and verification command.
+- Slice A write scope: none for discovery.
+- Slice A return contract: ranked candidates, non-duplicate evidence, recommended implementation owner, focused verification path, and residual risk.
+- Slice A formal sink: this execution log.
+- Slice A integration owner/order: TPM integrates after runtime slice; selected candidate gets implemented by TPM or a bounded worker.
+- Slice B role: `runtime_engineer`.
+- Slice B type: bounded professional discovery/confirmation for runtime/server/native hot paths and behavior-preserving abstraction optimizations.
+- Slice B model configuration: intended default subagent runtime per workflow source-of-truth; actual dispatched model/reasoning: inherited/unverified due tool limitation.
+- Slice B context delivery mode: full-thread/full-history fork plus this mandatory checklist.
+- Slice B mandatory context checklist/packet: identity and authority = `AGENTS.md`, `/Users/scc/.codex/RTK.md`, and `.agents/roles/runtime_engineer.md`; workflow governance = `doc/engineering/workflow/source-of-truth.md`; task truth = `.pm/tasks/task_3fa598816b3d4ffda8f44105433a032f.{yaml,execution.md}`; user intent = continue bounded performance/abstraction optimization to merge; scoped repo context = `crates/oasis7*` runtime-related paths, excluding recently completed project rows; collaboration boundary = no edits, return candidates only with semantic risk and verification commands.
+- Slice B write scope: none for discovery.
+- Slice B return contract: ranked candidates, file/function evidence, runtime/replay/recovery risk, focused verification path, and whether implementation should require additional roles.
+- Slice B formal sink: this execution log.
+- Slice B integration owner/order: TPM integrates with repository-health findings and selects one bounded implementation.
+
+## 2026-06-29 14:23:00 CST / repository_health_engineer
+- 完成内容: Bounded read-only discovery slice returned candidate findings. Recommended implementation candidate: `crates/oasis7/src/runtime/world/governance.rs::governance_finality_stake_root`, where current payload construction allocates one formatted string per signer, collects a vector, then joins before hashing. Expected benefit: build the exact same payload in a single `String` buffer and reduce intermediate allocation in governance finality stake-root computation. Other candidates were `scripts/p2p-mixed-topology-matrix.sh` repeated `jq` summary parsing and `crates/oasis7/src/network_tier_manifest.rs::validate_tier_semantics` claim-list membership abstraction.
+- 遗留事项: Governance finality stake-root single-buffer construction remains a valid follow-up candidate but is not selected for this PR because runtime slice identified a gameplay tick hot path with direct clone/allocation savings.
+- Action: Integrate repository-health candidate discovery.
+- Validation Command: Subagent read-only slice over scripts, network tier manifest, governance finality, and head validation scans.
+- Expected Result: One concrete non-duplicate performance/abstraction optimization candidate with verification path.
+- Actual Result: PASS. Candidate recorded as follow-up context; runtime gameplay tick candidate selected for this PR.
+- Blocker / Next Action: Implement selected runtime candidate.
+
+## 2026-06-29 14:23:00 CST / runtime_engineer
+- 完成内容: Bounded read-only discovery slice returned runtime candidate findings. Recommended implementation candidate: `crates/oasis7/src/runtime/world/gameplay_loop.rs::collect_gameplay_tick_emits`, where all `tick-` / `infra-tick-` `ModuleEmitEvent`s are cloned into a `Vec` before the caller filters non-lifecycle emits and non-active gameplay modules. Expected benefit: move `kind == GAMEPLAY_LIFECYCLE_EMIT_KIND` and active gameplay module checks into the helper so only lifecycle emits that will be parsed/applied are cloned.
+- 遗留事项: Additional runtime candidates were module output cap membership lookup and artifact usage active-module lookup; both remain later small optimization candidates.
+- Action: Integrate runtime candidate discovery and select implementation target.
+- Validation Command: Subagent read-only slice over `gameplay_loop.rs`, module runtime/base-layer cap checks, artifact action lookup, and existing gameplay regression tests.
+- Expected Result: Runtime professional slice identifies one low-risk hot-path optimization and focused validation path.
+- Actual Result: PASS. Selected `collect_gameplay_tick_emits` early filtering for implementation.
+- Blocker / Next Action: Apply behavior-preserving filter move and run focused gameplay module regression tests.
+
+## 2026-06-29 16:42:00 CST / tpm
+- 完成内容: Implemented the selected runtime optimization. `collect_gameplay_tick_emits()` now applies lifecycle-kind and active-gameplay-module filters before cloning tick module emits, and `process_gameplay_cycles_with_modules()` consumes the already-filtered helper output. Added a local unit test that constructs active gameplay/domain module registry entries and verifies only active gameplay lifecycle tick emits are returned. Added `doc/engineering/project.md` trace row `gameplay-tick-lifecycle-emit-filtering-performance`.
+- 遗留事项: Focused gameplay wasm regression tests are environment-heavy locally. `./scripts/cargo-dev.sh test -p oasis7 --features wasmtime,test_tier_full --lib step_with_modules_ -- --nocapture` ran the target tests but two deterministic wasm fallback cases failed because `cargo-dev.sh` sets shared `CARGO_TARGET_DIR`, while wasm build scripts require it unset. Raw `env -u RUSTC_WRAPPER -u CARGO_TARGET_DIR cargo test ... step_with_modules_ ...` avoided that env mismatch but spent excessive time in builtin wasm fallback/native artifact builds and was interrupted. A narrower `./scripts/cargo-dev.sh test -p oasis7 --no-default-features collect_gameplay_tick_emits -- --nocapture` also entered long local `oasis7` test artifact compilation and was interrupted before test execution; it produced no assertion failure. These attempts are recorded as local verification boundary, not pass evidence.
+- Action: Implement code/doc changes and record validation boundary.
+- Validation Command: `rtk ./scripts/cargo-dev.sh fmt --all --check`; `rtk git diff -- crates/oasis7/src/runtime/world/gameplay_loop.rs`; focused test attempts listed above.
+- Expected Result: Code is formatted; diff shows clone-before-filter moved into helper after semantic filters; heavy local test boundaries are explicit.
+- Actual Result: PASS for format and diff review. Focused local test execution did not produce pass evidence due local build/runtime boundary described above.
+- Blocker / Next Action: Run remaining lightweight gates, dispatch pre-PR local role review, then close out and create PR for CI-backed validation.
+
+## 2026-06-29 16:56:00 CST / tpm
+- 完成内容: Ran lightweight local gates after implementation.
+- 遗留事项: `scripts/doc-governance-check.sh` was attempted twice and interrupted after long local no-output runs; process inspection showed the shell script still active but effectively quiet/low-CPU. Treat as local governance gate boundary, not pass evidence.
+- Action: Local verification before pre-PR review.
+- Validation Command: `rtk ./scripts/cargo-dev.sh fmt --all --check`; `rtk ./scripts/pm/workflow-lint.sh --task-uid task_3fa598816b3d4ffda8f44105433a032f --phase current`; `rtk git diff --check`; `rtk bash scripts/doc-governance-check.sh`.
+- Expected Result: Formatting, workflow lint, and whitespace checks pass; doc governance either passes or records a clear local boundary.
+- Actual Result: PASS: `fmt --all --check`; PASS: `workflow-lint: OK`; PASS: `git diff --check`. Boundary: doc governance did not complete locally before interruption.
+- Blocker / Next Action: Commit implementation snapshot, regenerate review package against the implementation commit, and dispatch pre-PR local role review.

--- a/.pm/tasks/task_3fa598816b3d4ffda8f44105433a032f.yaml
+++ b/.pm/tasks/task_3fa598816b3d4ffda8f44105433a032f.yaml
@@ -4,7 +4,7 @@ owner_role: tpm
 module: engineering
 worktree_hint: /Users/scc/ccwork/worktrees/oasis7-engineering-perf-abstraction-optimization-7
 execution_log_path: .pm/tasks/task_3fa598816b3d4ffda8f44105433a032f.execution.md
-status: committed
+status: done
 priority: P2
 source_signal: null
 source_refs:
@@ -18,5 +18,11 @@ acceptance:
   - "Implement the selected bounded optimization with behavior-preserving tests or focused verification."
   - "Update task/project trace evidence and pass focused verification, formatting, workflow, doc-governance, and diff hygiene checks."
 handoff_to: []
-updated_at: 2026-06-29T14:15:13+08:00
+updated_at: 2026-06-29T17:32:37+08:00
 last_started_at: 2026-06-29T14:15:13+08:00
+last_claim_type: task_complete
+last_verify_command: "./scripts/cargo-dev.sh test -p oasis7 --no-default-features runtime::world::gameplay_loop::tests::collect_gameplay_tick_emits_filters_before_returning_events -- --exact --nocapture"
+last_verified_at: 2026-06-29T17:32:35+08:00
+last_verification_exit_code: 0
+last_verification_status: verified
+last_closed_at: 2026-06-29T17:32:37+08:00

--- a/.pm/tasks/task_3fa598816b3d4ffda8f44105433a032f.yaml
+++ b/.pm/tasks/task_3fa598816b3d4ffda8f44105433a032f.yaml
@@ -1,0 +1,22 @@
+task_uid: task_3fa598816b3d4ffda8f44105433a032f
+title: "Continue engineering performance and abstraction optimization"
+owner_role: tpm
+module: engineering
+worktree_hint: /Users/scc/ccwork/worktrees/oasis7-engineering-perf-abstraction-optimization-7
+execution_log_path: .pm/tasks/task_3fa598816b3d4ffda8f44105433a032f.execution.md
+status: committed
+priority: P2
+source_signal: null
+source_refs:
+  - doc/engineering/project.md
+doc_refs:
+  - doc/engineering/project.md
+related_prd:
+  - PRD-ENGINEERING
+acceptance:
+  - "Repository-health/performance slice identifies one concrete non-duplicate performance or abstraction improvement opportunity."
+  - "Implement the selected bounded optimization with behavior-preserving tests or focused verification."
+  - "Update task/project trace evidence and pass focused verification, formatting, workflow, doc-governance, and diff hygiene checks."
+handoff_to: []
+updated_at: 2026-06-29T14:15:13+08:00
+last_started_at: 2026-06-29T14:15:13+08:00

--- a/crates/oasis7/src/runtime/world/gameplay_loop.rs
+++ b/crates/oasis7/src/runtime/world/gameplay_loop.rs
@@ -91,13 +91,6 @@ impl World {
 
         let mut emitted = Vec::new();
         for module_emit in self.collect_gameplay_tick_emits(journal_start_event_id) {
-            if module_emit.kind != GAMEPLAY_LIFECYCLE_EMIT_KIND {
-                continue;
-            }
-            if !self.is_active_gameplay_module(module_emit.module_id.as_str()) {
-                continue;
-            }
-
             let directives = self.parse_gameplay_directives(&module_emit)?;
             for directive in directives {
                 self.apply_gameplay_directive(directive, &mut emitted)?;
@@ -137,7 +130,13 @@ impl World {
                     if module_emit.trace_id.starts_with("tick-")
                         || module_emit.trace_id.starts_with("infra-tick-") =>
                 {
-                    Some(module_emit.clone())
+                    if module_emit.kind == GAMEPLAY_LIFECYCLE_EMIT_KIND
+                        && self.is_active_gameplay_module(module_emit.module_id.as_str())
+                    {
+                        Some(module_emit.clone())
+                    } else {
+                        None
+                    }
                 }
                 _ => None,
             })
@@ -667,5 +666,110 @@ impl World {
             emitted.push(event.clone());
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::{
+        ModuleAbiContract, ModuleKind, ModuleLimits, ModuleManifest, ModuleRecord, ModuleRegistry,
+        ModuleRole,
+    };
+    use serde_json::json;
+
+    fn manifest(module_id: &str, role: ModuleRole) -> ModuleManifest {
+        ModuleManifest {
+            module_id: module_id.to_string(),
+            name: module_id.to_string(),
+            version: "0.1.0".to_string(),
+            kind: ModuleKind::Reducer,
+            role,
+            wasm_hash: format!("sha256:{module_id}"),
+            interface_version: "wasm-1".to_string(),
+            exports: vec!["reduce".to_string()],
+            subscriptions: Vec::new(),
+            required_caps: Vec::new(),
+            abi_contract: ModuleAbiContract::default(),
+            artifact_identity: None,
+            limits: ModuleLimits::unbounded(),
+        }
+    }
+
+    fn activate_module(world: &mut World, manifest: ModuleManifest) {
+        let key = ModuleRegistry::record_key(&manifest.module_id, &manifest.version);
+        world
+            .module_registry
+            .active
+            .insert(manifest.module_id.clone(), manifest.version.clone());
+        world.module_registry.records.insert(
+            key,
+            ModuleRecord {
+                manifest,
+                registered_at: 0,
+                registered_by: "test".to_string(),
+                audit_event_id: None,
+            },
+        );
+    }
+
+    fn module_emit(module_id: &str, trace_id: &str, kind: &str) -> ModuleEmitEvent {
+        ModuleEmitEvent {
+            module_id: module_id.to_string(),
+            trace_id: trace_id.to_string(),
+            kind: kind.to_string(),
+            payload: json!({"directives": []}),
+        }
+    }
+
+    #[test]
+    fn collect_gameplay_tick_emits_filters_before_returning_events() {
+        let mut world = World::new();
+        activate_module(&mut world, manifest("m.gameplay", ModuleRole::Gameplay));
+        activate_module(&mut world, manifest("m.domain", ModuleRole::Domain));
+
+        world
+            .append_event(
+                WorldEventBody::ModuleEmitted(module_emit(
+                    "m.gameplay",
+                    "tick-1",
+                    GAMEPLAY_LIFECYCLE_EMIT_KIND,
+                )),
+                None,
+            )
+            .expect("append gameplay lifecycle emit");
+        world
+            .append_event(
+                WorldEventBody::ModuleEmitted(module_emit("m.gameplay", "tick-1", "telemetry")),
+                None,
+            )
+            .expect("append non-lifecycle emit");
+        world
+            .append_event(
+                WorldEventBody::ModuleEmitted(module_emit(
+                    "m.domain",
+                    "tick-1",
+                    GAMEPLAY_LIFECYCLE_EMIT_KIND,
+                )),
+                None,
+            )
+            .expect("append domain lifecycle emit");
+        world
+            .append_event(
+                WorldEventBody::ModuleEmitted(module_emit(
+                    "m.gameplay",
+                    "module-call-1",
+                    GAMEPLAY_LIFECYCLE_EMIT_KIND,
+                )),
+                None,
+            )
+            .expect("append non-tick lifecycle emit");
+
+        let emits = world.collect_gameplay_tick_emits(0);
+
+        assert_eq!(emits.len(), 1);
+        assert_eq!(emits[0].module_id, "m.gameplay");
+        assert_eq!(emits[0].trace_id, "tick-1");
+        assert_eq!(emits[0].kind, GAMEPLAY_LIFECYCLE_EMIT_KIND);
     }
 }

--- a/doc/engineering/project.md
+++ b/doc/engineering/project.md
@@ -80,6 +80,8 @@
 
 - [x] libp2p-request-peer-candidate-filtering-performance (PRD-ENGINEERING/GOVERNANCE) [test_tier_required]: Optimize libp2p request peer candidate filtering to classify preferred and soft-deprioritized fallback peers in one pass instead of rescanning the peer vector on fallback, preserving hard-block exclusion and fallback ordering semantics. Trace: .pm/tasks/task_584c960d09974a70b98cf65f8d10afb7.yaml
 
+- [x] gameplay-tick-lifecycle-emit-filtering-performance (PRD-ENGINEERING/GOVERNANCE) [test_tier_required]: Optimize gameplay tick lifecycle emit collection to filter non-lifecycle and non-active gameplay module emits before cloning, preserving module-driven directive semantics. Trace: .pm/tasks/task_3fa598816b3d4ffda8f44105433a032f.yaml
+
 - [x] engineering-active-review-checklist-snapshot-deletion (PRD-ENGINEERING-021/025) [test_tier_required]: 删除已降格为历史兼容路径的 `active-engineering.md` PRD review checklist snapshot，将当前 engineering 阅读/状态语义收敛到 `doc/engineering/README.md`、`doc/engineering/prd.index.md` 与 `doc/engineering/project.md`。 Trace: .pm/tasks/task_a66e81168faa4ae0ada01030bd992edd.yaml
 
 - [x] game-active-review-checklist-snapshot-deletion (PRD-ENGINEERING-021/025) [test_tier_required]: 删除已降格为历史兼容路径的 `active-game.md` PRD review checklist snapshot，将当前 game 阅读/状态语义收敛到 `doc/game/README.md`、`doc/game/prd.index.md` 与 `doc/game/project.md`。 Trace: .pm/tasks/task_0f123c70222c404dacb01f7c64e24208.yaml


### PR DESCRIPTION
## Summary

- Move gameplay lifecycle-kind and active-gameplay-module filtering into `collect_gameplay_tick_emits()` before cloning module emit events.
- Keep `process_gameplay_cycles_with_modules()` consuming already-filtered gameplay tick emits.
- Add a focused unit test for active gameplay lifecycle inclusion and non-lifecycle, non-gameplay, non-tick exclusion.

## Verification

- `./scripts/cargo-dev.sh test -p oasis7 --no-default-features runtime::world::gameplay_loop::tests::collect_gameplay_tick_emits_filters_before_returning_events -- --exact --nocapture`
- `./scripts/cargo-dev.sh fmt --all --check`
- `./scripts/pm/workflow-lint.sh --task-uid task_3fa598816b3d4ffda8f44105433a032f --phase current`
- `./scripts/doc-governance-check.sh`
- `git diff --check`

## Review

- Pre-PR local role review: passed.
- Roles: runtime_engineer, qa_engineer, repository_health_engineer, producer_system_designer.
- Residual risk: full gameplay wasm/module integration remains covered by CI or a clean deterministic wasm environment.
