### PR TITLE
Fix fresh observer high-checkpoint retry

### DIFF
--- a/crates/oasis7_node/src/node_engine_replication.rs
+++ b/crates/oasis7_node/src/node_engine_replication.rs
@@ -848,6 +848,9 @@ impl PosNodeEngine {
                     Err(err) => return Err(err),
                 }
             }
+            if self.hold_fresh_observer_for_high_peer_heads(advertised_network_height) {
+                return Ok(());
+            }
             if let Some(reason) = missing_checkpoint_closure_reason {
                 return Err(NodeError::Replication { reason });
             }
@@ -867,7 +870,6 @@ impl PosNodeEngine {
         ) {
             return Ok(());
         }
-
         let mut next_height = next_height;
         if replication_gap_sync_provider_blob_route_blocked_in_cooldown(
             self.last_replication_gap_sync_blocked_height,
@@ -1150,7 +1152,6 @@ impl PosNodeEngine {
         }
         Ok(())
     }
-
     pub(super) fn refresh_replication_persisted_height(
         &mut self,
         replication_runtime: &ReplicationRuntime,
@@ -1183,7 +1184,6 @@ impl PosNodeEngine {
         )?;
         Ok(())
     }
-
     fn refresh_replication_persisted_height_from_local_execution_baseline(&mut self) {
         if !self.require_execution_on_commit
             || self.committed_height == 0

--- a/crates/oasis7_node/src/node_engine_replication_checkpoint.rs
+++ b/crates/oasis7_node/src/node_engine_replication_checkpoint.rs
@@ -29,6 +29,10 @@ impl PosNodeEngine {
         &self,
         advertised_head: Option<&WorldHeadAnnounce>,
     ) -> bool {
+        let high_head_retry_pending = self.fresh_observer_checkpoint_bootstrap_retry_pending
+            && (advertised_head
+                .is_some_and(|head| head.height >= REPLICATION_GAP_SYNC_MAX_HEIGHTS_PER_POLL)
+                || self.network_committed_height >= REPLICATION_GAP_SYNC_MAX_HEIGHTS_PER_POLL);
         self.checkpoint_bootstrap_enabled
             && self.committed_height == 0
             && self.replication_persisted_height == 0
@@ -36,9 +40,7 @@ impl PosNodeEngine {
             && (self
                 .fresh_observer_checkpoint_low_head_confirmation
                 .is_some()
-                || (advertised_head
-                    .is_some_and(|head| head.height >= REPLICATION_GAP_SYNC_MAX_HEIGHTS_PER_POLL)
-                    && self.fresh_observer_checkpoint_bootstrap_retry_pending))
+                || high_head_retry_pending)
     }
 
     /// Keep a fresh observer at height zero while connected peers advertise a
@@ -99,7 +101,11 @@ impl PosNodeEngine {
             return Ok(FreshObserverCheckpointBootstrap::PreflightUnavailable);
         };
         self.fresh_observer_checkpoint_preflight_unavailable = false;
-        self.fresh_observer_checkpoint_bootstrap_retry_pending = false;
+        let preserve_high_checkpoint_retry =
+            self.network_committed_height >= REPLICATION_GAP_SYNC_MAX_HEIGHTS_PER_POLL;
+        if !preserve_high_checkpoint_retry {
+            self.fresh_observer_checkpoint_bootstrap_retry_pending = false;
+        }
         if advertised_head.height < REPLICATION_GAP_SYNC_MAX_HEIGHTS_PER_POLL {
             // An already observed network height can require an immediate low-height
             // checkpoint to recover missing history. Only a completely unestablished
@@ -124,6 +130,7 @@ impl PosNodeEngine {
             self.fresh_observer_checkpoint_low_head_confirmation = Some(identity);
             return Ok(FreshObserverCheckpointBootstrap::LowHeadConfirmationPending);
         }
+        self.fresh_observer_checkpoint_bootstrap_retry_pending = false;
         self.fresh_observer_checkpoint_low_head_confirmation = None;
         match self.try_sync_high_replication_checkpoint_boundary(
             endpoint,

--- a/crates/oasis7_node/src/node_engine_replication_checkpoint.rs
+++ b/crates/oasis7_node/src/node_engine_replication_checkpoint.rs
@@ -41,6 +41,39 @@ impl PosNodeEngine {
                     && self.fresh_observer_checkpoint_bootstrap_retry_pending))
     }
 
+    /// Keep a fresh observer at height zero while connected peers advertise a
+    /// high, unresolved head that the world-head lookup may not expose yet.
+    ///
+    /// The world-head lookup is a bounded DHT/connected-provider probe and may
+    /// transiently return a stale height-one candidate even though the
+    /// validated peer-head cache already contains a current connected
+    /// validator head.  Replaying that candidate would bypass checkpoint
+    /// closure and can trigger an execution-peer mismatch without a height-zero
+    /// rollback.  This gate is intentionally conservative: it is only
+    /// used for a fresh observer with an unresolved high peer head, and callers
+    /// still require a verified checkpoint receipt before advancing.
+    pub(super) fn hold_fresh_observer_for_high_peer_heads(
+        &mut self,
+        advertised_network_height: u64,
+    ) -> bool {
+        if !self.checkpoint_bootstrap_enabled
+            || self.committed_height != 0
+            || self.replication_persisted_height != 0
+            || self.last_execution_height != 0
+            || advertised_network_height < REPLICATION_GAP_SYNC_MAX_HEIGHTS_PER_POLL
+        {
+            return false;
+        }
+        let hold = self
+            .peer_heads
+            .values()
+            .any(|head| head.height >= REPLICATION_GAP_SYNC_MAX_HEIGHTS_PER_POLL);
+        if hold {
+            self.fresh_observer_checkpoint_bootstrap_retry_pending = true;
+        }
+        hold
+    }
+
     pub(super) fn try_bootstrap_fresh_observer_from_advertised_checkpoint(
         &mut self,
         endpoint: &ReplicationNetworkEndpoint,

--- a/crates/oasis7_node/src/pos_state_store.rs
+++ b/crates/oasis7_node/src/pos_state_store.rs
@@ -4,7 +4,9 @@ use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
 
-use crate::{NodeError, NodeReplicationConfig, PosNodeEngine};
+use crate::{
+    NodeError, NodeReplicationConfig, PosNodeEngine, REPLICATION_GAP_SYNC_MAX_HEIGHTS_PER_POLL,
+};
 
 const POS_STATE_FILE_NAME: &str = "node_pos_state.json";
 
@@ -237,6 +239,13 @@ impl PosNodeEngine {
         self.pending_consensus_actions.clear();
         self.committed_height = committed_height;
         self.network_committed_height = restored_network_committed_height;
+        // Peer heads are intentionally memory-only. A zero-height observer
+        // restored with a high durable network head must re-enter the
+        // checkpoint retry hold until a fresh signed closure is installed.
+        self.fresh_observer_checkpoint_bootstrap_retry_pending = self.checkpoint_bootstrap_enabled
+            && committed_height == 0
+            && last_execution_height == 0
+            && restored_network_committed_height >= REPLICATION_GAP_SYNC_MAX_HEIGHTS_PER_POLL;
         self.next_height = restored_next_height;
         self.next_slot = restored_next_slot;
         self.last_observed_slot = self

--- a/crates/oasis7_node/src/tests_storage_replication_stale_dht_checkpoint.rs
+++ b/crates/oasis7_node/src/tests_storage_replication_stale_dht_checkpoint.rs
@@ -43,9 +43,11 @@ fn assert_stale_dht_checkpoint_provenance(
                     && observation["signed_request"].as_bool() == Some(true)
                     && observation["connected_peer_ids"]
                         .as_array()
-                        .is_some_and(|candidates| candidates
-                            .iter()
-                            .any(|candidate| candidate.as_str() == Some("node-a")))
+                        .is_some_and(|candidates| {
+                            candidates
+                                .iter()
+                                .any(|candidate| candidate.as_str() == Some("node-a"))
+                        })
             }),
         "checkpoint receipt must retain signed connected-peer provenance: {receipt}"
     );
@@ -244,7 +246,11 @@ fn fresh_observer_keeps_height_zero_when_connected_high_heads_have_no_checkpoint
         "node-c",
         high_head("node-c", deterministic_keypair_hex(189).1),
     );
