### PR TITLE
Hold fresh observer for connected validator quorum

### DIFF
--- a/crates/oasis7/src/bin/oasis7_chain_runtime.rs
+++ b/crates/oasis7/src/bin/oasis7_chain_runtime.rs
@@ -926,7 +926,10 @@ fn attach_default_replication_network(
                 .with_local_provider_id(network.peer_id().to_string()),
         )
         .with_replica_maintenance_dht(handle_dht)
-        .with_replication_network_consensus_enabled(false);
+        // ObserverLight may subscribe to signed consensus commits (the lane
+        // policy still forbids observer publication). This lets checkpoint
+        // preflight observe validated high peer heads before replication ingest.
+        .with_replication_network_consensus_enabled(true);
     Ok((runtime, network))
 }
 

--- a/crates/oasis7_node/src/node_engine_replication_checkpoint.rs
+++ b/crates/oasis7_node/src/node_engine_replication_checkpoint.rs
@@ -85,35 +85,15 @@ impl PosNodeEngine {
         hold
     }
 
+    /// Transport connectivity is not checkpoint authority. Keep this test
+    /// seam available for regression probes without shipping a quorum hold.
+    #[cfg(test)]
     pub(super) fn hold_fresh_observer_for_connected_validator_quorum(
         &mut self,
-        endpoint: &ReplicationNetworkEndpoint,
-        advertised_height: u64,
+        _endpoint: &ReplicationNetworkEndpoint,
+        _advertised_height: u64,
     ) -> bool {
-        if !self.checkpoint_bootstrap_enabled
-            || self.committed_height != 0
-            || self.replication_persisted_height != 0
-            || self.last_execution_height != 0
-            || advertised_height >= REPLICATION_GAP_SYNC_MAX_HEIGHTS_PER_POLL
-        {
-            return false;
-        }
-        let connected_validator_ids = endpoint
-            .connected_peer_ids()
-            .into_iter()
-            .filter_map(|node_id| self.validator_id_for_peer_head(node_id.as_str()))
-            .filter(|validator_id| !self.quarantined_validators.contains(validator_id))
-            .collect::<BTreeSet<_>>();
-        let connected_stake = connected_validator_ids
-            .iter()
-            .filter_map(|validator_id| self.validators.get(validator_id).copied())
-            .sum::<u64>();
-        if connected_stake < self.required_stake || connected_stake == 0 {
-            return false;
-        }
-        self.fresh_observer_checkpoint_low_head_confirmation = None;
-        self.fresh_observer_checkpoint_bootstrap_retry_pending = true;
-        true
+        false
     }
 
     fn cached_high_checkpoint_head(&self, world_id: &str) -> Option<WorldHeadAnnounce> {
@@ -207,12 +187,6 @@ impl PosNodeEngine {
                     }
                     Err(err) => Err(err),
                 };
-            }
-            if self.hold_fresh_observer_for_connected_validator_quorum(
-                endpoint,
-                advertised_head.height,
-            ) {
-                return Ok(FreshObserverCheckpointBootstrap::HighCheckpointPending);
             }
             // Preserve the existing fail-closed hold for high heads that are
             // not trustworthy checkpoint candidates (for example, an unknown

--- a/crates/oasis7_node/src/node_engine_replication_checkpoint.rs
+++ b/crates/oasis7_node/src/node_engine_replication_checkpoint.rs
@@ -85,6 +85,37 @@ impl PosNodeEngine {
         hold
     }
 
