### PR TITLE
Remove retired PM wording from workflow docs

### DIFF
--- a/.agents/roles/repository_health_engineer.md
+++ b/.agents/roles/repository_health_engineer.md
@@ -28,7 +28,7 @@
 ## Outputs
 - 仓库健康度 findings：文档/代码不一致、语义歧义、缺陷风险、测试盲区、技术债和 owner 建议
 - 对 TPM 的合流建议：必须修复、可延后但需记录、可接受 residual risk、需要追加专业角色 slice
-- 债务处置建议：最小偿还 patch、后续 `.pm` task / reflection signal 建议、过期条件和验证命令
+- 债务处置建议：最小偿还 patch、后续 GitHub-backed task / reflection signal 建议、过期条件和验证命令
 - 文档清晰度建议：需要改写的 source-of-truth、role card、operator doc、task evidence 或错误信息
 
 ## Decisions

--- a/.agents/roles/templates/planning-self-checklist.md
+++ b/.agents/roles/templates/planning-self-checklist.md
@@ -15,7 +15,7 @@
 - [ ] 每条需求 / 验收点都有对应任务或验证面
   - 不能只写目标，不写落地 task、验证命令或预期结果
 - [ ] 命名保持一致
-  - `PRD-ID`、task slug、`.pm` task、分支 / worktree 名、文档标题、关键路径引用前后一致
+  - `PRD-ID`、task slug、GitHub-backed task、分支 / worktree 名、文档标题、关键路径引用前后一致
 - [ ] 原子步骤足够细
   - 接手人不需要额外口头补充，就能按步骤执行、验证、回写
 - [ ] subagent slices 已定义清楚

--- a/.agents/roles/templates/subagent-slice-card.md
+++ b/.agents/roles/templates/subagent-slice-card.md
@@ -5,11 +5,11 @@
 ## Required Fields（固定字段）
 - role:
 - slice type:
-- model configuration: compatibility marker; fill the intended/actual fields below.
+- model configuration: fill the intended/actual fields below.
 - intended model configuration: workflow source-of-truth `Default subagent runtime` by default; record reason for any requested override.
 - actual dispatched model/reasoning: selected model/reasoning when the tool permits and reports it; otherwise `inherited/unverified` plus connector/tool limitation, including cases where selection was requested but actual dispatch cannot be verified.
 - context delivery mode: full-thread/full-history fork by default; explicit context packet is delivery supplement/fallback only, with reason recorded.
-- mandatory context packet: compatibility marker; fill the mandatory context checklist/packet below.
+- mandatory context packet: fill the mandatory context checklist/packet below.
 - mandatory context checklist/packet:
   - identity and authority: assigned role + `.agents/roles/<role>.md` + owner role + TPM integration owner
   - workflow governance: `AGENTS.md` + `doc/engineering/workflow/source-of-truth.md` + selected workflow skill(s)

--- a/.agents/roles/tpm.md
+++ b/.agents/roles/tpm.md
@@ -39,7 +39,7 @@ TPM 只做 workflow coordination / integration，不做任何专业性工作本�
 - 派工前必须把当前 TODO、slice contract、formal sink 和 integration order 写入 GitHub Project-backed task truth 或 source-of-truth 指定的 fallback sink；project、handoff、signal、memory 或 PR evidence 只能作为补充 sink。
 - 专业角色 slice 默认请求 workflow source-of-truth 的 `Default subagent runtime` policy（具体配置真值在 `.codex/config.toml` 的 `[workflow.subagent_runtime]`）；slice contract 必须同时写明 intended model 与 actual dispatched model/reasoning。非默认、继承父线程、请求选择后无法验证 actual model、或其他无法验证 actual model 的情况都必须记录原因。
 - 专业角色 slice 默认使用 full-thread/full-history fork 或等价上下文；若改用手工显式 context packet，必须记录 fallback 原因，例如工具限制、上下文安全、模型选择冲突或默认 fork 卡住。
-- 兼容契约词：`mandatory context packet` 在当前语义下指必须记录的 mandatory context checklist/packet，不等同于必须手工组装显式上下文包。
+- `mandatory context packet` 指必须记录的 mandatory context checklist/packet，不等同于必须手工组装显式上下文包。
 - 非窄范围只读 explorer 的 subagent 必须获得 `AGENTS.md`、对应 role card、workflow source-of-truth、当前 GitHub issue/Project item/mapping record、相关 PRD/project/handoff、当前 diff/evidence 和 sibling slice 边界。
 - 可要求专业 subagent 补充验证、缩小 write scope 或重跑 evidence；不得用 TPM 自己的判断替代专业 subagent 结论，也不得用 subagent 结果替代 TPM 的最终流程合流和 fresh verification gate 记录。
 - 涉及世界规则、runtime 安全、玩家承诺或对外口径时，必须派生相应专业角色 subagent，而不是由 TPM 单独拍板。

--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -42,7 +42,7 @@
 
 Canonical phase mapping lives in `doc/engineering/workflow/source-of-truth.md#11-skill-map-by-phase`; this README is an index, not the workflow authority.
 
-GitHub Project-backed PM migration lives in `doc/engineering/workflow/source-of-truth.md#123-github-project-backed-pm-migration`; after Step 3, GitHub Issues + GitHub Project are the active task truth and GitHub issue comments are the execution/audit sink. `.pm/github-project-sync/task-archive.jsonl` is the retired local task-file audit bridge.
+GitHub Project-backed PM truth lives in `doc/engineering/workflow/source-of-truth.md#123-github-project-backed-pm-contract`: GitHub Issues + GitHub Project are active task truth, GitHub issue comments are the execution/audit sink, and `.pm/github-project-sync/` is the deterministic local mapping/archive surface for scripts.
 
 - 启动任何用户请求、需要先确认标准 task worktree / GitHub Project-backed task truth / owner role 真值，并把后续阶段接回 repo-owned 主链时：`.agents/skills/default-workflow-bootstrap/SKILL.md`
 - 只读/聊天请求也默认进入 task/worktree bootstrap；不要先用“只读/聊天/纯事实”分类决定是否跳过 bootstrap。如果要输出专业结论，进入 task truth 后仍由 TPM 派发对应 bounded 专业角色 slice。纯路径查找、命令输出复述等客观事实读取可由 TPM 在已绑定 task/worktree 内直接处理。
@@ -81,7 +81,7 @@ Specialist skills are domain-triggered through TPM routing or professional subag
 
 - upstream 的 `failing test first with subagents` 作为硬性门禁
 - 与 oasis7 无关的 agent-specific 安装 / 发布说明
-- 任何会替代 `AGENTS.md + .pm + GitHub PR review` 主链的第二套流程
+- 任何会替代 `AGENTS.md + GitHub-backed task truth + GitHub PR review` 主链的第二套流程
 
 ## Notes
 

--- a/.agents/skills/bounded-brainstorming/SKILL.md
+++ b/.agents/skills/bounded-brainstorming/SKILL.md
@@ -19,14 +19,14 @@ Use this skill when:
 Do not use this skill when:
 
 - the user already gave a concrete implementation task and the scope is clear enough to start
-- the task already has chosen direction in `prd.md`, `project.md`, handoff, or `.pm`
+- the task already has chosen direction in `prd.md`, `project.md`, handoff, or GitHub-backed task truth
 - you are using brainstorming only as a way to delay implementation
 
 ## Required Rules
 
 1. This is an optional pre-implementation layer, not a universal gate.
 2. Do not force per-section approval, mandatory spec drafting, or transition into a second planning system.