-    assert_eq!(engine_b.peer_heads.len(), 2, "two signed high peer heads observed");
+    assert_eq!(
+        engine_b.peer_heads.len(),
+        2,
+        "two signed high peer heads observed"
+    );
     assert!(engine_b.peer_heads.values().all(|head| head.height == 64));
     let mut execution_hook = BootstrapBeforeIncrementalHook {
         installed: Vec::new(),
@@ -269,7 +275,10 @@ fn fresh_observer_keeps_height_zero_when_connected_high_heads_have_no_checkpoint
         )
         .expect("unresolved high checkpoint must not execute height one");
 
-    assert_eq!(engine_b.committed_height, 0, "observer remains at height zero");
+    assert_eq!(
+        engine_b.committed_height, 0,
+        "observer remains at height zero"
+    );
     assert_eq!(engine_b.replication_persisted_height, 0);
     assert!(
         execution_hook.incremental_commits.is_empty(),
@@ -281,7 +290,9 @@ fn fresh_observer_keeps_height_zero_when_connected_high_heads_have_no_checkpoint
         "no unsigned or unavailable height-zero rollback may be attempted: {:?}",
         execution_hook.rollback_heights
     );
-    *head.lock().expect("downgrade world head for stale DHT retry") =
+    *head
+        .lock()
+        .expect("downgrade world head for stale DHT retry") =
         super::replication::FetchHeadResponse {
             found: true,
             head: Some(super::replication::ReplicationHeadSummary {
@@ -318,6 +329,206 @@ fn fresh_observer_keeps_height_zero_when_connected_high_heads_have_no_checkpoint
         "height-one execution must not occur on a later retry: {:?}",
         execution_hook.incremental_commits
     );
+    let _ = fs::remove_dir_all(&dir_a);
+    let _ = fs::remove_dir_all(&dir_b);
+}
+
+#[test]
+fn fresh_observer_restart_keeps_height_zero_when_high_peer_heads_are_not_repopulated() {
+    let _nonce_lock = lock_checkpoint_probe_nonce();
+    let world_id = "world-live-probe-height-zero-restart";
+    let dir_a = temp_dir("live-probe-height-zero-restart-a");
+    let dir_b = temp_dir("live-probe-height-zero-restart-b");
+    let (_, public_key_a) = deterministic_keypair_hex(190);
+    let (_, public_key_b) = deterministic_keypair_hex(191);
+    let pos_config = signed_pos_config_with_signer_seeds(
+        vec![
+            PosValidator {
+                validator_id: "node-a".to_string(),
+                stake: 50,
+            },
+            PosValidator {
+                validator_id: "node-c".to_string(),
+                stake: 50,
+            },
+        ],
+        &[("node-a", 190), ("node-c", 191)],
+    );
+    let replication_config_a = signed_replication_config(dir_a.clone(), 190)
+        .with_remote_writer_allowlist(vec![public_key_b.clone()])
+        .expect("allowlist a")
+        .with_fetch_requester_allowlist(vec![public_key_b])
+        .expect("fetch allowlist a");
+    let replication_config_b = signed_replication_config(dir_b.clone(), 191)
+        .with_remote_writer_allowlist(vec![public_key_a.clone()])
+        .expect("allowlist b")
+        .with_fetch_requester_allowlist(vec![public_key_a])
+        .expect("fetch allowlist b");
+    let config_a = NodeConfig::new("node-a", world_id, NodeRole::Sequencer)
+        .expect("config a")
+        .with_pos_config(pos_config.clone())
+        .expect("pos config a")
+        .with_replication(replication_config_a.clone());
+    let config_b = NodeConfig::new("node-b", world_id, NodeRole::Observer)
+        .expect("config b")
+        .with_pos_config(pos_config)
+        .expect("pos config b")
+        .with_replication(replication_config_b.clone());
+    let mut replication_a =
+        ReplicationRuntime::new(config_a.replication.as_ref().expect("repl a"), "node-a")
+            .expect("runtime a");
+    let height_one_message = replication_a
+        .build_local_commit_message(
+            "node-a",
+            world_id,
+            9_100,
+            &committed_decision(1),
+            Some("peer-exec-block-1"),
+            Some("peer-exec-state-1"),
+        )
+        .expect("build height-one message")
+        .expect("height-one message");
+    let head = Arc::new(Mutex::new(super::replication::FetchHeadResponse {
+        found: true,
+        head: Some(super::replication::ReplicationHeadSummary {
+            world_id: world_id.to_string(),
+            height: 64,
+            block_hash: "block-64".to_string(),
+            state_root: "exec-state-64".to_string(),
+            timestamp_ms: 9_164,
+        }),
+    }));
+    let fetch_protocols = Arc::new(Mutex::new(Vec::new()));
+    let checkpoint_fetch_available = Arc::new(AtomicBool::new(false));
+    let checkpoint_fetch_not_found = Arc::new(AtomicBool::new(true));
+    let network: Arc<
+        dyn oasis7_proto::distributed_net::DistributedNetwork<WorldError> + Send + Sync,
+    > = Arc::new(PeerHeadCheckpointNetwork {
+        inner: Arc::new(TestInMemoryNetwork::default()),
+        fetch_protocols,
+        head: Arc::clone(&head),
+        checkpoint_fetch_available,
+        checkpoint_fetch_not_found,
+        connected_peer_ids: vec!["node-a".to_string(), "node-c".to_string()],
+    });
+    register_replication_fetch_handlers(
+        &NodeReplicationNetworkHandle::new(Arc::clone(&network)),
+        &replication_config_a,
+        world_id,
+        &config_a.network_policy,
+    )
+    .expect("register provider handlers");
+    let handle_b = NodeReplicationNetworkHandle::new(Arc::clone(&network));
+    let mut endpoint_b =
+        ReplicationNetworkEndpoint::new(&handle_b, world_id, true, &config_b.network_policy)
+            .expect("fresh observer endpoint");
+    let mut replication_b =
+        ReplicationRuntime::new(config_b.replication.as_ref().expect("repl b"), "node-b")
+            .expect("runtime b");
+    let mut engine_b = PosNodeEngine::new(&config_b).expect("fresh observer engine");
+    let high_head = |public_key_hex: String| PeerCommittedHead {
+        height: 64,
+        block_hash: "block-64".to_string(),
+        committed_at_ms: 9_164,
+        observed_at_ms: 9_200,
+        execution_block_hash: Some("exec-block-64".to_string()),
+        execution_state_root: Some("exec-state-64".to_string()),
+        action_root: empty_action_root(),
+        public_key_hex: Some(public_key_hex),
+        signature_hex: Some("signed-high-head-64".to_string()),
+    };
+    engine_b.observe_peer_committed_head("node-a", high_head(deterministic_keypair_hex(190).1));
+    engine_b.observe_peer_committed_head("node-c", high_head(deterministic_keypair_hex(191).1));
+    let mut execution_hook = BootstrapBeforeIncrementalHook {
+        installed: Vec::new(),
+        incremental_commits: Vec::new(),
+        rollback_heights: Vec::new(),
+    };
+    endpoint_b
+        .publish_replication(&height_one_message)
+        .expect("publish height-one tail");
+    engine_b
+        .tick(
+            "node-b",
+            world_id,
+            9_300,
+            None,
+            Some(&mut replication_b),
+            Some(&mut endpoint_b),
+            None,
+            Vec::new(),
+            Some(&mut execution_hook),
+        )
+        .expect("high unresolved checkpoint must establish zero-height hold");
+    assert_eq!(engine_b.committed_height, 0);
+    assert!(execution_hook.incremental_commits.is_empty());
+
+    // Persist only the durable state; peer_heads and retry markers are
+    // intentionally process-local and disappear across restart.
+    let state_store = super::pos_state_store::PosNodeStateStore::from_replication(
+        config_b.replication.as_ref().expect("repl b config"),
+    );
+    state_store
+        .save_engine_state(&engine_b)
+        .expect("persist zero-height high-network snapshot");
+    let persisted_snapshot = state_store
+        .load()
+        .expect("load persisted snapshot")
+        .expect("persisted snapshot");
+    assert_eq!(persisted_snapshot.committed_height, 0);
+    assert_eq!(persisted_snapshot.network_committed_height, 64);
+
+    let mut restarted_engine = PosNodeEngine::new(&config_b).expect("restarted engine");
+    restarted_engine
+        .restore_state_snapshot(persisted_snapshot, Some(9_400))
+        .expect("restore persisted high network snapshot");
+    assert_eq!(restarted_engine.committed_height, 0);
+    assert_eq!(restarted_engine.network_committed_height, 64);
+    assert!(
+        restarted_engine.peer_heads.is_empty(),
+        "peer heads are not durable in the current snapshot"
+    );
+    *head.lock().expect("downgrade world head for restart") =
+        super::replication::FetchHeadResponse {
+            found: true,
+            head: Some(super::replication::ReplicationHeadSummary {
+                world_id: world_id.to_string(),
+                height: 1,
+                block_hash: "block-1".to_string(),
+                state_root: "peer-exec-state-1".to_string(),
+                timestamp_ms: 9_100,
+            }),
+        };
+    let mut restarted_replication = ReplicationRuntime::new(
+        config_b.replication.as_ref().expect("repl b restart"),
+        "node-b",
+    )
+    .expect("restart replication runtime");
+    let mut restarted_hook = BootstrapBeforeIncrementalHook {
+        installed: Vec::new(),
+        incremental_commits: Vec::new(),
+        rollback_heights: Vec::new(),
+    };
+    endpoint_b
+        .publish_replication(&height_one_message)
+        .expect("publish stale height-one tail after restart");
+    let result = restarted_engine.tick(
+        "node-b",
+        world_id,
+        9_500,
+        None,
+        Some(&mut restarted_replication),
+        Some(&mut endpoint_b),
+        None,
+        Vec::new(),
+        Some(&mut restarted_hook),
+    );
+    assert!(
+        result.is_ok(),
+        "restart must remain fail-closed at height zero, got {result:?}"
+    );
+    assert_eq!(restarted_engine.committed_height, 0);
+    assert!(restarted_hook.incremental_commits.is_empty());
     let _ = fs::remove_dir_all(&dir_a);
     let _ = fs::remove_dir_all(&dir_b);
 }

--- a/crates/oasis7_node/src/tests_storage_replication_stale_dht_checkpoint.rs
+++ b/crates/oasis7_node/src/tests_storage_replication_stale_dht_checkpoint.rs
@@ -128,3 +128,196 @@ fn seed_consistent_high_peer_heads(engine: &mut PosNodeEngine, height: u64) {
     engine.peer_heads.insert("node-a".to_string(), head.clone());
     engine.peer_heads.insert("node-c".to_string(), head);
 }
+
+#[test]
+fn fresh_observer_keeps_height_zero_when_connected_high_heads_have_no_checkpoint_closure() {
+    let _nonce_lock = lock_checkpoint_probe_nonce();
+    let world_id = "world-live-probe-height-zero-persistence";
+    let dir_a = temp_dir("live-probe-height-zero-persistence-a");
+    let dir_b = temp_dir("live-probe-height-zero-persistence-b");
+    let (_, public_key_a) = deterministic_keypair_hex(188);
+    let (_, public_key_b) = deterministic_keypair_hex(189);
+    let pos_config = signed_pos_config_with_signer_seeds(
+        vec![
+            PosValidator {
+                validator_id: "node-a".to_string(),
+                stake: 50,
+            },
+            PosValidator {
+                validator_id: "node-c".to_string(),
+                stake: 50,
+            },
+        ],
+        &[("node-a", 188), ("node-c", 189)],
+    );
+    let replication_config_a = signed_replication_config(dir_a.clone(), 188)
+        .with_remote_writer_allowlist(vec![public_key_b.clone()])
+        .expect("allowlist a")
+        .with_fetch_requester_allowlist(vec![public_key_b])
+        .expect("fetch allowlist a");
+    let replication_config_b = signed_replication_config(dir_b.clone(), 189)
+        .with_remote_writer_allowlist(vec![public_key_a.clone()])
+        .expect("allowlist b")
+        .with_fetch_requester_allowlist(vec![public_key_a])
+        .expect("fetch allowlist b");
+    let config_a = NodeConfig::new("node-a", world_id, NodeRole::Sequencer)
+        .expect("config a")
+        .with_pos_config(pos_config.clone())
+        .expect("pos config a")
+        .with_replication(replication_config_a.clone());
+    let config_b = NodeConfig::new("node-b", world_id, NodeRole::Observer)
+        .expect("config b")
+        .with_pos_config(pos_config)
+        .expect("pos config b")
+        .with_replication(replication_config_b.clone());
+    let mut replication_a =
+        ReplicationRuntime::new(config_a.replication.as_ref().expect("repl a"), "node-a")
+            .expect("runtime a");
+    let height_one_message = replication_a
+        .build_local_commit_message(
+            "node-a",
+            world_id,
+            8_100,
+            &committed_decision(1),
+            Some("peer-exec-block-1"),
+            Some("peer-exec-state-1"),
+        )
+        .expect("build height-one message")
+        .expect("height-one message");
+    let fetch_protocols = Arc::new(Mutex::new(Vec::new()));
+    let head = Arc::new(Mutex::new(super::replication::FetchHeadResponse {
+        // The first package poll sees a high connected-provider head, but the
+        // checkpoint closure is still unavailable. The second poll models a
+        // stale DHT/world-head response masking that same higher signed head.
+        found: true,
+        head: Some(super::replication::ReplicationHeadSummary {
+            world_id: world_id.to_string(),
+            height: 64,
+            block_hash: "block-64".to_string(),
+            state_root: "exec-state-64".to_string(),
+            timestamp_ms: 8_164,
+        }),
+    }));
+    let checkpoint_fetch_available = Arc::new(AtomicBool::new(false));
+    let checkpoint_fetch_not_found = Arc::new(AtomicBool::new(true));
+    let network: Arc<
+        dyn oasis7_proto::distributed_net::DistributedNetwork<WorldError> + Send + Sync,
+    > = Arc::new(PeerHeadCheckpointNetwork {
+        inner: Arc::new(TestInMemoryNetwork::default()),
+        fetch_protocols,
+        head: Arc::clone(&head),
+        checkpoint_fetch_available,
+        checkpoint_fetch_not_found,
+        connected_peer_ids: vec!["node-a".to_string(), "node-c".to_string()],
+    });
+    register_replication_fetch_handlers(
+        &NodeReplicationNetworkHandle::new(Arc::clone(&network)),
+        &replication_config_a,
+        world_id,
+        &config_a.network_policy,
+    )
+    .expect("register provider handlers");
+    let handle_b = NodeReplicationNetworkHandle::new(Arc::clone(&network));
+    let mut endpoint_b =
+        ReplicationNetworkEndpoint::new(&handle_b, world_id, true, &config_b.network_policy)
+            .expect("fresh observer endpoint");
+    let mut replication_b =
+        ReplicationRuntime::new(config_b.replication.as_ref().expect("repl b"), "node-b")
+            .expect("runtime b");
+    let mut engine_b = PosNodeEngine::new(&config_b).expect("fresh observer engine");
+    let high_head = |node_id: &str, public_key_hex: String| PeerCommittedHead {
+        height: 64,
+        block_hash: "block-64".to_string(),
+        committed_at_ms: 8_164,
+        observed_at_ms: 8_200,
+        execution_block_hash: Some("exec-block-64".to_string()),
+        execution_state_root: Some("exec-state-64".to_string()),
+        action_root: empty_action_root(),
+        public_key_hex: Some(public_key_hex),
+        signature_hex: Some(format!("signed-{node_id}-64")),
+    };
+    engine_b.observe_peer_committed_head(
+        "node-a",
+        high_head("node-a", deterministic_keypair_hex(188).1),
+    );
+    engine_b.observe_peer_committed_head(
+        "node-c",
+        high_head("node-c", deterministic_keypair_hex(189).1),
+    );
+    assert_eq!(engine_b.peer_heads.len(), 2, "two signed high peer heads observed");
+    assert!(engine_b.peer_heads.values().all(|head| head.height == 64));
+    let mut execution_hook = BootstrapBeforeIncrementalHook {
+        installed: Vec::new(),
+        incremental_commits: Vec::new(),
+        rollback_heights: Vec::new(),
+    };
+    endpoint_b
+        .publish_replication(&height_one_message)
+        .expect("publish height-one tail");
+
+    engine_b
+        .tick(
+            "node-b",
+            world_id,
+            8_300,
+            None,
+            Some(&mut replication_b),
+            Some(&mut endpoint_b),
+            None,
+            Vec::new(),
+            Some(&mut execution_hook),
+        )
+        .expect("unresolved high checkpoint must not execute height one");
+
+    assert_eq!(engine_b.committed_height, 0, "observer remains at height zero");
+    assert_eq!(engine_b.replication_persisted_height, 0);
+    assert!(
+        execution_hook.incremental_commits.is_empty(),
+        "height-one execution must remain deferred while checkpoint closure is unresolved: {:?}",
+        execution_hook.incremental_commits
+    );
+    assert!(
+        execution_hook.rollback_heights.is_empty(),
+        "no unsigned or unavailable height-zero rollback may be attempted: {:?}",
+        execution_hook.rollback_heights
+    );
+    *head.lock().expect("downgrade world head for stale DHT retry") =
+        super::replication::FetchHeadResponse {
+            found: true,
+            head: Some(super::replication::ReplicationHeadSummary {
+                world_id: world_id.to_string(),
+                height: 1,
+                block_hash: "block-1".to_string(),
+                state_root: "peer-exec-state-1".to_string(),
+                timestamp_ms: 8_100,
+            }),
+        };
+    endpoint_b
+        .publish_replication(&height_one_message)
+        .expect("republish height-one tail after stale DHT downgrade");
+    engine_b
+        .tick(
+            "node-b",
+            world_id,
+            8_400,
+            None,
+            Some(&mut replication_b),
+            Some(&mut endpoint_b),
+            None,
+            Vec::new(),
+            Some(&mut execution_hook),
+        )
+        .expect("unresolved high checkpoint must remain fail-closed on retry");
+    assert_eq!(
+        engine_b.committed_height, 0,
+        "observer must remain at height zero across retries"
+    );
+    assert_eq!(engine_b.replication_persisted_height, 0);
+    assert!(
+        execution_hook.incremental_commits.is_empty(),
+        "height-one execution must not occur on a later retry: {:?}",
+        execution_hook.incremental_commits
+    );
+    let _ = fs::remove_dir_all(&dir_a);
+    let _ = fs::remove_dir_all(&dir_b);
+}


### PR DESCRIPTION
## Summary

Task: task_143a9f36cb2d41c8a1ab089058d1a6d1

Refs #3125
- keep fresh zero-height observers in high-checkpoint retry when a stale DHT/world-head response falls back to height one while connected high peer heads remain
- prevent generic height-one replay from bypassing unresolved checkpoint closure
- add a deterministic two-tick regression matching the live governed probe failure

## Verification

- targeted live-shaped regression: 1/1 passed
- first-ready checkpoint suite: 12/12 passed
- high-checkpoint focused suites: passed
- serial full lib: 431/441, with all 10 timing/resource failures passing in isolated reruns
- `cargo check -p oasis7_node`
- `cargo fmt --all -- --check`
- `./scripts/check-rust-file-size.sh`
- `git diff --check`

## Authority

The fix does not bypass checkpoint receipt, hash/size, connected-candidate provenance, or fail-closed authority. Windows and macOS rollout remains paused until the frozen merged package passes the Linux fresh governed closure.

Closes #3125
