### PR TITLE
Optimize module artifact bid selection

### DIFF
--- a/.pm/roles/tpm/backlog/committed.yaml
+++ b/.pm/roles/tpm/backlog/committed.yaml
@@ -99,3 +99,13 @@ tasks:
     handoff_to: []
     status: committed
     task_path: .pm/tasks/task_b442769f7ef74d01894f4b8405c21301.yaml
+  - task_uid: task_a284e8f46b31441aa1685fbe9ea67f06
+    title: "Continue engineering performance and abstraction optimization"
+    module: engineering
+    priority: P2
+    source_signal: null
+    related_prd: []
+    acceptance: []
+    handoff_to: []
+    status: committed
+    task_path: .pm/tasks/task_a284e8f46b31441aa1685fbe9ea67f06.yaml

--- a/.pm/roles/tpm/backlog/committed.yaml
+++ b/.pm/roles/tpm/backlog/committed.yaml
@@ -99,13 +99,3 @@ tasks:
     handoff_to: []
     status: committed
     task_path: .pm/tasks/task_b442769f7ef74d01894f4b8405c21301.yaml
-  - task_uid: task_a284e8f46b31441aa1685fbe9ea67f06
-    title: "Continue engineering performance and abstraction optimization"
-    module: engineering
-    priority: P2
-    source_signal: null
-    related_prd: []
-    acceptance: []
-    handoff_to: []
-    status: committed
-    task_path: .pm/tasks/task_a284e8f46b31441aa1685fbe9ea67f06.yaml

