### PR TITLE
Guard fetch-blob response egress per peer

### DIFF
--- a/crates/oasis7_net/src/libp2p_net.rs
+++ b/crates/oasis7_net/src/libp2p_net.rs
@@ -13,6 +13,7 @@ mod peer_manager_active_set;
 mod peer_record;
 mod peer_record_republish;
 mod reachability;
+mod response_budget;
 mod runtime_loop;
 mod runtime_support;
 mod swarm_behaviour;
@@ -21,7 +22,7 @@ mod traffic_metrics;
 mod transport_paths;
 mod utils;
 mod wire_bytes;
-use crate::{error::WorldError, util::to_canonical_cbor};
+use crate::error::WorldError;
 pub use config::Libp2pNetworkConfig;
 use connection_lifecycle::{
     clear_disconnected_peer_state, failover_after_disconnect, log_active_transport_path,
@@ -41,7 +42,6 @@ use discovery::{
     peer_record_enables_rendezvous, peer_record_world_id, process_discovered_peer_record,
     publish_discovery_provider, start_peer_discovery_query,
 };
-use error_mapping::error_response_from_world_error;
 use futures::channel::mpsc;
 use futures::{FutureExt, StreamExt};
 use kad_queries::{DhtProgressAction, PendingDhtQuery, handle_dht_progress};
@@ -75,6 +75,7 @@ pub use reachability::{
     LiveTransportKind, LiveTransportTransition, LiveTransportTransitionCounters,
 };
 use reachability::{note_hole_punch_result, note_relay_reservation_accepted, snapshot_clone};
+use response_budget::{FetchBlobResponseBudget, budgeted_response_bytes};
 use runtime_loop::{
     Command, CommandContext, CommandOutcome, CommandStateRefs, PendingResponse,
     fail_pending_request, handle_command,
@@ -103,14 +104,11 @@ use transport_paths::{
     TransportPath, bootstrap_transport_path_state, retry_transport_path_after_error,
 };
 use utils::{
-    decode_membership_directory, decode_world_head, now_ms, push_bounded_clone,
-    push_bounded_string_with_keyed_cooldown, should_republish, try_send_command,
+    LIFECYCLE_EVENT_ERROR_COOLDOWN_MS, decode_membership_directory, decode_world_head, now_ms,
+    push_bounded_clone, push_bounded_string_with_keyed_cooldown, should_republish,
+    try_send_command,
 };
 use wire_bytes::{SharedLibp2pWireByteCounters, init_shared_wire_byte_counters};
-const RR_GET_LOCAL_PEER_RECORD: &str = "/aw/rr/1.0.0/get_local_peer_record";
-const RR_GET_CACHED_PEER_RECORD: &str = "/aw/rr/1.0.0/get_cached_peer_record";
-const RR_GET_CACHED_DISCOVERY_PEERS: &str = "/aw/rr/1.0.0/get_cached_discovery_peers";
-const LIFECYCLE_EVENT_ERROR_COOLDOWN_MS: i64 = 5_000;
 type CommandResponseSender<T> = std::sync::mpsc::Sender<Result<T, WorldError>>;
 #[derive(Clone)]
 pub struct Libp2pNetwork {
@@ -191,6 +189,7 @@ impl Libp2pNetwork {
             let mut topic_map: HashMap<TopicHash, String> = HashMap::new();
             let mut topic_inbox_limits: HashMap<String, usize> = HashMap::new();
             let mut handlers: HashMap<String, Handler> = HashMap::new();
+            let mut fetch_blob_response_budget = FetchBlobResponseBudget::default();
             let mut pending: HashMap<request_response::OutboundRequestId, PendingResponse> =
                 HashMap::new();
             let mut pending_peer_record_requests: HashMap<
@@ -353,7 +352,7 @@ impl Libp2pNetwork {
                                 }
                                 SwarmEvent::Behaviour(BehaviourEvent::RequestResponse(event)) => {
                                     match event {
-                                        request_response::Event::Message { message, peer: _, .. } => {
+                                        request_response::Event::Message { message, peer, .. } => {
                                             match message {
                                                 request_response::Message::Request { request, channel, .. } => {
                                                     record_request_inbound(
@@ -372,13 +371,13 @@ impl Libp2pNetwork {
                                                             .allow_loopback_external_addrs_for_testing,
                                                         &discovered_peer_records,
                                                     );
-                                                    let response_bytes = match reply {
-                                                        Ok(bytes) => bytes,
-                                                        Err(err) => to_canonical_cbor(
-                                                            &error_response_from_world_error(&err),
-                                                        )
-                                                        .unwrap_or_default(),
-                                                    };
+                                                    let response_bytes = budgeted_response_bytes(
+                                                        &mut fetch_blob_response_budget,
+                                                        peer,
+                                                        request.protocol.as_str(),
+                                                        reply,
+                                                        now_ms(),
+                                                    );
                                                     record_response_outbound(
                                                         &event_traffic_metrics,
                                                         request.protocol.as_str(),

--- a/crates/oasis7_net/src/libp2p_net/discovery.rs
+++ b/crates/oasis7_net/src/libp2p_net/discovery.rs
@@ -34,6 +34,10 @@ use super::transport_paths::{
 use super::utils::push_bounded_string_with_keyed_cooldown;
 use super::{Handler, push_bounded_clone};
 
+const RR_GET_LOCAL_PEER_RECORD: &str = "/aw/rr/1.0.0/get_local_peer_record";
+pub(super) const RR_GET_CACHED_PEER_RECORD: &str = "/aw/rr/1.0.0/get_cached_peer_record";
+const RR_GET_CACHED_DISCOVERY_PEERS: &str = "/aw/rr/1.0.0/get_cached_discovery_peers";
+
 pub(super) enum PendingPeerRecordRequest {
     ConnectedPeerRecord {
         peer_id: PeerId,
@@ -51,9 +55,9 @@ pub(super) enum PendingPeerRecordRequest {
 impl PendingPeerRecordRequest {
     pub(super) fn protocol_label(&self) -> &'static str {
         match self {
-            Self::ConnectedPeerRecord { .. } => super::RR_GET_LOCAL_PEER_RECORD,
-            Self::CachedPeerRecord { .. } => super::RR_GET_CACHED_PEER_RECORD,
-            Self::CachedDiscoveryPeers { .. } => super::RR_GET_CACHED_DISCOVERY_PEERS,
+            Self::ConnectedPeerRecord { .. } => RR_GET_LOCAL_PEER_RECORD,
+            Self::CachedPeerRecord { .. } => RR_GET_CACHED_PEER_RECORD,
+            Self::CachedDiscoveryPeers { .. } => RR_GET_CACHED_DISCOVERY_PEERS,
         }
     }
 }
@@ -339,11 +343,11 @@ pub(super) fn maybe_request_connected_peer_record(
     {
         return false;
     }
-    record_request_outbound(traffic_metrics, super::RR_GET_LOCAL_PEER_RECORD, 0);
+    record_request_outbound(traffic_metrics, RR_GET_LOCAL_PEER_RECORD, 0);
     let request_id = swarm.behaviour_mut().request_response.send_request(
         &peer_id,
         NetworkRequest {
-            protocol: super::RR_GET_LOCAL_PEER_RECORD.to_string(),
+            protocol: RR_GET_LOCAL_PEER_RECORD.to_string(),
             payload: Vec::new(),
         },
     );
@@ -381,13 +385,13 @@ fn request_cached_peer_record_via(
     }
     record_request_outbound(
         traffic_metrics,
-        super::RR_GET_CACHED_PEER_RECORD,
+        RR_GET_CACHED_PEER_RECORD,
         peer_id.to_string().len(),
     );
     let request_id = swarm.behaviour_mut().request_response.send_request(
         &ask_peer,
         NetworkRequest {
-            protocol: super::RR_GET_CACHED_PEER_RECORD.to_string(),
+            protocol: RR_GET_CACHED_PEER_RECORD.to_string(),
             payload: peer_id.to_string().into_bytes(),
         },
     );
@@ -472,11 +476,11 @@ pub(super) fn maybe_request_cached_discovery_peers(
     {
         return false;
     }
-    record_request_outbound(traffic_metrics, super::RR_GET_CACHED_DISCOVERY_PEERS, 0);
+    record_request_outbound(traffic_metrics, RR_GET_CACHED_DISCOVERY_PEERS, 0);
     let request_id = swarm.behaviour_mut().request_response.send_request(
         &peer_id,
         NetworkRequest {
-            protocol: super::RR_GET_CACHED_DISCOVERY_PEERS.to_string(),
+            protocol: RR_GET_CACHED_DISCOVERY_PEERS.to_string(),
             payload: Vec::new(),
         },
     );
@@ -631,10 +635,10 @@ pub(super) fn handle_request_response_request(
     discovered_peer_records: &HashMap<PeerId, SignedPeerRecord>,
 ) -> Result<Vec<u8>, WorldError> {
     match request.protocol.as_str() {
-        super::RR_GET_LOCAL_PEER_RECORD => {
+        RR_GET_LOCAL_PEER_RECORD => {
             let Some(template) = peer_record_template else {
                 return Err(WorldError::NetworkProtocolUnavailable {
-                    protocol: super::RR_GET_LOCAL_PEER_RECORD.to_string(),
+                    protocol: RR_GET_LOCAL_PEER_RECORD.to_string(),
                 });
             };
             let record = build_configured_peer_record(
@@ -646,7 +650,7 @@ pub(super) fn handle_request_response_request(
             )?;
             to_canonical_cbor(&record)
         }
-        super::RR_GET_CACHED_PEER_RECORD => {
+        RR_GET_CACHED_PEER_RECORD => {
             let peer_id = String::from_utf8(request.payload.clone())
                 .map_err(|_| WorldError::NetworkProtocolUnavailable {
                     protocol: "cached peer record payload must be utf-8".to_string(),
@@ -664,7 +668,7 @@ pub(super) fn handle_request_response_request(
             })?;
             to_canonical_cbor(record)
         }
-        super::RR_GET_CACHED_DISCOVERY_PEERS => {
+        RR_GET_CACHED_DISCOVERY_PEERS => {
             let peers: Vec<String> = discovered_peer_records
                 .values()
                 .filter(|record| {

--- a/crates/oasis7_net/src/libp2p_net/response_budget.rs
+++ b/crates/oasis7_net/src/libp2p_net/response_budget.rs
@@ -1,0 +1,138 @@
+use std::collections::HashMap;
+
+use libp2p::PeerId;
+use oasis7_proto::distributed::DistributedErrorCode;
+
+use crate::error::WorldError;
+use crate::util::to_canonical_cbor;
+
+use super::error_mapping::error_response_from_world_error;
+
+const FETCH_BLOB_PROTOCOL: &str = "/aw/node/replication/fetch-blob/1.0.0";
+const FETCH_BLOB_RESPONSE_WINDOW_MS: i64 = 60_000;
+const FETCH_BLOB_RESPONSE_BYTES_PER_WINDOW: usize = 8 * 1024 * 1024;
+
+#[derive(Default)]
+pub(super) struct FetchBlobResponseBudget {
+    by_peer: HashMap<PeerId, ResponseWindow>,
+}
+
+#[derive(Clone, Copy)]
+struct ResponseWindow {
+    started_at_ms: i64,
+    bytes: usize,
+}
+
+impl FetchBlobResponseBudget {
+    pub(super) fn admit(
+        &mut self,
+        peer: PeerId,
+        protocol: &str,
+        response_bytes: usize,
+        now_ms: i64,
+    ) -> Result<(), WorldError> {
+        if protocol != FETCH_BLOB_PROTOCOL {
+            return Ok(());
+        }
+
+        let window = self.by_peer.entry(peer).or_insert(ResponseWindow {
+            started_at_ms: now_ms,
+            bytes: 0,
+        });
+        if now_ms.saturating_sub(window.started_at_ms) >= FETCH_BLOB_RESPONSE_WINDOW_MS {
+            *window = ResponseWindow {
+                started_at_ms: now_ms,
+                bytes: 0,
+            };
+        }
+
+        if response_bytes > FETCH_BLOB_RESPONSE_BYTES_PER_WINDOW.saturating_sub(window.bytes) {
+            return Err(WorldError::NetworkRequestFailed {
+                code: DistributedErrorCode::ErrRateLimited,
+                message: format!(
+                    "fetch-blob response budget exhausted for peer={peer}; retry after window reset"
+                ),
+                retryable: false,
+            });
+        }
+
+        window.bytes = window.bytes.saturating_add(response_bytes);
+        Ok(())
+    }
+}
+
+pub(super) fn budgeted_response_bytes(
+    budget: &mut FetchBlobResponseBudget,
+    peer: PeerId,
+    protocol: &str,
+    reply: Result<Vec<u8>, WorldError>,
+    now_ms: i64,
+) -> Vec<u8> {
+    let response_bytes = reply.unwrap_or_else(|err| {
+        to_canonical_cbor(&error_response_from_world_error(&err)).unwrap_or_default()
+    });
+    budget
+        .admit(peer, protocol, response_bytes.len(), now_ms)
+        .map(|()| response_bytes)
+        .unwrap_or_else(|err| {
+            to_canonical_cbor(&error_response_from_world_error(&err)).unwrap_or_default()
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fetch_blob_budget_is_per_peer_and_resets_after_its_window() {
+        let mut budget = FetchBlobResponseBudget::default();
+        let first_peer = PeerId::random();
+        let second_peer = PeerId::random();
+        let first_window = 1_000;
+
+        budget
+            .admit(
+                first_peer,
+                FETCH_BLOB_PROTOCOL,
+                FETCH_BLOB_RESPONSE_BYTES_PER_WINDOW,
+                first_window,
+            )
+            .expect("first peer fits exactly once");
+        let err = budget
+            .admit(first_peer, FETCH_BLOB_PROTOCOL, 1, first_window)
+            .expect_err("same peer is limited inside its window");
+        assert!(matches!(
+            err,
+            WorldError::NetworkRequestFailed {
+                code: DistributedErrorCode::ErrRateLimited,
+                retryable: false,
+                ..
+            }
+        ));
+
+        budget
+            .admit(second_peer, FETCH_BLOB_PROTOCOL, 1, first_window)
+            .expect("another peer has an independent budget");
+        budget
+            .admit(
+                first_peer,
+                FETCH_BLOB_PROTOCOL,
+                1,
+                first_window + FETCH_BLOB_RESPONSE_WINDOW_MS,
+            )
+            .expect("expired window resets budget");
+    }
+
+    #[test]
+    fn fetch_blob_budget_does_not_apply_to_other_protocols() {
+        let mut budget = FetchBlobResponseBudget::default();
+        budget
+            .admit(
+                PeerId::random(),
+                "/aw/node/replication/fetch-commit/1.0.0",
+                FETCH_BLOB_RESPONSE_BYTES_PER_WINDOW.saturating_add(1),
+                1_000,
+            )
+            .expect("other protocols are unaffected");
+    }
+}

--- a/crates/oasis7_net/src/libp2p_net/tests.rs
+++ b/crates/oasis7_net/src/libp2p_net/tests.rs
@@ -10,6 +10,7 @@ use super::transport_paths::{
 };
 use super::utils::push_bounded_vec;
 use super::*;
+use crate::util::to_canonical_cbor;
 use libp2p::kad::RecordKey;
 use oasis7_proto::distributed_dht::{PeerDeploymentMode, PeerNodeRole};
 use oasis7_proto::distributed_net::DistributedNetwork as _;

--- a/crates/oasis7_net/src/libp2p_net/tests/discovery_peer_record_tests.rs
+++ b/crates/oasis7_net/src/libp2p_net/tests/discovery_peer_record_tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::util::to_canonical_cbor;
 
 #[test]
 fn routing_update_defers_bootstrap_peer_record_until_connection_exists() {
@@ -714,7 +715,7 @@ fn clear_disconnected_peer_state_removes_peer_record_cooldowns() {
 #[test]
 fn cached_peer_record_request_handler_reports_not_found_on_cache_miss() {
     let request = NetworkRequest {
-        protocol: super::super::RR_GET_CACHED_PEER_RECORD.to_string(),
+        protocol: super::super::discovery::RR_GET_CACHED_PEER_RECORD.to_string(),
         payload: PeerId::random().to_string().into_bytes(),
     };
     let handlers = HashMap::new();

--- a/crates/oasis7_net/src/libp2p_net/utils.rs
+++ b/crates/oasis7_net/src/libp2p_net/utils.rs
@@ -11,6 +11,7 @@ use oasis7_proto::distributed_dht::MembershipDirectorySnapshot;
 use super::Command;
 
 const RECENT_VALUE_PRUNE_INTERVAL_MS: i64 = 1_000;
+pub(super) const LIFECYCLE_EVENT_ERROR_COOLDOWN_MS: i64 = 5_000;
 
 pub(super) fn decode_world_head(bytes: &[u8]) -> Result<WorldHeadAnnounce, WorldError> {
     Ok(serde_cbor::from_slice(bytes)?)


### PR DESCRIPTION
Closes #2205

## What changed
- Adds a responder-side per-peer byte budget for `/aw/node/replication/fetch-blob/1.0.0`.
- Caps each peer at 8 MiB per 60-second window and returns a non-retryable `ErrRateLimited` response when exhausted.
- Keeps all other request-response protocols and independent peers unaffected.

## Why
204 sustained high outbound traffic by successfully serving full fetch-blob responses to lagging peers. Existing timeout/retry cooldowns only constrained the requester side.

## Validation
- `./scripts/cargo-dev.sh test -p oasis7_net` (186 passed)
- `env -u RUSTC_WRAPPER cargo check -p oasis7_node`
- `cargo fmt --check`
- `git diff --check`

## Rollout
The temporary 204 firewall quarantine remains until the merged package is deployed to 204/205 and low egress plus readiness are revalidated.

## Review note
Required runtime/ops local review slices were dispatched repeatedly but the current subagent channel returned no verdicts; this is recorded on #2205. Remote CI and PR review remain required.