### PR TITLE
Hold fresh observers on cached high validator heads

### DIFF
--- a/crates/oasis7_node/src/node_engine_replication_checkpoint.rs
+++ b/crates/oasis7_node/src/node_engine_replication_checkpoint.rs
@@ -70,6 +70,39 @@ impl PosNodeEngine {
         hold
     }
 
+    fn cached_high_checkpoint_head(&self, world_id: &str) -> Option<WorldHeadAnnounce> {
+        self.peer_heads
+            .iter()
+            .filter_map(|(node_id, head)| {
+                let validator_id = self.validator_id_for_peer_head(node_id)?;
+                if self.quarantined_validators.contains(&validator_id)
+                    || head.height < REPLICATION_GAP_SYNC_MAX_HEIGHTS_PER_POLL
+                    || head.block_hash.is_empty()
+                {
+                    return None;
+                }
+                let execution_block_hash = head.execution_block_hash.as_ref()?;
+                let state_root = head.execution_state_root.as_ref()?;
+                if execution_block_hash.is_empty() || state_root.is_empty() {
+                    return None;
+                }
+                Some(WorldHeadAnnounce {
+                    world_id: world_id.to_string(),
+                    height: head.height,
+                    block_hash: head.block_hash.clone(),
+                    state_root: state_root.clone(),
+                    timestamp_ms: head.committed_at_ms,
+                    signature: String::new(),
+                })
+            })
+            .max_by(|left, right| {
+                left.height
+                    .cmp(&right.height)
+                    .then_with(|| left.block_hash.cmp(&right.block_hash))
+                    .then_with(|| left.state_root.cmp(&right.state_root))
+            })
+    }
+
     pub(super) fn try_bootstrap_fresh_observer_from_advertised_checkpoint(
         &mut self,
         endpoint: &ReplicationNetworkEndpoint,
@@ -103,13 +136,43 @@ impl PosNodeEngine {
             // authority before low-head confirmation so a later height-one
             // candidate cannot enter incremental execution without a verified
             // checkpoint closure.
+            if let Some(cached_head) = self.cached_high_checkpoint_head(world_id) {
+                self.fresh_observer_checkpoint_low_head_confirmation = None;
+                self.fresh_observer_checkpoint_bootstrap_retry_pending = false;
+                return match self.try_sync_high_replication_checkpoint_boundary(
+                    endpoint,
+                    node_id,
+                    world_id,
+                    replication_runtime,
+                    cached_head.height,
+                    0,
+                    Some(&cached_head),
+                    execution_hook,
+                    progress_callback,
+                ) {
+                    Ok(true) => Ok(FreshObserverCheckpointBootstrap::Installed),
+                    Ok(false) => {
+                        self.fresh_observer_checkpoint_bootstrap_retry_pending = true;
+                        Ok(FreshObserverCheckpointBootstrap::HighCheckpointPending)
+                    }
+                    Err(err) if Self::high_replication_checkpoint_probe_can_continue(&err) => {
+                        self.fresh_observer_checkpoint_bootstrap_retry_pending = true;
+                        Ok(FreshObserverCheckpointBootstrap::RetryPending)
+                    }
+                    Err(err) => Err(err),
+                };
+            }
+            // Preserve the existing fail-closed hold for high heads that are
+            // not trustworthy checkpoint candidates (for example, an unknown
+            // or incomplete peer binding).  They must not be allowed to age
+            // into low-head confirmation and height-one replay.
             if self
                 .peer_heads
                 .values()
                 .any(|head| head.height >= REPLICATION_GAP_SYNC_MAX_HEIGHTS_PER_POLL)
             {
-                self.fresh_observer_checkpoint_bootstrap_retry_pending = true;
                 self.fresh_observer_checkpoint_low_head_confirmation = None;
+                self.fresh_observer_checkpoint_bootstrap_retry_pending = true;
                 return Ok(FreshObserverCheckpointBootstrap::HighCheckpointPending);
             }
             // An already observed network height can require an immediate low-height

--- a/crates/oasis7_node/src/node_engine_replication_checkpoint.rs
+++ b/crates/oasis7_node/src/node_engine_replication_checkpoint.rs
@@ -96,6 +96,22 @@ impl PosNodeEngine {
         };
         self.fresh_observer_checkpoint_preflight_unavailable = false;
         if advertised_head.height < REPLICATION_GAP_SYNC_MAX_HEIGHTS_PER_POLL {
+            // A stale world-head response must not revoke a high connected
+            // peer-head observation.  The DHT/peer world-head route can still
+            // report height one while a fresh observer has already observed
+            // a retained high head from a validator.  Establish retry
+            // authority before low-head confirmation so a later height-one
+            // candidate cannot enter incremental execution without a verified
+            // checkpoint closure.
+            if self
+                .peer_heads
+                .values()
+                .any(|head| head.height >= REPLICATION_GAP_SYNC_MAX_HEIGHTS_PER_POLL)
+            {
+                self.fresh_observer_checkpoint_bootstrap_retry_pending = true;
+                self.fresh_observer_checkpoint_low_head_confirmation = None;
+                return Ok(FreshObserverCheckpointBootstrap::HighCheckpointPending);
+            }
             // An already observed network height can require an immediate low-height
             // checkpoint to recover missing history. Only a completely unestablished
             // fresh observer needs to wait one poll for a stale peer head to advance.

--- a/crates/oasis7_node/src/tests_storage_replication_stale_dht_checkpoint.rs
+++ b/crates/oasis7_node/src/tests_storage_replication_stale_dht_checkpoint.rs
@@ -1009,3 +1009,191 @@ fn fresh_observer_package_probe_keeps_height_zero_before_two_candidate_ingest() 
     let _ = fs::remove_dir_all(&dir_b);
     let _ = fs::remove_dir_all(&dir_c);
 }
+
+#[test]
+fn fresh_observer_package_probe_does_not_reenter_height_one_after_300s_without_checkpoint_receipt() {
+    let _nonce_lock = lock_checkpoint_probe_nonce();
+    let _probe_nonce = CheckpointProbeNonceGuard::install();
+    let world_id = "world-live-package-probe-300s-height-one-reentry";
+    let dir_a = temp_dir("live-package-probe-300s-height-one-reentry-a");
+    let dir_b = temp_dir("live-package-probe-300s-height-one-reentry-b");
+    let (_, public_key_a) = deterministic_keypair_hex(207);
+    let (_, public_key_c) = deterministic_keypair_hex(208);
+    let pos_config = signed_pos_config_with_signer_seeds(
+        vec![
+            PosValidator {
+                validator_id: "node-a".to_string(),
+                stake: 50,
+            },
+            PosValidator {
+                validator_id: "node-c".to_string(),
+                stake: 50,
+            },
+        ],
+        &[("node-a", 207), ("node-c", 208)],
+    );
+    let replication_config_a = signed_replication_config(dir_a.clone(), 207)
+        .with_remote_writer_allowlist(vec![deterministic_keypair_hex(209).1])
+        .expect("allowlist a")
+        .with_fetch_requester_allowlist(vec![deterministic_keypair_hex(209).1])
+        .expect("fetch allowlist a");
+    let replication_config_b = signed_replication_config(dir_b.clone(), 209)
+        .with_remote_writer_allowlist(vec![public_key_a.clone(), public_key_c.clone()])
+        .expect("allowlist b")
+        .with_fetch_requester_allowlist(vec![public_key_a.clone(), public_key_c.clone()])
+        .expect("fetch allowlist b");
+    let config_a = NodeConfig::new("node-a", world_id, NodeRole::Sequencer)
+        .expect("config a")
+        .with_pos_config(pos_config.clone())
+        .expect("pos config a")
+        .with_replication(replication_config_a);
+    let config_b = NodeConfig::new("node-b", world_id, NodeRole::Observer)
+        .expect("config b")
+        .with_pos_config(pos_config)
+        .expect("pos config b")
+        .with_require_execution_on_commit(true)
+        .with_replication(replication_config_b.clone());
+    let mut replication_a =
+        ReplicationRuntime::new(config_a.replication.as_ref().expect("repl a"), "node-a")
+            .expect("runtime a");
+    let height_one = replication_a
+        .build_local_commit_message(
+            "node-a",
+            world_id,
+            20_100,
+            &committed_decision(1),
+            Some("peer-exec-block-1"),
+            Some("peer-exec-state-1"),
+        )
+        .expect("build delayed height-one candidate")
+        .expect("delayed height-one candidate");
+
+    let checkpoint_height = 43_340;
+    let head = Arc::new(Mutex::new(super::replication::FetchHeadResponse {
+        found: true,
+        head: Some(super::replication::ReplicationHeadSummary {
+            world_id: world_id.to_string(),
+            height: 1,
+            block_hash: "block-1".to_string(),
+            state_root: "peer-exec-state-1".to_string(),
+            timestamp_ms: 20_100,
+        }),
+    }));
+    let network: Arc<
+        dyn oasis7_proto::distributed_net::DistributedNetwork<WorldError> + Send + Sync,
+    > = Arc::new(PeerHeadCheckpointNetwork {
+        inner: Arc::new(TestInMemoryNetwork::default()),
+        fetch_protocols: Arc::new(Mutex::new(Vec::new())),
+        head: Arc::clone(&head),
+        checkpoint_fetch_available: Arc::new(AtomicBool::new(false)),
+        checkpoint_fetch_not_found: Arc::new(AtomicBool::new(true)),
+        connected_peer_ids: vec!["node-a".to_string(), "node-c".to_string()],
+    });
+    network
+        .register_handler(
+            REPLICATION_FETCH_COMMIT_PROTOCOL,
+            Box::new(|_| {
+                serde_json::to_vec(&super::replication::FetchCommitResponse {
+                    found: false,
+                    message: None,
+                })
+                .map_err(|err| WorldError::DistributedValidationFailed {
+                    reason: format!("encode absent checkpoint response failed: {err}"),
+                })
+            }),
+        )
+        .expect("register absent checkpoint response");
+    let handle_b = NodeReplicationNetworkHandle::new(Arc::clone(&network));
+    let mut endpoint_b =
+        ReplicationNetworkEndpoint::new(&handle_b, world_id, true, &config_b.network_policy)
+            .expect("fresh observer endpoint");
+    let mut replication_b =
+        ReplicationRuntime::new(config_b.replication.as_ref().expect("repl b"), "node-b")
+            .expect("fresh observer runtime");
+    let mut engine_b = PosNodeEngine::new(&config_b).expect("fresh observer engine");
+    let high_head = |node_id: &str, public_key_hex: String| PeerCommittedHead {
+        height: checkpoint_height,
+        block_hash: format!("block-{checkpoint_height}"),
+        committed_at_ms: 20_164,
+        observed_at_ms: 20_200,
+        execution_block_hash: Some(format!("exec-block-{checkpoint_height}")),
+        execution_state_root: Some(format!("exec-state-{checkpoint_height}")),
+        action_root: empty_action_root(),
+        public_key_hex: Some(public_key_hex),
+        signature_hex: Some(format!("signed-{node_id}-{checkpoint_height}")),
+    };
+    engine_b.peer_heads.insert(
+        "node-a".to_string(),
+        high_head("node-a", deterministic_keypair_hex(207).1),
+    );
+    engine_b.peer_heads.insert(
+        "node-c".to_string(),
+        high_head("node-c", deterministic_keypair_hex(208).1),
+    );
+    assert_eq!(engine_b.peer_heads.len(), 2);
+    assert!(engine_b.peer_heads.values().all(|head| {
+        head.height == checkpoint_height
+            && head.block_hash == format!("block-{checkpoint_height}")
+            && head.public_key_hex.is_some()
+            && head.signature_hex.is_some()
+    }));
+    let mut execution_hook = PackageProbeHeightOneFailureHook {
+        incremental_commits: Vec::new(),
+        rollback_heights: Vec::new(),
+    };
+    macro_rules! package_tick {
+        ($now_ms:expr) => {
+            engine_b.tick(
+                "node-b",
+                world_id,
+                $now_ms,
+                None,
+                Some(&mut replication_b),
+                Some(&mut endpoint_b),
+                None,
+                Vec::new(),
+                Some(&mut execution_hook),
+            )
+        };
+    }
+    package_tick!(20_300)
+        .expect("initial stale package probe must stay at height zero");
+    assert_eq!(engine_b.committed_height, 0);
+    package_tick!(320_300)
+        .expect("300s package probe must stay at height zero");
+    assert_eq!(engine_b.committed_height, 0);
+    assert!(!dir_b
+        .join("checkpoint-verification")
+        .join(format!("{checkpoint_height}.json"))
+        .exists());
+    endpoint_b
+        .publish_replication(&height_one)
+        .expect("publish delayed height-one candidate");
+    let result = package_tick!(320_301);
+    assert!(
+        result.is_ok(),
+        "fresh package observer must remain at height zero after 300s without checkpoint receipt: result={result:?} incremental={:?} rollback={:?}",
+        execution_hook.incremental_commits,
+        execution_hook.rollback_heights
+    );
+    let snapshot = result.expect("height-zero package probe snapshot");
+    assert_eq!(snapshot.consensus_snapshot.committed_height, 0);
+    assert!(execution_hook.incremental_commits.is_empty());
+    assert!(execution_hook.rollback_heights.is_empty());
+    endpoint_b
+        .publish_replication(&height_one)
+        .expect("republish delayed height-one candidate");
+    let result = package_tick!(320_302);
+    assert!(
+        result.is_ok(),
+        "fresh package observer must remain at height zero after unresolved 300s checkpoint probe: result={result:?} incremental={:?} rollback={:?}",
+        execution_hook.incremental_commits,
+        execution_hook.rollback_heights
+    );
+    let snapshot = result.expect("height-zero package reentry snapshot");
+    assert_eq!(snapshot.consensus_snapshot.committed_height, 0);
+    assert!(execution_hook.incremental_commits.is_empty());
+    assert!(execution_hook.rollback_heights.is_empty());
+    let _ = fs::remove_dir_all(&dir_a);
+    let _ = fs::remove_dir_all(&dir_b);
+}

--- a/crates/oasis7_node/src/tests_storage_replication_stale_dht_checkpoint.rs
+++ b/crates/oasis7_node/src/tests_storage_replication_stale_dht_checkpoint.rs
@@ -707,11 +707,9 @@ fn fresh_observer_does_not_reenter_height_one_after_high_checkpoint_retry_become
     checkpoint_fetch_available.store(true, Ordering::SeqCst);
     checkpoint_fetch_not_found.store(false, Ordering::SeqCst);
 
-    // The next poll receives the stale height-one candidate even though the
-    // connected validator heads above are still higher and consistent. The
-    // live probe has already observed that early candidate, so the current
-    // implementation clears the retry marker and re-enters incremental replay
-    // immediately instead of keeping the observer at height zero.
+    // The next poll receives a stale height-one candidate while the cached
+    // validator heads remain higher; the recovered closure must be retried
+    // before any height-one replay.
     *head.lock().expect("downgrade world head for stale retry") =
         super::replication::FetchHeadResponse {
             found: true,
@@ -738,16 +736,17 @@ fn fresh_observer_does_not_reenter_height_one_after_high_checkpoint_retry_become
             Vec::new(),
             Some(&mut execution_hook),
         )
-        .expect("stale height-one candidate must remain deferred before checkpoint receipt");
-    assert_eq!(result.consensus_snapshot.committed_height, 0);
+        .expect("stale height-one candidate must retry the recovered checkpoint");
+    assert_eq!(result.consensus_snapshot.committed_height, checkpoint_height);
     assert!(
         execution_hook.incremental_commits.is_empty(),
         "height-one execution must remain deferred while checkpoint retry is authoritative: {:?}",
         execution_hook.incremental_commits
     );
     assert!(execution_hook.rollback_heights.is_empty());
-    assert_eq!(engine_b.committed_height, 0);
-    assert_eq!(engine_b.replication_persisted_height, 0);
+    assert_eq!(execution_hook.installed, vec![checkpoint_height]);
+    assert_eq!(engine_b.committed_height, checkpoint_height);
+    assert_eq!(engine_b.replication_persisted_height, checkpoint_height);
     let _ = fs::remove_dir_all(&dir_a);
     let _ = fs::remove_dir_all(&dir_b);
 }


### PR DESCRIPTION
## Summary

- keep fresh observers at height zero when a stale low world-head conflicts with cached high validator heads
- preserve checkpoint retry authority until a verified checkpoint path succeeds
- add the deterministic 300-second delayed height-one package-probe regression

Task: task_3fd58bf1928f46d5be039ad69a5d5231

Refs #3158

## Verification

- focused regression twice
- fresh observer suite 14/14
- first-ready checkpoint suite 16/16
- high-checkpoint suite 30/30
- serial `oasis7_node --lib`: 445/445
- `cargo check`, format, diff, Rust file-size, and doc-governance gates

Live testnet package/receipt closure remains a post-merge release gate; observers are still untouched.