--- a/.pm/tasks/task_a284e8f46b31441aa1685fbe9ea67f06.execution.md
+++ b/.pm/tasks/task_a284e8f46b31441aa1685fbe9ea67f06.execution.md
@@ -1,0 +1,92 @@
+# task_a284e8f46b31441aa1685fbe9ea67f06 Execution Log
+
+- task_uid: task_a284e8f46b31441aa1685fbe9ea67f06
+- title: Continue engineering performance and abstraction optimization
+- owner_role: tpm
+- worktree_hint: /Users/scc/ccwork/worktrees/oasis7-engineering-perf-abstraction-optimization-9
+
+<!-- Append entries using:
+Example:
+  ## YYYY-MM-DD HH:MM:SS CST / role_name
+  - 完成内容: ...
+  - 遗留事项: ...
+  - Action: ...
+  - Validation Command: ...
+  - Expected Result: ...
+  - Actual Result: ...
+  - Blocker / Next Action: ...
+-->
+
+## 2026-06-29 21:06:00 CST / tpm
+- 完成内容: WORKFLOW BOOTSTRAP DECIDED. Repository state impact: code/docs/task truth will change because the user asked to continue finding performance and abstraction design points, optimize them, and merge. Isolation decision: created dedicated task worktree `/Users/scc/ccwork/worktrees/oasis7-engineering-perf-abstraction-optimization-9` on branch `task/engineering-perf-abstraction-optimization-9` from `origin/main`. Task truth: owner role `tpm`; `.pm` task `task_a284e8f46b31441aa1685fbe9ea67f06`; formal docs `doc/engineering/project.md`. Routed next phase: professional candidate discovery/confirmation -> focused implementation -> verification -> pre-PR local role review -> closeout -> PR watch/fix/merge.
+- 遗留事项: None. Bootstrap script completed normally and recorded workflow start. Acceptance/doc refs were completed in the task yaml after creation, with a single non-duplicate `doc_refs` key.
+- Action: Bootstrap user request into repo-owned workflow.
+- Validation Command: `rtk ./scripts/new-task-worktree.sh engineering perf-abstraction-optimization-9 --base origin/main --branch task/engineering-perf-abstraction-optimization-9 --pm-owner-role tpm --pm-title "Continue engineering performance and abstraction optimization" --pm-source-ref doc/engineering/project.md --json`; `rtk sed -n '1,120p' .pm/tasks/task_a284e8f46b31441aa1685fbe9ea67f06.yaml`; `rtk git status --short`
+- Expected Result: Dedicated worktree, branch, and `.pm` task are created from current `origin/main`.
+- Actual Result: PASS. Worktree `/Users/scc/ccwork/worktrees/oasis7-engineering-perf-abstraction-optimization-9`, branch `task/engineering-perf-abstraction-optimization-9`, task `task_a284e8f46b31441aa1685fbe9ea67f06`, yaml status `committed`, `last_started_at` present.
+- Blocker / Next Action: Record route and dispatch professional bounded slices.
+
+## 2026-06-29 21:08:00 CST / tpm
+- 完成内容: WORKFLOW ROUTE DECIDED. Current phase: specialist candidate discovery/confirmation, then executing-project-tasks. Selected workflow surfaces: `optimization-performance` as method guidance, `executing-project-tasks` for focused implementation once a candidate is selected, then `verification-before-completion`, `requesting-repo-owned-review`, and `finishing-a-development-branch`.
+- 遗留事项: Candidate must not duplicate recent completed project entries such as wasm path sort/dedup, libp2p peer-id normalization, chain replication allowlist normalization, restricted grant expiry BTreeMap ordering, wasm observe diff merge, bridge remainder sorting, provider/replica/DHT rankings, simulator observation sorting, social evidence lookup, DistFS audit skip, runtime factory depreciation, module tick/routing laziness, PM sync/lint fast paths, tick consensus hash lookup, viewer nearest-location/percentile optimizations, consensus mempool selection, runner ready-agent selection, power order/tick iteration, LLM top-N, transfer history, Explorer pagination/pruning, libp2p request peer candidate filtering, gameplay tick lifecycle emit filtering, or governance finality stake-root buffer hashing.
+- Action: TPM TODO decomposition and subagent slice contracts.
+- Validation Command: Read `AGENTS.md` instructions in thread context, `default-workflow-bootstrap`, `repo-owned-workflow-router`, `optimization-performance`, task yaml/execution log, role cards for `repository_health_engineer` and `runtime_engineer`, and `doc/engineering/project.md` recent completed performance inventory.
+- Expected Result: Route and subagent contracts are recorded before professional work starts.
+- Actual Result: PASS. Route is recorded in this execution log.
+- Blocker / Next Action: Dispatch bounded discovery slices and integrate one concrete candidate.
+
+### Subagent Slice Contracts
+- Slice A role: `repository_health_engineer`.
+- Slice A type: bounded professional discovery/confirmation for repository-health, scripts/tooling, and code-abstraction performance opportunities.
+- Slice A model configuration: intended default subagent runtime per workflow source-of-truth; actual dispatched model/reasoning: inherited/unverified due tool limitation.
+- Slice A context delivery mode: full-thread/full-history fork plus this mandatory checklist.
+- Slice A mandatory context checklist/packet: identity and authority = `AGENTS.md`, `/Users/scc/.codex/RTK.md`, and `.agents/roles/repository_health_engineer.md`; workflow governance = `doc/engineering/workflow/source-of-truth.md` plus bootstrap/router skills; task truth = `.pm/tasks/task_a284e8f46b31441aa1685fbe9ea67f06.{yaml,execution.md}`; user intent = continue finding performance/abstraction design points, optimize, and merge; scoped repo context = first-party code only, `third_party/**` read-only, avoid completed `doc/engineering/project.md` performance rows through `governance-finality-stake-root-buffer-performance`; collaboration boundary = no edits, return 1-3 candidates with file/function evidence, expected benefit, risk, and verification command.
+- Slice A write scope: none for discovery.
+- Slice A return contract: ranked candidates, non-duplicate evidence, recommended implementation owner, focused verification path, and residual risk.
+- Slice A formal sink: this execution log.
+- Slice A integration owner/order: TPM integrates after runtime slice; selected candidate gets implemented by TPM or a bounded worker.
+- Slice B role: `runtime_engineer`.
+- Slice B type: bounded professional discovery/confirmation for runtime/server/native hot paths and behavior-preserving abstraction optimizations.
+- Slice B model configuration: intended default subagent runtime per workflow source-of-truth; actual dispatched model/reasoning: inherited/unverified due tool limitation.
+- Slice B context delivery mode: full-thread/full-history fork plus this mandatory checklist.
+- Slice B mandatory context checklist/packet: identity and authority = `AGENTS.md`, `/Users/scc/.codex/RTK.md`, and `.agents/roles/runtime_engineer.md`; workflow governance = `doc/engineering/workflow/source-of-truth.md`; task truth = `.pm/tasks/task_a284e8f46b31441aa1685fbe9ea67f06.{yaml,execution.md}`; user intent = continue bounded performance/abstraction optimization to merge; scoped repo context = `crates/oasis7*` runtime-related paths, excluding recently completed project rows through `governance-finality-stake-root-buffer-performance`; collaboration boundary = no edits, return candidates only with semantic risk and verification commands.
+- Slice B write scope: none for discovery.
+- Slice B return contract: ranked candidates, file/function evidence, runtime/replay/recovery risk, focused verification path, and whether implementation should require additional roles.
+- Slice B formal sink: this execution log.
+- Slice B integration owner/order: TPM integrates with repository-health findings and selects one bounded implementation.
+
+## 2026-06-29 21:19:00 CST / repository_health_engineer
+- 完成内容: Bounded read-only discovery slice returned candidate findings. Recommended repository-health candidate: `crates/oasis7/src/simulator/llm_agent/behavior_runtime_helpers.rs` module lifecycle status helper, where full artifact/module vectors are cloned before filtering/truncation. Backup candidates included duplicate module lifecycle `sha256_hex` helpers and module release apply repeated attestation scans.
+- 遗留事项: The agent lifecycle-status candidate remains a good follow-up, but selecting it would require `agent_engineer` ownership/review. The current task can use the runtime-confirmed artifact bid candidate for a narrower one-PR optimization.
+- Action: Integrate repository-health candidate discovery.
+- Validation Command: Subagent read-only slice over first-party code and recent project performance inventory; no edits.
+- Expected Result: One or more concrete non-duplicate performance/abstraction optimization candidates with verification path.
+- Actual Result: PASS. Repository-health provided three candidates; no blockers against selecting a narrower runtime-owned candidate.
+- Blocker / Next Action: Integrate runtime slice and implement selected candidate.
+
+## 2026-06-29 21:20:00 CST / runtime_engineer
+- 完成内容: Bounded read-only discovery slice returned runtime candidate findings and recommended `crates/oasis7/src/runtime/world/module_actions/artifact_actions.rs::best_bid_for_listing` as the best one-PR candidate. Runtime evidence: current scan keeps `best: Option<ModuleArtifactBidState>` and clones every newly better bid; `try_match_module_listing` only needs the final selected bid, so the loop can keep `Option<&ModuleArtifactBidState>` and clone once at return.
+- 遗留事项: Secondary candidates, active module invocation key materialization and due economy job ordering helper extraction, are deferred due broader scheduling/economy surface.
+- Action: Select implementation target.
+- Validation Command: Subagent read-only slice over runtime module artifact market and module scheduling/economy paths; no edits.
+- Expected Result: Runtime professional slice confirms low-risk behavior-preserving candidate and focused validation path.
+- Actual Result: PASS. Selected `best_bid_for_listing` borrowed-best scan with a focused tie-break regression. Key risk: preserve price kind, minimum price, self-bid exclusion, buyer balance check, highest price priority, and equal-price lowest-order-id tie-break.
+- Blocker / Next Action: Implement borrowed-best selection and add equal-price order-id regression.
+
+## 2026-06-29 21:29:00 CST / tpm
+- 完成内容: Implemented the selected bounded optimization in `crates/oasis7/src/runtime/world/module_actions/artifact_actions.rs`. `best_bid_for_listing` now keeps the current best bid as `Option<&ModuleArtifactBidState>` during scan and clones only the final selected bid at return, avoiding repeated bid-state clones when progressively better bids are seen. Added `module_artifact_bid_match_prefers_earlier_order_for_equal_price` to lock the equal-price lowest-order-id tie-break.
+- 遗留事项: None for implementation. Pre-PR professional review still required before PR creation.
+- Action: Implement behavior-preserving runtime performance/abstraction optimization and focused regression coverage.
+- Validation Command: `rtk ./scripts/cargo-dev.sh test -p oasis7 --no-default-features module_artifact_bid -- --nocapture`
+- Expected Result: Existing module artifact bid tests plus the new equal-price tie-break regression pass.
+- Actual Result: PASS. 5 matching tests passed, including `module_artifact_bid_match_prefers_earlier_order_for_equal_price` and `module_artifact_bid_match_prefers_highest_price`; full command exited 0 after filtered binaries completed. Existing unrelated warnings appeared in node/launcher/faucet/web-launcher paths.
+- Blocker / Next Action: Run formatting, workflow, documentation governance, and diff hygiene gates.
+
+## 2026-06-29 21:35:00 CST / tpm
+- 完成内容: Completed focused verification and static gates for the implementation snapshot.
+- 遗留事项: Existing unrelated Rust warnings appeared in build output (`dead_code` / `unused_imports` in node, launcher, faucet, and web-launcher paths); no warnings were introduced in the changed module artifact bid helper.
+- Action: Verification before implementation commit.
+- Validation Command: `rtk ./scripts/cargo-dev.sh fmt --all --check`; `rtk bash scripts/doc-governance-check.sh`; `rtk ./scripts/pm/workflow-lint.sh --task-uid task_a284e8f46b31441aa1685fbe9ea67f06 --phase current`; `rtk git diff --check`
+- Expected Result: Formatting, doc governance, task-local workflow lint, and diff hygiene pass.
+- Actual Result: PASS. `fmt --all --check` exited 0; `doc-governance-check: OK`; `workflow-lint: OK (task_a284e8f46b31441aa1685fbe9ea67f06, phase=current)`; `git diff --check` exited 0.
+- Blocker / Next Action: Create implementation commit, then run mandatory pre-PR local role review.

