### PR TITLE
Require observer signed consensus subscription

### DIFF
--- a/crates/oasis7_node/src/lib.rs
+++ b/crates/oasis7_node/src/lib.rs
@@ -188,7 +188,6 @@ const REPLICATION_FETCH_BLOB_GENERIC_ROUTE_ATTEMPTS: usize = 3;
 const REPLICATION_SUCCESSOR_PROBE_COOLDOWN_MS: i64 = 1_000;
 const EXECUTION_BINDING_HISTORY_LIMIT: usize = 256;
 const FINALITY_LATENCY_HISTORY_LIMIT: usize = 128;
-
 pub const EXECUTION_MISSING_PREDECESSOR_RECORD_SIGNATURE: &str =
     "execution driver missing predecessor record for non-contiguous committed height";
 
@@ -437,7 +436,8 @@ impl NodeRuntime {
         };
         let mut consensus_network = if let Some(network) = &self.replication_network {
             let subscribe = self.replication_network_consensus_enabled
-                || self.config.role == NodeRole::Observer;
+                || (self.config.role == NodeRole::Observer
+                    && network.uses_default_topic(self.config.world_id.as_str()));
             if subscribe {
                 match ConsensusNetworkEndpoint::new(
                     network,
@@ -1152,7 +1152,6 @@ struct PosNodeEngine {
 
 type PendingProposal = NodePosPendingProposal<NodeConsensusAction, PosConsensusStatus>;
 type PosDecision = NodePosDecision<NodeConsensusAction, PosConsensusStatus>;
-
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct PeerCommittedHead {
     height: u64,
@@ -1190,6 +1189,7 @@ struct ConsensusMisbehaviorEvidence {
     validator_stake_root: String,
     quarantined: bool,
 }
+
 #[cfg(test)]
 mod tests;
 #[cfg(test)]

--- a/crates/oasis7_node/src/lib.rs
+++ b/crates/oasis7_node/src/lib.rs
@@ -436,7 +436,9 @@ impl NodeRuntime {
             None
         };
         let mut consensus_network = if let Some(network) = &self.replication_network {
-            if self.replication_network_consensus_enabled {
+            let subscribe = self.replication_network_consensus_enabled
+                || self.config.role == NodeRole::Observer;
+            if subscribe {
                 match ConsensusNetworkEndpoint::new(
                     network,
                     &self.config.world_id,
@@ -1188,7 +1190,6 @@ struct ConsensusMisbehaviorEvidence {
     validator_stake_root: String,
     quarantined: bool,
 }
-
 #[cfg(test)]
 mod tests;
 #[cfg(test)]

--- a/crates/oasis7_node/src/network_bridge.rs
+++ b/crates/oasis7_node/src/network_bridge.rs
@@ -378,6 +378,10 @@ impl NodeReplicationNetworkHandle {
             .unwrap_or_else(|| default_replication_topic(world_id))
     }
 
+    pub(crate) fn uses_default_topic(&self, world_id: &str) -> bool {
+        self.resolved_topic(world_id) == default_replication_topic(world_id)
+    }
+
     fn resolved_lane_registry(&self, world_id: &str) -> TrafficLaneRegistry {
         TrafficLaneRegistry::for_handle(self, world_id)
     }

--- a/crates/oasis7_node/src/tests_observer_consensus_subscription.rs
+++ b/crates/oasis7_node/src/tests_observer_consensus_subscription.rs
@@ -14,9 +14,11 @@ fn production_observer_runtime_enables_consensus_subscription_without_publish() 
     );
 
     let world_id = "world-observer-consensus-policy";
-    let network = Arc::new(TestInMemoryNetwork::default());
-    let config = NodeConfig::new("observer", world_id, NodeRole::Observer)
-        .expect("observer config");
+    let network: Arc<
+        dyn oasis7_proto::distributed_net::DistributedNetwork<WorldError> + Send + Sync,
+    > = Arc::new(TestInMemoryNetwork::default());
+    let config =
+        NodeConfig::new("observer", world_id, NodeRole::Observer).expect("observer config");
     let endpoint = ConsensusNetworkEndpoint::new(
         &NodeReplicationNetworkHandle::new(network),
         world_id,
@@ -30,7 +32,9 @@ fn production_observer_runtime_enables_consensus_subscription_without_publish() 
 #[test]
 fn observer_replication_runtime_ingests_signed_commit_before_checkpoint_preflight() {
     let world_id = "world-observer-consensus-preflight";
-    let network = Arc::new(TestInMemoryNetwork::default());
+    let network: Arc<
+        dyn oasis7_proto::distributed_net::DistributedNetwork<WorldError> + Send + Sync,
+    > = Arc::new(TestInMemoryNetwork::default());
     let (_, validator_public_key) = deterministic_keypair_hex(207);
     let pos_config = signed_pos_config_with_signer_seeds(
         vec![PosValidator {
@@ -81,7 +85,10 @@ fn observer_replication_runtime_ingests_signed_commit_before_checkpoint_prefligh
         .expect("observer tick")
         .with_pos_config(pos_config)
         .expect("observer validators")
-        .with_replication(signed_replication_config(temp_dir("observer-consensus-preflight"), 209));
+        .with_replication(signed_replication_config(
+            temp_dir("observer-consensus-preflight"),
+            209,
+        ));
     let mut runtime = NodeRuntime::new(config)
         .with_replication_network(NodeReplicationNetworkHandle::new(network))
         // Mirrors the live chain-runtime assembly: ObserverLight subscribes to
@@ -96,8 +103,183 @@ fn observer_replication_runtime_ingests_signed_commit_before_checkpoint_prefligh
     assert!(
         observed,
         "signed validator commit must populate peer_heads before replication checkpoint preflight: known_peer_heads={} peer_heads={:?} last_error={:?}",
+        snapshot.consensus.known_peer_heads, snapshot.consensus.peer_heads, snapshot.last_error
+    );
+}
+
+#[test]
+fn testnet_250_default_consensus_topic_delivers_two_signed_validator_heads_before_preflight() {
+    let world_id = "world-testnet-250-default-consensus-topic";
+    let network: Arc<
+        dyn oasis7_proto::distributed_net::DistributedNetwork<WorldError> + Send + Sync,
+    > = Arc::new(TestInMemoryNetwork::default());
+    let validators = vec![
+        PosValidator {
+            validator_id: "node-a".to_string(),
+            stake: 50,
+        },
+        PosValidator {
+            validator_id: "node-c".to_string(),
+            stake: 50,
+        },
+    ];
+    let pos_config =
+        signed_pos_config_with_signer_seeds(validators, &[("node-a", 250), ("node-c", 251)]);
+    let publish_config = NodeConfig::new("node-a", world_id, NodeRole::Sequencer)
+        .expect("validator config")
+        .with_pos_config(pos_config.clone())
+        .expect("validator pos config");
+    let publish_endpoint = ConsensusNetworkEndpoint::new(
+        &NodeReplicationNetworkHandle::new(Arc::clone(&network)),
+        world_id,
+        false,
+        &publish_config.network_policy,
+    )
+    .expect("validator consensus endpoint");
+    for (node_id, seed, height) in [("node-a", 250_u8, 256_u64), ("node-c", 251, 256)] {
+        let mut commit = GossipCommitMessage {
+            version: 1,
+            world_id: world_id.to_string(),
+            node_id: node_id.to_string(),
+            player_id: node_id.to_string(),
+            height,
+            slot: height,
+            epoch: 0,
+            block_hash: format!("block-{node_id}-{height}"),
+            action_root: empty_action_root(),
+            actions: Vec::new(),
+            committed_at_ms: height as i64 * 1_000,
+            execution_block_hash: Some(format!("exec-block-{node_id}-{height}")),
+            execution_state_root: Some(format!("exec-state-{node_id}-{height}")),
+            public_key_hex: None,
+            signature_hex: None,
+        };
+        let (private_hex, public_hex) = deterministic_keypair_hex(seed);
+        let signing_key = SigningKey::from_bytes(
+            &hex::decode(private_hex)
+                .expect("decode validator private key")
+                .try_into()
+                .expect("validator private key length"),
+        );
+        let signer =
+            ConsensusMessageSigner::new(signing_key, public_hex).expect("validator commit signer");
+        sign_commit_message(&mut commit, &signer).expect("sign validator commit");
+        publish_endpoint
+            .publish_commit(&commit)
+            .expect("validator endpoint publishes signed commit");
+    }
+
+    let observer_config = NodeConfig::new("observer", world_id, NodeRole::Observer)
+        .expect("observer config")
+        .with_tick_interval(Duration::from_millis(10))
+        .expect("observer tick")
+        .with_pos_config(pos_config)
+        .expect("observer validators")
+        .with_replication(signed_replication_config(
+            temp_dir("testnet-250-consensus"),
+            252,
+        ));
+    let mut runtime = NodeRuntime::new(observer_config)
+        .with_replication_network(NodeReplicationNetworkHandle::new(Arc::clone(&network)))
+        // RED fixture: this is the pre-enable ObserverLight assembly. The
+        // production chain runtime must turn this lane on before preflight.
+        .with_replication_network_consensus_enabled(false);
+    runtime.start().expect("start observer runtime");
+    let converged = wait_until(Instant::now() + Duration::from_secs(2), || {
+        let snapshot = runtime.snapshot();
+        snapshot.consensus.known_peer_heads >= 2
+            && snapshot.consensus.network_committed_height >= 256
+    });
+    let snapshot = runtime.snapshot();
+    runtime.stop().expect("stop observer runtime");
+    assert!(
+        converged,
+        "testnet.250 signed validator authority must arrive on the default consensus commit topic before checkpoint preflight: known_peer_heads={} network_committed_height={} peer_heads={:?} last_error={:?}",
         snapshot.consensus.known_peer_heads,
+        snapshot.consensus.network_committed_height,
         snapshot.consensus.peer_heads,
         snapshot.last_error
     );
+}
+
+#[derive(Clone)]
+struct Testnet250ConnectedOnlyNetwork {
+    inner: Arc<TestInMemoryNetwork>,
+    peers: Vec<String>,
+}
+
+impl oasis7_proto::distributed_net::DistributedNetwork<WorldError>
+    for Testnet250ConnectedOnlyNetwork
+{
+    fn publish(&self, topic: &str, payload: &[u8]) -> Result<(), WorldError> {
+        self.inner.publish(topic, payload)
+    }
+
+    fn subscribe(&self, topic: &str) -> Result<NetworkSubscription, WorldError> {
+        self.inner.subscribe(topic)
+    }
+
+    fn request(&self, protocol: &str, payload: &[u8]) -> Result<Vec<u8>, WorldError> {
+        self.inner.request(protocol, payload)
+    }
+
+    fn connected_peer_ids(&self) -> Vec<String> {
+        self.peers.clone()
+    }
+
+    fn known_peer_ids(&self) -> Vec<String> {
+        self.peers.clone()
+    }
+
+    fn register_handler(
+        &self,
+        protocol: &str,
+        handler: Box<dyn Fn(&[u8]) -> Result<Vec<u8>, WorldError> + Send + Sync>,
+    ) -> Result<(), WorldError> {
+        self.inner.register_handler(protocol, handler)
+    }
+}
+
+#[test]
+fn testnet_250_connected_quorum_without_commit_publication_does_not_create_authority() {
+    let world_id = "world-testnet-250-connected-without-publication";
+    let network: Arc<
+        dyn oasis7_proto::distributed_net::DistributedNetwork<WorldError> + Send + Sync,
+    > = Arc::new(Testnet250ConnectedOnlyNetwork {
+        inner: Arc::new(TestInMemoryNetwork::default()),
+        peers: vec!["node-a".to_string(), "node-c".to_string()],
+    });
+    let pos_config = signed_pos_config_with_signer_seeds(
+        vec![
+            PosValidator {
+                validator_id: "node-a".to_string(),
+                stake: 50,
+            },
+            PosValidator {
+                validator_id: "node-c".to_string(),
+                stake: 50,
+            },
+        ],
+        &[("node-a", 250), ("node-c", 251)],
+    );
+    let config = NodeConfig::new("observer", world_id, NodeRole::Observer)
+        .expect("observer config")
+        .with_tick_interval(Duration::from_millis(10))
+        .expect("observer tick")
+        .with_pos_config(pos_config)
+        .expect("observer validators")
+        .with_replication(signed_replication_config(
+            temp_dir("testnet-250-no-publication"),
+            252,
+        ));
+    let mut runtime = NodeRuntime::new(config)
+        .with_replication_network(NodeReplicationNetworkHandle::new(network))
+        .with_replication_network_consensus_enabled(true);
+    runtime.start().expect("start observer runtime");
+    thread::sleep(Duration::from_millis(300));
+    let snapshot = runtime.snapshot();
+    runtime.stop().expect("stop observer runtime");
+    assert_eq!(snapshot.consensus.known_peer_heads, 0);
+    assert_eq!(snapshot.consensus.network_committed_height, 0);
+    assert_eq!(snapshot.consensus.committed_height, 0);
 }


### PR DESCRIPTION
Task: task_a50c7050e6f740a083773474dc61ef35
Refs #3161

Follow-up to #3174 after testnet.250 clean-room evidence showed direct validator quorum without signed commit ingestion. Observer runtimes now always subscribe to the signed consensus lane whenever replication networking exists, while publication remains forbidden. Includes deterministic two-validator default-topic RED/GREEN and no-publication authority guard.

Live rollout remains fail-closed pending fresh checkpoint descriptor/receipt/hash/size/provenance.