+    pub(super) fn hold_fresh_observer_for_connected_validator_quorum(
+        &mut self,
+        endpoint: &ReplicationNetworkEndpoint,
+        advertised_height: u64,
+    ) -> bool {
+        if !self.checkpoint_bootstrap_enabled
+            || self.committed_height != 0
+            || self.replication_persisted_height != 0
+            || self.last_execution_height != 0
+            || advertised_height >= REPLICATION_GAP_SYNC_MAX_HEIGHTS_PER_POLL
+        {
+            return false;
+        }
+        let connected_validator_ids = endpoint
+            .connected_peer_ids()
+            .into_iter()
+            .filter_map(|node_id| self.validator_id_for_peer_head(node_id.as_str()))
+            .filter(|validator_id| !self.quarantined_validators.contains(validator_id))
+            .collect::<BTreeSet<_>>();
+        let connected_stake = connected_validator_ids
+            .iter()
+            .filter_map(|validator_id| self.validators.get(validator_id).copied())
+            .sum::<u64>();
+        if connected_stake < self.required_stake || connected_stake == 0 {
+            return false;
+        }
+        self.fresh_observer_checkpoint_low_head_confirmation = None;
+        self.fresh_observer_checkpoint_bootstrap_retry_pending = true;
+        true
+    }
+
     fn cached_high_checkpoint_head(&self, world_id: &str) -> Option<WorldHeadAnnounce> {
         self.peer_heads
             .iter()
@@ -176,6 +207,12 @@ impl PosNodeEngine {
                     }
                     Err(err) => Err(err),
                 };
+            }
+            if self.hold_fresh_observer_for_connected_validator_quorum(
+                endpoint,
+                advertised_head.height,
+            ) {
+                return Ok(FreshObserverCheckpointBootstrap::HighCheckpointPending);
             }
             // Preserve the existing fail-closed hold for high heads that are
             // not trustworthy checkpoint candidates (for example, an unknown

--- a/crates/oasis7_node/src/tests.rs
+++ b/crates/oasis7_node/src/tests.rs
@@ -83,6 +83,7 @@ fn test_fetch_blob_response(
 include!("tests_consensus_signatures.rs");
 include!("tests_clock_and_replication.rs");
 include!("tests_replication_gossip.rs");
+include!("tests_observer_consensus_subscription.rs");
 include!("tests_replication_rebroadcast.rs");
 include!("tests_storage_replication.rs");
 mod non_sequencer_followers;

--- a/crates/oasis7_node/src/tests_observer_consensus_subscription.rs
+++ b/crates/oasis7_node/src/tests_observer_consensus_subscription.rs
@@ -1,0 +1,103 @@
+#[test]
+fn production_observer_runtime_enables_consensus_subscription_without_publish() {
+    let source = include_str!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../oasis7/src/bin/oasis7_chain_runtime.rs"
+    ));
+    let attach = source
+        .split_once("fn attach_default_replication_network")
+        .map(|(_, body)| body)
+        .expect("default replication attachment exists");
+    assert!(
+        attach.contains("with_replication_network_consensus_enabled(true)"),
+        "production observer runtime must enable consensus subscription before checkpoint preflight"
+    );
+
+    let world_id = "world-observer-consensus-policy";
+    let network = Arc::new(TestInMemoryNetwork::default());
+    let config = NodeConfig::new("observer", world_id, NodeRole::Observer)
+        .expect("observer config");
+    let endpoint = ConsensusNetworkEndpoint::new(
+        &NodeReplicationNetworkHandle::new(network),
+        world_id,
+        true,
+        &config.network_policy,
+    )
+    .expect("observer consensus subscription endpoint");
+    assert!(!endpoint.allows_publish());
+}
+
+#[test]
+fn observer_replication_runtime_ingests_signed_commit_before_checkpoint_preflight() {
+    let world_id = "world-observer-consensus-preflight";
+    let network = Arc::new(TestInMemoryNetwork::default());
+    let (_, validator_public_key) = deterministic_keypair_hex(207);
+    let pos_config = signed_pos_config_with_signer_seeds(
+        vec![PosValidator {
+            validator_id: "node-a".to_string(),
+            stake: 100,
+        }],
+        &[("node-a", 207)],
+    );
+    let mut commit = GossipCommitMessage {
+        version: 1,
+        world_id: world_id.to_string(),
+        node_id: "node-a".to_string(),
+        player_id: "node-a".to_string(),
+        height: 128,
+        slot: 128,
+        epoch: 0,
+        block_hash: "block-128".to_string(),
+        action_root: empty_action_root(),
+        actions: Vec::new(),
+        committed_at_ms: 128_000,
+        execution_block_hash: None,
+        execution_state_root: None,
+        public_key_hex: None,
+        signature_hex: None,
+    };
+    let signing_key = SigningKey::from_bytes(
+        &hex::decode(deterministic_keypair_hex(207).0)
+            .expect("decode validator private key")
+            .try_into()
+            .expect("validator private key length"),
+    );
+    let signer = ConsensusMessageSigner::new(signing_key, validator_public_key)
+        .expect("validator commit signer");
+    sign_commit_message(&mut commit, &signer).expect("sign validator commit");
+    let commit_topic = super::network_bridge::default_consensus_commit_topic(world_id);
+    oasis7_proto::distributed_net::DistributedNetwork::publish(
+        network.as_ref(),
+        commit_topic.as_str(),
+        serde_json::to_vec(&commit)
+            .expect("encode validator commit")
+            .as_slice(),
+    )
+    .expect("publish validator commit");
+
+    let config = NodeConfig::new("observer", world_id, NodeRole::Observer)
+        .expect("observer config")
+        .with_tick_interval(Duration::from_millis(10))
+        .expect("observer tick")
+        .with_pos_config(pos_config)
+        .expect("observer validators")
+        .with_replication(signed_replication_config(temp_dir("observer-consensus-preflight"), 209));
+    let mut runtime = NodeRuntime::new(config)
+        .with_replication_network(NodeReplicationNetworkHandle::new(network))
+        // Mirrors the live chain-runtime assembly: ObserverLight subscribes to
+        // consensus gossip while its network policy still forbids publishing.
+        .with_replication_network_consensus_enabled(true);
+    runtime.start().expect("start observer runtime");
+    let observed = wait_until(Instant::now() + Duration::from_secs(2), || {
+        runtime.snapshot().consensus.known_peer_heads >= 1
+    });
+    let snapshot = runtime.snapshot();
+    runtime.stop().expect("stop observer runtime");
+    assert!(
+        observed,
+        "signed validator commit must populate peer_heads before replication checkpoint preflight: known_peer_heads={} peer_heads={:?} last_error={:?}",
+        snapshot.consensus.known_peer_heads,
+        snapshot.consensus.peer_heads,
+        snapshot.last_error
+    );
+}

