### PR TITLE
Hold fresh observer until checkpoint closure is available

### DIFF
--- a/crates/oasis7_node/src/node_engine_replication.rs
+++ b/crates/oasis7_node/src/node_engine_replication.rs
@@ -145,7 +145,6 @@ impl PosNodeEngine {
         }
         Ok(())
     }
-
     pub(super) fn enforce_storage_challenge_gate(
         &mut self,
         replication: &ReplicationRuntime,
@@ -297,7 +296,6 @@ impl PosNodeEngine {
         }
         Ok(())
     }
-
     pub(super) fn ingest_network_replications(
         &mut self,
         endpoint: &ReplicationNetworkEndpoint,
@@ -315,7 +313,6 @@ impl PosNodeEngine {
             None,
         )
     }
-
     pub(super) fn ingest_network_replications_with_progress(
         &mut self,
         endpoint: &ReplicationNetworkEndpoint,
@@ -500,7 +497,6 @@ impl PosNodeEngine {
         }
         Ok(())
     }
-
     fn observe_network_replication_commit(
         &mut self,
         peer_node_id: &str,
@@ -532,7 +528,6 @@ impl PosNodeEngine {
             },
         );
     }
-
     pub(super) fn sync_missing_replication_commits(
         &mut self,
         endpoint: &ReplicationNetworkEndpoint,
@@ -551,7 +546,6 @@ impl PosNodeEngine {
             true,
         )
     }
-
     pub(super) fn try_sync_high_replication_checkpoint_boundary(
         &mut self,
         endpoint: &ReplicationNetworkEndpoint,
@@ -747,7 +741,6 @@ impl PosNodeEngine {
         }
         Ok(true)
     }