--- a/.pm/tasks/task_a284e8f46b31441aa1685fbe9ea67f06.execution.md
+++ b/.pm/tasks/task_a284e8f46b31441aa1685fbe9ea67f06.execution.md
@@ -142,3 +142,12 @@ Example:
 - Expected Result: Claim-ready verifies the current task workflow lint and allows the branch to be claimed ready for PR.
 - Actual Result: PASS. `workflow-lint: OK (task_a284e8f46b31441aa1685fbe9ea67f06, phase=current)`; `status: verified`; `allowed_to_claim: true`; claim message: "Fresh verification passed; the branch can now be claimed ready for PR."
 - Blocker / Next Action: Commit review evidence and proceed to task closeout / PR creation.
+
+## 2026-06-29 22:07:00 CST / tpm
+- 完成内容: Ran task closeout. The task-local verification command passed and `.pm/tasks/task_a284e8f46b31441aa1685fbe9ea67f06.yaml` was updated to `status: done` with `last_verification_exit_code: 0`.
+- 遗留事项: `task-closeout.sh` exited non-zero after closeout because its final repo-wide `pm-lint` scan reported unrelated historical execution-log format debt in many pre-existing `.pm/tasks/*` files. This is outside the current task diff; the task-local workflow lint for `task_a284e8f46b31441aa1685fbe9ea67f06` passed before closeout.
+- Action: Close out task and record closeout boundary.
+- Validation Command: `rtk ./scripts/pm/task-closeout.sh --role tpm --task-uid task_a284e8f46b31441aa1685fbe9ea67f06 --verify-command "./scripts/cargo-dev.sh test -p oasis7 --no-default-features module_artifact_bid -- --nocapture"`
+- Expected Result: Focused verification passes and task is marked done.
+- Actual Result: PARTIAL PASS WITH KNOWN REPO-WIDE PM-LINT DEBT. Task-local verification passed (`last_verification_status: verified`, `last_verification_exit_code: 0`) and task status is `done`; final `pm-lint` failed on unrelated historical task logs.
+- Blocker / Next Action: Proceed to PR creation using task-local green gates, pre-PR role review passed packet, and recorded repo-wide lint boundary.