--- a/crates/oasis7_node/src/tests_storage_replication_stale_dht_checkpoint_long_probe.rs
+++ b/crates/oasis7_node/src/tests_storage_replication_stale_dht_checkpoint_long_probe.rs
@@ -183,13 +183,16 @@ fn fresh_observer_package_probe_does_not_reenter_height_one_after_300s_without_c
 }
 
 #[test]
-fn testnet_249_connected_high_heads_without_cache_reenter_height_one_after_probe_window() {
+fn testnet_249_low_world_connected_transport_without_high_evidence_completes_confirmation() {
+    // Authority correction: this fixture has only an unsigned low FetchHead
+    // and transport connectivity. It intentionally supplies no signed high
+    // peer-head/commit evidence, so connected quorum must not be treated as a
+    // high-head checkpoint authority source; legitimate low-head confirmation
+    // must complete instead of holding forever.
     let _nonce_lock = lock_checkpoint_probe_nonce();
     let _probe_nonce = CheckpointProbeNonceGuard::install();
     let world_id = "world-testnet-249-connected-high-heads-without-cache";
-    let dir_a = temp_dir("testnet-249-connected-high-heads-a");
     let dir_b = temp_dir("testnet-249-connected-high-heads-b");
-    let dir_c = temp_dir("testnet-249-connected-high-heads-c");
     let (_, public_key_a) = deterministic_keypair_hex(249);
     let (_, public_key_b) = deterministic_keypair_hex(250);
     let (_, public_key_c) = deterministic_keypair_hex(251);
@@ -200,60 +203,17 @@ fn testnet_249_connected_high_heads_without_cache_reenter_height_one_after_probe
         ],
         &[("node-a", 249), ("node-c", 251)],
     );