-3. Keep the output anchored to repo truth: chosen direction must flow back into `prd.md`, `project.md`, a handoff, or `.pm` evidence when it affects scope.
+3. Keep the output anchored to repo truth: chosen direction must flow back into `prd.md`, `project.md`, a handoff, or GitHub task issue evidence when it affects scope.
 4. Prefer 2-3 concrete approaches with tradeoffs and one clear recommendation.
 5. Only use a visual companion when the problem is inherently visual; do not turn browser mockups into default ceremony.
 6. If scope is too large, split it into smaller, executable slices before implementation starts.
@@ -87,7 +87,7 @@ BOUNDED BRAINSTORMING COMPLETE
 ## Repo Truth Writeback
 - `prd.md`:
 - `project.md`:
-- handoff / `.pm`:
+- handoff / GitHub task issue evidence:
 ```
 
 ## Guardrails

--- a/.agents/skills/content-creation/SKILL.md
+++ b/.agents/skills/content-creation/SKILL.md
@@ -12,7 +12,7 @@ In oasis7, this skill is a content-format and copywriting aid, not the owner of
 player promises, incident communication, release positioning, or community
 strategy. When the content is external-facing, `liveops_community` must own or
 verify the professional conclusion, and TPM must keep the work bound to the
-same `.pm` task/worktree/PR chain.
+same GitHub-backed task/worktree/PR chain.
 
 Use this skill to shape the artifact after the task has a clear audience,
 channel, factual basis, and approval boundary. Do not use it to invent product

--- a/.agents/skills/default-workflow-bootstrap/SKILL.md
+++ b/.agents/skills/default-workflow-bootstrap/SKILL.md
@@ -5,7 +5,7 @@ description: Use when any oasis7 user request starts and needs standard task wor
 
 > Workflow authority: `doc/engineering/workflow/source-of-truth.md` is the single normative workflow spec. Keep this skill as short operational guidance only; if behavior changes, update source-of-truth first, then sync this file.
 
-> GitHub PM migration note: Step 3 retired repo-local `.pm/tasks/*`. GitHub Issues/Project plus `.pm/github-project-sync/tasks.json` are active task truth; task evidence is recorded as GitHub issue comments.
+> PM truth: GitHub Issues/Project plus `.pm/github-project-sync/tasks.json` are active task truth; task evidence is recorded as GitHub issue comments.
 
 
 # Default Workflow Bootstrap

--- a/.agents/skills/executing-project-tasks/SKILL.md
+++ b/.agents/skills/executing-project-tasks/SKILL.md
@@ -5,7 +5,7 @@ description: Use when a task already has repo truth such as `prd.md`, `project.m
 
 # Executing Project Tasks
 
-> GitHub PM migration note: Step 3 retired repo-local `.pm/tasks/*`. Use GitHub Project as the active queue/status gate and keep atomic execution evidence in GitHub task issue comments.
+> PM truth: use GitHub Project as the active queue/status gate and keep atomic execution evidence in GitHub task issue comments.
 
 ## When to Use
 
@@ -70,7 +70,7 @@ Stop and report the blocker instead of guessing when:
 
 - the written plan is missing required affected paths, verification, or acceptance mapping
 - the task has drifted beyond the documented scope
-- instructions conflict across `prd.md`, `project.md`, handoff, or `.pm` truth
+- instructions conflict across `prd.md`, `project.md`, handoff, or GitHub-backed task truth
 - the same verification keeps failing and the failure is no longer producing new information
 
 When blocked, lead with:
@@ -82,14 +82,14 @@ When blocked, lead with:
 
 ## Known Failure Modes
 
-- Executing implementation from an informal chat plan instead of canonical `.pm`, PRD, project, or handoff truth.
+- Executing implementation from an informal chat plan instead of canonical GitHub-backed task, PRD, project, or handoff truth.
 - Batching several behavior changes before recording step evidence, which makes later verification failures hard to attribute.
 - Treating planned verification as equivalent to observed verification output.
 - Continuing after repeated identical failures without recording a blocker or narrowing the failing surface.
 
 ## Guardrails
 
-- Do not create a second planning system outside `prd.md` / `project.md` / `.pm`.
+- Do not create a second planning system outside `prd.md` / `project.md` / GitHub-backed task truth.
 - Do not batch many unverified steps and only test at the very end if step-level verification was available.
 - Do not record only planned validation; step evidence must include the actual observed result.
 - Do not continue through ambiguity by silently choosing one interpretation.

--- a/.agents/skills/finishing-a-development-branch/SKILL.md
+++ b/.agents/skills/finishing-a-development-branch/SKILL.md
@@ -5,7 +5,7 @@ description: "Use when implementation is done and the work needs final verificat
 
 > Workflow authority: `doc/engineering/workflow/source-of-truth.md` is the single normative workflow spec. Keep this skill as short operational guidance only; if behavior changes, update source-of-truth first, then sync this file.
 
-> GitHub PM migration note: before final PM closeout or PR creation, confirm Project/mapping/local mirror consistency when the task touched PM queue/status state.
+> PM truth: before final PM closeout or PR creation, confirm Project/mapping/local mirror consistency when the task touched PM queue/status state.
 
 
 # Finishing a Development Branch
@@ -32,7 +32,7 @@ Use this skill when code and docs are already updated and you are moving into br
 3. Before final closeout, apply the source-of-truth Learning Intake / Loop
    Closeout ladder to reusable findings from the task:
    - no-op for transient observations
-   - short execution-log note for current-task-only route or evidence details
+   - short GitHub issue evidence note for current-task-only route or evidence details
    - reflection signal for useful follow-up ideas or repeated friction that is
      not ready for committed task truth
    - task-scoped `working_memory` for temporary structured learning that
@@ -144,4 +144,4 @@ The pre-PR local role review packet is recorded before final closeout/commit and
 - Do not merge a normal PR without first checking PR comments and review threads and resolving or answering actionable items.
 - Do not auto-merge PRs opened specifically for manual packaging/release CI until the operator/user resumes the normal merge path.
 - Do not turn learning intake into a universal extra gate; use no-op or a short
-  execution-log note when there is no reusable learning to preserve.
+  GitHub issue evidence note when there is no reusable learning to preserve.

--- a/.agents/skills/game-design-theory/SKILL.md
+++ b/.agents/skills/game-design-theory/SKILL.md
@@ -40,7 +40,7 @@ Do not use this skill when:
 
 ## Core Workflow
 
-1. Start from current repo truth: `.pm` task, relevant PRD/project docs, role
+1. Start from current repo truth: GitHub-backed task, relevant PRD/project docs, role
    card, and any playtest or community evidence.
 2. Pick the smallest useful theory lens, such as core loop, motivation,
    progression pressure, balance tradeoff, or player feedback timing.

--- a/.agents/skills/prd/SKILL.md
+++ b/.agents/skills/prd/SKILL.md
@@ -223,4 +223,4 @@ Critical dimensions that cannot be `❌`:
 ## Guardrails
 
 - Keep PRDs aligned with repo truth and acceptance evidence.
-- Do not let generated PRD content replace `.pm` task truth in oasis7.
+- Do not let generated PRD content replace GitHub-backed task truth in oasis7.

--- a/.agents/skills/repo-owned-workflow-router/SKILL.md
+++ b/.agents/skills/repo-owned-workflow-router/SKILL.md
@@ -5,7 +5,7 @@ description: Use when a bound oasis7 task needs phase selection across repo-owne
 
 > Workflow authority: `doc/engineering/workflow/source-of-truth.md` is the single normative workflow spec. Keep this skill as short operational guidance only; if behavior changes, update source-of-truth first, then sync this file.
 
-> GitHub PM migration note: route decisions write to GitHub task issue evidence comments, and GitHub issue evidence comment (mandatory) is the active task-truth writeback sink for router outputs. Queue/status drift should be checked through `./scripts/pm/github-project-workflow.sh ... audit` when task status or Project-backed PM state changes.
+> PM truth: route decisions write to GitHub task issue evidence comments, and GitHub issue evidence comment (mandatory) is the active task-truth writeback sink for router outputs. Queue/status drift should be checked through `./scripts/pm/github-project-workflow.sh ... audit` when task status or Project-backed PM state changes.
 
 
 # Repo-Owned Workflow Router
@@ -53,7 +53,7 @@ Check the task in this order:
    - Apply this router step after `default-workflow-bootstrap`; read-only professional/domain judgments must already be task-bound.
    - Dispatch the matching bounded role slice.
    - Unbound read-only professional questions are invalid under the always-bootstrap workflow; bootstrap first, then route and record the slice contract in GitHub task issue evidence comments.
-   - Compatibility marker: record the slice contract in `.pm` now means record it in the GitHub issue evidence comment sink backed by `.pm/github-project-sync/tasks.json`, not recreate retired `.pm/tasks/*` task files.
+   - Record the slice contract in the GitHub issue evidence comment sink backed by `.pm/github-project-sync/tasks.json`.
    - Skip professional dispatch only for pure fact lookup or command-output restatement.
 1. `bounded-brainstorming`
    - Use when direction is still fuzzy, scope is too large, or the problem is inherently option-heavy or visual.
@@ -90,7 +90,7 @@ Ask and answer these in order:
 10. Is this task editing local skill surfaces or skill governance?
 11. Did this step produce reusable learning, a follow-up idea, repeated
     friction, or a failure signature that should use the learning-intake
-    ladder: no-op, short execution-log note, reflection signal,
+    ladder: no-op, short GitHub issue evidence note, reflection signal,
     task-scoped `working_memory`, or candidate task/memory promotion?
 
 ## Expected Output
@@ -122,11 +122,11 @@ WORKFLOW ROUTE DECIDED
 ## Subagent Slice Plan (If Needed)
 - role:
 - slice type:
-- model configuration: compatibility marker; fill the intended/actual fields below
+- model configuration: fill the intended/actual fields below
 - intended model configuration: workflow source-of-truth `Default subagent runtime` by default; record reason for any requested override
 - actual dispatched model/reasoning: record the selected model/reasoning when the tool permits and reports it; otherwise record `inherited/unverified` plus the connector/tool limitation, including cases where selection was requested but actual dispatch cannot be verified
 - context delivery mode: full-thread/full-history fork by default; explicit context packet is delivery supplement/fallback only, with reason recorded
-- mandatory context packet: compatibility marker; fill the mandatory context checklist/packet below
+- mandatory context packet: fill the mandatory context checklist/packet below
 - mandatory context checklist/packet:
   - identity and authority:
   - workflow governance:

--- a/.agents/skills/requesting-repo-owned-review/SKILL.md
+++ b/.agents/skills/requesting-repo-owned-review/SKILL.md
@@ -5,7 +5,7 @@ description: Use when a branch is about to create a PR and must collect fresh in
 
 # Requesting Repo-Owned Review
 
-> GitHub PM migration note: PM workflow/script changes should include repository-health review and should treat GitHub Project audit evidence as part of the review target when queue/status semantics changed.
+> PM truth: PM workflow/script changes should include repository-health review and should treat GitHub Project audit evidence as part of the review target when queue/status semantics changed.
 
 Use this skill when the work is about to enter the GitHub PR path.
 
@@ -140,7 +140,7 @@ role reviews and addressing findings:
 ## Known Failure Modes
 
 - Treating the local role review as optional when the branch is already on the PR path.
-- Recording a review request in chat only, leaving `.pm` without the evidence packet required by preflight.
+- Recording a review request in chat only, leaving GitHub task issue evidence comments without the packet required by preflight.
 - Selecting roles from convenience instead of changed paths, role ownership, task history, and user-facing claims.
 - Resolving or dismissing GitHub review threads based only on local repo-owned review evidence.
 

--- a/.agents/skills/synchronization-algorithms/SKILL.md
+++ b/.agents/skills/synchronization-algorithms/SKILL.md
@@ -15,7 +15,7 @@ In oasis7, this is a runtime domain skill for state consistency and authority
 semantics. It is domain-triggered and non-default; it does not replace
 `runtime_engineer` ownership of runtime correctness.
 
-Use it only inside the bound `.pm` task/worktree and tie conclusions to current
+Use it only inside the bound GitHub-backed task/worktree and tie conclusions to current
 runtime code, tests, design docs, traces, or playtest evidence.
 
 ## When to Use

--- a/.agents/skills/verification-before-completion/SKILL.md
+++ b/.agents/skills/verification-before-completion/SKILL.md
@@ -5,7 +5,7 @@ description: Use when about to claim a task is complete, tests passed, a branch 
 
 > Workflow authority: `doc/engineering/workflow/source-of-truth.md` is the single normative workflow spec. Keep this skill as short operational guidance only; if behavior changes, update source-of-truth first, then sync this file.
 
-> GitHub PM migration note: if the claim depends on PM queue/status state, include `./scripts/pm/github-project-workflow.sh ... audit` as a fresh verification input.
+> PM truth: if the claim depends on PM queue/status state, include `./scripts/pm/github-project-workflow.sh ... audit` as a fresh verification input.
 
 
 # Verification Before Completion

--- a/.agents/skills/writing-repo-owned-skills/SKILL.md
+++ b/.agents/skills/writing-repo-owned-skills/SKILL.md
@@ -5,7 +5,7 @@ description: Use when creating a new skill under .agents/skills, replacing an up
 
 # Writing Repo-Owned Skills
 
-> GitHub PM migration note: skill edits must not redefine the Project-backed PM migration contract; link back to `doc/engineering/workflow/source-of-truth.md#123-github-project-backed-pm-migration` and keep this surface operational.
+> PM truth: skill edits must not redefine the GitHub Project-backed PM contract; link back to `doc/engineering/workflow/source-of-truth.md#123-github-project-backed-pm-contract` and keep this surface operational.
 
 ## When to Use
 
@@ -62,7 +62,7 @@ Do not directly borrow:
 
 - mandatory subagent-based failing-test-first loops as a hard gate
 - generic deployment advice unrelated to oasis7
-- any process that competes with `AGENTS.md + .pm + GitHub PR review`
+- any process that competes with `AGENTS.md + GitHub-backed task truth + GitHub PR review`
 
 ## Oasis7-Specific Surfaces
 

--- a/.pm/github-project-sync/tasks.json
+++ b/.pm/github-project-sync/tasks.json
@@ -12638,6 +12638,57 @@
       "title": "add local changed-path required validation recommendation",
       "worktree_hint": "/home/scc/worktrees/oasis7-engineering-workflow-friction-priority-burn-down"
     },
+    "task_f8c51bd6be804fe5bf89b233a70c7349": {
+      "acceptance": [
+        "Formal workflow source-of-truth keeps only GitHub Project / issue comments semantics outside minimal changelog history.",
+        "Active repo-owned workflow docs and skills no longer instruct readers to reinterpret .pm/tasks or execution logs as compatibility aliases."
+      ],
+      "claim_verifications": [
+        {
+          "allowed_to_claim": true,
+          "blocked_phrase": "Do not claim the task is complete.",
+          "claim_message": "Fresh verification passed; the task can now be claimed complete.",
+          "claim_type": "task_complete",
+          "status": "verified",
+          "success_phrase": "Fresh verification passed; the task can now be claimed complete.",
+          "task_uid": "task_f8c51bd6be804fe5bf89b233a70c7349",
+          "verification_exit_code": 0,
+          "verified_at": "2026-06-30T19:17:29+08:00",
+          "verify_command": "rtk proxy bash scripts/pm/workflow-behavior-eval.sh"
+        }
+      ],
+      "created_at": "2026-06-30T18:54:50+08:00",
+      "doc_refs": [
+        "doc/engineering/workflow/source-of-truth.md"
+      ],
+      "evidence_comments": [
+        "https://github.com/eng-cc/oasis7/issues/1640#issuecomment-4842624894",
+        "https://github.com/eng-cc/oasis7/issues/1640#issuecomment-4842628271",
+        "https://github.com/eng-cc/oasis7/issues/1640#issuecomment-4842780176",
+        "https://github.com/eng-cc/oasis7/issues/1640#issuecomment-4842789367"
+      ],
+      "evidence_sink": "https://github.com/eng-cc/oasis7/issues/1640",
+      "handoff_to": [],
+      "issue_number": 1640,
+      "issue_url": "https://github.com/eng-cc/oasis7/issues/1640",
+      "last_claim_verification_at": "2026-06-30T19:17:29+08:00",
+      "last_closed_at": "2026-06-30T19:17:32+08:00",
+      "last_evidence_at": "2026-06-30T19:17:32+08:00",
+      "last_started_at": "2026-06-30T18:55:13+08:00",
+      "module": "engineering",
+      "owner_role": "tpm",
+      "priority": "P2",
+      "project_item_id": "PVTI_lAHOALIiks4Bb-WtzgxRVCQ",
+      "related_prd": [],
+      "source_refs": [
+        "doc/engineering/workflow/source-of-truth.md"
+      ],
+      "status": "done",
+      "task_uid": "task_f8c51bd6be804fe5bf89b233a70c7349",
+      "title": "Remove retired PM compatibility wording from formal workflow docs",
+      "updated_at": "2026-06-30T19:17:32+08:00",
+      "worktree_hint": "/Users/scc/ccwork/worktrees/oasis7-engineering-workflow-source-truth-new-semantics"
+    },
     "task_f8cc5a3ee1cb5adda34ca0c635a8e58f": {
       "content_id": "I_kwDORHhWec8AAAABHFW37Q",
       "execution_log_path": ".pm/tasks/task_f8cc5a3ee1cb5adda34ca0c635a8e58f.execution.md",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,15 +12,15 @@
 5. 仓库变更任务按统一阶段推进：bootstrap → router →（可选）brainstorming/TDD → execution → verification → closeout。
 6. 禁止在 `main` 分支 / 主 worktree 直接修改任何文件；所有改动必须先创建或进入对应 task worktree。
 7. 不得在 bootstrap 前先把请求判定为“只读/聊天/纯事实/专业判断”来决定是否需要 task/worktree；任何看似允许只读绕过的旧说明，都以 `doc/engineering/workflow/source-of-truth.md` 当前版本为准。
-8. 还没决定创建 `.pm` task 的顺手 TODO / discovery，用 `./scripts/pm/capture-todo.sh --source-ref <path> --summary "<text>"` 先记录为 `reflection` signal；只有显式 `--create-task` 或后续 `new-task` 才进入正式 task 真值。
+8. 还没决定创建 GitHub-backed task 的顺手 TODO / discovery，用 `./scripts/pm/capture-todo.sh --source-ref <path> --summary "<text>"` 先记录为 `reflection` signal；只有显式 `--create-task` 或后续 `new-task` 才进入正式 task 真值。
 9. 所有 gate、责任边界、失败回退路径，统一引用：
    - 阶段图：`doc/engineering/workflow/source-of-truth.md#1-phase-diagram`
    - 责任边界：`doc/engineering/workflow/source-of-truth.md#2-responsibility-boundary`
    - 必需/可选 gate：`doc/engineering/workflow/source-of-truth.md#3-gates`
    - 失败回退：`doc/engineering/workflow/source-of-truth.md#4-failure-and-rollback-paths`
-   - 关键规范细节（worktree/执行证据/closeout/PR）：`doc/engineering/workflow/source-of-truth.md#5-normative-details-from-legacy-agents-workflow`
+   - 关键规范细节（worktree/执行证据/closeout/PR）：`doc/engineering/workflow/source-of-truth.md#5-normative-details`
    - skill 阶段映射：`doc/engineering/workflow/source-of-truth.md#11-skill-map-by-phase`
-   - 语义迁移核对清单：`doc/engineering/workflow/source-of-truth.md#8-semantic-migration-checklist`
+   - 工作流契约核对清单：`doc/engineering/workflow/source-of-truth.md#8-workflow-contract-checklist`
 10. 流程改动必须先改 source-of-truth，再同步脚本/技能/其余文档。
 11. PR 创建后默认进入正常 PR CI / comments watch-fix-merge 主链；除非 task/用户明确说明该 PR 只是为了触发手动打包/发布 CI，否则 TPM 必须持续盯 required checks、mergeability、PR comments 与 review threads；`REVIEW_REQUIRED` 只作为状态信息回报，不是 block 项。`mergeStateStatus=BEHIND` 本身也不是 block 项；若 PR 仍然 mergeable 且 GitHub/repo merge path 接受直接合入，可不先 rebase。若 `mergeStateStatus=BLOCKED` 仅因缺少 review approval，且用户/task policy 明确授权跳过 approval，则这是正常流程，可在复查 checks、mergeability、requested changes、comments/thread 后使用 repo admin merge path。checks 失败、requested changes、不可合并、存在 actionable comments / unresolved blocking threads，或 GitHub merge API/branch protection 明确要求先更新分支/解决冲突时，才回到修复/验证/推送、branch sync 或 comment closeout 循环；通过且 comments/thread 已收口后合入并清理 worktree。
 12. 单模块闭环测试不等于发布放行：任务可用 `module_required` / `module_full` 快速迭代，但跨模块行为、玩家可发布、真实节点/浏览器/服务信心必须按验证矩阵升级到 `integration_required` / `release_full`。
@@ -33,8 +33,8 @@
 - subagent 派发授权：oasis7 项目策略已授权 TPM 在 workflow 要求时直接派发所需 bounded 专业 subagent slice，不需要逐次向用户请求额外许可；本段即为用户对本仓库 workflow subagent 派发的显式、持续授权，当工具/运行时策略要求 “explicit user request for sub-agents, delegation, or parallel agent work” 时，本段应被视为已满足该条件；若当前运行环境、connector 或工具策略仍阻止实际派发，TPM 必须在 GitHub Project-backed task truth 或 source-of-truth 指定的 fallback sink 记录 intended dispatch、actual limitation、fallback evidence path 和 attribution boundary，且不得把 fallback 下的 TPM 分析包装成专业角色结论。
 - subagent 默认模型：具体默认值以 `.codex/config.toml` 的 `[workflow.subagent_runtime]` 为唯一配置真值，并由 `doc/engineering/workflow/source-of-truth.md#52-tpm-planning-and-subagent-dispatch` 的 `Default subagent runtime` policy 引用；专业角色 slice 默认请求该 runtime，若用户要求其他模型、slice 明确需要更强/更快/更省配置，当前 subagent 工具只能继承父线程模型，或请求选择后无法验证实际派发模型，必须在 slice contract 同时记录 intended model、actual dispatched model/reasoning 与原因；无法验证实际模型时记录 `actual model: inherited/unverified`。
 - subagent 默认上下文：专业角色 slice 默认使用 full-thread/full-history fork 或最接近的等价上下文；slice contract 仍必须记录 mandatory context checklist。手工显式 context packet 只能作为补充或 fallback，且必须记录为什么不能使用默认 fork（例如工具限制、上下文安全、模型选择冲突或默认 fork 卡住）。
-- 兼容契约词：`mandatory context packet` 在当前语义下指必须记录的 mandatory context checklist/packet，不等同于必须手工组装显式上下文包。
-- 兼容契约词：TPM 的 TODO decomposition、subagent slice contracts、mandatory context packet 和 integration order 必须先写入 GitHub Project-backed task truth 或 source-of-truth 指定的 fallback sink；其中 `mandatory context packet` 按当前语义解释为 mandatory context checklist/packet。
+- `mandatory context packet`：指必须记录的 mandatory context checklist/packet，不等同于必须手工组装显式上下文包。
+- TPM 的 TODO decomposition、subagent slice contracts、mandatory context packet 和 integration order 必须先写入 GitHub Project-backed task truth 或 source-of-truth 指定的 fallback sink；其中 `mandatory context packet` 指 mandatory context checklist/packet。
 - 默认协作口径：`tpm` 主 Agent + 专业角色 subagents；TPM 只做 workflow coordination / integration。对已绑定 task 或会改变仓库状态的工作，TPM 的 TODO decomposition、subagent slice contracts、mandatory context checklist/packet 和 integration order 必须先写入 GitHub Project-backed task truth 或 source-of-truth 指定的 fallback sink，其他 formal sink 只能补充，不能替代正式 task evidence sink。
 - 专业结论来源约束：产品/系统设计、玩法设计、游戏视觉/交互、runtime、blockchain ops、WASM、agent、viewer、QA、repository health、LiveOps/community 等专业分析、实现、验证、评审或对外口径，必须来自对应专业角色 slice；TPM 只能合流和标注证据来源。
 - 创建 PR 前必须通过 `.agents/skills/requesting-repo-owned-review/SKILL.md` 新建/派发本地相关专业角色 subagent review；TPM 必须合流 findings/no_findings/residual_risk，并在有效 findings 整改或基于证据驳回后，写入 `Pre-PR Local Role Review: passed` evidence packet，随后才能进入 `prepare-task-pr --create`。

--- a/doc/engineering/workflow/source-of-truth.md
+++ b/doc/engineering/workflow/source-of-truth.md
@@ -11,14 +11,6 @@ Mandatory rule:
 2. After this file is updated, sync all related scripts/docs/skills to match.
 3. PRs that change workflow scripts without updating this file are invalid.
 
-Step 3 migration note:
-As of v1.5.2, repo-local `.pm/tasks/*` task files are retired. Outside the
-GitHub Project migration section, older references to
-`.pm/tasks/<TASK-UID>.yaml`, `.pm/tasks/<TASK-UID>.execution.md`, `.pm task`,
-or `.pm execution log` are legacy wording and must be read as the current
-GitHub Project-backed task truth plus the evidence sink documented in
-section 1.2.3. Do not recreate `.pm/tasks/*` for normal workflow.
-
 ## 1. Phase Diagram
 ```mermaid
 flowchart TD
@@ -83,8 +75,8 @@ small question into a heavyweight workflow.
 - Once a request is already inside the bound task/worktree, pure fact lookup,
   path lookup, command-output restatement, or mechanical evidence collection may
   use the objective-fact fast path: TPM gathers the evidence, answers directly,
-  and records a short execution-log note only when the fact materially affects
-  task truth, PR evidence, or a future decision.
+  and records a short GitHub issue evidence note only when the fact materially
+  affects task truth, PR evidence, or a future decision.
 - Read-only professional/domain questions still require a matching role slice,
   but the default slice should be bounded and time-boxed: one concrete question,
   explicit evidence paths, `findings/no_findings` or verdict return, and no file
@@ -116,7 +108,7 @@ or reusable failure signature:
 
 1. **No-op**: choose this when the observation is transient, already captured by
    the current command output, or has no likely reuse value.
-2. **Short execution-log note**: choose this when the observation changes the
+2. **Short GitHub issue evidence note**: choose this when the observation changes the
    current task's route, verification interpretation, PR evidence, or handoff,
    but should not outlive the task as a separate signal.
 3. **Reflection signal**: choose this for useful follow-up ideas, repeated
@@ -132,7 +124,7 @@ or reusable failure signature:
 5. **Candidate task or memory promotion**: choose this only after owner review
    when the signal or working memory is stable enough to become executable
    backlog work or long-term role memory. Promotion must preserve source refs
-   and must not bypass owner, role, PRD/project, or `.pm` truth.
+   and must not bypass owner, role, PRD/project, or GitHub-backed task truth.
 
 Learning intake is not a new mandatory gate before every answer. It is a
 closeout habit for moments where the task produced reusable knowledge. When the
@@ -143,14 +135,10 @@ question or observation, evidence path or command, answer or decision, and
 whether it changes task truth. Use the full bootstrap/router packets only when
 the owner, scope, route, professional slice plan, or PR chain actually changes.
 
-### 1.2.3 GitHub Project-Backed PM Migration
-The repository has migrated project management from file-backed `.pm` task
-objects to GitHub Issues + GitHub Project. GitHub Project is the authoritative active-work queue. Step 3 deletion is forbidden until all of these gates pass;
-Step 3 retired repo-local `.pm/tasks/*` task files after full historical
-Project coverage and archive export. GitHub Project is now the authoritative
-active-work queue and external state gate.
-
-Authoritative after Step 3:
+### 1.2.3 GitHub Project-Backed PM Contract
+GitHub Issues + GitHub Project are the authoritative project-management
+surface for oasis7 tasks. Local files under `.pm/github-project-sync/` are a
+deterministic mirror/cache for scripts and audits, not a parallel task queue.
 
 - GitHub Issue is the task collaboration envelope.
 - GitHub Project item fields are authoritative for active queue/status views:
@@ -161,74 +149,39 @@ Authoritative after Step 3:
 - `.pm/github-project-sync/tasks.json` is the deterministic local mapping cache
   from `task_uid` to issue/project item handles.
 - `.pm/github-project-sync/task-archive.jsonl` is the immutable repo-local
-  archive for retired task metadata and historical execution logs. It is an
-  audit bridge, not a new active planning queue.
-- Active lifecycle wrappers `new-task.sh`, `move-task.sh`,
-  `append-execution-log.sh`, `workflow-report.sh`, `task-closeout.sh`, and
-  `claim-ready.sh` must use GitHub Issues/Project plus
-  `.pm/github-project-sync/tasks.json`; they must not recreate `.pm/tasks/*`.
-
-Retired after Step 3:
-
-- `.pm/tasks/<TASK-UID>.yaml` and `.pm/tasks/<TASK-UID>.execution.md` are no
-  longer active task truth and must not be recreated for normal workflow.
-- New execution evidence should be attached to the GitHub Issue/Project-backed
-  task envelope or to a deterministic replacement sink documented here before
-  use.
+  archive for historical task metadata and evidence records. It is an audit
+  bridge, not a planning queue.
+- Lifecycle wrappers `new-task.sh`, `move-task.sh`, `append-execution-log.sh`,
+  `workflow-report.sh`, `task-closeout.sh`, and `claim-ready.sh` use GitHub
+  Issues/Project plus `.pm/github-project-sync/tasks.json`.
+- Execution evidence is recorded in GitHub task issue evidence comments.
 - role memory, task-scoped `working_memory`, signals, stage/gate state, and
   this workflow source-of-truth remain repo-local unless a later source-of-truth
   update explicitly migrates them.
 
 Deterministic script contract:
 
-- `./scripts/pm/github-project-workflow.sh ... sync` applies repo-local task
-  metadata or the Step 3 archive to GitHub Issues/Project items idempotently.
+- `./scripts/pm/github-project-workflow.sh ... sync` applies mapping/archive
+  task metadata to GitHub Issues/Project items idempotently.
 - `./scripts/pm/github-project-workflow.sh ... audit` verifies the selected
   task set, mapping, and GitHub Project item/field state agree. Its default
   path must be selected-task / mapping-targeted and must not list the full
-  Project during ordinary task closeout or PR readiness checks. After Step 3 it
-  must load task truth from archive + mapping, and fail if repo-local retired
-  `.pm/tasks/task_*.yaml` or `*.execution.md` files are present.
-- `./scripts/pm/github-project-workflow.sh ... step3-gate` remains the hard
-  full historical coverage check after deletion; it may list the full Project
-  and uses the archive fallback when `.pm/tasks/*` is absent.
-- `./scripts/pm/github-project-retire-tasks.sh --delete` archives task yaml and
-  execution logs to `.pm/github-project-sync/task-archive.jsonl` before deleting
-  repo-local `.pm/tasks/*`. If the archive already exists, it must preserve
-  existing records and upsert only the task UIDs represented by current retired
-  task files.
+  Project during ordinary task closeout or PR readiness checks. It loads task
+  truth from archive + mapping and fails if local task-file artifacts reappear.
+- `./scripts/pm/github-project-workflow.sh ... step3-gate` is the full
+  historical coverage audit for the GitHub Project/mapping/archive set.
+- `./scripts/pm/github-project-retire-tasks.sh --delete` maintains
+  `.pm/github-project-sync/task-archive.jsonl`; if the archive already exists,
+  it must preserve existing records and upsert only the task UIDs represented by
+  the current input set.
 - `./scripts/pm/github-project-task.py` is the active task lifecycle adapter:
   create issue/project task, append evidence comments, move Project status, and
   close tasks after fresh verification.
 - `scripts/prepare-task-pr.sh` must read passed local role review packets from
-  GitHub task issue evidence comments and mapping-backed task truth. The review
-  gate stays the same; only the evidence read path changes.
+  GitHub task issue evidence comments and mapping-backed task truth.
 - All future GitHub-backed create/move/report/closeout helpers must use
   deterministic `gh`/GitHub API paths, preserve or recover the `task_uid`
   mapping, and refuse ambiguous duplicate mappings.
-
-Step 3 deletion required these gates to pass:
-
-- New task gate: a script can create GitHub issue + Project item + `task_uid`
-  and enter the standard worktree chain deterministically.
-- Status gate: `candidate`, `committed`, `blocked`, `done`, and `deferred`
-  transitions are script-driven and Project/mapping/repo mirror state stays
-  idempotent.
-- Evidence gate: execution evidence has a proven repo-local or GitHub-backed
-  sink for slice contracts, verification, review, closeout, and PR packets.
-- PR gate: PR helpers can read required task metadata from the GitHub-backed
-  truth path or its deterministic local mirror.
-- Recovery gate: a missing local mapping can be recovered from GitHub Project
-  items and issue bodies without creating duplicates.
-- Audit gate: active tasks pass low-cost selected-task `audit`; historical
-  `done/deferred` tasks have an explicit archive/import policy and pass the
-  full `step3-gate`.
-- Reference gate: formal docs/project traces no longer rely on paths that would
-  be deleted, or their replacement trace target is explicitly documented.
-
-The full historical task set was explicitly imported for Step 3 coverage before
-local task-file retirement. Future bulk imports must still be explicit and
-audited because the repository can contain hundreds of historical tasks.
 
 ## 2. Responsibility Boundary
 - `tpm`: default main Agent / workflow coordinator / canonical integrator only; owns phase decision, role allocation, subagent dispatch, integration order, task-truth writeback, fresh-verification gate coordination, completion-claim coordination, and PR chain coordination.
@@ -301,7 +254,7 @@ audited because the repository can contain hundreds of historical tasks.
 - If scripts/skills/docs conflict with this file, this file wins.
 - Sync downstream artifacts immediately in the same change set where possible.
 
-## 5. Normative Details (from legacy AGENTS workflow)
+## 5. Normative Details
 ### 5.1 Worktree + task truth
 - Every user request uses a dedicated task worktree by default, regardless of whether the immediate answer is chat-only, read-only, fact lookup, professional analysis, implementation, verification, review, or external messaging.
 - Only explicit user authorization allows reuse of an existing task worktree.
@@ -318,11 +271,11 @@ audited because the repository can contain hundreds of historical tasks.
 - Project policy authorizes TPM to dispatch required bounded professional subagent slices directly whenever this workflow requires them; TPM must not pause for per-slice user permission. This project policy is an explicit standing user authorization to use subagents for workflow-required professional role slices; when a tool/runtime requires an "explicit user request for sub-agents, delegation, or parallel agent work", this policy satisfies that requirement for the matching repo-owned workflow slice. If the current runtime, connector, or tool policy still prevents actual subagent dispatch, TPM must record the intended dispatch, actual limitation, fallback evidence path, and attribution boundary in GitHub task issue evidence comments, and must not present TPM's own analysis as a professional role conclusion.
 - Each subagent slice must declare role, slice type, intended model configuration, actual dispatched model/reasoning, context delivery mode, mandatory context checklist/packet, write scope, return contract, validation command, GitHub task issue evidence sink, and integration order.
 - Default subagent runtime policy is defined only in `.codex/config.toml` under `[workflow.subagent_runtime]`. TPM should request that configured default for bounded professional slices when the available subagent tool permits model selection, unless the user explicitly requests another model or the slice contract records a concrete reason to use a stronger, faster, or cheaper model.
-- Compatibility marker: Any non-default subagent model or reasoning effort must be recorded in the slice contract.
+- Any non-default subagent model or reasoning effort must be recorded in the slice contract.
 - Any actual non-default subagent model or reasoning effort must be recorded in the slice contract with the reason, such as high-risk architecture/review work, simple read-only exploration, a user-specified override, a connector/tool limitation that forces inheritance from the parent thread, or a requested model/reasoning selection whose actual dispatch cannot be verified. If the actual dispatched model cannot be verified, the contract must say `actual model: inherited/unverified` and explain why.
 - Context delivery defaults to full-thread/full-history fork or the closest available equivalent so the subagent receives the same conversation and repository-governance context as TPM. The slice contract must still record a mandatory context checklist identifying the governance/task/user/repo/collaboration context the subagent is expected to have. A manually assembled explicit context packet is allowed only as a delivery supplement or fallback when full-history fork is unavailable, unsafe, stalled, or incompatible with required model/reasoning selection; the slice contract must record that fallback reason.
-- Compatibility marker: mandatory context packet means the recorded mandatory context checklist/packet, not necessarily a manually assembled explicit delivery packet.
-- Compatibility marker: The mandatory context packet must include:
+- Mandatory context packet means the recorded mandatory context checklist/packet, not necessarily a manually assembled explicit delivery packet.
+- The mandatory context packet must include:
 - The mandatory context checklist/packet must include:
   - identity and authority: assigned role, role card path, owner role, and TPM integration owner
   - workflow governance: `AGENTS.md`, `doc/engineering/workflow/source-of-truth.md`, and the selected workflow skills
@@ -337,7 +290,7 @@ audited because the repository can contain hundreds of historical tasks.
 - If the plan changes during execution, TPM must append a GitHub issue evidence comment before continuing the changed work.
 - Pre-task discoveries, loose TODOs, and follow-up ideas found before an owner decides to create a GitHub-backed task should be captured with `./scripts/pm/capture-todo.sh --source-ref <path> --summary "<text>"`. This records a `source_type=reflection` signal by default and must not be treated as committed task truth until explicitly promoted with `--create-task` or another task-creation path.
 - After task truth exists, use the section 1.2.2 learning-intake ladder for
-  discoveries and follow-ups: no-op, short execution-log note, reflection
+  discoveries and follow-ups: no-op, short GitHub issue evidence note, reflection
   signal, task-scoped `working_memory`, or owner-reviewed candidate task/memory
   promotion. Do not skip directly from a lightweight observation to committed
   task truth unless the owner explicitly selects that promotion.
@@ -363,7 +316,7 @@ audited because the repository can contain hundreds of historical tasks.
 ### 5.3 Execution evidence
 - Atomic steps should be recorded with `Action / Validation Command / Expected Result / Actual Result`.
 - If blocked, also record `Blocker / Next Action`.
-- For tasks started with the `2026-05-23` execution-log template or later, these fields are mandatory per entry.
+- These fields are mandatory for GitHub task issue evidence entries.
 
 ### 5.4 Claim / closeout chain
 - Before completion claims, run fresh verification (prefer `./scripts/pm/claim-ready.sh --claim-type <type> --verify-command "<cmd>"` when applicable).
@@ -427,34 +380,27 @@ audited because the repository can contain hundreds of historical tasks.
 
 ## 7. Change Log
 - **v1.5.2 (2026-06-30)**
-  - Hardened the post-Step 3 contract so default PM audit and lint fail when
-    retired `.pm/tasks/task_*.yaml` or `*.execution.md` files reappear.
-  - Clarified that active module grouping and subagent/evidence sinks use
-    GitHub Project fields, GitHub task issue evidence comments, and
-    `.pm/github-project-sync/tasks.json`, not repo-local task files.
-  - Required task retirement archive updates to preserve existing archive
-    records and upsert only currently retired task UIDs.
+  - Hardened the GitHub Project-backed PM contract so audit/lint reject local
+    task-file artifacts and active evidence uses GitHub task issue comments.
+  - Required archive updates to preserve existing records and upsert only the
+    task UIDs represented by the current input set.
 - **v1.5.1 (2026-06-30)**
-  - Retired repo-local `.pm/tasks/*` files after GitHub Project Step 3 export.
-    Historical task metadata and execution logs now live in
-    `.pm/github-project-sync/task-archive.jsonl`; GitHub Project/Issues plus
-    `.pm/github-project-sync/tasks.json` are the active PM path.
-  - Replaced active PM lifecycle wrappers with GitHub Project-backed task
-    create/evidence/status/closeout behavior and kept PR preflight review
-    evidence gates by reading GitHub issue comments.
+  - Completed the GitHub Project PM transition: GitHub Issues/Project plus
+    `.pm/github-project-sync/tasks.json` became the active PM path, with
+    historical records archived in `.pm/github-project-sync/task-archive.jsonl`.
+  - Moved task create/evidence/status/closeout and PR preflight evidence reads
+    to the GitHub-backed path.
 - **v1.5.0 (2026-06-29)**
-  - Introduced the GitHub Project-backed PM migration contract: Project is the
-    authoritative active queue during Step 2, repo-local `.pm` remains the
-    execution/audit sink until Step 3 gates pass, and deterministic
-    sync/audit/step3-gate scripts are required before deleting task files.
+  - Introduced the GitHub Project-backed PM migration plan and deterministic
+    sync/audit/step3-gate scripts.
 - **v1.4.28 (2026-06-27)**
   - Added the Learning Intake / Loop Closeout ladder so task learning can flow
-    to no-op, short execution-log note, reflection signal, task-scoped
+    to no-op, short GitHub issue evidence note, reflection signal, task-scoped
     `working_memory`, or owner-reviewed candidate task/memory without creating
     heavy ceremony for every small loop.
 - **v1.4.27 (2026-06-24)**
   - Added friction controls after task truth so objective fact lookups, bounded read-only role slices, and small follow-ups do not become heavyweight workflow by default.
-  - Added `.pm` task `module` as the default large-module marker for grouping, reporting, and parallel work queues.
+  - Added GitHub Project `module` as the default large-module marker for grouping, reporting, and parallel work queues.
   - Clarified that module-local test evidence does not imply integration or release readiness.
 - **v1.4.26 (2026-06-23)**
   - Tightened pre-PR role inference backstops for producer product/system docs, viewer/launcher implementation/docs/scripts, and agent/subagent workflow contract surfaces.
@@ -471,7 +417,7 @@ audited because the repository can contain hundreds of historical tasks.
   - Added surface-specific verification matrix expectations for gameplay, runtime, WASM, UI/visual, and manual packaging/release ops evidence.
   - Added batching/timeout policy for large all-role review dispatches and stronger manual packaging hold ownership/resume criteria.
 - **v1.4.23 (2026-06-22)**
-  - Added file-based review package and lightweight slice ledger artifacts for pre-PR local role review, while keeping `.pm/tasks/<TASK-UID>.execution.md` canonical.
+  - Added file-based review package and lightweight slice ledger artifacts for pre-PR local role review.
   - Required pre-PR role review packets to record `Review Package`, per-role dual `Review Verdicts`, and `Slice Ledger` fields.
   - Clarified that dual verdicts strengthen involved-role review and do not replace oasis7 professional role ownership with a generic reviewer.
 - **v1.4.22 (2026-06-18)**
@@ -510,11 +456,11 @@ audited because the repository can contain hundreds of historical tasks.
 - **v1.4.11 (2026-06-03)**
   - Replaced the optional/risk-based local supplemental review gate with a required pre-PR local role-subagent review gate.
   - Removed the Copilot review request from the standard PR helper flow.
-  - Required `prepare-task-pr.sh --create` to verify passed local role review evidence in the task execution log before creating a PR.
+  - Required `prepare-task-pr.sh --create` to verify passed local role review evidence before creating a PR.
 - **v1.4.10 (2026-06-03)**
   - Updated the default subagent runtime policy.
   - Consolidated synced guidance, templates, and workflow eval checks to reference the section 5.2 `Default subagent runtime` policy instead of duplicating the concrete model string.
-  - Added the `capture-todo.sh` pre-task discovery intake path for loose TODOs and follow-up ideas that should become `reflection` signals before any explicit `.pm` task promotion.
+  - Added the `capture-todo.sh` pre-task discovery intake path for loose TODOs and follow-up ideas that should become `reflection` signals before explicit task promotion.
   - 2026-06-08 amendment: moved the concrete default subagent runtime value into the repo-tracked `.codex/config.toml` `[workflow.subagent_runtime]` block so the model configuration has one canonical source.
   - 2026-06-08 amendment: updated the workflow source-of-truth and workflow eval contract to reference the config-backed policy instead of carrying the concrete runtime value in prose.
 - **v1.4.9 (2026-06-02)**
@@ -522,12 +468,12 @@ audited because the repository can contain hundreds of historical tasks.
   - Required subagent slice contracts to distinguish intended default model from actual dispatched model, including inherited/unverified connector cases.
   - Made full-thread/full-history context the default subagent context delivery mode, with mandatory context checklist recording and explicit context packets as delivery supplement/fallback only when recorded.
 - **v1.4.8 (2026-06-01)**
-  - Required every user request to create or enter standard task worktree / `.pm` task truth before substantive handling, including read-only, chat-only, and pure fact lookup requests.
-  - Removed the read-only/chat-only bypass for `default-workflow-bootstrap`; read-only professional slices now record their contract and sink in `.pm/tasks/<TASK-UID>.execution.md`.
+  - Required every user request to create or enter standard task worktree/task truth before substantive handling, including read-only, chat-only, and pure fact lookup requests.
+  - Removed the read-only/chat-only bypass for `default-workflow-bootstrap`.
   - Clarified that professional routing still happens after bootstrap, but no request is handled outside task/worktree truth.
 - **v1.4.7 (2026-06-01)**
   - Defined the sink for unbound read-only professional slices as the role-tagged user-facing answer or preserved chat/thread transcript. Superseded by v1.4.8, which forbids unbound read-only professional slices.
-  - Clarified that `.pm` execution-log sinks are mandatory for task-bound or repository-changing subagent work, not for standalone read-only professional answers. Superseded by v1.4.8, which requires `.pm` task truth for every request.
+  - Clarified task-bound evidence sink expectations for repository-changing subagent work. Superseded by v1.4.8, which requires task truth for every request.
 - **v1.4.6 (2026-06-01)**
   - Added the default subagent runtime policy.
   - Required slice contracts to record model configuration and reasons for non-default model/reasoning overrides.
@@ -546,14 +492,14 @@ audited because the repository can contain hundreds of historical tasks.
   - Added the normative skill map by workflow phase so each core skill has an explicit trigger, requiredness level, and evidence sink.
   - Clarified that specialist skills are domain-triggered through TPM routing rather than mandatory default workflow phases.
 - **v1.4.1 (2026-06-01)**
-  - Tightened TPM planning governance: TODO decomposition, subagent slice contracts, and integration order must be written to the task execution log before delegated work begins.
-  - Clarified that other formal sinks may supplement but cannot replace `.pm/tasks/<TASK-UID>.execution.md` for task execution truth.
+  - Tightened TPM planning governance: TODO decomposition, subagent slice contracts, and integration order must be written to the task evidence sink before delegated work begins.
+  - Clarified that other formal sinks may supplement but cannot replace canonical task evidence.
 - **v1.4.0 (2026-06-01)**
   - Added `tpm` as the default main Agent / orchestrator / canonical integrator.
   - Required all professional roles to participate as bounded subagent slices under TPM coordination.
 - **v1.3.0 (2026-06-01)**
   - Removed the `trivial` / `non-trivial` workflow split for repository-changing work.
-  - Required every repository-changing request to enter the standard task worktree + `.pm` task flow before edits begin.
+  - Required every repository-changing request to enter the standard task worktree + task flow before edits begin.
   - Kept read-only inspection and chat-only answers outside repository writeback requirements. Superseded by v1.4.8, which requires task/worktree truth for every request.
 - **v1.2.3 (2026-05-28)**
   - Required all file edits to happen from a task worktree instead of the `main` branch/worktree.
@@ -566,19 +512,20 @@ audited because the repository can contain hundreds of historical tasks.
   - Required new task worktrees to link ignored `target` to the repo-family shared cargo target cache.
 - **v1.1.0 (2026-05-25)**
   - Restored high-impact normative details that were previously only in `AGENTS.md` (worktree/task-truth policy, execution evidence fields, claim/closeout chain, PR/review chain).
-  - Clarified semantic migration to avoid policy loss after dedup.
+  - Clarified workflow policy preservation during dedup.
 - **v1.0.0 (2026-05-25)**
   - Created single source-of-truth workflow spec with phase diagram, role boundary, required/optional gates, and rollback paths.
   - Established policy: workflow changes must update this document first, then sync scripts/docs/skills.
 
 
-## 8. Semantic Migration Checklist
-This checklist records whether key legacy `AGENTS.md` workflow semantics were preserved here to avoid policy loss during deduplication.
+## 8. Workflow Contract Checklist
+This checklist records the active workflow contract so later edits do not lose
+required task, review, verification, or merge semantics.
 
-- [x] Single owner / single `.pm` task / single worktree / single PR chain.
+- [x] Single owner / single GitHub-backed task / single worktree / single PR chain.
 - [x] Standard task worktree flow for every user request, with explicit-reuse-only policy.
-- [x] Owner role selection and `.pm` task binding before implementation.
-- [x] TPM planning/TODO decomposition and subagent slice contracts written to `.pm` execution log before delegated execution.
+- [x] Owner role selection and GitHub-backed task binding before implementation.
+- [x] TPM planning/TODO decomposition and subagent slice contracts written to GitHub task issue evidence comments before delegated execution.
 - [x] TPM is workflow coordinator/integrator only; professional findings and judgments must come from matching role slices.
 - [x] Read-only professional/domain questions require matching bounded role slices after task/worktree bootstrap.
 - [x] Subagent intended model configuration defaults to the `Default subagent runtime` policy; actual dispatched model/reasoning and non-default/inherited/unverified rationale are recorded.

--- a/scripts/pm/workflow-behavior-eval.sh
+++ b/scripts/pm/workflow-behavior-eval.sh
@@ -132,19 +132,19 @@ checks = [
             "Module-local verification remains distinct from integration/release readiness claims",
             "### 1.2.2 Learning Intake / Loop Closeout",
             "no-op",
-            "short execution-log note",
+            "short GitHub issue evidence note",
             "Reflection signal",
             "Task-scoped `working_memory`",
             "Candidate task or memory promotion",
             "By default this creates `source_type=reflection` only",
             "The minimum record for a micro loop inside an already-bound task is:",
-            "### 1.2.3 GitHub Project-Backed PM Migration",
-            "GitHub Project is the authoritative active-work queue",
+            "### 1.2.3 GitHub Project-Backed PM Contract",
+            "GitHub Issues + GitHub Project are the authoritative project-management",
             "Task UID` remains the stable internal identity",
             "github-project-workflow.sh ... sync",
             "github-project-workflow.sh ... audit",
             "github-project-workflow.sh ... step3-gate",
-            "Step 3 deletion is forbidden until all of these gates pass",
+            "Lifecycle wrappers `new-task.sh`, `move-task.sh`",
         ],
     ),
     (
@@ -534,7 +534,7 @@ scenarios = [
             "Already-bound read-only professional/domain judgment",
             "read-only professional/domain judgments must already be task-bound",
             "Unbound read-only professional questions are invalid under the always-bootstrap workflow",
-            "record the slice contract in `.pm`",
+            "Record the slice contract in the GitHub issue evidence comment sink",
         ],
     },
     {
@@ -562,8 +562,8 @@ scenarios = [
         ],
     },
     {
-        "id": "working_memory_supplements_not_replaces_execution_log",
-        "expected_route": "learning intake -> task-scoped working_memory may supplement execution log only",
+        "id": "working_memory_supplements_not_replaces_issue_evidence",
+        "expected_route": "learning intake -> task-scoped working_memory may supplement GitHub task issue evidence only",
         "surface": "doc/engineering/workflow/source-of-truth.md",
         "required_markers": [
             "Task-scoped `working_memory`",
@@ -631,7 +631,7 @@ scenarios = [
         "required_markers": [
             "the task already has written scope in `prd.md`, `project.md`, a handoff, or GitHub-backed task truth",
             "Run a brief plan-gap review before editing",
-            "Do not create a second planning system outside `prd.md` / `project.md` / `.pm`.",
+            "Do not create a second planning system outside `prd.md` / `project.md` / GitHub-backed task truth.",
         ],
     },
     {


### PR DESCRIPTION
## Summary
- rewrite workflow source-of-truth PM section as the current GitHub Issues/Project contract
- remove retired `.pm/tasks` compatibility framing from active AGENTS, role, skill, and template guidance
- sync workflow behavior eval markers and GitHub-backed task mapping/closeout evidence

## Verification
- strict residue scan for retired compatibility/task-file wording: no matches
- `rtk proxy bash scripts/pm/workflow-behavior-eval.sh`: OK
- `rtk proxy bash scripts/lint-skills.sh && rtk proxy bash scripts/pm/lint.sh && rtk proxy bash scripts/doc-governance-check.sh && git diff --check`: OK
- `rtk proxy bash scripts/pm/github-project-workflow.sh --repo eng-cc/oasis7 --project-owner eng-cc --project-number 1 --mapping .pm/github-project-sync/tasks.json audit --json`: status ok, selected_count=40

Task: #1640