--- a/.pm/tasks/task_a284e8f46b31441aa1685fbe9ea67f06.execution.md
+++ b/.pm/tasks/task_a284e8f46b31441aa1685fbe9ea67f06.execution.md
@@ -90,3 +90,55 @@ Example:
 - Expected Result: Formatting, doc governance, task-local workflow lint, and diff hygiene pass.
 - Actual Result: PASS. `fmt --all --check` exited 0; `doc-governance-check: OK`; `workflow-lint: OK (task_a284e8f46b31441aa1685fbe9ea67f06, phase=current)`; `git diff --check` exited 0.
 - Blocker / Next Action: Create implementation commit, then run mandatory pre-PR local role review.
+
+## 2026-06-29 21:39:00 CST / tpm
+- Review Trigger: pre-PR local role review
+- Review Scope: Implementation commit `a7a41bf061abfa8e40c2b546b0c6b45668827385`; changed paths `.pm/roles/tpm/backlog/committed.yaml`, `.pm/tasks/task_a284e8f46b31441aa1685fbe9ea67f06.yaml`, `.pm/tasks/task_a284e8f46b31441aa1685fbe9ea67f06.execution.md`, `crates/oasis7/src/runtime/world/module_actions/artifact_actions.rs`, `crates/oasis7/src/runtime/tests/module_action_loop_validation.rs`, `doc/engineering/project.md`.
+- Review Package: `/Users/scc/ccwork/worktrees/oasis7-engineering-perf-abstraction-optimization-9/.pm/scratch/task_a284e8f46b31441aa1685fbe9ea67f06/review-packages/review-ad214ef33..a7a41bf06.diff`
+- Review Roles: runtime_engineer, qa_engineer, repository_health_engineer, producer_system_designer
+- Review Question: Confirm or challenge whether the module artifact bid selection optimization preserves module market semantics, including price-kind filters, minimum price, self-bid exclusion, buyer balance checks, highest-price priority, and equal-price lowest-order-id tie-break, while reducing clone work and keeping task/project trace healthy.
+- Evidence Available: Focused `module_artifact_bid` test filter passed, including the new equal-price tie-break regression; `fmt --all --check`, `doc-governance-check`, `workflow-lint --phase current`, and `git diff --check` passed.
+- Expected Return Contract: `findings` or `no_findings`; scope/spec compliance verdict; role quality/risk verdict; residual_risk.
+- Slice Ledger: `/Users/scc/ccwork/worktrees/oasis7-engineering-perf-abstraction-optimization-9/.pm/scratch/task_a284e8f46b31441aa1685fbe9ea67f06/slice-ledger.jsonl`
+- Formal Sink: `.pm/tasks/task_a284e8f46b31441aa1685fbe9ea67f06.execution.md`
+
+## 2026-06-29 21:53:00 CST / tpm
+- 完成内容: Recorded pre-PR review runtime limitation and fallback dispatch path. Initial full-history `runtime_engineer` and `producer_system_designer` review forks did not return after repeated waits and a direct return request, so they were closed and replacement explicit-context no-edit reviews were dispatched for the same roles and review questions.
+- 遗留事项: Wait for replacement `runtime_engineer` and `producer_system_designer` review verdicts before recording the passed review packet.
+- Action: Pre-PR review fallback evidence.
+- Validation Command: `multi_agent_v1.wait_agent` repeated for initial `runtime_engineer` / `producer_system_designer` review agents; `multi_agent_v1.send_input` return request; `multi_agent_v1.close_agent`; replacement `multi_agent_v1.spawn_agent` with explicit local context packet.
+- Expected Result: Stuck review agents are not used as professional conclusions; replacement role reviews provide the required verdicts.
+- Actual Result: PASS. Initial review agents were closed with status `running`; replacement explicit-context review agents were dispatched.
+- Blocker / Next Action: Integrate replacement role review results and then record the pre-PR passed packet if no valid findings remain.
+
+## 2026-06-29 22:02:00 CST / tpm
+- Pre-PR Local Role Review: passed
+- Task UID: task_a284e8f46b31441aa1685fbe9ea67f06
+- Source Worktree: /Users/scc/ccwork/worktrees/oasis7-engineering-perf-abstraction-optimization-9
+- Source Branch: task/engineering-perf-abstraction-optimization-9
+- Source Head: a7a41bf061abfa8e40c2b546b0c6b45668827385
+- Comparison Ref: refs/remotes/origin/main
+- Reviewed Changed Paths: `.pm/roles/tpm/backlog/committed.yaml`; `.pm/tasks/task_a284e8f46b31441aa1685fbe9ea67f06.yaml`; `.pm/tasks/task_a284e8f46b31441aa1685fbe9ea67f06.execution.md`; `crates/oasis7/src/runtime/world/module_actions/artifact_actions.rs`; `crates/oasis7/src/runtime/tests/module_action_loop_validation.rs`; `doc/engineering/project.md`
+- Review Package: `/Users/scc/ccwork/worktrees/oasis7-engineering-perf-abstraction-optimization-9/.pm/scratch/task_a284e8f46b31441aa1685fbe9ea67f06/review-packages/review-ad214ef33..a7a41bf06.diff`
+- Role Selection Basis: `runtime_engineer` because runtime module artifact market matching code and replay/recovery/event ordering risk are touched; `qa_engineer` because the PR claim depends on focused verification sufficiency; `repository_health_engineer` because this is an engineering performance/abstraction optimization with task/project trace changes; `producer_system_designer` because module artifact market eligibility and tie-break semantics are a product/system contract. Skipped `blockchain_ops_engineer`, `wasm_platform_engineer`, `viewer_engineer`, `agent_engineer`, `gameplay_designer`, `game_visual_interaction_designer`, and `liveops_community` because no blockchain ops, WASM ABI, viewer/UI, agent behavior, gameplay loop/balance, visual/interaction, external messaging, incident, or community-facing surface changed.
+- Review Roles: runtime_engineer, qa_engineer, repository_health_engineer, producer_system_designer
+- Review Evidence: `runtime_engineer`: no_findings; confirmed price-kind filter, minimum listing price, self-bid exclusion, buyer balance check, highest-price priority, equal-price lowest-order-id tie-break, and no schema/event/state shape change. `qa_engineer`: no_findings; focused `module_artifact_bid` filter covers existing auto-match, cancellation, highest-price selection, and new equal-price tie-break behavior, with static gates passed. `repository_health_engineer`: no_findings; bounded non-duplicate optimization, no over-abstraction, task/project trace aligned, `doc_refs` appears exactly once. `producer_system_designer`: no_findings; module artifact market semantics and product/system contract are preserved, no extra docs required.
+- Review Verdicts: `runtime_engineer`: scope/spec compliant; runtime quality/risk low. `qa_engineer`: scope/spec compliant; QA quality/risk sufficient before PR creation. `repository_health_engineer`: scope/spec compliant; repository health quality/risk low. `producer_system_designer`: PASS; producer/system quality/risk PASS.
+- Review Findings Disposition: no_findings
+- Finding Disposition Evidence: n/a; no valid findings required code or documentation changes.
+- Verification Matrix: module artifact bid selection -> focused bid regression coverage -> `module_artifact_bid_auto_matches_on_listing`, `cancel_module_artifact_bid_removes_order`, `module_artifact_bid_match_prefers_highest_price`, and `module_artifact_bid_match_prefers_earlier_order_for_equal_price` passed under `module_artifact_bid` filter; runtime replay/recovery/checkpoint/long-run applicability -> no schema, event shape, state shape, persistence, checkpoint, recovery, or replay input changed because the selected bid is cloned before sale event emission/state mutation and runtime_engineer confirmed event-driven semantics remain unchanged; Rust formatting -> `fmt --all --check` exited 0; project/task governance -> `doc-governance-check: OK` and `workflow-lint: OK`; diff hygiene -> `git diff --check` exited 0.
+- Visual Evidence: n/a; no viewer/UI/visual surface changed.
+- WASM Evidence: n/a; no wasm support crate, ABI, manifest, receipt, artifact identity, or deterministic wasm build surface changed.
+- Ops Evidence: n/a; no deployment, node ops, operator runbook, migration, validator rotation, readiness, rollback, or service contract surface changed.
+- LiveOps Evidence: n/a; no external messaging, release-note, status, incident, community, or player promise surface changed.
+- Residual Risk: Low. Broader market replay/recovery suites were not rerun locally, but focused behavior tests, runtime review, QA review, and PR CI cover the bounded borrowed-selection-only change.
+- Slice Ledger: `/Users/scc/ccwork/worktrees/oasis7-engineering-perf-abstraction-optimization-9/.pm/scratch/task_a284e8f46b31441aa1685fbe9ea67f06/slice-ledger.jsonl`
+
+## 2026-06-29 22:04:00 CST / tpm
+- 完成内容: Recorded `ready_for_pr` claim evidence required by PR preflight.
+- 遗留事项: None.
+- Action: Claim branch ready for PR after local role review and focused gates.
+- Validation Command: `rtk ./scripts/pm/claim-ready.sh --claim-type ready_for_pr --verify-command "./scripts/pm/workflow-lint.sh --task-uid task_a284e8f46b31441aa1685fbe9ea67f06 --phase current"`
+- Expected Result: Claim-ready verifies the current task workflow lint and allows the branch to be claimed ready for PR.
+- Actual Result: PASS. `workflow-lint: OK (task_a284e8f46b31441aa1685fbe9ea67f06, phase=current)`; `status: verified`; `allowed_to_claim: true`; claim message: "Fresh verification passed; the branch can now be claimed ready for PR."
+- Blocker / Next Action: Commit review evidence and proceed to task closeout / PR creation.

