### PR TITLE
docs: define governed regional capability lifecycle

### DIFF
--- a/doc/game/README.md
+++ b/doc/game/README.md
@@ -1,6 +1,6 @@
 # game 文档索引
 
-产品层归属：`game` 是“世界规则与核心玩法”的专业域权威；区域设施专题同时向“大世界基础设施”产品 PRD 汇报组合关系，但不形成并列产品入口。产品总导航见 `doc/product/README.md`。
+产品层归属：`game` 是“世界规则与核心玩法”的专业域权威；区域设施的产品组合关系由该模块的 [`受治理的区域能力与扩展`](../product/world-rules-core-gameplay/governed-regional-capabilities-and-extensions.prd.md) 专题承载，不形成并列产品入口。产品总导航见 `doc/product/README.md`。
 
 审计轮次: 12
 

--- a/doc/game/prd.index.md
+++ b/doc/game/prd.index.md
@@ -1,6 +1,6 @@
 # game PRD 文件级索引
 
-区域设施阅读顺序：先从 `doc/product/README.md` 选择“大世界基础设施”，再由其产品 PRD 下钻到本索引中的 `micro_depot` 专题。`PRD-GAME-016` 继续是该设施玩法与经济边界的专业域权威。
+区域设施阅读顺序：先从 `doc/product/README.md` 选择“世界规则与核心玩法”，再读其 [`受治理的区域能力与扩展`](../product/world-rules-core-gameplay/governed-regional-capabilities-and-extensions.prd.md) 产品专题，最后下钻到本索引中的 `micro_depot` 专业合同。`PRD-GAME-016` 继续是该设施玩法与经济边界的专业域权威。
 审计轮次: 12
 
 更新时间：2026-07-06

--- a/doc/game/prd.md
+++ b/doc/game/prd.md
@@ -1,6 +1,6 @@
 # game PRD
 
-> 专业域 authority：本文件是 `game` 的活跃玩法基线与路由入口，拥有 PRD-ID、专题范围、活跃阅读路径和状态指针；专题在其声明范围内拥有详细玩法合同与验收。产品承诺仍由四模块 `doc/product/` 层拥有，不因本文件或专题而形成并列产品入口。`micro_depot` 等设施规则仍由 `game` 管理；跨域产品承诺由 [`doc/product/world-infrastructure/prd.md`](../product/world-infrastructure/prd.md) 汇总。
+> 专业域 authority：本文件是 `game` 的活跃玩法基线与路由入口，拥有 PRD-ID、专题范围、活跃阅读路径和状态指针；专题在其声明范围内拥有详细玩法合同与验收。产品承诺仍由四模块 `doc/product/` 层拥有，不因本文件或专题而形成并列产品入口。`micro_depot` 等设施规则仍由 `game` 管理；跨域产品承诺由世界规则与核心玩法模块的 [`受治理的区域能力与扩展`](../product/world-rules-core-gameplay/governed-regional-capabilities-and-extensions.prd.md) 专题汇总，确定性执行、最终性与恢复底座继续下钻到 [`大世界基础设施`](../product/world-infrastructure/prd.md)。
 
 审计轮次: 11
 

--- a/doc/product/world-infrastructure/prd.md
+++ b/doc/product/world-infrastructure/prd.md
@@ -33,7 +33,7 @@
 ### 非权威迁移索引
 
 - [`世界连续性与恢复（历史引用）`](world-continuity-governance-and-recovery.prd.md)：已退休的旧路径，保留仅为存量专业链接；不构成 active authority 或验收。
-- [`区域能力与扩展（待迁移）`](governed-regional-capabilities-and-extensions.prd.md)、[`区域 charter/tenure（待迁移）`](regional-charter-tenure-and-public-funding.prd.md)、[`工业/市场（待迁移）`](governed-industry-market-and-emergency-supply.prd.md) 与 [`普通治理（部分待迁移）`](global-governance-organization-continuity-and-constitutional-guardrails.prd.md) 都是 `superseded` 迁移债务：各页迁移头记录接收 owner、已吸收切片与删除条件，内容仍可供接收模块 owner 迁移，但这些路径不再构成本模块产品 authority、路线图、active topic 或验收。原 frontier 迁移债务已由世界规则与核心玩法吸收，不再保留在本模块索引。
+- [`区域 charter/tenure（待迁移）`](regional-charter-tenure-and-public-funding.prd.md)、[`工业/市场（待迁移）`](governed-industry-market-and-emergency-supply.prd.md) 与 [`普通治理（部分待迁移）`](global-governance-organization-continuity-and-constitutional-guardrails.prd.md) 都是 `superseded` 迁移债务：各页迁移头记录接收 owner、已吸收切片与删除条件，内容仍可供接收模块 owner 迁移，但这些路径不再构成本模块产品 authority、路线图、active topic 或验收。原 frontier 与区域能力/扩展迁移债务已由世界规则与核心玩法吸收，不再保留在本模块索引。
 
 此前的区域设施、市场/工业、charter、frontier 与普通治理分册已从本模块退休：它们是上层 gameplay/world-rule 产品语义，不能再作为基础设施的 taxonomy 或验收门槛。对应专业域与其他产品模块继续拥有其规则、实现合同和现状证据；本次退休不宣称这些能力已迁移、实现或公开可用。
 

