### PR TITLE
Fix fresh observer height-one checkpoint retry reentry

### DIFF
--- a/crates/oasis7_node/src/node_engine_replication.rs
+++ b/crates/oasis7_node/src/node_engine_replication.rs
@@ -413,6 +413,7 @@ impl PosNodeEngine {
                 && self.replication_persisted_height == 0
                 && self.last_execution_height == 0
                 && (self.network_committed_height >= REPLICATION_GAP_SYNC_MAX_HEIGHTS_PER_POLL
+                    || self.should_defer_fresh_observer_checkpoint_retry()
                     || checkpoint_preflight_unavailable
                     || checkpoint_bootstrap_retry_pending
                     || checkpoint_bootstrap_preflight.should_defer_height_one());
@@ -772,7 +773,7 @@ impl PosNodeEngine {
             // execute the height-one tail before a checkpoint bootstrap.
             return Ok(());
         }
-        if self.should_defer_fresh_observer_checkpoint_retry(advertised_world_head.as_ref()) {
+        if self.should_defer_fresh_observer_checkpoint_retry() {
             return Ok(());
         }
         let advertised_network_height = self.network_committed_height.max(
@@ -790,7 +791,6 @@ impl PosNodeEngine {
             self.last_replication_gap_sync_blocked_at_ms = None;
             return Ok(());
         }
-
         let network_lag =
             advertised_network_height.saturating_sub(self.replication_persisted_height);
         let next_height = checked_replication_successor(

--- a/crates/oasis7_node/src/node_engine_replication_checkpoint.rs
+++ b/crates/oasis7_node/src/node_engine_replication_checkpoint.rs
@@ -25,14 +25,8 @@ impl PosNodeEngine {
     // the aligned retained-window boundaries, including the latest completed boundary.
     const HIGH_REPLICATION_CHECKPOINT_LOOKBACK_WINDOWS: u64 = 8;
 
-    pub(super) fn should_defer_fresh_observer_checkpoint_retry(
-        &self,
-        advertised_head: Option<&WorldHeadAnnounce>,
-    ) -> bool {
-        let high_head_retry_pending = self.fresh_observer_checkpoint_bootstrap_retry_pending
-            && (advertised_head
-                .is_some_and(|head| head.height >= REPLICATION_GAP_SYNC_MAX_HEIGHTS_PER_POLL)
-                || self.network_committed_height >= REPLICATION_GAP_SYNC_MAX_HEIGHTS_PER_POLL);
+    pub(super) fn should_defer_fresh_observer_checkpoint_retry(&self) -> bool {
+        let high_head_retry_pending = self.fresh_observer_checkpoint_bootstrap_retry_pending;
         self.checkpoint_bootstrap_enabled
             && self.committed_height == 0
             && self.replication_persisted_height == 0
@@ -101,8 +95,12 @@ impl PosNodeEngine {
             return Ok(FreshObserverCheckpointBootstrap::PreflightUnavailable);
         };
         self.fresh_observer_checkpoint_preflight_unavailable = false;
-        let preserve_high_checkpoint_retry =
-            self.network_committed_height >= REPLICATION_GAP_SYNC_MAX_HEIGHTS_PER_POLL;
+        let preserve_high_checkpoint_retry = self.network_committed_height
+            >= REPLICATION_GAP_SYNC_MAX_HEIGHTS_PER_POLL
+            || self
+                .peer_heads
+                .values()
+                .any(|head| head.height >= REPLICATION_GAP_SYNC_MAX_HEIGHTS_PER_POLL);
         if !preserve_high_checkpoint_retry {
             self.fresh_observer_checkpoint_bootstrap_retry_pending = false;
         }
@@ -112,7 +110,11 @@ impl PosNodeEngine {
             // fresh observer needs to wait one poll for a stale peer head to advance.
             if self.network_committed_height != 0 {
                 self.fresh_observer_checkpoint_low_head_confirmation = None;
-                return Ok(FreshObserverCheckpointBootstrap::NotInstalled);
+                return Ok(if self.fresh_observer_checkpoint_bootstrap_retry_pending {
+                    FreshObserverCheckpointBootstrap::HighCheckpointPending
+                } else {
+                    FreshObserverCheckpointBootstrap::NotInstalled
+                });
             }
             let identity = (
                 advertised_head.height,

--- a/crates/oasis7_node/src/tests_storage_replication_stale_dht_checkpoint.rs
+++ b/crates/oasis7_node/src/tests_storage_replication_stale_dht_checkpoint.rs
@@ -532,3 +532,222 @@ fn fresh_observer_restart_keeps_height_zero_when_high_peer_heads_are_not_repopul
     let _ = fs::remove_dir_all(&dir_a);
     let _ = fs::remove_dir_all(&dir_b);
 }
+
+#[test]
+fn fresh_observer_does_not_reenter_height_one_after_high_checkpoint_retry_becomes_stale() {
+    let _nonce_lock = lock_checkpoint_probe_nonce();
+    let _probe_nonce = CheckpointProbeNonceGuard::install();
+    let world_id = "world-live-probe-height-one-reentry-after-retry";
+    let dir_a = temp_dir("live-probe-height-one-reentry-after-retry-a");
+    let dir_b = temp_dir("live-probe-height-one-reentry-after-retry-b");
+    let (_, public_key_a) = deterministic_keypair_hex(192);
+    let (_, public_key_b) = deterministic_keypair_hex(193);
+    let pos_config = signed_pos_config_with_signer_seeds(
+        vec![
+            PosValidator {
+                validator_id: "node-a".to_string(),
+                stake: 50,
+            },
+            PosValidator {
+                validator_id: "node-c".to_string(),
+                stake: 50,
+            },
+        ],
+        &[("node-a", 192), ("node-c", 193)],
+    );
+    let replication_config_a = signed_replication_config(dir_a.clone(), 192)
+        .with_remote_writer_allowlist(vec![public_key_b.clone()])
+        .expect("allowlist a")
+        .with_fetch_requester_allowlist(vec![public_key_b])
+        .expect("fetch allowlist a");
+    let replication_config_b = signed_replication_config(dir_b.clone(), 193)
+        .with_remote_writer_allowlist(vec![public_key_a.clone()])
+        .expect("allowlist b")
+        .with_fetch_requester_allowlist(vec![public_key_a])
+        .expect("fetch allowlist b");
+    let config_a = NodeConfig::new("node-a", world_id, NodeRole::Sequencer)
+        .expect("config a")
+        .with_pos_config(pos_config.clone())
+        .expect("pos config a")
+        .with_replication(replication_config_a.clone());
+    let config_b = NodeConfig::new("node-b", world_id, NodeRole::Observer)
+        .expect("config b")
+        .with_pos_config(pos_config)
+        .expect("pos config b")
+        .with_require_execution_on_commit(true)
+        .with_replication(replication_config_b.clone());
+    let checkpoint_height = 41_620;
+    let checkpoint_block_hash = format!("exec-block-{checkpoint_height}");
+    let checkpoint_state_root = format!("exec-state-{checkpoint_height}");
+    let mut replication_a =
+        ReplicationRuntime::new(config_a.replication.as_ref().expect("repl a"), "node-a")
+            .expect("runtime a");
+    let height_one_message = replication_a
+        .build_local_commit_message(
+            "node-a",
+            world_id,
+            10_100,
+            &committed_decision(1),
+            Some("peer-exec-block-1"),
+            Some("peer-exec-state-1"),
+        )
+        .expect("build early height-one message")
+        .expect("early height-one message");
+    replication_a
+        .build_local_commit_message_with_checkpoint(
+            "node-a",
+            world_id,
+            10_164,
+            &committed_decision(checkpoint_height),
+            Some(checkpoint_block_hash.as_str()),
+            Some(checkpoint_state_root.as_str()),
+            Some(checkpoint_bundle(
+                checkpoint_height,
+                checkpoint_block_hash.as_str(),
+                checkpoint_state_root.as_str(),
+            )),
+        )
+        .expect("build high checkpoint closure")
+        .expect("high checkpoint message");
+    let fetch_protocols = Arc::new(Mutex::new(Vec::new()));
+    let head = Arc::new(Mutex::new(super::replication::FetchHeadResponse {
+        found: true,
+        head: Some(super::replication::ReplicationHeadSummary {
+            world_id: world_id.to_string(),
+            height: checkpoint_height,
+            block_hash: format!("block-{checkpoint_height}"),
+            state_root: checkpoint_state_root.clone(),
+            timestamp_ms: 10_164,
+        }),
+    }));
+    let checkpoint_fetch_available = Arc::new(AtomicBool::new(false));
+    let checkpoint_fetch_not_found = Arc::new(AtomicBool::new(true));
+    let network: Arc<
+        dyn oasis7_proto::distributed_net::DistributedNetwork<WorldError> + Send + Sync,
+    > = Arc::new(PeerHeadCheckpointNetwork {
+        inner: Arc::new(TestInMemoryNetwork::default()),
+        fetch_protocols,
+        head: Arc::clone(&head),
+        checkpoint_fetch_available: Arc::clone(&checkpoint_fetch_available),
+        checkpoint_fetch_not_found: Arc::clone(&checkpoint_fetch_not_found),
+        connected_peer_ids: vec!["node-a".to_string(), "node-c".to_string()],
+    });
+    register_replication_fetch_handlers(
+        &NodeReplicationNetworkHandle::new(Arc::clone(&network)),
+        &replication_config_a,
+        world_id,
+        &config_a.network_policy,
+    )
+    .expect("register high-checkpoint provider handlers");
+    let handle_b = NodeReplicationNetworkHandle::new(Arc::clone(&network));
+    let mut endpoint_b =
+        ReplicationNetworkEndpoint::new(&handle_b, world_id, true, &config_b.network_policy)
+            .expect("fresh strict observer endpoint");
+    let mut replication_b =
+        ReplicationRuntime::new(config_b.replication.as_ref().expect("repl b"), "node-b")
+            .expect("fresh observer runtime");
+    let mut engine_b = PosNodeEngine::new(&config_b).expect("fresh observer engine");
+    let high_head = |node_id: &str, public_key_hex: String| PeerCommittedHead {
+        height: checkpoint_height,
+        block_hash: format!("block-{checkpoint_height}"),
+        committed_at_ms: 10_164,
+        observed_at_ms: 10_200,
+        execution_block_hash: Some(checkpoint_block_hash.clone()),
+        execution_state_root: Some(checkpoint_state_root.clone()),
+        action_root: empty_action_root(),
+        public_key_hex: Some(public_key_hex),
+        signature_hex: Some(format!("signed-{node_id}-{checkpoint_height}")),
+    };
+    // Two connected validators have the same signed high head. Keep this
+    // validated peer-head cache separate from network_committed_height to model
+    // the live probe's stale world-head downgrade after a failed high probe.
+    engine_b.peer_heads.insert(
+        "node-a".to_string(),
+        high_head("node-a", deterministic_keypair_hex(192).1),
+    );
+    engine_b.peer_heads.insert(
+        "node-c".to_string(),
+        high_head("node-c", deterministic_keypair_hex(193).1),
+    );
+    assert_eq!(engine_b.peer_heads.len(), 2);
+    assert!(engine_b.peer_heads.values().all(|head| head.height == checkpoint_height));
+    let mut execution_hook = BootstrapBeforeIncrementalHook {
+        installed: Vec::new(),
+        incremental_commits: Vec::new(),
+        rollback_heights: Vec::new(),
+    };
+
+    endpoint_b
+        .publish_replication(&height_one_message)
+        .expect("publish early height-one candidate");
+    engine_b
+        .tick(
+            "node-b",
+            world_id,
+            10_300,
+            None,
+            Some(&mut replication_b),
+            Some(&mut endpoint_b),
+            None,
+            Vec::new(),
+            Some(&mut execution_hook),
+        )
+        .expect("first high checkpoint probe must hold the observer");
+    assert_eq!(engine_b.committed_height, 0);
+    assert_eq!(engine_b.replication_persisted_height, 0);
+    assert!(execution_hook.incremental_commits.is_empty());
+    assert!(
+        engine_b.fresh_observer_checkpoint_bootstrap_retry_pending,
+        "high checkpoint probe must establish retry authority"
+    );
+
+    // The authorized high checkpoint closure becomes available after the
+    // transient miss, but the world-head probe now returns an early candidate.
+    // Receipt publication must still precede any height-one replay.
+    checkpoint_fetch_available.store(true, Ordering::SeqCst);
+    checkpoint_fetch_not_found.store(false, Ordering::SeqCst);
+
+    // The next poll receives the stale height-one candidate even though the
+    // connected validator heads above are still higher and consistent. The
+    // live probe has already observed that early candidate, so the current
+    // implementation clears the retry marker and re-enters incremental replay
+    // immediately instead of keeping the observer at height zero.
+    *head.lock().expect("downgrade world head for stale retry") =
+        super::replication::FetchHeadResponse {
+            found: true,
+            head: Some(super::replication::ReplicationHeadSummary {
+                world_id: world_id.to_string(),
+                height: 1,
+                block_hash: "block-1".to_string(),
+                state_root: "peer-exec-state-1".to_string(),
+                timestamp_ms: 10_100,
+            }),
+        };
+    endpoint_b
+        .publish_replication(&height_one_message)
+        .expect("publish reentered stale height-one candidate");
+    let result = engine_b
+        .tick(
+            "node-b",
+            world_id,
+            10_600,
+            None,
+            Some(&mut replication_b),
+            Some(&mut endpoint_b),
+            None,
+            Vec::new(),
+            Some(&mut execution_hook),
+        )
+        .expect("stale height-one candidate must remain deferred before checkpoint receipt");
+    assert_eq!(result.consensus_snapshot.committed_height, 0);
+    assert!(
+        execution_hook.incremental_commits.is_empty(),
+        "height-one execution must remain deferred while checkpoint retry is authoritative: {:?}",
+        execution_hook.incremental_commits
+    );
+    assert!(execution_hook.rollback_heights.is_empty());
+    assert_eq!(engine_b.committed_height, 0);
+    assert_eq!(engine_b.replication_persisted_height, 0);
+    let _ = fs::remove_dir_all(&dir_a);
+    let _ = fs::remove_dir_all(&dir_b);
+}


### PR DESCRIPTION
Task: task_af008ca5d78742219beb2c24496ad2a2
Refs #3133

## Summary
- preserve fresh-observer checkpoint retry authority while validated higher peer heads remain cached
- defer stale height-one sync/ingest until authorized checkpoint closure succeeds
- add deterministic regression for the live testnet.239 probe failure

## Verification
- exact regression RED -> GREEN
- first-ready checkpoint 14/14
- fresh observer 12/12
- high-checkpoint 30/30
- recovery 6/6
- full serial oasis7_node lib 443/443
- cargo check, fmt, diff and Rust file-size gates pass

Closes #3133
Related rollout: #3098