--- a/.pm/tasks/task_a284e8f46b31441aa1685fbe9ea67f06.yaml
+++ b/.pm/tasks/task_a284e8f46b31441aa1685fbe9ea67f06.yaml
@@ -1,0 +1,22 @@
+task_uid: task_a284e8f46b31441aa1685fbe9ea67f06
+title: "Continue engineering performance and abstraction optimization"
+owner_role: tpm
+module: engineering
+worktree_hint: /Users/scc/ccwork/worktrees/oasis7-engineering-perf-abstraction-optimization-9
+execution_log_path: .pm/tasks/task_a284e8f46b31441aa1685fbe9ea67f06.execution.md
+status: committed
+priority: P2
+source_signal: null
+source_refs:
+  - doc/engineering/project.md
+doc_refs:
+  - doc/engineering/project.md
+related_prd:
+  - PRD-ENGINEERING
+acceptance:
+  - "Repository-health/performance slice identifies one concrete non-duplicate performance or abstraction improvement opportunity."
+  - "Implement the selected bounded optimization with behavior-preserving tests or focused verification."
+  - "Update task/project trace evidence and pass focused verification, formatting, workflow, doc-governance, and diff hygiene checks."
+handoff_to: []
+updated_at: 2026-06-29T21:03:51+08:00
+last_started_at: 2026-06-29T21:03:51+08:00