--- a/doc/product/world-rules-core-gameplay/governed-regional-capabilities-and-extensions.prd.md
+++ b/doc/product/world-rules-core-gameplay/governed-regional-capabilities-and-extensions.prd.md
@@ -1,17 +1,12 @@
-# 受治理的区域能力与扩展（待迁移）
+# 受治理的区域能力与扩展
 
 ## 文档身份
 
-- 所属产品模块：大世界基础设施
+- 所属产品模块：世界规则与核心玩法
 - 上位产品 PRD：[`prd.md`](prd.md)
-- 生命周期：`superseded`
+- 生命周期：`active`
 - Owner role：`producer_system_designer`
 - 专业域权威：[`区域设施合同`](../../game/gameplay/gameplay-regional-infrastructure-micro-depot-contract.prd.md)、[`玩家发布实体合同`](../../world-runtime/module/player-published-entities.prd.md)、[`doc/p2p/prd.md`](../../p2p/prd.md)、[`doc/testing/prd.md`](../../testing/prd.md)
-
-## 迁移状态
-
-本页保留完整、未吸收的稳定产品语义和验收，避免在迁移前丢失规则。它已不再是大世界基础设施的 active authority、路线图或验收入口：基础设施只提供最终性、权威状态、复制、存储、恢复和确定性执行边界。接收 authority 是 [`世界规则与核心玩法`](../world-rules-core-gameplay/prd.md)；其 owner 必须完成语义回填和活跃引用修复后，才能删除本页。专业实现、数值、runtime/P2P 合同和当前公开 claim 仍由各自专业 authority 拥有。
-
 
 本文承载受治理的区域设施与工业能力扩展的长期产品承诺：玩家以有限、可读和可审计的方式改变局部世界，授权创作者也只能经治理把新的可用能力接入同一权威世界。它不把每项设施或每个制成品写成独立产品入口，也不冻结实现合同、数值或当前可用性。
 
@@ -27,6 +22,8 @@
 - 设施应在玩家已经理解基础控制权、资源压力和区域 blocker 后提供有限区域 leverage；低价值或不合适的选择必须仍可解释，而不被呈现为必选 buff。
 - 受治理扩展让新制成品、配方、工厂或等价工业能力在批准后进入可用世界能力；玩家和创作者不能任意上传、直接写入权威状态、覆盖既有世界身份或取得默认全局治理权。
 - 设施和扩展都必须保留世界唯一性：玩家报价、确认、权威执行、持久结果、恢复和重连后的可见结果属于同一条可审计链路。
+- 报价只描述当前条件，不预留资源、设施容量、价格、资格或排队顺位；提交时必须按最新权威状态重新校验。报价后条件变化时，系统只能接受一次并产生一个权威结果，或原子拒绝并返回更新后的 blocker、取舍和下一步。
+- 重复、过期、重连或跨入口重试不能产生第二次扣减、设施服务、发布或恢复结果。尚未获得权威确认的交接、发布或恢复保持待决；玩家和创作者不能把请求送达、技术构建成功或本地缓存当作已生效能力。
 - 可扩展不等于已公开、无限容量或所有创作均已支持；当前公开状态与实际证据继续由根 README 和专业域拥有。
 
 ## 3. 权威边界
@@ -47,6 +44,7 @@
 - GR-3：代表性受治理扩展流程贯通创作者提案、授权审查、权威生效、世界可用能力、审计与异常恢复；任一阶段不能用技术旁路替代治理。
 - GR-4：设施和扩展的同一身份在玩家表达、权威执行、持久化/replay、适用的复制或恢复以及重连可见结果中保持一致。
 - GR-5：产品、game、runtime、WASM、P2P 与 testing 证据绑定同一候选；单独的传输 green、模块提交、文档迁移或局部 UI 不得代签端到端闭环。
