### PR TITLE
fix: hold fresh observers for checkpoint retry

### DIFF
--- a/crates/oasis7_node/src/node_engine_replication_checkpoint.rs
+++ b/crates/oasis7_node/src/node_engine_replication_checkpoint.rs
@@ -109,7 +109,10 @@ impl PosNodeEngine {
             // matching verified checkpoint or observed that head change. In
             // particular, a bounded fetch probe can return `NotFound` while
             // the connected peer is still becoming request-ready.
-            Ok(false) => Ok(FreshObserverCheckpointBootstrap::HighCheckpointPending),
+            Ok(false) => {
+                self.fresh_observer_checkpoint_bootstrap_retry_pending = true;
+                Ok(FreshObserverCheckpointBootstrap::HighCheckpointPending)
+            }
             Err(err) if Self::high_replication_checkpoint_probe_can_continue(&err) => {
                 self.fresh_observer_checkpoint_bootstrap_retry_pending = true;
                 Ok(FreshObserverCheckpointBootstrap::RetryPending)

--- a/crates/oasis7_node/src/tests_storage_replication_first_ready_checkpoint.rs
+++ b/crates/oasis7_node/src/tests_storage_replication_first_ready_checkpoint.rs
@@ -88,26 +88,19 @@ impl oasis7_proto::distributed_net::DistributedNetwork<WorldError> for PeerHeadC
         if protocol == REPLICATION_FETCH_COMMIT_PROTOCOL
             && !self.checkpoint_fetch_available.load(Ordering::SeqCst)
         {
-            if self.checkpoint_fetch_not_found.load(Ordering::SeqCst) {
-                let request = serde_json::from_slice::<super::replication::FetchCommitRequest>(
-                    payload,
-                )
-                .map_err(|err| WorldError::DistributedValidationFailed {
-                    reason: format!("decode checkpoint fetch request failed: {err}"),
-                })?;
-                if request.height > 1 {
-                    return serde_json::to_vec(&super::replication::FetchCommitResponse {
-                        found: false,
-                        message: None,
-                    })
-                    .map_err(|err| WorldError::DistributedValidationFailed {
-                        reason: format!("encode unavailable checkpoint response failed: {err}"),
-                    });
-                }
-            }
             if !self.checkpoint_fetch_not_found.load(Ordering::SeqCst) {
                 return Err(WorldError::NetworkProtocolUnavailable {
                     protocol: protocol.to_string(),
+                });
+            }
+            let request = serde_json::from_slice::<super::replication::FetchCommitRequest>(payload)
+                .map_err(|err| WorldError::DistributedValidationFailed {
+                    reason: format!("decode checkpoint fetch request failed: {err}"),
+                })?;
+            if request.height > 1 {
+                return serde_json::to_vec(&super::replication::FetchCommitResponse { found: false, message: None })
+                .map_err(|err| WorldError::DistributedValidationFailed {
+                    reason: format!("encode unavailable checkpoint response failed: {err}"),
                 });
             }
         }
@@ -953,7 +946,6 @@ fn peer_head_checkpoint_before_height_one_with_stale_dht(
     initial_checkpoint_fetch_available: bool,
     stale_dht_height_one: bool,
     initial_checkpoint_fetch_not_found: bool,
-    dual_connected_provider_heads: bool,
 ) {
     let _nonce_lock = lock_checkpoint_probe_nonce();
     let _probe_nonce = stale_dht_height_one.then(CheckpointProbeNonceGuard::install);
@@ -1069,11 +1061,7 @@ fn peer_head_checkpoint_before_height_one_with_stale_dht(
         head: Arc::clone(&peer_head),
         checkpoint_fetch_available: Arc::clone(&checkpoint_fetch_available),
         checkpoint_fetch_not_found: Arc::clone(&checkpoint_fetch_not_found),
-        connected_peer_ids: if dual_connected_provider_heads {
-            vec!["node-a".to_string(), "node-c".to_string()]
-        } else {
-            vec!["node-a".to_string()]
-        },
+        connected_peer_ids: vec!["node-a".to_string(), "node-c".to_string()],
     });
     register_replication_fetch_handlers(
         &NodeReplicationNetworkHandle::new(Arc::clone(&network)),

--- a/crates/oasis7_node/src/tests_storage_replication_first_ready_checkpoint.rs
+++ b/crates/oasis7_node/src/tests_storage_replication_first_ready_checkpoint.rs
@@ -18,6 +18,8 @@ struct PeerHeadCheckpointNetwork {
     fetch_protocols: Arc<Mutex<Vec<String>>>,
     head: Arc<Mutex<super::replication::FetchHeadResponse>>,
     checkpoint_fetch_available: Arc<AtomicBool>,
+    checkpoint_fetch_not_found: Arc<AtomicBool>,
+    connected_peer_ids: Vec<String>,
 }
 
 impl oasis7_proto::distributed_net::DistributedNetwork<WorldError>
@@ -86,9 +88,28 @@ impl oasis7_proto::distributed_net::DistributedNetwork<WorldError> for PeerHeadC
         if protocol == REPLICATION_FETCH_COMMIT_PROTOCOL
             && !self.checkpoint_fetch_available.load(Ordering::SeqCst)
         {
-            return Err(WorldError::NetworkProtocolUnavailable {
-                protocol: protocol.to_string(),
-            });
+            if self.checkpoint_fetch_not_found.load(Ordering::SeqCst) {
+                let request = serde_json::from_slice::<super::replication::FetchCommitRequest>(
+                    payload,
+                )
+                .map_err(|err| WorldError::DistributedValidationFailed {
+                    reason: format!("decode checkpoint fetch request failed: {err}"),
+                })?;
+                if request.height > 1 {
+                    return serde_json::to_vec(&super::replication::FetchCommitResponse {
+                        found: false,
+                        message: None,
+                    })
+                    .map_err(|err| WorldError::DistributedValidationFailed {
+                        reason: format!("encode unavailable checkpoint response failed: {err}"),
+                    });
+                }
+            }
+            if !self.checkpoint_fetch_not_found.load(Ordering::SeqCst) {
+                return Err(WorldError::NetworkProtocolUnavailable {
+                    protocol: protocol.to_string(),
+                });
+            }
         }
         self.fetch_protocols
             .lock()
@@ -98,11 +119,11 @@ impl oasis7_proto::distributed_net::DistributedNetwork<WorldError> for PeerHeadC
     }
 
     fn connected_peer_ids(&self) -> Vec<String> {
-        vec!["node-a".to_string()]
+        self.connected_peer_ids.clone()
     }
 
     fn known_peer_ids(&self) -> Vec<String> {
-        vec!["node-a".to_string()]
+        self.connected_peer_ids.clone()
     }
 
     fn register_handler(
@@ -931,6 +952,8 @@ fn peer_head_checkpoint_before_height_one_with_stale_dht(
     initial_peer_head: InitialPeerHead,
     initial_checkpoint_fetch_available: bool,
     stale_dht_height_one: bool,
+    initial_checkpoint_fetch_not_found: bool,
+    dual_connected_provider_heads: bool,
 ) {
     let _nonce_lock = lock_checkpoint_probe_nonce();
     let _probe_nonce = stale_dht_height_one.then(CheckpointProbeNonceGuard::install);
@@ -1001,6 +1024,7 @@ fn peer_head_checkpoint_before_height_one_with_stale_dht(
         .expect("checkpoint message");
     let fetch_protocols = Arc::new(Mutex::new(Vec::new()));
     let checkpoint_fetch_available = Arc::new(AtomicBool::new(initial_checkpoint_fetch_available));
+    let checkpoint_fetch_not_found = Arc::new(AtomicBool::new(initial_checkpoint_fetch_not_found));
     let peer_head = Arc::new(Mutex::new(match initial_peer_head {
         InitialPeerHead::Unavailable => super::replication::FetchHeadResponse {
             found: false,
@@ -1044,6 +1068,12 @@ fn peer_head_checkpoint_before_height_one_with_stale_dht(
         fetch_protocols: Arc::clone(&fetch_protocols),
         head: Arc::clone(&peer_head),
         checkpoint_fetch_available: Arc::clone(&checkpoint_fetch_available),
+        checkpoint_fetch_not_found: Arc::clone(&checkpoint_fetch_not_found),
+        connected_peer_ids: if dual_connected_provider_heads {
+            vec!["node-a".to_string(), "node-c".to_string()]
+        } else {
+            vec!["node-a".to_string()]
+        },
     });
     register_replication_fetch_handlers(
         &NodeReplicationNetworkHandle::new(Arc::clone(&network)),
@@ -1101,7 +1131,9 @@ fn peer_head_checkpoint_before_height_one_with_stale_dht(
         )
         .expect("peer-head checkpoint bootstrap must precede first height-one execution");
 
-    if initial_peer_head != InitialPeerHead::HighCheckpoint || !initial_checkpoint_fetch_available {
+    if initial_peer_head != InitialPeerHead::HighCheckpoint
+        || !initial_checkpoint_fetch_available
+    {
         assert!(
             execution_hook.incremental_commits.is_empty(),
             "fresh observer must defer height one while peer-head preflight is temporarily unavailable: {:?}",
@@ -1115,6 +1147,7 @@ fn peer_head_checkpoint_before_height_one_with_stale_dht(
                 high_peer_head;
         }
         checkpoint_fetch_available.store(true, Ordering::SeqCst);
+        checkpoint_fetch_not_found.store(false, Ordering::SeqCst);
 
         engine_b
             .tick(

--- a/crates/oasis7_node/src/tests_storage_replication_stale_dht_checkpoint.rs
+++ b/crates/oasis7_node/src/tests_storage_replication_stale_dht_checkpoint.rs
@@ -59,6 +59,8 @@ fn peer_head_checkpoint_before_height_one(
         initial_peer_head,
         initial_checkpoint_fetch_available,
         false,
+        false,
+        false,
     );
 }
 
@@ -86,6 +88,19 @@ fn fresh_observer_defers_height_one_until_stale_peer_head_advances_to_high_check
 fn fresh_observer_prefers_connected_high_checkpoint_over_stale_dht_height_one() {
     peer_head_checkpoint_before_height_one_with_stale_dht(
         InitialPeerHead::HighCheckpoint,
+        true,
+        true,
+        false,
+        false,
+    );
+}
+
+#[test]
+fn fresh_observer_defers_height_one_when_signed_checkpoint_is_temporarily_not_found() {
+    peer_head_checkpoint_before_height_one_with_stale_dht(
+        InitialPeerHead::HighCheckpoint,
+        false,
+        false,
         true,
         true,
     );

--- a/crates/oasis7_node/src/tests_storage_replication_stale_dht_checkpoint.rs
+++ b/crates/oasis7_node/src/tests_storage_replication_stale_dht_checkpoint.rs
@@ -60,7 +60,6 @@ fn peer_head_checkpoint_before_height_one(
         initial_checkpoint_fetch_available,
         false,
         false,
-        false,
     );
 }
 
@@ -91,7 +90,6 @@ fn fresh_observer_prefers_connected_high_checkpoint_over_stale_dht_height_one() 
         true,
         true,
         false,
-        false,
     );
 }
 
@@ -101,7 +99,6 @@ fn fresh_observer_defers_height_one_when_signed_checkpoint_is_temporarily_not_fo
         InitialPeerHead::HighCheckpoint,
         false,
         false,
-        true,
         true,
     );
 }


### PR DESCRIPTION
Task: task_d32800c6d14649e2926de84f4b4c1296

Refs #3102

Generated by ./scripts/prepare-task-pr.sh.