-    let replication_config_a = signed_replication_config(dir_a.clone(), 249)
-        .with_remote_writer_allowlist(vec![public_key_b.clone()])
-        .expect("allowlist a")
-        .with_fetch_requester_allowlist(vec![public_key_b.clone()])
-        .expect("fetch allowlist a");
     let replication_config_b = signed_replication_config(dir_b.clone(), 250)
-        .with_remote_writer_allowlist(vec![public_key_a.clone(), public_key_c.clone()])
+        .with_remote_writer_allowlist(vec![public_key_a, public_key_c])
         .expect("allowlist b")
-        .with_fetch_requester_allowlist(vec![public_key_a.clone(), public_key_c.clone()])
-        .expect("fetch allowlist b");
-    let replication_config_c = signed_replication_config(dir_c.clone(), 251)
-        .with_remote_writer_allowlist(vec![public_key_b.clone()])
-        .expect("allowlist c")
         .with_fetch_requester_allowlist(vec![public_key_b.clone()])
-        .expect("fetch allowlist c");
-    let config_a = NodeConfig::new("node-a", world_id, NodeRole::Sequencer)
-        .expect("config a")
-        .with_pos_config(pos_config.clone())
-        .expect("pos config a")
-        .with_replication(replication_config_a);
+        .expect("fetch allowlist b");
     let config_b = NodeConfig::new("node-b", world_id, NodeRole::Observer)
         .expect("config b")
         .with_pos_config(pos_config.clone())
         .expect("pos config b")
         .with_require_execution_on_commit(true)
         .with_replication(replication_config_b.clone());
