### PR TITLE
Prioritize static peers for world head recovery

### DIFF
--- a/crates/oasis7_net/src/libp2p_net.rs
+++ b/crates/oasis7_net/src/libp2p_net.rs
@@ -47,12 +47,9 @@ use futures::{FutureExt, StreamExt};
 use kad_queries::{DhtProgressAction, PendingDhtQuery, handle_dht_progress};
 use libp2p::gossipsub::{self, TopicHash};
 use libp2p::identity::Keypair;
-use libp2p::kad::{self};
-use libp2p::relay;
-use libp2p::rendezvous;
-use libp2p::request_response::{self};
 use libp2p::swarm::SwarmEvent;
 use libp2p::{Multiaddr, PeerId};
+use libp2p::{kad, relay, rendezvous, request_response};
 use oasis7_proto::distributed::WorldHeadAnnounce;
 use oasis7_proto::distributed_dht::{
     MembershipDirectorySnapshot, PeerRecord, ProviderRecord, SignedPeerRecord,
@@ -200,7 +197,7 @@ impl Libp2pNetwork {
             let mut peers: Vec<PeerId> = Vec::new();
             let mut provider_keys: HashMap<String, i64> = HashMap::new();
             let mut discovered_peer_records: HashMap<PeerId, SignedPeerRecord> = HashMap::new();
-            let (mut known_transport_paths, mut failed_transport_path_labels) =
+            let (mut known_transport_paths, mut failed_transport_path_labels, static_bootstrap_peer_ids) =
                 bootstrap_transport_path_state(&config_clone.bootstrap_peers);
             let mut last_dialed_transport_paths: HashMap<PeerId, TransportPath> = HashMap::new();
             let mut active_transport_paths: HashMap<PeerId, TransportPath> = HashMap::new();
@@ -416,6 +413,7 @@ impl Libp2pNetwork {
                                                             max_error_messages,
                                                             &event_errors,
                                                             &config_clone.peer_manager_policy,
+                                                            &static_bootstrap_peer_ids,
                                                         );
                                                         (
                                                             peer_healths_by_id,
@@ -541,6 +539,7 @@ impl Libp2pNetwork {
                                                                 &mut failed_transport_path_labels,
                                                                 peer_record_template.as_ref(),
                                                                 &config_clone.peer_manager_policy,
+                                                                &static_bootstrap_peer_ids,
                                                                 record,
                                                             ) {
                                                                 push_bounded_clone(

--- a/crates/oasis7_net/src/libp2p_net/discovery.rs
+++ b/crates/oasis7_net/src/libp2p_net/discovery.rs
@@ -20,6 +20,7 @@ use oasis7_proto::distributed_net::NetworkRequest;
 use super::kad_queries::PendingDhtQuery;
 use super::peer_manager::{
     PeerManagerHealthStatus, PeerManagerPolicy, recompute_peer_manager_healths,
+    retain_static_bootstrap_provenance,
 };
 use super::peer_record::{
     build_configured_peer_record, put_record_query, validate_discovered_peer_record,
@@ -564,7 +565,8 @@ pub(super) fn process_discovered_peer_record(
     failed_transport_path_labels: &mut HashSet<String>,
     template: Option<&PeerRecord>,
     peer_manager_policy: &PeerManagerPolicy,
-    record: SignedPeerRecord,
+    static_bootstrap_peer_ids: &HashSet<PeerId>,
+    mut record: SignedPeerRecord,
 ) -> Result<(), WorldError> {
     validate_discovered_peer_record(&record, template)?;
     let peer_id = record.record.peer_id.parse::<PeerId>().map_err(|_| {
@@ -572,6 +574,7 @@ pub(super) fn process_discovered_peer_record(
             protocol: "peer record peer_id must be valid".to_string(),
         }
     })?;
+    retain_static_bootstrap_provenance(&mut record, peer_id, static_bootstrap_peer_ids);
     let allow_single_source_bootstrap_dial = record
         .record
         .discovery_sources
@@ -721,6 +724,7 @@ pub(super) fn handle_peer_record_response(
     max_error_messages: usize,
     event_errors: &Arc<Mutex<Vec<String>>>,
     peer_manager_policy: &PeerManagerPolicy,
+    static_bootstrap_peer_ids: &HashSet<PeerId>,
 ) {
     clear_pending_peer_record_request(
         &kind,
@@ -791,6 +795,7 @@ pub(super) fn handle_peer_record_response(
                 failed_transport_path_labels,
                 peer_record_template,
                 peer_manager_policy,
+                static_bootstrap_peer_ids,
                 record.clone(),
             ) {
                 push_bounded_clone(

--- a/crates/oasis7_net/src/libp2p_net/peer_manager.rs
+++ b/crates/oasis7_net/src/libp2p_net/peer_manager.rs
@@ -131,6 +131,24 @@ pub struct PeerManagerBlockArtifact {
     pub last_cleared_at_ms: Option<i64>,
 }
 
+pub(super) fn retain_static_bootstrap_provenance(
+    record: &mut SignedPeerRecord,
+    peer_id: PeerId,
+    static_bootstrap_peer_ids: &HashSet<PeerId>,
+) {
+    if static_bootstrap_peer_ids.contains(&peer_id)
+        && !record
+            .record
+            .discovery_sources
+            .contains(&PeerDiscoverySource::StaticBootstrap)
+    {
+        record
+            .record
+            .discovery_sources
+            .push(PeerDiscoverySource::StaticBootstrap);
+    }
+}
+
 pub(super) fn recompute_peer_manager_healths(
     discovered_peer_records: &HashMap<PeerId, SignedPeerRecord>,
     active_transport_paths: &HashMap<PeerId, TransportPath>,

--- a/crates/oasis7_net/src/libp2p_net/tests/discovery_dial_tests.rs
+++ b/crates/oasis7_net/src/libp2p_net/tests/discovery_dial_tests.rs
@@ -39,6 +39,7 @@ fn process_discovered_peer_record_dials_candidate_peer() {
             &mut failed_transport_path_labels,
             None,
             &PeerManagerPolicy::default(),
+            &HashSet::new(),
             record.clone(),
         )
         .expect("process candidate peer record");

--- a/crates/oasis7_net/src/libp2p_net/tests/discovery_peer_record_tests.rs
+++ b/crates/oasis7_net/src/libp2p_net/tests/discovery_peer_record_tests.rs
@@ -123,7 +123,7 @@ fn routing_update_skips_peer_record_for_unconnected_non_bootstrap_peer() {
 }
 
 #[test]
-fn process_discovered_peer_record_keeps_single_source_bootstrap_peer_dial_eligible() {
+fn process_discovered_peer_record_retains_local_static_bootstrap_provenance() {
     super::super::runtime_support::run_on_libp2p_test_runtime(|| {
         let mut swarm = super::super::swarm_behaviour::build_swarm(
             &Keypair::generate_ed25519(),
@@ -136,7 +136,7 @@ fn process_discovered_peer_record_keeps_single_source_bootstrap_peer_dial_eligib
         let peer_id = PeerId::from(peer_key.public());
         let suspect_record = super::signed_discovery_peer_record(
             &peer_key,
-            vec![crate::dht::PeerDiscoverySource::StaticBootstrap],
+            vec![crate::dht::PeerDiscoverySource::Dht],
             1,
         );
         let upgraded_record = super::signed_discovery_peer_record(
@@ -152,6 +152,7 @@ fn process_discovered_peer_record_keeps_single_source_bootstrap_peer_dial_eligib
         let mut last_dialed_transport_paths = HashMap::new();
         let active_transport_paths = HashMap::new();
         let mut failed_transport_path_labels = HashSet::new();
+        let static_bootstrap_peer_ids = HashSet::from([peer_id]);
 
         super::super::discovery::process_discovered_peer_record(
             &mut swarm,
@@ -162,6 +163,7 @@ fn process_discovered_peer_record_keeps_single_source_bootstrap_peer_dial_eligib
             &mut failed_transport_path_labels,
             None,
             &PeerManagerPolicy::default(),
+            &static_bootstrap_peer_ids,
             suspect_record,
         )
         .expect("process suspect peer record");
@@ -182,6 +184,7 @@ fn process_discovered_peer_record_keeps_single_source_bootstrap_peer_dial_eligib
             &mut failed_transport_path_labels,
             None,
             &PeerManagerPolicy::default(),
+            &static_bootstrap_peer_ids,
             upgraded_record,
         )
         .expect("process upgraded peer record");
@@ -201,7 +204,10 @@ fn process_discovered_peer_record_keeps_single_source_bootstrap_peer_dial_eligib
             .map(|source| peer_manager::discovery_source_label(*source))
             .collect();
         upgraded_source_labels.sort_unstable();
-        assert_eq!(upgraded_source_labels, ["dht", "rendezvous"]);
+        assert_eq!(
+            upgraded_source_labels,
+            ["dht", "rendezvous", "static_bootstrap"]
+        );
         assert_eq!(
             upgraded_sources.len(),
             upgraded_source_labels.len(),
@@ -241,11 +247,54 @@ fn process_discovered_peer_record_keeps_dht_only_suspect_peer_non_dialable() {
         &mut failed_transport_path_labels,
         None,
         &PeerManagerPolicy::default(),
+        &HashSet::new(),
         suspect_record,
     )
     .expect("process dht-only suspect peer record");
 
     assert!(discovered_peer_records.contains_key(&peer_id));
+    assert!(!last_dialed_transport_paths.contains_key(&peer_id));
+}
+
+#[test]
+fn process_discovered_peer_record_rejects_invalid_static_peer_record() {
+    let mut swarm = super::super::swarm_behaviour::build_swarm(
+        &Keypair::generate_ed25519(),
+        false,
+        true,
+        std::time::Duration::from_secs(30),
+        super::super::wire_bytes::init_shared_wire_byte_counters(),
+    );
+    let peer_key = Keypair::generate_ed25519();
+    let peer_id = PeerId::from(peer_key.public());
+    let mut invalid_record = super::signed_discovery_peer_record(
+        &peer_key,
+        vec![crate::dht::PeerDiscoverySource::Dht],
+        1,
+    );
+    invalid_record.record.world_id = "tampered-world".to_string();
+    let mut discovered_peer_records = HashMap::new();
+    let mut known_transport_paths = HashMap::new();
+    let mut last_dialed_transport_paths = HashMap::new();
+    let active_transport_paths = HashMap::new();
+    let mut failed_transport_path_labels = HashSet::new();
+
+    let err = super::super::discovery::process_discovered_peer_record(
+        &mut swarm,
+        &mut discovered_peer_records,
+        &mut known_transport_paths,
+        &mut last_dialed_transport_paths,
+        &active_transport_paths,
+        &mut failed_transport_path_labels,
+        None,
+        &PeerManagerPolicy::default(),
+        &HashSet::from([peer_id]),
+        invalid_record,
+    )
+    .expect_err("invalid signed peer record must remain rejected");
+
+    assert!(format!("{err:?}").contains("signature"));
+    assert!(!discovered_peer_records.contains_key(&peer_id));
     assert!(!last_dialed_transport_paths.contains_key(&peer_id));
 }
 
@@ -807,6 +856,7 @@ fn cached_peer_record_not_found_retries_via_another_connected_peer() {
         16,
         &event_errors,
         &PeerManagerPolicy::default(),
+        &HashSet::new(),
     );
 
     assert_eq!(pending_peer_record_requests.len(), 1);
@@ -994,6 +1044,7 @@ fn cached_peer_record_not_found_stops_after_all_connected_proxies_are_tried() {
         16,
         &event_errors,
         &PeerManagerPolicy::default(),
+        &HashSet::new(),
     );
 
     assert!(pending_peer_record_requests.is_empty());

--- a/crates/oasis7_net/src/libp2p_net/tests/peer_health_refresh_tests.rs
+++ b/crates/oasis7_net/src/libp2p_net/tests/peer_health_refresh_tests.rs
@@ -108,6 +108,47 @@ fn refresh_peer_manager_healths_admits_record_exchange_pending_active_peer() {
 }
 
 #[test]
+fn refresh_peer_manager_healths_does_not_quarantine_static_single_source_peer() {
+    let peer_key = Keypair::generate_ed25519();
+    let peer_id = PeerId::from(peer_key.public());
+    let discovered_peer_records = HashMap::from([(
+        peer_id,
+        signed_discovery_peer_record(
+            &peer_key,
+            vec![crate::dht::PeerDiscoverySource::StaticBootstrap],
+            1,
+        ),
+    )]);
+    let active_transport_paths = HashMap::from([(
+        peer_id,
+        active_transport_path_from_endpoint(
+            &HashMap::new(),
+            peer_id,
+            &"/ip4/10.0.0.2/tcp/6832"
+                .parse()
+                .expect("bootstrap endpoint"),
+        ),
+    )]);
+    let event_peer_healths = Arc::new(Mutex::new(HashMap::new()));
+    let event_block_artifacts = Arc::new(Mutex::new(HashMap::new()));
+    let event_errors = Arc::new(Mutex::new(Vec::new()));
+
+    let (_healths, quarantined, admitted) = refresh_peer_manager_healths(
+        &discovered_peer_records,
+        &active_transport_paths,
+        &HashSet::new(),
+        &PeerManagerPolicy::default(),
+        &event_peer_healths,
+        &event_block_artifacts,
+        &event_errors,
+        32,
+    );
+
+    assert!(quarantined.is_empty());
+    assert_eq!(admitted, HashSet::from([peer_id]));
+}
+
+#[test]
 fn refresh_peer_manager_healths_uses_peer_id_order_for_constrained_pending_peers() {
     let first_key = Keypair::generate_ed25519();
     let second_key = Keypair::generate_ed25519();

--- a/crates/oasis7_net/src/libp2p_net/transport_paths.rs
+++ b/crates/oasis7_net/src/libp2p_net/transport_paths.rs
@@ -213,7 +213,11 @@ pub(super) fn sync_static_bootstrap_transport_paths(
 
 pub(super) fn bootstrap_transport_path_state(
     bootstrap_peers: &[Multiaddr],
-) -> (HashMap<PeerId, Vec<TransportPath>>, HashSet<String>) {
+) -> (
+    HashMap<PeerId, Vec<TransportPath>>,
+    HashSet<String>,
+    HashSet<PeerId>,
+) {
     let mut known_transport_paths = HashMap::new();
     let mut failed_transport_path_labels = HashSet::new();
     sync_static_bootstrap_transport_paths(
@@ -221,7 +225,15 @@ pub(super) fn bootstrap_transport_path_state(
         &mut failed_transport_path_labels,
         bootstrap_peers,
     );
-    (known_transport_paths, failed_transport_path_labels)
+    let static_bootstrap_peer_ids = bootstrap_peers
+        .iter()
+        .filter_map(|addr| split_peer_id(addr.clone()).0)
+        .collect();
+    (
+        known_transport_paths,
+        failed_transport_path_labels,
+        static_bootstrap_peer_ids,
+    )
 }
 
 pub(super) fn select_preferred_transport_path(

--- a/crates/oasis7_net/src/libp2p_net/transport_retry_tests.rs
+++ b/crates/oasis7_net/src/libp2p_net/transport_retry_tests.rs
@@ -73,6 +73,7 @@ fn process_discovered_peer_record_retries_failed_candidate_dial_on_rediscovery()
             &mut failed_transport_path_labels,
             None,
             &PeerManagerPolicy::default(),
+            &HashSet::new(),
             record.clone(),
         )
         .expect("first discovery dial");
@@ -96,6 +97,7 @@ fn process_discovered_peer_record_retries_failed_candidate_dial_on_rediscovery()
             &mut failed_transport_path_labels,
             None,
             &PeerManagerPolicy::default(),
+            &HashSet::new(),
             record,
         )
         .expect("rediscovery must retry dial");

--- a/crates/oasis7_node/src/libp2p_replication_network/bootstrap_provider_tests.rs
+++ b/crates/oasis7_node/src/libp2p_replication_network/bootstrap_provider_tests.rs
@@ -93,6 +93,11 @@ fn libp2p_replication_network_known_peers_includes_bootstrap_providers_before_co
             .any(|peer_id| peer_id == &storage.peer_id().to_string()),
         "bootstrap storage provider should be visible to gap-sync peer sweeps before it is connected"
     );
+    assert_eq!(
+        observer.configured_static_bootstrap_peer_ids(),
+        vec![storage.peer_id().to_string()],
+        "static bootstrap peer IDs should retain their configured provenance"
+    );
 }
 
 #[test]

--- a/crates/oasis7_node/src/libp2p_replication_network/net_impl.rs
+++ b/crates/oasis7_node/src/libp2p_replication_network/net_impl.rs
@@ -101,6 +101,16 @@ impl ProtoDistributedNetwork<WorldError> for Libp2pReplicationNetwork {
         peers
     }
 
+    fn configured_static_bootstrap_peer_ids(&self) -> Vec<String> {
+        let mut peers = self
+            .bootstrap_addrs_by_peer_id
+            .keys()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>();
+        sort_dedup_peer_ids(&mut peers);
+        peers
+    }
+
     fn request_with_providers(
         &self,
         protocol: &str,

--- a/crates/oasis7_node/src/network_bridge.rs
+++ b/crates/oasis7_node/src/network_bridge.rs
@@ -4,6 +4,8 @@ use std::path::Path;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
+mod network_bridge_world_head;
+
 use oasis7_proto::distributed::WorldHeadAnnounce;
 use oasis7_proto::distributed_dht as proto_dht;
 use oasis7_proto::distributed_net::{
@@ -37,9 +39,8 @@ pub(crate) use crate::network_error_classification::{
     replication_network_error_should_keep_timeout_over_provider_gap,
 };
 use crate::replication::{
-    FetchCommitRequest, FetchCommitResponse, FetchHeadRequest, FetchHeadResponse,
-    GossipReplicationMessage, REPLICATION_FETCH_COMMIT_PROTOCOL, REPLICATION_GET_HEAD_PROTOCOL,
-    load_blob_from_root,
+    FetchCommitRequest, FetchCommitResponse, GossipReplicationMessage,
+    REPLICATION_FETCH_COMMIT_PROTOCOL, REPLICATION_GET_HEAD_PROTOCOL, load_blob_from_root,
 };
 use crate::{
     NodeError, NodeExecutionCheckpointDescriptor, NodeNetworkPolicy,
@@ -398,98 +399,6 @@ impl ReplicationNetworkEndpoint {
             }
         }
         self.request_world_head_from_peers(world_id)
-    }
-
-    fn request_world_head_from_peers(
-        &self,
-        world_id: &str,
-    ) -> Result<Option<WorldHeadAnnounce>, NodeError> {
-        let request = FetchHeadRequest {
-            world_id: world_id.to_string(),
-        };
-        let mut connected_peer_ids = self.network.connected_peer_ids();
-        connected_peer_ids.sort();
-        connected_peer_ids.dedup();
-        let mut peer_ids = connected_peer_ids.clone();
-        let mut candidate_peer_ids = self.network.known_peer_ids();
-        candidate_peer_ids.sort();
-        candidate_peer_ids.dedup();
-        candidate_peer_ids.retain(|peer_id| !connected_peer_ids.contains(peer_id));
-        peer_ids.extend(candidate_peer_ids);
-        peer_ids.retain(|peer_id| !peer_id.trim().is_empty());
-        let mut best_head = None;
-        if peer_ids.is_empty() {
-            self.maybe_update_best_peer_head(
-                world_id,
-                &mut best_head,
-                self.request_json_budget(
-                    REPLICATION_GET_HEAD_PROTOCOL,
-                    &request,
-                    GAP_SYNC_FETCH_HEAD_REQUEST_TIMEOUT_MS,
-                    GAP_SYNC_FETCH_HEAD_RETRY_BUDGET_MS,
-                ),
-            )?;
-        } else {
-            for peer_id in peer_ids
-                .into_iter()
-                .take(GAP_SYNC_FETCH_HEAD_MAX_PROVIDER_ROUTES_PER_POLL)
-            {
-                self.maybe_update_best_peer_head(
-                    world_id,
-                    &mut best_head,
-                    self.request_json_with_providers_budget(
-                        REPLICATION_GET_HEAD_PROTOCOL,
-                        &request,
-                        std::slice::from_ref(&peer_id),
-                        GAP_SYNC_FETCH_HEAD_REQUEST_TIMEOUT_MS,
-                        GAP_SYNC_FETCH_HEAD_RETRY_BUDGET_MS,
-                    ),
-                )?;
-            }
-        }
-        Ok(best_head)
-    }
-
-    fn maybe_update_best_peer_head(
-        &self,
-        world_id: &str,
-        best_head: &mut Option<WorldHeadAnnounce>,
-        response: Result<FetchHeadResponse, NodeError>,
-    ) -> Result<(), NodeError> {
-        match response {
-            Ok(FetchHeadResponse {
-                found: true,
-                head: Some(head),
-            }) => {
-                if head.world_id != world_id {
-                    return Err(NodeError::Replication {
-                        reason: format!(
-                            "replication peer head mismatch: expected={} actual={}",
-                            world_id, head.world_id
-                        ),
-                    });
-                }
-                let candidate = WorldHeadAnnounce {
-                    world_id: head.world_id,
-                    height: head.height,
-                    block_hash: head.block_hash,
-                    state_root: head.state_root,
-                    timestamp_ms: head.timestamp_ms,
-                    signature: String::new(),
-                };
-                if best_head
-                    .as_ref()
-                    .map(|current| candidate.height > current.height)
-                    .unwrap_or(true)
-                {
-                    *best_head = Some(candidate);
-                }
-                Ok(())
-            }
-            Ok(_) => Ok(()),
-            Err(err) if world_head_lookup_can_fallback(&err) => Ok(()),
-            Err(err) => Err(err),
-        }
     }
 
     pub(crate) fn request_json<Req, Resp>(

--- a/crates/oasis7_node/src/network_bridge.rs
+++ b/crates/oasis7_node/src/network_bridge.rs
@@ -407,9 +407,18 @@ impl ReplicationNetworkEndpoint {
         let request = FetchHeadRequest {
             world_id: world_id.to_string(),
         };
-        let connected_peer_ids = self.network.connected_peer_ids();
+        let mut connected_peer_ids = self.network.connected_peer_ids();
+        connected_peer_ids.sort();
+        connected_peer_ids.dedup();
+        let mut peer_ids = connected_peer_ids.clone();
+        let mut candidate_peer_ids = self.network.known_peer_ids();
+        candidate_peer_ids.sort();
+        candidate_peer_ids.dedup();
+        candidate_peer_ids.retain(|peer_id| !connected_peer_ids.contains(peer_id));
+        peer_ids.extend(candidate_peer_ids);
+        peer_ids.retain(|peer_id| !peer_id.trim().is_empty());
         let mut best_head = None;
-        if connected_peer_ids.is_empty() {
+        if peer_ids.is_empty() {
             self.maybe_update_best_peer_head(
                 world_id,
                 &mut best_head,
@@ -421,7 +430,7 @@ impl ReplicationNetworkEndpoint {
                 ),
             )?;
         } else {
-            for peer_id in connected_peer_ids
+            for peer_id in peer_ids
                 .into_iter()
                 .take(GAP_SYNC_FETCH_HEAD_MAX_PROVIDER_ROUTES_PER_POLL)
             {

--- a/crates/oasis7_node/src/network_bridge/network_bridge_world_head.rs
+++ b/crates/oasis7_node/src/network_bridge/network_bridge_world_head.rs
@@ -1,0 +1,109 @@
+use crate::NodeError;
+use crate::replication::{FetchHeadRequest, FetchHeadResponse, REPLICATION_GET_HEAD_PROTOCOL};
+use oasis7_proto::distributed::WorldHeadAnnounce;
+
+use super::{
+    GAP_SYNC_FETCH_HEAD_MAX_PROVIDER_ROUTES_PER_POLL, GAP_SYNC_FETCH_HEAD_REQUEST_TIMEOUT_MS,
+    GAP_SYNC_FETCH_HEAD_RETRY_BUDGET_MS, ReplicationNetworkEndpoint,
+    world_head_lookup_can_fallback,
+};
+
+impl ReplicationNetworkEndpoint {
+    pub(super) fn request_world_head_from_peers(
+        &self,
+        world_id: &str,
+    ) -> Result<Option<WorldHeadAnnounce>, NodeError> {
+        let request = FetchHeadRequest {
+            world_id: world_id.to_string(),
+        };
+        let mut connected_peer_ids = self.network.connected_peer_ids();
+        connected_peer_ids.sort();
+        connected_peer_ids.dedup();
+        let mut peer_ids = connected_peer_ids.clone();
+        let mut static_bootstrap_peer_ids = self.network.configured_static_bootstrap_peer_ids();
+        static_bootstrap_peer_ids.sort();
+        static_bootstrap_peer_ids.dedup();
+        static_bootstrap_peer_ids
+            .retain(|peer_id| !peer_id.trim().is_empty() && !connected_peer_ids.contains(peer_id));
+        peer_ids.extend(static_bootstrap_peer_ids);
+        let mut candidate_peer_ids = self.network.known_peer_ids();
+        candidate_peer_ids.sort();
+        candidate_peer_ids.dedup();
+        candidate_peer_ids.retain(|peer_id| !peer_ids.contains(peer_id));
+        peer_ids.extend(candidate_peer_ids);
+        peer_ids.retain(|peer_id| !peer_id.trim().is_empty());
+        let mut best_head = None;
+        if peer_ids.is_empty() {
+            self.maybe_update_best_peer_head(
+                world_id,
+                &mut best_head,
+                self.request_json_budget(
+                    REPLICATION_GET_HEAD_PROTOCOL,
+                    &request,
+                    GAP_SYNC_FETCH_HEAD_REQUEST_TIMEOUT_MS,
+                    GAP_SYNC_FETCH_HEAD_RETRY_BUDGET_MS,
+                ),
+            )?;
+        } else {
+            for peer_id in peer_ids
+                .into_iter()
+                .take(GAP_SYNC_FETCH_HEAD_MAX_PROVIDER_ROUTES_PER_POLL)
+            {
+                self.maybe_update_best_peer_head(
+                    world_id,
+                    &mut best_head,
+                    self.request_json_with_providers_budget(
+                        REPLICATION_GET_HEAD_PROTOCOL,
+                        &request,
+                        std::slice::from_ref(&peer_id),
+                        GAP_SYNC_FETCH_HEAD_REQUEST_TIMEOUT_MS,
+                        GAP_SYNC_FETCH_HEAD_RETRY_BUDGET_MS,
+                    ),
+                )?;
+            }
+        }
+        Ok(best_head)
+    }
+
+    pub(super) fn maybe_update_best_peer_head(
+        &self,
+        world_id: &str,
+        best_head: &mut Option<WorldHeadAnnounce>,
+        response: Result<FetchHeadResponse, NodeError>,
+    ) -> Result<(), NodeError> {
+        match response {
+            Ok(FetchHeadResponse {
+                found: true,
+                head: Some(head),
+            }) => {
+                if head.world_id != world_id {
+                    return Err(NodeError::Replication {
+                        reason: format!(
+                            "replication peer head mismatch: expected={} actual={}",
+                            world_id, head.world_id
+                        ),
+                    });
+                }
+                let candidate = WorldHeadAnnounce {
+                    world_id: head.world_id,
+                    height: head.height,
+                    block_hash: head.block_hash,
+                    state_root: head.state_root,
+                    timestamp_ms: head.timestamp_ms,
+                    signature: String::new(),
+                };
+                if best_head
+                    .as_ref()
+                    .map(|current| candidate.height > current.height)
+                    .unwrap_or(true)
+                {
+                    *best_head = Some(candidate);
+                }
+                Ok(())
+            }
+            Ok(_) => Ok(()),
+            Err(err) if world_head_lookup_can_fallback(&err) => Ok(()),
+            Err(err) => Err(err),
+        }
+    }
+}

--- a/crates/oasis7_node/src/tests_storage_replication_peer_head.rs
+++ b/crates/oasis7_node/src/tests_storage_replication_peer_head.rs
@@ -4,6 +4,7 @@ use super::*;
 struct PeerDirectedHeadTestNetwork {
     inner: Arc<TestInMemoryNetwork>,
     connected_peer_ids: Vec<String>,
+    known_peer_ids: Vec<String>,
     peer_heads: Arc<Mutex<HashMap<String, super::replication::FetchHeadResponse>>>,
     head_request_errors: Arc<Mutex<HashMap<String, WorldError>>>,
     unsupported_head_peers: Vec<String>,
@@ -29,6 +30,10 @@ impl oasis7_proto::distributed_net::DistributedNetwork<WorldError> for PeerDirec
 
     fn connected_peer_ids(&self) -> Vec<String> {
         self.connected_peer_ids.clone()
+    }
+
+    fn known_peer_ids(&self) -> Vec<String> {
+        self.known_peer_ids.clone()
     }
 
     fn request_with_providers(
@@ -126,6 +131,7 @@ fn waitable_fetch_commit_error(protocol: &str) -> WorldError {
 fn peer_directed_head_endpoint(
     world_id: &str,
     connected_peer_ids: Vec<String>,
+    known_peer_ids: Vec<String>,
     peer_heads: Arc<Mutex<HashMap<String, super::replication::FetchHeadResponse>>>,
     head_request_errors: Arc<Mutex<HashMap<String, WorldError>>>,
 ) -> (
@@ -138,6 +144,7 @@ fn peer_directed_head_endpoint(
     > = Arc::new(PeerDirectedHeadTestNetwork {
         inner: Arc::new(TestInMemoryNetwork::default()),
         connected_peer_ids,
+        known_peer_ids,
         peer_heads,
         head_request_errors,
         unsupported_head_peers: Vec::new(),
@@ -184,6 +191,7 @@ fn peer_world_head_probe_continues_after_connected_peer_timeout() {
     let (endpoint, provider_attempts) = peer_directed_head_endpoint(
         world_id,
         vec!["peer-a".to_string(), "peer-b".to_string()],
+        vec!["peer-a".to_string(), "peer-b".to_string()],
         peer_heads,
         head_request_errors,
     );
@@ -201,6 +209,53 @@ fn peer_world_head_probe_continues_after_connected_peer_timeout() {
             .expect("lock provider attempts")
             .as_slice(),
         &[vec!["peer-a".to_string()], vec!["peer-b".to_string()]]
+    );
+}
+
+#[test]
+fn peer_world_head_probe_uses_candidate_static_peer_after_active_peer_timeout() {
+    let world_id = "world-peer-head-static-candidate-fallback";
+    let peer_heads = Arc::new(Mutex::new(HashMap::from([(
+        "static-204".to_string(),
+        super::replication::FetchHeadResponse {
+            found: true,
+            head: Some(super::replication::ReplicationHeadSummary {
+                world_id: world_id.to_string(),
+                height: 204,
+                block_hash: "block-204".to_string(),
+                state_root: "state-204".to_string(),
+                timestamp_ms: 4_204,
+            }),
+        },
+    )])));
+    let head_request_errors = Arc::new(Mutex::new(HashMap::from([(
+        "static-205".to_string(),
+        WorldError::NetworkRequestFailed {
+            code: DistributedErrorCode::ErrTimeout,
+            message: REPLICATION_GET_HEAD_PROTOCOL.to_string(),
+            retryable: true,
+        },
+    )])));
+    let (endpoint, provider_attempts) = peer_directed_head_endpoint(
+        world_id,
+        vec!["static-205".to_string()],
+        vec!["static-205".to_string(), "static-204".to_string()],
+        peer_heads,
+        head_request_errors,
+    );
+
+    let head = endpoint
+        .lookup_world_head(world_id)
+        .expect("active timeout should fall through to candidate static peer")
+        .expect("candidate static peer head");
+
+    assert_eq!(head.height, 204);
+    assert_eq!(
+        provider_attempts
+            .lock()
+            .expect("lock provider attempts")
+            .as_slice(),
+        &[vec!["static-205".to_string()], vec!["static-204".to_string()]]
     );
 }
 
@@ -231,6 +286,7 @@ fn peer_world_head_probe_continues_after_protocol_omitted_libp2p_timeout() {
     );
     let (endpoint, provider_attempts) = peer_directed_head_endpoint(
         world_id,
+        vec!["peer-a".to_string(), "peer-b".to_string()],
         vec!["peer-a".to_string(), "peer-b".to_string()],
         peer_heads,
         head_request_errors,
@@ -283,6 +339,7 @@ fn peer_world_head_probe_rejects_mismatched_world_without_fallback() {
     );
     let (endpoint, provider_attempts) = peer_directed_head_endpoint(
         world_id,
+        vec!["peer-a".to_string(), "peer-b".to_string()],
         vec!["peer-a".to_string(), "peer-b".to_string()],
         peer_heads,
         Arc::new(Mutex::new(HashMap::new())),
@@ -408,6 +465,7 @@ fn observer_gap_sync_continues_peer_world_head_probe_after_peer_without_head() {
     > = Arc::new(PeerDirectedHeadTestNetwork {
         inner: Arc::new(TestInMemoryNetwork::default()),
         connected_peer_ids: vec!["peer-a".to_string(), "peer-b".to_string()],
+        known_peer_ids: vec!["peer-a".to_string(), "peer-b".to_string()],
         peer_heads: Arc::clone(&peer_heads),
         head_request_errors: Arc::new(Mutex::new(HashMap::new())),
         unsupported_head_peers: vec!["peer-a".to_string()],
@@ -540,6 +598,7 @@ fn peer_world_head_fallback_retains_high_network_height_after_partial_sync() {
     > = Arc::new(PeerDirectedHeadTestNetwork {
         inner: Arc::new(TestInMemoryNetwork::default()),
         connected_peer_ids: vec!["peer-a".to_string()],
+        known_peer_ids: vec!["peer-a".to_string()],
         peer_heads,
         head_request_errors: Arc::new(Mutex::new(HashMap::new())),
         unsupported_head_peers: Vec::new(),
@@ -666,6 +725,7 @@ fn peer_world_head_fallback_retains_high_network_height_after_waitable_gap() {
     > = Arc::new(PeerDirectedHeadTestNetwork {
         inner: Arc::new(TestInMemoryNetwork::default()),
         connected_peer_ids: vec!["peer-a".to_string()],
+        known_peer_ids: vec!["peer-a".to_string()],
         peer_heads,
         head_request_errors: Arc::new(Mutex::new(HashMap::new())),
         unsupported_head_peers: Vec::new(),

--- a/crates/oasis7_node/src/tests_storage_replication_peer_head.rs
+++ b/crates/oasis7_node/src/tests_storage_replication_peer_head.rs
@@ -5,11 +5,13 @@ struct PeerDirectedHeadTestNetwork {
     inner: Arc<TestInMemoryNetwork>,
     connected_peer_ids: Vec<String>,
     known_peer_ids: Vec<String>,
+    configured_static_bootstrap_peer_ids: Vec<String>,
     peer_heads: Arc<Mutex<HashMap<String, super::replication::FetchHeadResponse>>>,
     head_request_errors: Arc<Mutex<HashMap<String, WorldError>>>,
     unsupported_head_peers: Vec<String>,
     waitable_fetch_commit_heights: Arc<Mutex<Vec<u64>>>,
     provider_attempts: Arc<Mutex<Vec<Vec<String>>>>,
+    provider_budgets: Arc<Mutex<Vec<(u64, u64)>>>,
 }
 
 impl oasis7_proto::distributed_net::DistributedNetwork<WorldError> for PeerDirectedHeadTestNetwork {
@@ -34,6 +36,25 @@ impl oasis7_proto::distributed_net::DistributedNetwork<WorldError> for PeerDirec
 
     fn known_peer_ids(&self) -> Vec<String> {
         self.known_peer_ids.clone()
+    }
+
+    fn configured_static_bootstrap_peer_ids(&self) -> Vec<String> {
+        self.configured_static_bootstrap_peer_ids.clone()
+    }
+
+    fn request_with_providers_budget(
+        &self,
+        protocol: &str,
+        payload: &[u8],
+        providers: &[String],
+        request_timeout_ms: u64,
+        retry_budget_ms: u64,
+    ) -> Result<Vec<u8>, WorldError> {
+        self.provider_budgets
+            .lock()
+            .expect("lock provider budgets")
+            .push((request_timeout_ms, retry_budget_ms));
+        self.request_with_providers(protocol, payload, providers)
     }
 
     fn request_with_providers(
@@ -132,24 +153,29 @@ fn peer_directed_head_endpoint(
     world_id: &str,
     connected_peer_ids: Vec<String>,
     known_peer_ids: Vec<String>,
+    configured_static_bootstrap_peer_ids: Vec<String>,
     peer_heads: Arc<Mutex<HashMap<String, super::replication::FetchHeadResponse>>>,
     head_request_errors: Arc<Mutex<HashMap<String, WorldError>>>,
 ) -> (
     ReplicationNetworkEndpoint,
     Arc<Mutex<Vec<Vec<String>>>>,
+    Arc<Mutex<Vec<(u64, u64)>>>,
 ) {
     let provider_attempts = Arc::new(Mutex::new(Vec::<Vec<String>>::new()));
+    let provider_budgets = Arc::new(Mutex::new(Vec::<(u64, u64)>::new()));
     let network: Arc<
         dyn oasis7_proto::distributed_net::DistributedNetwork<WorldError> + Send + Sync,
     > = Arc::new(PeerDirectedHeadTestNetwork {
         inner: Arc::new(TestInMemoryNetwork::default()),
         connected_peer_ids,
         known_peer_ids,
+        configured_static_bootstrap_peer_ids,
         peer_heads,
         head_request_errors,
         unsupported_head_peers: Vec::new(),
         waitable_fetch_commit_heights: Arc::new(Mutex::new(Vec::new())),
         provider_attempts: Arc::clone(&provider_attempts),
+        provider_budgets: Arc::clone(&provider_budgets),
     });
     let handle = NodeReplicationNetworkHandle::new(network);
     let endpoint = ReplicationNetworkEndpoint::new(
@@ -159,7 +185,7 @@ fn peer_directed_head_endpoint(
         &NodeNetworkPolicy::for_runtime_role(NodeRole::Observer),
     )
     .expect("peer-directed head endpoint");
-    (endpoint, provider_attempts)
+    (endpoint, provider_attempts, provider_budgets)
 }
 
 #[test]
@@ -188,10 +214,11 @@ fn peer_world_head_probe_continues_after_connected_peer_timeout() {
             retryable: true,
         },
     );
-    let (endpoint, provider_attempts) = peer_directed_head_endpoint(
+    let (endpoint, provider_attempts, _) = peer_directed_head_endpoint(
         world_id,
         vec!["peer-a".to_string(), "peer-b".to_string()],
         vec!["peer-a".to_string(), "peer-b".to_string()],
+        Vec::new(),
         peer_heads,
         head_request_errors,
     );
@@ -236,9 +263,10 @@ fn peer_world_head_probe_uses_candidate_static_peer_after_active_peer_timeout() 
             retryable: true,
         },
     )])));
-    let (endpoint, provider_attempts) = peer_directed_head_endpoint(
+    let (endpoint, provider_attempts, _) = peer_directed_head_endpoint(
         world_id,
         vec!["static-205".to_string()],
+        vec!["static-205".to_string(), "static-204".to_string()],
         vec!["static-205".to_string(), "static-204".to_string()],
         peer_heads,
         head_request_errors,
@@ -256,6 +284,62 @@ fn peer_world_head_probe_uses_candidate_static_peer_after_active_peer_timeout() 
             .expect("lock provider attempts")
             .as_slice(),
         &[vec!["static-205".to_string()], vec!["static-204".to_string()]]
+    );
+}
+
+#[test]
+fn peer_world_head_probe_prioritizes_static_bootstrap_before_earlier_dht_candidate() {
+    let world_id = "world-peer-head-static-bootstrap-priority";
+    let peer_heads = Arc::new(Mutex::new(HashMap::from([(
+        "static-204".to_string(),
+        super::replication::FetchHeadResponse {
+            found: true,
+            head: Some(super::replication::ReplicationHeadSummary {
+                world_id: world_id.to_string(),
+                height: 204,
+                block_hash: "block-204".to_string(),
+                state_root: "state-204".to_string(),
+                timestamp_ms: 4_204,
+            }),
+        },
+    )])));
+    let head_request_errors = Arc::new(Mutex::new(HashMap::from([(
+        "static-205".to_string(),
+        WorldError::NetworkRequestFailed {
+            code: DistributedErrorCode::ErrTimeout,
+            message: REPLICATION_GET_HEAD_PROTOCOL.to_string(),
+            retryable: true,
+        },
+    )])));
+    let (endpoint, provider_attempts, provider_budgets) = peer_directed_head_endpoint(
+        world_id,
+        vec!["static-205".to_string()],
+        vec![
+            "dht-001".to_string(),
+            "static-204".to_string(),
+            "static-205".to_string(),
+        ],
+        vec!["static-205".to_string(), "static-204".to_string()],
+        peer_heads,
+        head_request_errors,
+    );
+
+    let head = endpoint
+        .lookup_world_head(world_id)
+        .expect("active timeout should fall through to static bootstrap provider")
+        .expect("static bootstrap provider head");
+
+    assert_eq!(head.height, 204);
+    assert_eq!(
+        provider_attempts
+            .lock()
+            .expect("lock provider attempts")
+            .as_slice(),
+        &[vec!["static-205".to_string()], vec!["static-204".to_string()]]
+    );
+    assert_eq!(
+        provider_budgets.lock().expect("lock provider budgets").as_slice(),
+        &[(1_500, 3_000), (1_500, 3_000)]
     );
 }
 
@@ -284,10 +368,11 @@ fn peer_world_head_probe_continues_after_protocol_omitted_libp2p_timeout() {
                 .to_string(),
         },
     );
-    let (endpoint, provider_attempts) = peer_directed_head_endpoint(
+    let (endpoint, provider_attempts, _) = peer_directed_head_endpoint(
         world_id,
         vec!["peer-a".to_string(), "peer-b".to_string()],
         vec!["peer-a".to_string(), "peer-b".to_string()],
+        Vec::new(),
         peer_heads,
         head_request_errors,
     );
@@ -337,10 +422,11 @@ fn peer_world_head_probe_rejects_mismatched_world_without_fallback() {
             }),
         },
     );
-    let (endpoint, provider_attempts) = peer_directed_head_endpoint(
+    let (endpoint, provider_attempts, _) = peer_directed_head_endpoint(
         world_id,
         vec!["peer-a".to_string(), "peer-b".to_string()],
         vec!["peer-a".to_string(), "peer-b".to_string()],
+        Vec::new(),
         peer_heads,
         Arc::new(Mutex::new(HashMap::new())),
     );
@@ -466,11 +552,13 @@ fn observer_gap_sync_continues_peer_world_head_probe_after_peer_without_head() {
         inner: Arc::new(TestInMemoryNetwork::default()),
         connected_peer_ids: vec!["peer-a".to_string(), "peer-b".to_string()],
         known_peer_ids: vec!["peer-a".to_string(), "peer-b".to_string()],
+        configured_static_bootstrap_peer_ids: Vec::new(),
         peer_heads: Arc::clone(&peer_heads),
         head_request_errors: Arc::new(Mutex::new(HashMap::new())),
         unsupported_head_peers: vec!["peer-a".to_string()],
         waitable_fetch_commit_heights: Arc::new(Mutex::new(Vec::new())),
         provider_attempts: Arc::clone(&provider_attempts),
+        provider_budgets: Arc::new(Mutex::new(Vec::new())),
     });
     register_replication_fetch_handlers(
         &NodeReplicationNetworkHandle::new(Arc::clone(&network)),
@@ -599,11 +687,13 @@ fn peer_world_head_fallback_retains_high_network_height_after_partial_sync() {
         inner: Arc::new(TestInMemoryNetwork::default()),
         connected_peer_ids: vec!["peer-a".to_string()],
         known_peer_ids: vec!["peer-a".to_string()],
+        configured_static_bootstrap_peer_ids: Vec::new(),
         peer_heads,
         head_request_errors: Arc::new(Mutex::new(HashMap::new())),
         unsupported_head_peers: Vec::new(),
         waitable_fetch_commit_heights: Arc::new(Mutex::new(Vec::new())),
         provider_attempts,
+        provider_budgets: Arc::new(Mutex::new(Vec::new())),
     });
     register_replication_fetch_handlers(
         &NodeReplicationNetworkHandle::new(Arc::clone(&network)),
@@ -726,11 +816,13 @@ fn peer_world_head_fallback_retains_high_network_height_after_waitable_gap() {
         inner: Arc::new(TestInMemoryNetwork::default()),
         connected_peer_ids: vec!["peer-a".to_string()],
         known_peer_ids: vec!["peer-a".to_string()],
+        configured_static_bootstrap_peer_ids: Vec::new(),
         peer_heads,
         head_request_errors: Arc::new(Mutex::new(HashMap::new())),
         unsupported_head_peers: Vec::new(),
         waitable_fetch_commit_heights: Arc::new(Mutex::new(vec![2])),
         provider_attempts: Arc::new(Mutex::new(Vec::new())),
+        provider_budgets: Arc::new(Mutex::new(Vec::new())),
     });
     register_replication_fetch_handlers(
         &NodeReplicationNetworkHandle::new(Arc::clone(&network)),

--- a/crates/oasis7_proto/src/distributed_net.rs
+++ b/crates/oasis7_proto/src/distributed_net.rs
@@ -174,6 +174,9 @@ pub trait DistributedNetwork<E> {
     fn known_peer_ids(&self) -> Vec<String> {
         self.connected_peer_ids()
     }
+    fn configured_static_bootstrap_peer_ids(&self) -> Vec<String> {
+        Vec::new()
+    }
     fn request_with_providers(
         &self,
         protocol: &str,


### PR DESCRIPTION
Task: task_b03d3dbdec634442ad080acf710ffa51

Closes #2217

Follow-up to merged #2218: restores static bootstrap priority for world-head recovery and prevents DHT candidate starvation.