### PR TITLE
Polish GitHub Pages homepage

### DIFF
--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -425,6 +425,21 @@ h3 {
   gap: 0.58rem;
 }
 
+.hero-overview-link {
+  align-self: center;
+  color: #b9cfdd;
+  font-size: 0.86rem;
+  font-weight: 700;
+  text-decoration: underline;
+  text-decoration-color: rgba(131, 188, 220, 0.44);
+  text-underline-offset: 0.22em;
+}
+
+.hero-overview-link:hover {
+  color: #e7fff3;
+  text-decoration-color: var(--accent);
+}
+
 .button {
   display: inline-flex;
   align-items: center;
@@ -483,6 +498,63 @@ h3 {
   display: grid;
   gap: 0.58rem;
   grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.hero-facts {
+  margin-top: 0.88rem;
+}
+
+.preview-badge {
+  display: inline-flex;
+  align-items: center;
+  min-height: 2.25rem;
+  border: 1px solid rgba(255, 184, 107, 0.58);
+  border-radius: 999px;
+  background: linear-gradient(145deg, rgba(55, 35, 19, 0.94), rgba(19, 28, 28, 0.9));
+  box-shadow: 0 10px 18px rgba(255, 184, 107, 0.1);
+  color: #fff2dd;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.015em;
+  padding: 0.34rem 0.72rem;
+}
+
+.preview-badge::before {
+  content: "";
+  width: 7px;
+  height: 7px;
+  margin-right: 0.44rem;
+  border-radius: 999px;
+  background: var(--accent-warm);
+  box-shadow: 0 0 0 3px rgba(255, 184, 107, 0.16);
+}
+
+.hero-facts dl {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.48rem;
+  margin: 0.56rem 0 0;
+}
+
+.hero-facts dl > div {
+  min-width: 0;
+  border-left: 2px solid rgba(67, 239, 187, 0.44);
+  padding: 0.12rem 0 0.12rem 0.52rem;
+}
+
+.hero-facts dt {
+  color: #85b4a9;
+  font-family: "JetBrains Mono", "SFMono-Regular", Consolas, monospace;
+  font-size: 0.66rem;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+}
+
+.hero-facts dd {
+  margin: 0.12rem 0 0;
+  color: #d8e9f3;
+  font-size: 0.76rem;
+  line-height: 1.38;
 }
 
 .metric-box {
@@ -2250,6 +2322,28 @@ code {
     align-items: stretch;
   }
 
+  .hero-overview-link {
+    align-self: stretch;
+    padding: 0.12rem 0;
+    text-align: center;
+  }
+
+  .hero-facts dl {
+    grid-template-columns: 1fr;
+    gap: 0.34rem;
+  }
+
+  .hero-facts dl > div {
+    display: grid;
+    grid-template-columns: 5.4rem minmax(0, 1fr);
+    gap: 0.42rem;
+    align-items: baseline;
+  }
+
+  .hero-facts dd {
+    margin: 0;
+  }
+
   .hero .proof-strip .proof-chip {
     width: 100%;
   }
@@ -2377,7 +2471,30 @@ code {
     mask-image: linear-gradient(to bottom, rgba(0, 0, 0, 0.58) 0%, rgba(0, 0, 0, 0.9) 72%, rgba(0, 0, 0, 0.22) 100%);
   }
 
-  .hero-visual,
+  .hero-visual {
+    display: block;
+    margin-top: 0.1rem;
+  }
+
+  .hero-figure {
+    padding: 0.46rem;
+  }
+
+  .hero-figure::before {
+    inset: 0.46rem;
+  }
+
+  .hero-figure img {
+    aspect-ratio: 16 / 9;
+  }
+
+  .hero-figure figcaption {
+    margin-top: 0.32rem;
+    font-size: 0.7rem;
+    line-height: 1.35;
+  }
+
+  .hero-visual .pulse-panel,
   .hero-stats {
     display: none;
   }

--- a/site/en/index.html
+++ b/site/en/index.html
@@ -77,28 +77,38 @@
         <div class="hero-grid">
           <div>
             <p class="eyebrow">AI-Agent Civilization Sim</p>
-            <h1>Lead an AI-agent civilization in a fractured asteroid belt</h1>
+            <h1>When resources tighten, steer an AI-agent civilization through the fractured asteroid belt</h1>
             <p class="subtitle">
-              You guide the civilization from above: decide whether it races for ore, stabilizes its routes, or turns fragile cooperation into auditable agreements. Agents handle harvesting,
-              production, trade, coordination, and governance under hard limits, so prices, blocs, and policy shifts leave consequences behind in the same persistent world. What is public today is
-              still a gameplay preview.
+              Pressure comes first: power, compute, storage, and bandwidth all get tight. You set direction and constraints from outside the civilization; agents choose how to harvest,
+              produce, trade, coordinate, and govern, leaving inspectable price, relationship, and policy consequences in the same persistent world. What is public today is still a gameplay preview.
             </p>
             <div class="cta-row">
               <a class="button primary" href="#what">See The Core Loop In 30 Seconds</a>
               <a class="button secondary" href="#proof">See One Event Chain</a>
               <a
-                class="button ghost"
+                class="hero-overview-link"
                 href="../doc/en/project-overview.html"
                 target="_blank"
                 rel="noreferrer"
-                >Open Project Overview</a
+                >Read The Project Overview</a
               >
             </div>
-            <div class="proof-strip hero-proof-strip" aria-label="Homepage status evidence">
-              <span class="proof-chip is-highlight">World: fractured asteroid-belt civilization</span>
-              <span class="proof-chip">Player role: outside civilization strategist</span>
-              <span class="proof-chip">Loop: expansion / trade / cooperation / governance</span>
-              <span class="proof-chip" data-homepage-claim="preview-status">Status: limited playable technical preview</span>
+            <div class="hero-facts" aria-label="Homepage essentials">
+              <span class="preview-badge" data-homepage-claim="preview-status">Status: limited playable technical preview</span>
+              <dl>
+                <div>
+                  <dt>World</dt>
+                  <dd>fractured asteroid-belt civilization</dd>
+                </div>
+                <div>
+                  <dt>Your role</dt>
+                  <dd>set direction and constraints, not unit orders</dd>
+                </div>
+                <div>
+                  <dt>Loop</dt>
+                  <dd>pressure → autonomous agent choice → inspectable consequence</dd>
+                </div>
+              </dl>
             </div>
             <div class="hero-stats" aria-label="Hero gameplay pressure lines">
               <article class="metric-box">
@@ -325,7 +335,7 @@
           </article>
           <article class="proof-timeline-item" data-proof-event="triad" data-proof-visible="false">
             <span>Tick 149</span>
-            <p>triad_region: a multi-party pact lands on-chain, showing governance signaling is already auditable.</p>
+            <p>triad_region: a multi-party pact is recorded in an auditable trail, showing governance signaling is already auditable.</p>
           </article>
           <article class="proof-timeline-item" data-proof-event="triad" data-proof-visible="false">
             <span>Tick 155</span>
@@ -600,7 +610,7 @@
               >
               <a class="button secondary" href="../doc/en/index.html">Open Docs Hub</a>
               <a class="button primary" href="https://github.com/eng-cc/oasis7/issues" target="_blank" rel="noreferrer"
-                >Send Feedback</a
+                >Report A Preview Blocker</a
               >
             </div>
           </article>

--- a/site/index.html
+++ b/site/index.html
@@ -77,27 +77,38 @@
         <div class="hero-grid">
           <div>
             <p class="eyebrow">AI Agent 文明模拟游戏</p>
-            <h1>带着 AI Agent 文明，在破碎小行星带建设、交易与治理</h1>
+            <h1>资源吃紧时，带着 AI Agent 文明在破碎小行星带做选择</h1>
             <p class="subtitle">
-              你站在文明外部决定方向：是扩张矿带、稳定产线，还是把一段临时协作变成可审计的协议。Agent 会在有限的电力、算力、存储和带宽里自己采集、生产、交易、协作和治理，
-              让价格、关系和政策在同一个持续世界里留下后果。当前公开的是玩法技术预览。
+              压力先来：电力、算力、存储和带宽都会变紧。你从文明外部设定方向与约束；Agent 自己采集、生产、交易、协作和治理，
+              让每次选择在同一个持续世界里留下可回看的价格、关系和政策后果。当前公开的是玩法技术预览。
             </p>
             <div class="cta-row">
               <a class="button primary" href="#what">30 秒看懂玩法</a>
               <a class="button secondary" href="#proof">看一局事件链</a>
               <a
-                class="button ghost"
+                class="hero-overview-link"
                 href="doc/cn/project-overview.html"
                 target="_blank"
                 rel="noreferrer"
-                >看白皮书式总览</a
+                >阅读项目总览</a
               >
             </div>
-            <div class="proof-strip hero-proof-strip" aria-label="首页状态证据">
-              <span class="proof-chip is-highlight">世界：破碎小行星带文明</span>
-              <span class="proof-chip">玩家：文明外部指挥者</span>
-              <span class="proof-chip">玩法：扩张 / 交易 / 协作 / 治理</span>
-              <span class="proof-chip" data-homepage-claim="preview-status">状态：limited playable technical preview</span>
+            <div class="hero-facts" aria-label="首页核心事实">
+              <span class="preview-badge" data-homepage-claim="preview-status">状态：limited playable technical preview</span>
+              <dl>
+                <div>
+                  <dt>世界</dt>
+                  <dd>破碎小行星带文明</dd>
+                </div>
+                <div>
+                  <dt>你的角色</dt>
+                  <dd>定方向与约束，不逐个微操</dd>
+                </div>
+                <div>
+                  <dt>循环</dt>
+                  <dd>压力 → Agent 自主选择 → 回看后果</dd>
+                </div>
+              </dl>
             </div>
             <div class="hero-stats" aria-label="首屏玩法压力线">
               <article class="metric-box">
@@ -598,7 +609,7 @@
               >
               <a class="button ghost" href="doc/cn/index.html">看文档中心</a>
               <a class="button primary" href="https://github.com/eng-cc/oasis7/issues" target="_blank" rel="noreferrer"
-                >给反馈</a
+                >报告预览阻塞</a
               >
             </div>
           </article>


### PR DESCRIPTION
## Summary

- simplify the GitHub Pages hero into one primary action, one evidence action, and a compact preview boundary
- keep the controlled Viewer capture visible on mobile while hiding secondary panels
- align Chinese and English public copy, including auditable-trail and preview-blocker wording

## Verification

- `./scripts/site-link-check.sh`
- `./scripts/site-homepage-claim-check.sh`
- `./scripts/site-manual-sync-check.sh`
- `./scripts/site-download-check.sh`
- responsive browser checks at 1440x900, 390x844, and 360x800
- `git diff --check`

Refs #2387
Task: task_2fab607c4b274cfd8a0d1b99b5320d4f