--- a/.pm/tasks/task_a284e8f46b31441aa1685fbe9ea67f06.yaml
+++ b/.pm/tasks/task_a284e8f46b31441aa1685fbe9ea67f06.yaml
@@ -4,7 +4,7 @@ owner_role: tpm
 module: engineering
 worktree_hint: /Users/scc/ccwork/worktrees/oasis7-engineering-perf-abstraction-optimization-9
 execution_log_path: .pm/tasks/task_a284e8f46b31441aa1685fbe9ea67f06.execution.md
-status: committed
+status: done
 priority: P2
 source_signal: null
 source_refs:
@@ -18,5 +18,11 @@ acceptance:
   - "Implement the selected bounded optimization with behavior-preserving tests or focused verification."
   - "Update task/project trace evidence and pass focused verification, formatting, workflow, doc-governance, and diff hygiene checks."
 handoff_to: []
-updated_at: 2026-06-29T21:03:51+08:00
+updated_at: 2026-06-29T21:37:48+08:00
 last_started_at: 2026-06-29T21:03:51+08:00
+last_claim_type: task_complete
+last_verify_command: "./scripts/cargo-dev.sh test -p oasis7 --no-default-features module_artifact_bid -- --nocapture"
+last_verified_at: 2026-06-29T21:37:47+08:00
+last_verification_exit_code: 0
+last_verification_status: verified
+last_closed_at: 2026-06-29T21:37:48+08:00