+- GR-6：报价后资源、容量、资格、治理状态或世界前置发生变化时，提交只能按最新权威状态接受一次或原子拒绝；重复、过期、重连与跨入口重试不会产生第二次扣减、服务、发布或恢复结果，待决状态不会被表达为已生效。
 
 ### 4.1 验收追踪
 
@@ -56,6 +54,7 @@
 | GR-3 | runtime_engineer / wasm_platform_engineer / gameplay_designer | PRD-WORLD_RUNTIME-010 / PRD-WORLD_RUNTIME-011 / PRD-WORLD_RUNTIME-012 | 受治理扩展从提案到可用能力、拒绝和恢复的证据 | test_tier_required |
 | GR-4 | runtime_engineer / blockchain_ops_engineer / viewer_engineer | PRD-GAME-016 / PRD-WORLD_RUNTIME-001 / PRD-P2P-002 | 同一能力跨执行、回放、恢复和重连的组合证据 | test_tier_full |
 | GR-5 | producer_system_designer / qa_engineer | PRD-TESTING-003 | 同候选跨域组合审计 | test_tier_full |
+| GR-6 | gameplay_designer / runtime_engineer / wasm_platform_engineer / viewer_engineer / qa_engineer | PRD-GAME-016 / PRD-WORLD_RUNTIME-001 / PRD-WORLD_RUNTIME-010 / PRD-TESTING-003 | 报价后状态变化、重复/过期/重连/跨入口提交与待决表达的负例证据 | test_tier_required |
 
 ## 5. Non-Goals
 

--- a/doc/product/world-rules-core-gameplay/prd.md
+++ b/doc/product/world-rules-core-gameplay/prd.md
@@ -21,6 +21,7 @@
 - [`间接控制下的玩家能动性与续接`](indirect-control-agency-and-continuation.prd.md)：玩家通过 Agent 推动世界时的意图可读、因果可解释、干预重排、记忆纠正与回流续接。
 - [`Agent 所有权与持续经营`](agent-ownership-and-stewardship.prd.md)：玩家以明确承诺取得、维持或结束自己的 Agent 控制权，并读懂成本、风险和恢复选择。
 - [`成熟世界成长与区域参与`](mature-world-progression.prd.md)：首次持续能力之后的独立成长、区域专业化、有限影响与 anti-grind / 恢复边界。
+- [`受治理的区域能力与扩展`](governed-regional-capabilities-and-extensions.prd.md)：区域设施从条件报价到有限服务、维护/耗尽/退役的生命周期，以及创作者扩展从治理提案到权威生效、审计与恢复的产品边界。
 - [`区域冲突、软赛季与可恢复损失`](chartered-conflict-soft-seasons-and-recovery.prd.md)：宣战、有限参战范围、实体战利品/占领、可恢复重建和不重置世界的软赛季边界。
 - [`沟通、合同、声誉与 R&D 连续性`](communication-contracts-reputation-and-rd-continuity.prd.md)：人类沟通与 Agent 合同的边界、持续服务争端、情境声誉及研究归因/份额的长期产品语义。
 - [`组织连续性、解散与长期不活跃保护`](organization-continuity-dissolution-and-dormancy-protection.prd.md)：组织 charter 的个人保护底线、可审计解散顺序，以及长期不活跃时的保护、恢复主张与有限处置边界。
@@ -139,6 +140,7 @@ Data 是有归属、有获取成本且受授权边界约束的世界资源。未
 - SC-15：代表性组织解散与长期不活跃样例证明 charter 不越过个人资产、合同、退出、历史和 Agent 身份的保护底线；风险冻结、合同与托管处理、责任/成本、持续业务处置、剩余分配，以及通知、保护期、可恢复主张、申诉和有限后续处置均留在同一可审计世界因果链中，不产生静默没收、身份删除、历史重写或重复生效。
 - SC-16：代表性资源、资格或持续义务路径证明预览不产生世界效果；已接受承诺可读出范围、未决后果和下一步；已结算结果有 receipt 支持。报价与提交之间发生竞争性状态变化时，提交按当前条件至多结算一次并产生 receipt，或原子拒绝且不产生 sink/义务；`electricity_after` 不被误读为运行 runway 或不停机保证。过期、撤销、失效、重连重试和历史 receipt 重放不会制造第二次 sink、免费资源、资格续期或隐藏欠费，且未结算部分与既有已发生后果按相应专业合同保留可读 provenance、拒绝/待决或恢复路径。
 - SC-17：代表性共同决策样例证明普通治理只受理明示的政策、公共财库与既有 charter 日常事项；宪制、基本权利与系统安全事项被原子拒绝或路由到独立轨道，不产生部分世界效果。普通提案、财库、charter、技术升级、局部多数、历史声望与紧急状态均不能绕过保护底线；其他宪制变更只有在公开影响说明、延迟/复核、适用超多数、跨区域或受影响主体确认、独立审计与程序申诉全部成立时才生效。