-    let config_c = NodeConfig::new("node-c", world_id, NodeRole::Sequencer)
-        .expect("config c")
-        .with_pos_config(pos_config)
-        .expect("pos config c")
-        .with_replication(replication_config_c);
-    let mut replication_a = ReplicationRuntime::new(
-        config_a.replication.as_ref().expect("repl a"), "node-a",
-    )
-    .expect("runtime a");
-    let mut replication_c = ReplicationRuntime::new(
-        config_c.replication.as_ref().expect("repl c"), "node-c",
-    )
-    .expect("runtime c");
-    let height_one_a = replication_a
-        .build_local_commit_message(
-            "node-a", world_id, 249_100, &committed_decision(1),
-            Some("peer-exec-block-1"), Some("peer-exec-state-1"),
-        )
-        .expect("build node-a height-one candidate")
-        .expect("node-a height-one candidate");
-    let height_one_c = replication_c
-        .build_local_commit_message(
-            "node-c", world_id, 249_101,
-            &PosDecision { proposer_id: "node-c".to_string(), ..committed_decision(1) },
-            Some("peer-exec-block-1"), Some("peer-exec-state-1"),
-        )
-        .expect("build node-c height-one candidate")
-        .expect("node-c height-one candidate");
     let head = Arc::new(Mutex::new(super::replication::FetchHeadResponse {
         found: true,
         head: Some(super::replication::ReplicationHeadSummary {
@@ -313,28 +273,156 @@ fn testnet_249_connected_high_heads_without_cache_reenter_height_one_after_probe
     assert_eq!(engine_b.committed_height, 0);
     assert!(execution_hook.incremental_commits.is_empty());
     assert!(execution_hook.rollback_heights.is_empty());
-    endpoint_b
-        .publish_replication(&height_one_a)
-        .expect("publish first height-one candidate after probe window");
-    let first_result = package_tick!(549_301);
-    assert!(first_result.is_ok(), "first candidate should remain queued: {first_result:?}");
-    endpoint_b
-        .publish_replication(&height_one_c)
-        .expect("publish second height-one candidate after probe window");
-    let result = package_tick!(549_302);
+    let result = package_tick!(549_301);
     assert!(
         result.is_ok(),
-        "post-merge testnet.249 observer must remain fail-closed after two candidates; live bug signature: result={result:?} incremental={:?} rollback={:?}",
+        "legitimate low-head confirmation must complete: result={result:?} incremental={:?} rollback={:?}",
         execution_hook.incremental_commits,
         execution_hook.rollback_heights
     );
     let snapshot = result.expect("height-zero post-merge snapshot");
     assert_eq!(snapshot.consensus_snapshot.committed_height, 0);
+    assert!(!engine_b.fresh_observer_checkpoint_bootstrap_retry_pending);
+    assert!(engine_b.fresh_observer_checkpoint_low_head_confirmation.is_none());
     assert!(execution_hook.incremental_commits.is_empty());
     assert!(execution_hook.rollback_heights.is_empty());
     assert_eq!(engine_b.committed_height, 0);
     assert_eq!(engine_b.replication_persisted_height, 0);
-    let _ = fs::remove_dir_all(&dir_a);
     let _ = fs::remove_dir_all(&dir_b);
-    let _ = fs::remove_dir_all(&dir_c);
+}
+
+fn low_world_connected_quorum_fixture(
+    connected_peer_ids: Vec<String>,
+    world_id: &str,
+    bind_transport_peers: bool,
+) -> (
+    NodeConfig,
+    ReplicationRuntime,
+    ReplicationNetworkEndpoint,
+    PosNodeEngine,
+    Vec<std::path::PathBuf>,
+) {
+    let dir_a = temp_dir("low-world-connected-quorum-a");
+    let dir_b = temp_dir("low-world-connected-quorum-b");
+    let dir_c = temp_dir("low-world-connected-quorum-c");
+    let (_, public_key_a) = deterministic_keypair_hex(252);
+    let (_, public_key_b) = deterministic_keypair_hex(253);
+    let (_, public_key_c) = deterministic_keypair_hex(254);
+    let mut pos_config = signed_pos_config_with_signer_seeds(
+        vec![
+            PosValidator { validator_id: "node-a".to_string(), stake: 50 },
+            PosValidator { validator_id: "node-c".to_string(), stake: 50 },
+        ],
+        &[("node-a", 252), ("node-c", 254)],
+    );
+    if bind_transport_peers {
+        pos_config = pos_config
+            .with_validator_player_ids(
+                [
+                    ("node-a".to_string(), "12D3KooWvalidatorA".to_string()),
+                    ("node-c".to_string(), "12D3KooWvalidatorC".to_string()),
+                ]
+                .into_iter()
+                .collect(),
+            )
+            .expect("transport peer binding");
+    }
+    let replication_config = signed_replication_config(dir_b.clone(), 253)
+        .with_remote_writer_allowlist(vec![public_key_a, public_key_c])
+        .expect("allowlist")
+        .with_fetch_requester_allowlist(vec![public_key_b])
+        .expect("fetch allowlist");
+    let config = NodeConfig::new("node-b", world_id, NodeRole::Observer)
+        .expect("observer config")
+        .with_pos_config(pos_config)
+        .expect("pos config")
+        .with_require_execution_on_commit(true)
+        .with_replication(replication_config);
+    let head = Arc::new(Mutex::new(super::replication::FetchHeadResponse {
+        found: true,
+        head: Some(super::replication::ReplicationHeadSummary {
+            world_id: world_id.to_string(),
+            height: 1,
+            block_hash: "block-1".to_string(),
+            state_root: "state-1".to_string(),
+            timestamp_ms: 10_100,
+        }),
+    }));
+    let network: Arc<dyn oasis7_proto::distributed_net::DistributedNetwork<WorldError> + Send + Sync> =
+        Arc::new(PeerHeadCheckpointNetwork {
+            inner: Arc::new(TestInMemoryNetwork::default()),
+            fetch_protocols: Arc::new(Mutex::new(Vec::new())),
+            head,
+            checkpoint_fetch_available: Arc::new(AtomicBool::new(false)),
+            checkpoint_fetch_not_found: Arc::new(AtomicBool::new(true)),
+            connected_peer_ids,
+        });
+    let handle = NodeReplicationNetworkHandle::new(Arc::clone(&network));
+    let endpoint = ReplicationNetworkEndpoint::new(
+        &handle, world_id, true, &config.network_policy,
+    )
+    .expect("observer endpoint");
+    let replication = ReplicationRuntime::new(
+        config.replication.as_ref().expect("replication"), "node-b",
+    )
+    .expect("replication runtime");
+    let engine = PosNodeEngine::new(&config).expect("observer engine");
+    (config, replication, endpoint, engine, vec![dir_a, dir_b, dir_c])
+}
+
+#[test]
+fn unbound_validator_id_shaped_transport_peers_do_not_activate_checkpoint_quorum_hold() {
+    let world_id = "world-unbound-validator-id-shaped-transport-peer";
+    let (_config, _replication, endpoint, mut engine, dirs) =
+        low_world_connected_quorum_fixture(
+            vec!["12D3KooWvalidatorA".to_string(), "12D3KooWvalidatorC".to_string()],
+            world_id,
+            false,
+        );
+    let hold = engine.hold_fresh_observer_for_connected_validator_quorum(&endpoint, 1);
+    assert!(
+        !hold,
+        "transport IDs that merely resemble validator IDs must not activate high-head authority"
+    );
+    assert!(!engine.fresh_observer_checkpoint_bootstrap_retry_pending);
+    for dir in dirs {
+        let _ = fs::remove_dir_all(dir);
+    }
+}
+
+#[test]
+fn low_world_with_bound_transport_quorum_completes_confirmation_without_high_evidence() {
+    let _nonce_lock = lock_checkpoint_probe_nonce();
+    let _probe_nonce = CheckpointProbeNonceGuard::install();
+    let world_id = "world-low-head-connected-quorum-confirmation";
+    let (_config, mut replication, mut endpoint, mut engine, dirs) =
+        low_world_connected_quorum_fixture(
+            vec!["12D3KooWvalidatorA".to_string(), "12D3KooWvalidatorC".to_string()],
+            world_id,
+            true,
+        );
+    let mut execution_hook = PackageProbeHeightOneFailureHook {
+        incremental_commits: Vec::new(),
+        rollback_heights: Vec::new(),
+    };
+    engine
+        .tick(
+            "node-b", world_id, 10_300, None, Some(&mut replication),
+            Some(&mut endpoint), None, Vec::new(), Some(&mut execution_hook),
+        )
+        .expect("first legitimate low-head confirmation poll");
+    engine
+        .tick(
+            "node-b", world_id, 10_301, None, Some(&mut replication),
+            Some(&mut endpoint), None, Vec::new(), Some(&mut execution_hook),
+        )
+        .expect("second legitimate low-head confirmation poll");
+    assert!(
+        !engine.fresh_observer_checkpoint_bootstrap_retry_pending,
+        "low world without high-head evidence must complete low-head confirmation"
+    );
+    assert!(engine.fresh_observer_checkpoint_low_head_confirmation.is_none());
+    for dir in dirs {
+        let _ = fs::remove_dir_all(dir);
+    }
 }

--- a/crates/oasis7_node/src/tests_storage_replication_stale_dht_checkpoint_long_probe.rs
+++ b/crates/oasis7_node/src/tests_storage_replication_stale_dht_checkpoint_long_probe.rs
@@ -181,3 +181,160 @@ fn fresh_observer_package_probe_does_not_reenter_height_one_after_300s_without_c
     let _ = fs::remove_dir_all(&dir_a);
     let _ = fs::remove_dir_all(&dir_b);
 }
+
+#[test]
+fn testnet_249_connected_high_heads_without_cache_reenter_height_one_after_probe_window() {
+    let _nonce_lock = lock_checkpoint_probe_nonce();
+    let _probe_nonce = CheckpointProbeNonceGuard::install();
+    let world_id = "world-testnet-249-connected-high-heads-without-cache";
+    let dir_a = temp_dir("testnet-249-connected-high-heads-a");
+    let dir_b = temp_dir("testnet-249-connected-high-heads-b");
+    let dir_c = temp_dir("testnet-249-connected-high-heads-c");
+    let (_, public_key_a) = deterministic_keypair_hex(249);
+    let (_, public_key_b) = deterministic_keypair_hex(250);
+    let (_, public_key_c) = deterministic_keypair_hex(251);
+    let pos_config = signed_pos_config_with_signer_seeds(
+        vec![
+            PosValidator { validator_id: "node-a".to_string(), stake: 50 },
+            PosValidator { validator_id: "node-c".to_string(), stake: 50 },
+        ],
+        &[("node-a", 249), ("node-c", 251)],
+    );
+    let replication_config_a = signed_replication_config(dir_a.clone(), 249)
+        .with_remote_writer_allowlist(vec![public_key_b.clone()])
+        .expect("allowlist a")
+        .with_fetch_requester_allowlist(vec![public_key_b.clone()])
+        .expect("fetch allowlist a");
+    let replication_config_b = signed_replication_config(dir_b.clone(), 250)
+        .with_remote_writer_allowlist(vec![public_key_a.clone(), public_key_c.clone()])
+        .expect("allowlist b")
+        .with_fetch_requester_allowlist(vec![public_key_a.clone(), public_key_c.clone()])
+        .expect("fetch allowlist b");
+    let replication_config_c = signed_replication_config(dir_c.clone(), 251)
+        .with_remote_writer_allowlist(vec![public_key_b.clone()])
+        .expect("allowlist c")
+        .with_fetch_requester_allowlist(vec![public_key_b.clone()])
+        .expect("fetch allowlist c");
+    let config_a = NodeConfig::new("node-a", world_id, NodeRole::Sequencer)
+        .expect("config a")
+        .with_pos_config(pos_config.clone())
+        .expect("pos config a")
+        .with_replication(replication_config_a);
+    let config_b = NodeConfig::new("node-b", world_id, NodeRole::Observer)
+        .expect("config b")
+        .with_pos_config(pos_config.clone())
+        .expect("pos config b")
+        .with_require_execution_on_commit(true)
+        .with_replication(replication_config_b.clone());
+    let config_c = NodeConfig::new("node-c", world_id, NodeRole::Sequencer)
+        .expect("config c")
+        .with_pos_config(pos_config)
+        .expect("pos config c")
+        .with_replication(replication_config_c);
+    let mut replication_a = ReplicationRuntime::new(
+        config_a.replication.as_ref().expect("repl a"), "node-a",
+    )
+    .expect("runtime a");
+    let mut replication_c = ReplicationRuntime::new(
+        config_c.replication.as_ref().expect("repl c"), "node-c",
+    )
+    .expect("runtime c");
+    let height_one_a = replication_a
+        .build_local_commit_message(
+            "node-a", world_id, 249_100, &committed_decision(1),
+            Some("peer-exec-block-1"), Some("peer-exec-state-1"),
+        )
+        .expect("build node-a height-one candidate")
+        .expect("node-a height-one candidate");
+    let height_one_c = replication_c
+        .build_local_commit_message(
+            "node-c", world_id, 249_101,
+            &PosDecision { proposer_id: "node-c".to_string(), ..committed_decision(1) },
+            Some("peer-exec-block-1"), Some("peer-exec-state-1"),
+        )
+        .expect("build node-c height-one candidate")
+        .expect("node-c height-one candidate");
+    let head = Arc::new(Mutex::new(super::replication::FetchHeadResponse {
+        found: true,
+        head: Some(super::replication::ReplicationHeadSummary {
+            world_id: world_id.to_string(),
+            height: 1,
+            block_hash: "block-1".to_string(),
+            state_root: "peer-exec-state-1".to_string(),
+            timestamp_ms: 249_100,
+        }),
+    }));
+    let network: Arc<dyn oasis7_proto::distributed_net::DistributedNetwork<WorldError> + Send + Sync> =
+        Arc::new(PeerHeadCheckpointNetwork {
+            inner: Arc::new(TestInMemoryNetwork::default()),
+            fetch_protocols: Arc::new(Mutex::new(Vec::new())),
+            head,
+            checkpoint_fetch_available: Arc::new(AtomicBool::new(false)),
+            checkpoint_fetch_not_found: Arc::new(AtomicBool::new(true)),
+            connected_peer_ids: vec!["node-a".to_string(), "node-c".to_string()],
+        });
+    network
+        .register_handler(REPLICATION_FETCH_COMMIT_PROTOCOL, Box::new(|_| {
+            serde_json::to_vec(&super::replication::FetchCommitResponse {
+                found: false,
+                message: None,
+            })
+            .map_err(|err| WorldError::DistributedValidationFailed {
+                reason: format!("encode absent checkpoint response failed: {err}"),
+            })
+        }))
+        .expect("register absent checkpoint response");
+    let handle_b = NodeReplicationNetworkHandle::new(Arc::clone(&network));
+    let mut endpoint_b = ReplicationNetworkEndpoint::new(
+        &handle_b, world_id, true, &config_b.network_policy,
+    )
+    .expect("fresh observer endpoint");
+    assert_eq!(endpoint_b.connected_peer_ids(), vec!["node-a", "node-c"]);
+    let mut replication_b = ReplicationRuntime::new(
+        config_b.replication.as_ref().expect("repl b"), "node-b",
+    )
+    .expect("fresh observer runtime");
+    let mut engine_b = PosNodeEngine::new(&config_b).expect("fresh observer engine");
+    assert!(engine_b.peer_heads.is_empty());
+    let mut execution_hook = PackageProbeHeightOneFailureHook {
+        incremental_commits: Vec::new(),
+        rollback_heights: Vec::new(),
+    };
+    macro_rules! package_tick {
+        ($now_ms:expr) => {
+            engine_b.tick(
+                "node-b", world_id, $now_ms, None, Some(&mut replication_b),
+                Some(&mut endpoint_b), None, Vec::new(), Some(&mut execution_hook),
+            )
+        };
+    }
+    package_tick!(249_300).expect("initial stale world head must hold height zero");
+    package_tick!(549_300).expect("300s unavailable checkpoint probe must hold height zero");
+    assert_eq!(engine_b.committed_height, 0);
+    assert!(execution_hook.incremental_commits.is_empty());
+    assert!(execution_hook.rollback_heights.is_empty());
+    endpoint_b
+        .publish_replication(&height_one_a)
+        .expect("publish first height-one candidate after probe window");
+    let first_result = package_tick!(549_301);
+    assert!(first_result.is_ok(), "first candidate should remain queued: {first_result:?}");
+    endpoint_b
+        .publish_replication(&height_one_c)
+        .expect("publish second height-one candidate after probe window");
+    let result = package_tick!(549_302);
+    assert!(
+        result.is_ok(),
+        "post-merge testnet.249 observer must remain fail-closed after two candidates; live bug signature: result={result:?} incremental={:?} rollback={:?}",
+        execution_hook.incremental_commits,
+        execution_hook.rollback_heights
+    );
+    let snapshot = result.expect("height-zero post-merge snapshot");
+    assert_eq!(snapshot.consensus_snapshot.committed_height, 0);
+    assert!(execution_hook.incremental_commits.is_empty());
+    assert!(execution_hook.rollback_heights.is_empty());
+    assert_eq!(engine_b.committed_height, 0);
+    assert_eq!(engine_b.replication_persisted_height, 0);
+    let _ = fs::remove_dir_all(&dir_a);
+    let _ = fs::remove_dir_all(&dir_b);
+    let _ = fs::remove_dir_all(&dir_c);
+}


### PR DESCRIPTION
Task: task_a50c7050e6f740a083773474dc61ef35
Refs #3161

## Summary
- fail closed when a fresh observer has a connected configured validator stake quorum but stale low advertised head
- deduplicate validator bindings before stake calculation
- add deterministic testnet.249 ordering regression

## Verification
- focused regression twice: pass
- affected checkpoint suite: 17/17
- serial oasis7_node library suite: 446/446
- cargo check, fmt, diff, file-size, doc-governance: pass

Follow-up to #3170.