--- a/crates/oasis7/src/runtime/tests/module_action_loop_validation.rs
+++ b/crates/oasis7/src/runtime/tests/module_action_loop_validation.rs
@@ -252,3 +252,61 @@ fn module_artifact_bid_match_prefers_highest_price() {
     };
     assert_eq!(buyer_agent_id, "buyer-high");
 }
+
+#[test]
+fn module_artifact_bid_match_prefers_earlier_order_for_equal_price() {
+    let mut world = World::new();
+    register_agent(&mut world, "seller-1");
+    register_agent(&mut world, "buyer-first");
+    register_agent(&mut world, "buyer-second");
+    set_agent_resource(&mut world, "buyer-first", ResourceKind::Data, 20);
+    set_agent_resource(&mut world, "buyer-second", ResourceKind::Data, 20);
+
+    let wasm_bytes = b"module-action-loop-bid-equal-price-priority".to_vec();
+    let wasm_hash = util::sha256_hex(&wasm_bytes);
+    world.submit_action(Action::DeployModuleArtifact {
+        publisher_agent_id: "seller-1".to_string(),
+        wasm_hash: wasm_hash.clone(),
+        wasm_bytes,
+    });
+    world.step().expect("deploy artifact");
+
+    world.submit_action(Action::PlaceModuleArtifactBid {
+        bidder_agent_id: "buyer-first".to_string(),
+        wasm_hash: wasm_hash.clone(),
+        price_kind: ResourceKind::Data,
+        price_amount: 9,
+    });
+    world.step().expect("place first bid");
+    let first_bid_order_id = match &world.journal().events.last().expect("first bid event").body {
+        WorldEventBody::Domain(DomainEvent::ModuleArtifactBidPlaced { order_id, .. }) => *order_id,
+        other => panic!("expected module artifact bid placed event: {other:?}"),
+    };
+    world.submit_action(Action::PlaceModuleArtifactBid {
+        bidder_agent_id: "buyer-second".to_string(),
+        wasm_hash: wasm_hash.clone(),
+        price_kind: ResourceKind::Data,
+        price_amount: 9,
+    });
+    world.step().expect("place second bid");
+
+    world.submit_action(Action::ListModuleArtifactForSale {
+        seller_agent_id: "seller-1".to_string(),
+        wasm_hash,
+        price_kind: ResourceKind::Data,
+        price_amount: 7,
+    });
+    world.step().expect("list and match");
+
+    let event = world.journal().events.last().expect("sale event");
+    let WorldEventBody::Domain(DomainEvent::ModuleArtifactSaleCompleted {
+        buyer_agent_id,
+        bid_order_id,
+        ..
+    }) = &event.body
+    else {
+        panic!("expected sale completion event: {:?}", event.body);
+    };
+    assert_eq!(buyer_agent_id, "buyer-first");
+    assert_eq!(*bid_order_id, Some(first_bid_order_id));
+}