+- SC-18：代表性区域设施与受治理扩展样例证明玩家只能在可读压力、条件报价、有限作用域和维护/耗尽/退役边界内取得区域 leverage；创作者提案只有经治理审查和权威生效后才成为世界能力。报价后状态变化、重复/过期/重连或跨入口重试只产生一次权威结果或原子拒绝，待决请求不会被表达为已生效。
 
 ### 5.1 验收追踪
 
@@ -161,6 +163,7 @@ Data 是有归属、有获取成本且受授权边界约束的世界资源。未
 | SC-15 | producer_system_designer / gameplay_designer / agent_engineer / runtime_engineer / blockchain_ops_engineer / qa_engineer | PRD-GAME-002 / PRD-WORLD_RUNTIME-001 / PRD-P2P-003 / PRD-TESTING-003 | `doc/product/world-rules-core-gameplay/organization-continuity-dissolution-and-dormancy-protection.prd.md`; `doc/game/prd.md`; `doc/world-runtime/prd.md`; `doc/p2p/prd.md`; `doc/testing/prd.md` | charter 保护底线、解散 waterfall、通知/保护期、estate 或可撤销 delegation、reclaim/appeal、持续业务处置和历史/receipt 连续性的组合证据 | test_tier_full |
 | SC-16 | producer_system_designer / gameplay_designer / agent_engineer / runtime_engineer / viewer_engineer / qa_engineer | PRD-GAME-002 / PRD-GAME-014 / PRD-WORLD_RUNTIME-001 / PRD-WORLD_SIMULATOR-001 / PRD-TESTING-003 | `doc/game/prd.md`; `doc/world-runtime/prd.md`; `doc/world-simulator/prd.md`; `doc/testing/prd.md` | 同一条资源/资格/持续义务路径的预览、接受、结算、失效、重试与 receipt 重放负例组合证据；必须含“报价后竞争性状态变化”的接受一次/原子拒绝样例，以及正式玩家 surface 对余额、runway/停机风险、预览/待决/已结算的区分，不伪造自动恢复 | test_tier_full |
 | SC-17 | producer_system_designer / gameplay_designer / runtime_engineer / blockchain_ops_engineer / viewer_engineer / qa_engineer | PRD-GAME-002 / PRD-WORLD_RUNTIME-001 / PRD-P2P-003 / PRD-TESTING-003 | `doc/product/world-rules-core-gameplay/governed-common-decisions-and-constitutional-boundaries.prd.md`; `doc/game/prd.md`; `doc/world-runtime/prd.md`; `doc/p2p/prd.md`; `doc/testing/prd.md` | 普通事项白名单、排除事项原子拒绝/独立路由、宪制条件全满足/缺失、防绕过与玩家可读 receipt 因果的组合证据 | test_tier_full |
+| SC-18 | producer_system_designer / gameplay_designer / runtime_engineer / wasm_platform_engineer / blockchain_ops_engineer / viewer_engineer / qa_engineer | PRD-GAME-016 / PRD-WORLD_RUNTIME-001 / PRD-WORLD_RUNTIME-010 / PRD-P2P-002 / PRD-TESTING-003 | `doc/product/world-rules-core-gameplay/governed-regional-capabilities-and-extensions.prd.md`; `doc/game/prd.md`; `doc/world-runtime/prd.md`; `doc/p2p/prd.md`; `doc/testing/prd.md` | 区域设施生命周期、扩展治理准入、报价后状态变化、单次权威结果、待决表达与 replay/恢复身份一致性的组合证据 | test_tier_full |
 
 ## 6. Non-Goals
 


### PR DESCRIPTION
Task: task_ce2d55b1b3dc48059b091cb7d258f2ed

Refs #3071

Defines the governed regional facility and creator-extension lifecycle in the canonical world-rules product module, including quote revalidation, single-result retry/replay boundaries, and pending-vs-effective semantics.