### PR TITLE
Cover late observer checkpoint authority

### DIFF
--- a/crates/oasis7_node/src/tests_storage_replication_stale_dht_checkpoint_long_probe.rs
+++ b/crates/oasis7_node/src/tests_storage_replication_stale_dht_checkpoint_long_probe.rs
@@ -426,3 +426,239 @@ fn low_world_with_bound_transport_quorum_completes_confirmation_without_high_evi
         let _ = fs::remove_dir_all(dir);
     }
 }
+
+fn testnet_251_signed_high_heads_scenario(heads_before_preflight: bool) {
+    let _nonce_lock = lock_checkpoint_probe_nonce();
+    let _probe_nonce = CheckpointProbeNonceGuard::install();
+    let world_id = "world-testnet-251-signed-heads-no-closure";
+    let dir_a = temp_dir("testnet-251-signed-heads-a");
+    let dir_b = temp_dir("testnet-251-signed-heads-b");
+    let (_, public_key_a) = deterministic_keypair_hex(251);
+    let (_, public_key_b) = deterministic_keypair_hex(253);
+    let pos_config = signed_pos_config_with_signer_seeds(
+        vec![
+            PosValidator {
+                validator_id: "node-a".to_string(),
+                stake: 50,
+            },
+            PosValidator {
+                validator_id: "node-c".to_string(),
+                stake: 50,
+            },
+        ],
+        &[("node-a", 251), ("node-c", 252)],
+    );
+    let replication_config_a = signed_replication_config(dir_a.clone(), 251)
+        .with_remote_writer_allowlist(vec![public_key_b.clone()])
+        .expect("allowlist a")
+        .with_fetch_requester_allowlist(vec![public_key_b.clone()])
+        .expect("fetch allowlist a");
+    let replication_config_b = signed_replication_config(dir_b.clone(), 253)
+        .with_remote_writer_allowlist(vec![public_key_a.clone()])
+        .expect("allowlist b")
+        .with_fetch_requester_allowlist(vec![public_key_a.clone()])
+        .expect("fetch allowlist b");
+    let config_a = NodeConfig::new("node-a", world_id, NodeRole::Sequencer)
+        .expect("config a")
+        .with_pos_config(pos_config.clone())
+        .expect("pos config a")
+        .with_replication(replication_config_a.clone());
+    let config_b = NodeConfig::new("node-b", world_id, NodeRole::Observer)
+        .expect("config b")
+        .with_pos_config(pos_config)
+        .expect("pos config b")
+        .with_require_execution_on_commit(true)
+        .with_replication(replication_config_b.clone());
+    let mut replication_a =
+        ReplicationRuntime::new(config_a.replication.as_ref().expect("replication a"), "node-a")
+            .expect("runtime a");
+    let height_one = replication_a
+        .build_local_commit_message(
+            "node-a",
+            world_id,
+            251_100,
+            &committed_decision(1),
+            Some("peer-exec-block-1"),
+            Some("peer-exec-state-1"),
+        )
+        .expect("build height-one candidate")
+        .expect("height-one candidate");
+    let high_height = 64;
+    let network: Arc<
+        dyn oasis7_proto::distributed_net::DistributedNetwork<WorldError> + Send + Sync,
+    > = Arc::new(PeerHeadCheckpointNetwork {
+        inner: Arc::new(TestInMemoryNetwork::default()),
+        fetch_protocols: Arc::new(Mutex::new(Vec::new())),
+        head: Arc::new(Mutex::new(super::replication::FetchHeadResponse {
+            found: true,
+            head: Some(super::replication::ReplicationHeadSummary {
+                world_id: world_id.to_string(),
+                height: 1,
+                block_hash: "block-1".to_string(),
+                state_root: "peer-exec-state-1".to_string(),
+                timestamp_ms: 251_100,
+            }),
+        })),
+        checkpoint_fetch_available: Arc::new(AtomicBool::new(false)),
+        checkpoint_fetch_not_found: Arc::new(AtomicBool::new(true)),
+        connected_peer_ids: vec!["node-a".to_string(), "node-c".to_string()],
+    });
+    let handle = NodeReplicationNetworkHandle::new(Arc::clone(&network));
+    let mut replication_endpoint =
+        ReplicationNetworkEndpoint::new(&handle, world_id, true, &config_b.network_policy)
+            .expect("observer replication endpoint");
+    let mut consensus_endpoint =
+        ConsensusNetworkEndpoint::new(&handle, world_id, true, &config_b.network_policy)
+            .expect("observer consensus endpoint");
+    let publish_endpoint = ConsensusNetworkEndpoint::new(
+        &NodeReplicationNetworkHandle::new(Arc::clone(&network)),
+        world_id,
+        false,
+        &config_a.network_policy,
+    )
+    .expect("validator consensus endpoint");
+    let publish_signed_heads = || {
+        for (node_id, seed) in [("node-a", 251_u8), ("node-c", 252_u8)] {
+            let (private_hex, public_hex) = deterministic_keypair_hex(seed);
+            let signing_key = SigningKey::from_bytes(
+                &hex::decode(private_hex)
+                    .expect("decode validator key")
+                    .try_into()
+                    .expect("validator key length"),
+            );
+            let signer = ConsensusMessageSigner::new(signing_key, public_hex)
+                .expect("validator commit signer");
+            let mut commit = GossipCommitMessage {
+                version: 1,
+                world_id: world_id.to_string(),
+                node_id: node_id.to_string(),
+                player_id: node_id.to_string(),
+                height: high_height,
+                slot: high_height,
+                epoch: 0,
+                block_hash: "block-64".to_string(),
+                action_root: empty_action_root(),
+                actions: Vec::new(),
+                committed_at_ms: 251_164,
+                execution_block_hash: Some("exec-block-64".to_string()),
+                execution_state_root: Some("exec-state-64".to_string()),
+                public_key_hex: None,
+                signature_hex: None,
+            };
+            sign_commit_message(&mut commit, &signer).expect("sign validator commit");
+            publish_endpoint
+                .publish_commit(&commit)
+                .expect("publish signed validator head");
+        }
+    };
+    if heads_before_preflight {
+        publish_signed_heads();
+    }
+    let mut replication_b =
+        ReplicationRuntime::new(config_b.replication.as_ref().expect("replication b"), "node-b")
+            .expect("runtime b");
+    let mut engine_b = PosNodeEngine::new(&config_b).expect("observer engine");
+    let mut execution_hook = PackageProbeHeightOneFailureHook {
+        incremental_commits: Vec::new(),
+        rollback_heights: Vec::new(),
+    };
+    let preflight = engine_b.tick(
+        "node-b",
+        world_id,
+        251_300,
+        None,
+        Some(&mut replication_b),
+        Some(&mut replication_endpoint),
+        Some(&mut consensus_endpoint),
+        Vec::new(),
+        Some(&mut execution_hook),
+    );
+    assert!(preflight.is_ok(), "initial checkpoint preflight must not execute height one: {preflight:?}");
+    assert_eq!(engine_b.peer_heads.len(), if heads_before_preflight { 2 } else { 0 });
+    assert_eq!(engine_b.committed_height, 0);
+    assert!(execution_hook.incremental_commits.is_empty());
+    assert!(execution_hook.rollback_heights.is_empty());
+    if !heads_before_preflight {
+        publish_signed_heads();
+        let authority_tick = engine_b.tick(
+            "node-b",
+            world_id,
+            251_301,
+            None,
+            Some(&mut replication_b),
+            Some(&mut replication_endpoint),
+            Some(&mut consensus_endpoint),
+            Vec::new(),
+            Some(&mut execution_hook),
+        );
+        assert!(authority_tick.is_ok(), "late signed heads must be ingested without height-one execution: {authority_tick:?}");
+        assert_eq!(engine_b.peer_heads.len(), 2);
+        assert!(engine_b.peer_heads.values().all(|head| head.height == high_height));
+        assert_eq!(engine_b.committed_height, 0);
+        assert!(execution_hook.incremental_commits.is_empty());
+        assert!(execution_hook.rollback_heights.is_empty());
+    }
+    let unavailable_retry = engine_b.tick(
+        "node-b",
+        world_id,
+        551_300,
+        None,
+        Some(&mut replication_b),
+        Some(&mut replication_endpoint),
+        Some(&mut consensus_endpoint),
+        Vec::new(),
+        Some(&mut execution_hook),
+    );
+    assert!(
+        unavailable_retry.is_ok(),
+        "unavailable checkpoint closure must remain fail-closed through the probe window: {unavailable_retry:?}"
+    );
+    replication_endpoint
+        .publish_replication(&height_one)
+        .expect("publish height-one candidate after signed heads");
+    let result = engine_b.tick(
+        "node-b",
+        world_id,
+        551_301,
+        None,
+        Some(&mut replication_b),
+        Some(&mut replication_endpoint),
+        Some(&mut consensus_endpoint),
+        Vec::new(),
+        Some(&mut execution_hook),
+    );
+    assert!(
+        result.is_ok(),
+        "signed high authority without checkpoint closure must remain fail-closed: result={result:?} incremental={:?} rollback={:?}",
+        execution_hook.incremental_commits,
+        execution_hook.rollback_heights
+    );
+    let snapshot = result.expect("height-zero fail-closed snapshot");
+    assert_eq!(snapshot.consensus_snapshot.committed_height, 0);
+    assert_eq!(engine_b.committed_height, 0);
+    assert_eq!(engine_b.replication_persisted_height, 0);
+    assert!(execution_hook.incremental_commits.is_empty());
+    assert!(execution_hook.rollback_heights.is_empty());
+    let _ = fs::remove_dir_all(&dir_a);
+    let _ = fs::remove_dir_all(&dir_b);
+}
+
+#[test]
+fn testnet_251_signed_high_heads_hold_height_zero_without_checkpoint_closure() {
+    testnet_251_signed_high_heads_scenario(true);
+}
+
+#[test]
+fn testnet_251_late_signed_high_heads_hold_height_zero_without_checkpoint_closure() {
+    testnet_251_signed_high_heads_scenario(false);
+}
+
+#[test]
+fn testnet_251_signed_high_heads_install_verified_checkpoint_when_closure_available() {
+    peer_head_checkpoint_before_height_one_with_stale_dht(
+        InitialPeerHead::HighCheckpoint,
+        true,
+        true,
+        false,
+    );
+}


### PR DESCRIPTION
Task: task_a50c7050e6f740a083773474dc61ef35
Refs #3161

Adds deterministic regression coverage derived from testnet.251 clean-room ordering: signed high heads both before preflight and arriving after a stale low-head observation must keep a fresh observer at height zero while checkpoint closure is unavailable. Includes verified-closure control.

No production changes; current merged runtime is already GREEN. Live rollout remains fail-closed pending provider descriptor and receipt/hash/size/provenance closure.