-
     pub(super) fn sync_missing_replication_commits_with_progress(
         &mut self,
         endpoint: &ReplicationNetworkEndpoint,
@@ -857,6 +850,14 @@ impl PosNodeEngine {
             }
             if let Some(reason) = missing_checkpoint_closure_reason {
                 return Err(NodeError::Replication { reason });
+            }
+            if self.checkpoint_bootstrap_enabled
+                && self.committed_height == 0
+                && self.replication_persisted_height == 0
+                && self.last_execution_height == 0
+                && self.fresh_observer_checkpoint_preflight_unavailable
+            {
+                return Ok(());
             }
         }
         if Self::replication_gap_sync_local_state_blocked(

--- a/crates/oasis7_node/src/node_engine_replication.rs
+++ b/crates/oasis7_node/src/node_engine_replication.rs
@@ -771,7 +771,7 @@ impl PosNodeEngine {
             && self.committed_height == 0
             && self.replication_persisted_height == 0
             && self.last_execution_height == 0
-            && self.network_committed_height == 1
+            && self.peer_heads.values().all(|head| head.height <= 1)
             && self.fresh_observer_checkpoint_preflight_unavailable
         {
             // Match ingest's fresh-observer deferral above. A missing peer

--- a/crates/oasis7_node/src/tests_storage_replication_first_ready_checkpoint.rs
+++ b/crates/oasis7_node/src/tests_storage_replication_first_ready_checkpoint.rs
@@ -933,14 +933,13 @@ fn fresh_observer_bootstraps_checkpoint_at_boundary_before_height_one_peer_misma
     let _ = fs::remove_dir_all(&dir_a);
     let _ = fs::remove_dir_all(&dir_b);
 }
-
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum InitialPeerHead {
     Unavailable,
+    UnavailableWithObservedHigh,
     HighCheckpoint,
     StaleHeightOne,
 }
-
 fn peer_head_checkpoint_before_height_one_with_stale_dht(
     initial_peer_head: InitialPeerHead,
     initial_checkpoint_fetch_available: bool,
@@ -1018,7 +1017,7 @@ fn peer_head_checkpoint_before_height_one_with_stale_dht(
     let checkpoint_fetch_available = Arc::new(AtomicBool::new(initial_checkpoint_fetch_available));
     let checkpoint_fetch_not_found = Arc::new(AtomicBool::new(initial_checkpoint_fetch_not_found));
     let peer_head = Arc::new(Mutex::new(match initial_peer_head {
-        InitialPeerHead::Unavailable => super::replication::FetchHeadResponse {
+        InitialPeerHead::Unavailable | InitialPeerHead::UnavailableWithObservedHigh => super::replication::FetchHeadResponse {
             found: false,
             head: None,
         },
@@ -1096,6 +1095,9 @@ fn peer_head_checkpoint_before_height_one_with_stale_dht(
         ReplicationRuntime::new(config_b.replication.as_ref().expect("repl b"), "node-b")
             .expect("fresh observer runtime");
     let mut engine_b = PosNodeEngine::new(&config_b).expect("fresh observer engine");
+    if initial_peer_head == InitialPeerHead::UnavailableWithObservedHigh {
+        engine_b.network_committed_height = checkpoint_height;
+    }
     let mut execution_hook = BootstrapBeforeIncrementalHook {
         installed: Vec::new(),
         incremental_commits: Vec::new(),

--- a/crates/oasis7_node/src/tests_storage_replication_first_ready_checkpoint.rs
+++ b/crates/oasis7_node/src/tests_storage_replication_first_ready_checkpoint.rs
@@ -5,7 +5,6 @@ use std::sync::OnceLock;
 use super::*;
 use oasis7_proto::distributed::WorldHeadAnnounce;
 use oasis7_proto::distributed_dht::DistributedDht;
-
 #[derive(Clone)]
 struct FirstReadyHeadCheckpointNetwork {
     inner: Arc<TestInMemoryNetwork>,
@@ -1097,6 +1096,7 @@ fn peer_head_checkpoint_before_height_one_with_stale_dht(
     let mut engine_b = PosNodeEngine::new(&config_b).expect("fresh observer engine");
     if initial_peer_head == InitialPeerHead::UnavailableWithObservedHigh {
         engine_b.network_committed_height = checkpoint_height;
+        seed_consistent_high_peer_heads(&mut engine_b, checkpoint_height);
     }
     let mut execution_hook = BootstrapBeforeIncrementalHook {
         installed: Vec::new(),

--- a/crates/oasis7_node/src/tests_storage_replication_stale_dht_checkpoint.rs
+++ b/crates/oasis7_node/src/tests_storage_replication_stale_dht_checkpoint.rs
@@ -102,3 +102,13 @@ fn fresh_observer_defers_height_one_when_signed_checkpoint_is_temporarily_not_fo
         true,
     );
 }
+
+#[test]
+fn fresh_observer_with_observed_high_head_defers_height_one_without_checkpoint_closure() {
+    peer_head_checkpoint_before_height_one_with_stale_dht(
+        InitialPeerHead::UnavailableWithObservedHigh,
+        false,
+        false,
+        true,
+    );
+}

--- a/crates/oasis7_node/src/tests_storage_replication_stale_dht_checkpoint.rs
+++ b/crates/oasis7_node/src/tests_storage_replication_stale_dht_checkpoint.rs
@@ -112,3 +112,19 @@ fn fresh_observer_with_observed_high_head_defers_height_one_without_checkpoint_c
         true,
     );
 }
+
+fn seed_consistent_high_peer_heads(engine: &mut PosNodeEngine, height: u64) {
+    let head = PeerCommittedHead {
+        height,
+        block_hash: format!("block-{height}"),
+        committed_at_ms: 6_164,
+        observed_at_ms: 6_200,
+        execution_block_hash: Some(format!("exec-block-{height}")),
+        execution_state_root: Some(format!("exec-state-{height}")),
+        action_root: empty_action_root(),
+        public_key_hex: None,
+        signature_hex: None,
+    };
+    engine.peer_heads.insert("node-a".to_string(), head.clone());
+    engine.peer_heads.insert("node-c".to_string(), head);
+}


### PR DESCRIPTION
Refs #3108
Task: task_7626727f85a547d68de56ab26162c060

## Summary
- reproduce the live governed-probe path where an observed high network head bypasses the fresh preflight hold
- keep a fresh observer at height zero while all available peer commits remain height one
- preserve existing checkpoint receipt, hash, size, connected-candidate provenance, and fail-closed authority

## Verification
- deterministic RED/GREEN on the actual NodeRuntime tick path
- first-ready checkpoint suite: 11 passed
- high-checkpoint suite: 30 passed
- full `oasis7_node --lib`: 440 passed
- `cargo check -p oasis7_node`
- rust file-size, fmt, and diff checks passed