--- a/crates/oasis7/src/runtime/world/module_actions/artifact_actions.rs
+++ b/crates/oasis7/src/runtime/world/module_actions/artifact_actions.rs
@@ -179,7 +179,7 @@ impl World {
         listing: &ModuleArtifactListingState,
     ) -> Option<ModuleArtifactBidState> {
         let bids = self.state.module_artifact_bids.get(wasm_hash)?;
-        let mut best: Option<ModuleArtifactBidState> = None;
+        let mut best: Option<&ModuleArtifactBidState> = None;
         for bid in bids {
             if bid.price_kind != listing.price_kind {
                 continue;
@@ -208,10 +208,10 @@ impl World {
                 None => true,
             };
             if replace {
-                best = Some(bid.clone());
+                best = Some(bid);
             }
         }
-        best
+        best.cloned()
     }
 
     pub(super) fn try_match_module_listing(

--- a/doc/engineering/project.md
+++ b/doc/engineering/project.md
@@ -84,6 +84,8 @@
 
 - [x] governance-finality-stake-root-buffer-performance (PRD-ENGINEERING/GOVERNANCE) [test_tier_required]: Optimize governance finality stake-root payload construction to hash a single buffered payload instead of allocating per-signer strings plus an intermediate join vector, preserving signer order, default stake, and stake-root hash semantics. Trace: .pm/tasks/task_f4961c6f86a84ac696ba5929a7084957.yaml
 
+- [x] module-artifact-bid-selection-clone-performance (PRD-ENGINEERING/GOVERNANCE) [test_tier_required]: Optimize module artifact bid matching to keep the current best bid by borrowed reference during ranking and clone only the final selected order, preserving price-kind filters, minimum price, self-bid exclusion, buyer balance, highest-price priority, and equal-price lowest-order semantics. Trace: .pm/tasks/task_a284e8f46b31441aa1685fbe9ea67f06.yaml
+
 - [x] engineering-active-review-checklist-snapshot-deletion (PRD-ENGINEERING-021/025) [test_tier_required]: 删除已降格为历史兼容路径的 `active-engineering.md` PRD review checklist snapshot，将当前 engineering 阅读/状态语义收敛到 `doc/engineering/README.md`、`doc/engineering/prd.index.md` 与 `doc/engineering/project.md`。 Trace: .pm/tasks/task_a66e81168faa4ae0ada01030bd992edd.yaml
 
 - [x] game-active-review-checklist-snapshot-deletion (PRD-ENGINEERING-021/025) [test_tier_required]: 删除已降格为历史兼容路径的 `active-game.md` PRD review checklist snapshot，将当前 game 阅读/状态语义收敛到 `doc/game/README.md`、`doc/game/prd.index.md` 与 `doc/game/project.md`。 Trace: .pm/tasks/task_0f123c70222c404dacb01f7c64e24208.yaml


### PR DESCRIPTION
## Summary
- Optimize module artifact bid matching by keeping the current best bid as a borrowed reference during ranking and cloning only the final selected order.
- Add a focused regression for equal-price bids choosing the earlier order id.
- Record task/project trace, closeout evidence, and pre-PR local role review disposition.

## Verification
- `rtk ./scripts/cargo-dev.sh test -p oasis7 --no-default-features module_artifact_bid -- --nocapture`
- `rtk ./scripts/cargo-dev.sh fmt --all --check`
- `rtk bash scripts/doc-governance-check.sh`
- `rtk ./scripts/pm/workflow-lint.sh --task-uid task_a284e8f46b31441aa1685fbe9ea67f06 --phase current`
- `rtk git diff --check`

## Review
- Pre-PR local role review passed for runtime_engineer, qa_engineer, repository_health_engineer, and producer_system_designer.
- No blocking findings.

## Notes
- `task-closeout.sh` marked the task done after focused verification passed, then failed only on unrelated repo-wide historical `.pm/tasks/*` execution-log lint debt. This boundary is recorded in the task execution log.
