### PR TITLE
Clarify retired playability manual trace

### DIFF
--- a/doc/core/reviews/round-003-reviewed-files.md
+++ b/doc/core/reviews/round-003-reviewed-files.md
@@ -234,7 +234,7 @@
 - `doc/playability_test_result/game-test.prd.md`
 - `doc/playability_test_result/game-test.project.md`
 - `doc/playability_test_result/playability_test_card.md`
-- `doc/playability_test_result/project.md`（retired former `playability_test_manual.md` trace）
+- `playability_test_manual.md` retired/deleted manual trace
 - `doc/playability_test_result/prd.index.md`
 - `doc/playability_test_result/prd.md`
 - `doc/playability_test_result/project.md`

--- a/doc/core/reviews/round-004-audit-progress-log.md
+++ b/doc/core/reviews/round-004-audit-progress-log.md
@@ -445,7 +445,7 @@
 | 2026-03-06 12:02:31 +0800 | codex | `doc/playability_test_result/prd.md` | pass | - | 模块主 PRD 的证据流程与追踪口径完整，未发现 D4 即时问题。 |
 | 2026-03-06 12:02:56 +0800 | codex | `doc/playability_test_result/project.md` | pass | - | 任务拆解含 PRD-ID 映射且状态链路清晰，未发现 D4 新问题。 |
 | 2026-03-06 12:03:28 +0800 | codex | `doc/playability_test_result/playability_test_card.md` | pass | - | 反馈模板字段完整且可直接用于人工采集，未涉及不可执行命令口径。 |
-| 2026-03-06 12:03:55 +0800 | codex | `doc/playability_test_result/project.md`（retired former `playability_test_manual.md` trace） | pass | - | 归档提示与当时主入口引用一致，未发现 D4 问题。 |
+| 2026-03-06 12:03:55 +0800 | codex | `playability_test_manual.md` retired/deleted manual trace | pass | - | 归档提示与当时主入口引用一致，未发现 D4 问题。 |
 | 2026-03-06 12:04:22 +0800 | codex | `doc/playability_test_result/card_2026_02_28_19_22_20.md` | pass | - | 实测卡片证据链（访问地址/日志/录屏/指标）完整，未涉及命令可执行性缺陷。 |
 | 2026-03-06 12:04:48 +0800 | codex | `doc/playability_test_result/card_2026_02_28_21_22_51.md` | pass | - | 长玩卡片给出完整量化指标与证据路径，未发现 D4 命令可执行性问题。 |
 | 2026-03-06 12:05:09 +0800 | codex | `doc/playability_test_result/card_2026_02_28_22_47_14.md` | pass | - | 卡片包含完整采样与结论字段，未发现 D4-001~D4-008 命令问题。 |

--- a/doc/core/reviews/round-004-reviewed-files.md
+++ b/doc/core/reviews/round-004-reviewed-files.md
@@ -250,7 +250,7 @@
 - `doc/playability_test_result/game-test.prd.md`
 - `doc/playability_test_result/game-test.project.md`
 - `doc/playability_test_result/playability_test_card.md`
-- `doc/playability_test_result/project.md`（retired former `playability_test_manual.md` trace）
+- `playability_test_manual.md` retired/deleted manual trace
 - `doc/playability_test_result/prd.index.md`
 - `doc/playability_test_result/prd.md`
 - `doc/playability_test_result/project.md`

--- a/doc/core/reviews/round-005-audit-progress-log.md
+++ b/doc/core/reviews/round-005-audit-progress-log.md
@@ -96,7 +96,7 @@
 | 2026-03-06 18:04:31 +0800 | cc | `doc/playability_test_result/card_2026_03_01_00_20_13.md` | pass | A5-002 | 按 ROUND-005 范围完成逐文档审读并回写 `审计轮次: 5`。 |
 | 2026-03-06 18:04:31 +0800 | cc | `doc/playability_test_result/game-test.project.md` | pass | A5-002 | 按 ROUND-005 范围完成逐文档审读并回写 `审计轮次: 5`。 |
 | 2026-03-06 18:04:31 +0800 | cc | `doc/playability_test_result/prd.index.md` | pass | A5-002 | 按 ROUND-005 范围完成逐文档审读并回写 `审计轮次: 5`。 |
-| 2026-03-06 18:04:31 +0800 | cc | `doc/playability_test_result/project.md`（retired former `playability_test_manual.md` trace） | pass | A5-002 | 按 ROUND-005 范围完成逐文档审读并回写 `审计轮次: 5`。 |
+| 2026-03-06 18:04:31 +0800 | cc | `playability_test_manual.md` retired/deleted manual trace | pass | A5-002 | 按 ROUND-005 范围完成逐文档审读并回写 `审计轮次: 5`。 |
 | 2026-03-06 18:04:31 +0800 | cc | `doc/playability_test_result/game-test.prd.md` | pass | A5-002 | 按 ROUND-005 范围完成逐文档审读并回写 `审计轮次: 5`。 |
 | 2026-03-06 18:04:31 +0800 | cc | `doc/playability_test_result/card_2026_02_28_23_27_06.md` | pass | A5-002 | 按 ROUND-005 范围完成逐文档审读并回写 `审计轮次: 5`。 |
 | 2026-03-06 18:04:31 +0800 | cc | `doc/playability_test_result/playability_test_card.md` | pass | A5-002 | 按 ROUND-005 范围完成逐文档审读并回写 `审计轮次: 5`。 |

--- a/doc/core/reviews/round-005-reviewed-files.md
+++ b/doc/core/reviews/round-005-reviewed-files.md
@@ -174,7 +174,7 @@
 - `doc/playability_test_result/game-test.prd.md`
 - `doc/playability_test_result/game-test.project.md`
 - `doc/playability_test_result/playability_test_card.md`
-- `doc/playability_test_result/project.md`（retired former `playability_test_manual.md` trace）
+- `playability_test_manual.md` retired/deleted manual trace
 - `doc/playability_test_result/prd.index.md`
 - `doc/playability_test_result/prd.md`
 - `doc/playability_test_result/project.md`


### PR DESCRIPTION
Task: task_e61fb4d928ea49ecba5247a42b513a14
Fixes #1771

## Summary
- Replaces five synthetic `project.md` retired-manual trace entries with non-path `playability_test_manual.md` retired/deleted manual placeholders.
- Preserves the real `doc/playability_test_result/project.md` entries.
- Closes the post-merge PR #1772 P2 review residue around duplicate live-path inventory counts.

## Verification
- `./scripts/doc-governance-check.sh`
- `git diff --check`
- `./scripts/pm/workflow-lint.sh --task-uid task_e61fb4d928ea49ecba5247a42b513a14 --phase current`
- trace `rg` check confirming old synthetic path is absent and five deleted-manual placeholders remain

## Review
- repository_health_engineer pre-PR review: no_findings; scope/spec compliant; repository-health quality/risk acceptable low risk.
