### PR TITLE
Fix retained checkpoint bootstrap below live head

### DIFF
--- a/crates/oasis7_node/src/node_engine_replication.rs
+++ b/crates/oasis7_node/src/node_engine_replication.rs
@@ -567,6 +567,12 @@ impl PosNodeEngine {
         if payload.execution_block_hash.is_none() || payload.execution_state_root.is_none() {
             return Ok(false);
         }
+        if fresh_execution_bootstrap
+            && expected_checkpoint_head.is_none()
+            && !self.authenticated_checkpoint_writer_has_supermajority_stake(&message)
+        {
+            return Ok(false);
+        }
         if let Some(expected_head) = expected_checkpoint_head {
             if Self::validate_world_head_checkpoint_payload(world_id, &payload, expected_head)
                 .is_err()
@@ -713,6 +719,7 @@ impl PosNodeEngine {
         }
         Ok(true)
     }
+
     pub(super) fn sync_missing_replication_commits_with_progress(
         &mut self,
         endpoint: &ReplicationNetworkEndpoint,

--- a/crates/oasis7_node/src/node_engine_replication_checkpoint.rs
+++ b/crates/oasis7_node/src/node_engine_replication_checkpoint.rs
@@ -315,6 +315,41 @@ impl PosNodeEngine {
         Ok(())
     }
 
+    pub(super) fn authenticated_checkpoint_writer_has_supermajority_stake(
+        &self,
+        message: &replication::GossipReplicationMessage,
+    ) -> bool {
+        // The current replication/peer-head payloads do not carry a signed
+        // predecessor chain or a finality proof that could bind a retained
+        // checkpoint C below an authenticated live head H.  A matching writer
+        // key is therefore not sufficient lineage evidence: the writer could
+        // have signed a conflicting fork at C.  Keep the lower-candidate path
+        // fail-closed whenever any authenticated high peer head is present;
+        // the unsigned FetchHead fallback remains eligible only after the
+        // checkpoint writer itself passes the validator stake gate below.
+        if self.peer_heads.values().any(|head| {
+            head.height >= REPLICATION_GAP_SYNC_MAX_HEIGHTS_PER_POLL
+                && head.public_key_hex.is_some()
+                && head.signature_hex.is_some()
+        }) {
+            return false;
+        }
+        let Some((validator_id, _public_key_hex)) = self
+            .validator_signers
+            .iter()
+            .find(|(_, public_key_hex)| *public_key_hex == &message.record.writer_id)
+        else {
+            return false;
+        };
+        let Some(stake) = self.validators.get(validator_id).copied() else {
+            return false;
+        };
+        if stake < self.required_stake {
+            return false;
+        }
+        true
+    }
+
     pub(super) fn high_replication_checkpoint_candidates(
         advertised_network_height: u64,
         blocked_height: u64,

--- a/crates/oasis7_node/src/node_engine_replication_checkpoint.rs
+++ b/crates/oasis7_node/src/node_engine_replication_checkpoint.rs
@@ -165,28 +165,40 @@ impl PosNodeEngine {
             if let Some(cached_head) = self.cached_high_checkpoint_head(world_id) {
                 self.fresh_observer_checkpoint_low_head_confirmation = None;
                 self.fresh_observer_checkpoint_bootstrap_retry_pending = false;
-                return match self.try_sync_high_replication_checkpoint_boundary(
-                    endpoint,
-                    node_id,
-                    world_id,
-                    replication_runtime,
-                    cached_head.height,
-                    0,
-                    Some(&cached_head),
-                    execution_hook,
-                    progress_callback,
-                ) {
-                    Ok(true) => Ok(FreshObserverCheckpointBootstrap::Installed),
-                    Ok(false) => {
-                        self.fresh_observer_checkpoint_bootstrap_retry_pending = true;
-                        Ok(FreshObserverCheckpointBootstrap::HighCheckpointPending)
+                let mut retry_pending = false;
+                for checkpoint_candidate in
+                    Self::high_replication_checkpoint_candidates(cached_head.height, 0)
+                {
+                    let expected_candidate_head =
+                        (checkpoint_candidate == cached_head.height).then_some(&cached_head);
+                    match self.try_sync_high_replication_checkpoint_boundary(
+                        endpoint,
+                        node_id,
+                        world_id,
+                        replication_runtime,
+                        checkpoint_candidate,
+                        0,
+                        expected_candidate_head,
+                        execution_hook,
+                        progress_callback,
+                    ) {
+                        Ok(true) => {
+                            return Ok(FreshObserverCheckpointBootstrap::Installed);
+                        }
+                        Ok(false) => {}
+                        Err(err) if Self::high_replication_checkpoint_probe_can_continue(&err) => {
+                            retry_pending = true;
+                            self.fresh_observer_checkpoint_bootstrap_retry_pending = true;
+                        }
+                        Err(err) => return Err(err),
                     }
-                    Err(err) if Self::high_replication_checkpoint_probe_can_continue(&err) => {
-                        self.fresh_observer_checkpoint_bootstrap_retry_pending = true;
-                        Ok(FreshObserverCheckpointBootstrap::RetryPending)
-                    }
-                    Err(err) => Err(err),
-                };
+                }
+                self.fresh_observer_checkpoint_bootstrap_retry_pending = true;
+                return Ok(if retry_pending {
+                    FreshObserverCheckpointBootstrap::RetryPending
+                } else {
+                    FreshObserverCheckpointBootstrap::HighCheckpointPending
+                });
             }
             // Preserve the existing fail-closed hold for high heads that are
             // not trustworthy checkpoint candidates (for example, an unknown
@@ -230,33 +242,49 @@ impl PosNodeEngine {
         }
         self.fresh_observer_checkpoint_bootstrap_retry_pending = false;
         self.fresh_observer_checkpoint_low_head_confirmation = None;
-        match self.try_sync_high_replication_checkpoint_boundary(
-            endpoint,
-            node_id,
-            world_id,
-            replication_runtime,
-            advertised_head.height,
-            0,
-            Some(&advertised_head),
-            execution_hook,
-            progress_callback,
-        ) {
-            Ok(true) => Ok(FreshObserverCheckpointBootstrap::Installed),
-            // A high advertised head is evidence that replaying the height-one
-            // tail is unsafe until this observer has either installed the
-            // matching verified checkpoint or observed that head change. In
-            // particular, a bounded fetch probe can return `NotFound` while
-            // the connected peer is still becoming request-ready.
-            Ok(false) => {
-                self.fresh_observer_checkpoint_bootstrap_retry_pending = true;
-                Ok(FreshObserverCheckpointBootstrap::HighCheckpointPending)
+        // The advertised live head is not necessarily itself a retained
+        // checkpoint boundary (for example, head 52079 with the newest
+        // retained checkpoint at 52032). Probe the head first, then the
+        // bounded aligned candidates below it; each candidate must still
+        // return a descriptor whose height/hash/state binding matches that
+        // candidate before installation can proceed.
+        let mut retry_pending = false;
+        for checkpoint_candidate in
+            Self::high_replication_checkpoint_candidates(advertised_head.height, 0)
+        {
+            let expected_candidate_head =
+                (checkpoint_candidate == advertised_head.height).then_some(&advertised_head);
+            match self.try_sync_high_replication_checkpoint_boundary(
+                endpoint,
+                node_id,
+                world_id,
+                replication_runtime,
+                checkpoint_candidate,
+                0,
+                expected_candidate_head,
+                execution_hook,
+                progress_callback,
+            ) {
+                Ok(true) => return Ok(FreshObserverCheckpointBootstrap::Installed),
+                // A high advertised head is evidence that replaying the
+                // height-one tail is unsafe until this observer has either
+                // installed a verified retained checkpoint or observed that
+                // head change. A non-boundary head is expected to return no
+                // descriptor; continue to the newest aligned candidate.
+                Ok(false) => {}
+                Err(err) if Self::high_replication_checkpoint_probe_can_continue(&err) => {
+                    retry_pending = true;
+                    self.fresh_observer_checkpoint_bootstrap_retry_pending = true;
+                }
+                Err(err) => return Err(err),
             }
-            Err(err) if Self::high_replication_checkpoint_probe_can_continue(&err) => {
-                self.fresh_observer_checkpoint_bootstrap_retry_pending = true;
-                Ok(FreshObserverCheckpointBootstrap::RetryPending)
-            }
-            Err(err) => Err(err),
         }
+        self.fresh_observer_checkpoint_bootstrap_retry_pending = true;
+        Ok(if retry_pending {
+            FreshObserverCheckpointBootstrap::RetryPending
+        } else {
+            FreshObserverCheckpointBootstrap::HighCheckpointPending
+        })
     }
 
     pub(super) fn validate_world_head_checkpoint_payload(

--- a/crates/oasis7_node/src/tests_storage_replication.rs
+++ b/crates/oasis7_node/src/tests_storage_replication.rs
@@ -10,6 +10,8 @@ mod storage_replication_high_checkpoint_tests;
 mod storage_replication_first_ready_checkpoint_tests;
 #[path = "tests_storage_replication_high_checkpoint_retained.rs"]
 mod storage_replication_high_checkpoint_retained_tests;
+#[path = "tests_storage_replication_live_retained_boundary.rs"]
+mod storage_replication_live_retained_boundary_tests;
 #[path = "tests_storage_replication_high_checkpoint_timeout.rs"]
 mod storage_replication_high_checkpoint_timeout_tests;
 #[path = "tests_storage_replication_peer_head.rs"]

--- a/crates/oasis7_node/src/tests_storage_replication_first_ready_checkpoint.rs
+++ b/crates/oasis7_node/src/tests_storage_replication_first_ready_checkpoint.rs
@@ -133,17 +133,17 @@ struct CheckpointInstallingExecutionHook {
 
 static CHECKPOINT_PROBE_NONCE_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
 
-fn lock_checkpoint_probe_nonce() -> std::sync::MutexGuard<'static, ()> {
+pub(super) fn lock_checkpoint_probe_nonce() -> std::sync::MutexGuard<'static, ()> {
     CHECKPOINT_PROBE_NONCE_LOCK
         .get_or_init(|| Mutex::new(()))
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner())
 }
 
-struct CheckpointProbeNonceGuard;
+pub(super) struct CheckpointProbeNonceGuard;
 
 impl CheckpointProbeNonceGuard {
-    fn install() -> Self {
+    pub(super) fn install() -> Self {
         // SAFETY: tests serialize access with CHECKPOINT_PROBE_NONCE_LOCK.
         unsafe {
             std::env::set_var(

--- a/crates/oasis7_node/src/tests_storage_replication_high_checkpoint.rs
+++ b/crates/oasis7_node/src/tests_storage_replication_high_checkpoint.rs
@@ -470,6 +470,8 @@ fn observer_gap_sync_discovers_high_checkpoint_from_peer_world_head_request() {
 
 #[test]
 fn observer_gap_sync_installs_execution_checkpoint_bundle_when_low_history_is_missing() {
+    let _nonce_lock =
+        super::storage_replication_first_ready_checkpoint_tests::lock_checkpoint_probe_nonce();
     let world_id = "world-gap-sync-execution-checkpoint";
     let dir_a = temp_dir("gap-sync-execution-checkpoint-a");
     let dir_b = temp_dir("gap-sync-execution-checkpoint-b");

--- a/crates/oasis7_node/src/tests_storage_replication_high_checkpoint.rs
+++ b/crates/oasis7_node/src/tests_storage_replication_high_checkpoint.rs
@@ -121,6 +121,8 @@ fn committed_decision(height: u64, approved_stake: u64, required_stake: u64) -> 
 
 #[test]
 fn observer_gap_sync_installs_exported_checkpoint_for_legacy_commit_payload() {
+    let _nonce_lock =
+        super::storage_replication_first_ready_checkpoint_tests::lock_checkpoint_probe_nonce();
     let world_id = "world-gap-sync-exported-legacy-checkpoint";
     let dir_a = temp_dir("gap-sync-exported-legacy-checkpoint-a");
     let dir_b = temp_dir("gap-sync-exported-legacy-checkpoint-b");
@@ -249,6 +251,8 @@ fn observer_gap_sync_installs_exported_checkpoint_for_legacy_commit_payload() {
 
 #[test]
 fn observer_gap_sync_discovers_high_checkpoint_from_world_head() {
+    let _nonce_lock =
+        super::storage_replication_first_ready_checkpoint_tests::lock_checkpoint_probe_nonce();
     let world_id = "world-gap-sync-dht-head";
     let dir_a = temp_dir("gap-sync-dht-head-a");
     let dir_b = temp_dir("gap-sync-dht-head-b");
@@ -366,6 +370,8 @@ fn observer_gap_sync_discovers_high_checkpoint_from_world_head() {
 
 #[test]
 fn observer_gap_sync_discovers_high_checkpoint_from_peer_world_head_request() {
+    let _nonce_lock =
+        super::storage_replication_first_ready_checkpoint_tests::lock_checkpoint_probe_nonce();
     let world_id = "world-gap-sync-peer-head";
     let dir_a = temp_dir("gap-sync-peer-head-a");
     let dir_b = temp_dir("gap-sync-peer-head-b");
@@ -597,6 +603,8 @@ fn observer_gap_sync_installs_execution_checkpoint_bundle_when_low_history_is_mi
 
 #[test]
 fn observer_gap_sync_does_not_persist_sparse_execution_checkpoint_without_hook() {
+    let _nonce_lock =
+        super::storage_replication_first_ready_checkpoint_tests::lock_checkpoint_probe_nonce();
     let world_id = "world-gap-sync-checkpoint-no-hook";
     let dir_a = temp_dir("gap-sync-checkpoint-no-hook-a");
     let dir_b = temp_dir("gap-sync-checkpoint-no-hook-b");
@@ -702,6 +710,8 @@ fn observer_gap_sync_does_not_persist_sparse_execution_checkpoint_without_hook()
 
 #[test]
 fn observer_gap_sync_probes_checkpoint_boundary_below_non_checkpoint_head() {
+    let _nonce_lock =
+        super::storage_replication_first_ready_checkpoint_tests::lock_checkpoint_probe_nonce();
     let world_id = "world-gap-sync-boundary-below-head";
     let dir_a = temp_dir("gap-sync-boundary-below-head-a");
     let dir_b = temp_dir("gap-sync-boundary-below-head-b");
@@ -814,6 +824,8 @@ fn observer_gap_sync_probes_checkpoint_boundary_below_non_checkpoint_head() {
 
 #[test]
 fn observer_gap_sync_rejects_mismatched_world_head_checkpoint() {
+    let _nonce_lock =
+        super::storage_replication_first_ready_checkpoint_tests::lock_checkpoint_probe_nonce();
     let world_id = "world-gap-sync-dht-head-mismatch";
     let dir_a = temp_dir("gap-sync-dht-head-mismatch-a");
     let dir_b = temp_dir("gap-sync-dht-head-mismatch-b");
@@ -927,6 +939,8 @@ fn observer_gap_sync_rejects_mismatched_world_head_checkpoint() {
 
 #[test]
 fn high_checkpoint_gap_sync_does_not_skip_execution_history() {
+    let _nonce_lock =
+        super::storage_replication_first_ready_checkpoint_tests::lock_checkpoint_probe_nonce();
     let world_id = "world-gap-sync-high-checkpoint-execution-history";
     let dir_a = temp_dir("gap-sync-high-checkpoint-execution-history-a");
     let dir_b = temp_dir("gap-sync-high-checkpoint-execution-history-b");
@@ -1028,6 +1042,8 @@ fn high_checkpoint_gap_sync_does_not_skip_execution_history() {
 
 #[test]
 fn observer_gap_sync_bootstraps_from_high_checkpoint_when_low_commits_are_unavailable() {
+    let _nonce_lock =
+        super::storage_replication_first_ready_checkpoint_tests::lock_checkpoint_probe_nonce();
     let world_id = "world-gap-sync-high-checkpoint";
     let dir_a = temp_dir("gap-sync-high-checkpoint-a");
     let dir_b = temp_dir("gap-sync-high-checkpoint-b");

--- a/crates/oasis7_node/src/tests_storage_replication_high_checkpoint_retained.rs
+++ b/crates/oasis7_node/src/tests_storage_replication_high_checkpoint_retained.rs
@@ -670,6 +670,8 @@ fn fetch_commit_handler_does_not_block_on_checkpoint_provider_publish() {
 
 #[test]
 fn observer_gap_sync_recovers_local_state_block_with_retained_checkpoint() {
+    let _nonce_lock =
+        super::storage_replication_first_ready_checkpoint_tests::lock_checkpoint_probe_nonce();
     let world_id = "world-gap-sync-retained-window-below-head";
     let dir_a = temp_dir("gap-sync-retained-window-below-head-a");
     let dir_b = temp_dir("gap-sync-retained-window-below-head-b");

--- a/crates/oasis7_node/src/tests_storage_replication_high_checkpoint_timeout.rs
+++ b/crates/oasis7_node/src/tests_storage_replication_high_checkpoint_timeout.rs
@@ -777,6 +777,8 @@ fn high_checkpoint_without_complete_provider_stays_fail_closed_with_blob_hash() 
 
 #[test]
 fn high_checkpoint_all_rate_limited_providers_cool_down_then_resume_from_cached_blobs() {
+    let _nonce_lock =
+        super::storage_replication_first_ready_checkpoint_tests::lock_checkpoint_probe_nonce();
     let world_id = "world-gap-sync-provider-rate-limit-resume";
     let mut fixture = provider_rate_limit_checkpoint_fixture(world_id, 248, 249);
     fixture

--- a/crates/oasis7_node/src/tests_storage_replication_high_checkpoint_timeout.rs
+++ b/crates/oasis7_node/src/tests_storage_replication_high_checkpoint_timeout.rs
@@ -588,6 +588,8 @@ fn provider_rate_limit_checkpoint_fixture(
 
 #[test]
 fn high_checkpoint_rate_limited_provider_falls_through_to_next_advertised_provider() {
+    let _nonce_lock =
+        super::storage_replication_first_ready_checkpoint_tests::lock_checkpoint_probe_nonce();
     let world_id = "world-gap-sync-provider-rate-limit-failover";
     let mut fixture = provider_rate_limit_checkpoint_fixture(world_id, 246, 247);
     fixture.network.set_rate_limited_providers(&["provider-a"]);
@@ -627,6 +629,8 @@ fn high_checkpoint_rate_limited_provider_falls_through_to_next_advertised_provid
 
 #[test]
 fn high_checkpoint_stale_dht_provider_falls_through_to_connected_complete_peer() {
+    let _nonce_lock =
+        super::storage_replication_first_ready_checkpoint_tests::lock_checkpoint_probe_nonce();
     let world_id = "world-gap-sync-stale-dht-provider-failover";
     let mut fixture = provider_rate_limit_checkpoint_fixture(world_id, 249, 250);
     fixture.dht.set_providers(&["provider-a"]);
@@ -663,6 +667,8 @@ fn high_checkpoint_stale_dht_provider_falls_through_to_connected_complete_peer()
 
 #[test]
 fn high_checkpoint_rate_limited_sole_dht_provider_falls_through_to_connected_complete_peer() {
+    let _nonce_lock =
+        super::storage_replication_first_ready_checkpoint_tests::lock_checkpoint_probe_nonce();
     let world_id = "world-gap-sync-rate-limited-sole-dht-provider-failover";
     let mut fixture = provider_rate_limit_checkpoint_fixture(world_id, 250, 251);
     fixture.dht.set_providers(&["provider-a"]);
@@ -700,6 +706,8 @@ fn high_checkpoint_rate_limited_sole_dht_provider_falls_through_to_connected_com
 
 #[test]
 fn high_checkpoint_rate_limited_sole_dht_and_connected_peer_enters_cooldown() {
+    let _nonce_lock =
+        super::storage_replication_first_ready_checkpoint_tests::lock_checkpoint_probe_nonce();
     let world_id = "world-gap-sync-rate-limited-sole-dht-and-connected-peer";
     let mut fixture = provider_rate_limit_checkpoint_fixture(world_id, 252, 253);
     fixture.dht.set_providers(&["provider-a"]);
@@ -744,6 +752,8 @@ fn high_checkpoint_rate_limited_sole_dht_and_connected_peer_enters_cooldown() {
 
 #[test]
 fn high_checkpoint_without_complete_provider_stays_fail_closed_with_blob_hash() {
+    let _nonce_lock =
+        super::storage_replication_first_ready_checkpoint_tests::lock_checkpoint_probe_nonce();
     let world_id = "world-gap-sync-no-complete-checkpoint-provider";
     let mut fixture = provider_rate_limit_checkpoint_fixture(world_id, 251, 252);
     fixture.dht.set_providers(&["provider-a"]);
@@ -862,6 +872,8 @@ fn high_checkpoint_all_rate_limited_providers_cool_down_then_resume_from_cached_
 
 #[test]
 fn observer_gap_sync_continues_checkpoint_candidates_after_protocol_omitted_timeout() {
+    let _nonce_lock =
+        super::storage_replication_first_ready_checkpoint_tests::lock_checkpoint_probe_nonce();
     let world_id = "world-gap-sync-timeout-then-checkpoint";
     let dir_a = temp_dir("gap-sync-timeout-then-checkpoint-a");
     let dir_b = temp_dir("gap-sync-timeout-then-checkpoint-b");
@@ -988,6 +1000,8 @@ fn observer_gap_sync_continues_checkpoint_candidates_after_protocol_omitted_time
 
 #[test]
 fn observer_gap_sync_uses_network_height_when_dht_head_lookup_times_out() {
+    let _nonce_lock =
+        super::storage_replication_first_ready_checkpoint_tests::lock_checkpoint_probe_nonce();
     let world_id = "world-gap-sync-dht-timeout-then-checkpoint";
     let dir_a = temp_dir("gap-sync-dht-timeout-then-checkpoint-a");
     let dir_b = temp_dir("gap-sync-dht-timeout-then-checkpoint-b");

--- a/crates/oasis7_node/src/tests_storage_replication_live_retained_boundary.rs
+++ b/crates/oasis7_node/src/tests_storage_replication_live_retained_boundary.rs
@@ -119,13 +119,17 @@ fn retained_boundary_bundle(
 }
 
 fn committed_decision(height: u64) -> PosDecision {
+    committed_decision_with_block_hash(height, format!("block-{height}").as_str())
+}
+
+fn committed_decision_with_block_hash(height: u64, block_hash: &str) -> PosDecision {
     PosDecision {
         height,
         slot: height,
         epoch: 0,
         proposer_id: "node-a".to_string(),
         status: PosConsensusStatus::Committed,
-        block_hash: format!("block-{height}"),
+        block_hash: block_hash.to_string(),
         action_root: empty_action_root(),
         committed_actions: Vec::new(),
         approved_stake: 100,
@@ -319,6 +323,186 @@ fn fresh_observer_installs_latest_retained_checkpoint_below_non_aligned_live_hea
             .is_none(),
         "height-one tail must not be persisted before retained checkpoint closure"
     );
+    let _ = fs::remove_dir_all(&dir_a);
+    let _ = fs::remove_dir_all(&dir_b);
+}
+
+#[test]
+fn fresh_observer_rejects_lower_retained_checkpoint_without_head_lineage() {
+    let _nonce_lock = PROBE_NONCE_LOCK
+        .get_or_init(|| Mutex::new(()))
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let _probe_nonce = ProbeNonceGuard::install();
+    let world_id = "world-live-head-retained-fork-lineage-52079";
+    let dir_a = temp_dir("live-head-retained-fork-lineage-a");
+    let dir_b = temp_dir("live-head-retained-fork-lineage-b");
+    let (_, public_key_a) = deterministic_keypair_hex(210);
+    let (_, public_key_b) = deterministic_keypair_hex(211);
+    let (_, public_key_c) = deterministic_keypair_hex(212);
+    let advertised_height = 52_079;
+    let checkpoint_height = 52_032;
+    let advertised_block_hash = "fork-chain-head-52079";
+    let checkpoint_block_hash = "other-chain-retained-52032";
+    let pos_config = signed_pos_config_with_signer_seeds(
+        vec![
+            PosValidator {
+                validator_id: "node-a".to_string(),
+                stake: 60,
+            },
+            PosValidator {
+                validator_id: "node-c".to_string(),
+                stake: 40,
+            },
+        ],
+        &[("node-a", 210), ("node-c", 212)],
+    );
+    let replication_config_a = signed_replication_config(dir_a.clone(), 210)
+        .with_remote_writer_allowlist(vec![public_key_b.clone()])
+        .expect("allowlist a")
+        .with_fetch_requester_allowlist(vec![public_key_b.clone()])
+        .expect("fetch allowlist a");
+    let replication_config_b = signed_replication_config(dir_b.clone(), 211)
+        .with_remote_writer_allowlist(vec![public_key_a.clone(), public_key_c.clone()])
+        .expect("allowlist b")
+        .with_fetch_requester_allowlist(vec![public_key_a.clone(), public_key_c.clone()])
+        .expect("fetch allowlist b");
+    let config_a = NodeConfig::new("node-a", world_id, NodeRole::Sequencer)
+        .expect("config a")
+        .with_pos_config(pos_config.clone())
+        .expect("pos config a")
+        .with_replication(replication_config_a.clone());
+    let config_b = NodeConfig::new("node-b", world_id, NodeRole::Observer)
+        .expect("config b")
+        .with_pos_config(pos_config)
+        .expect("pos config b")
+        .with_require_execution_on_commit(true)
+        .with_replication(replication_config_b.clone());
+    let mut replication_a =
+        ReplicationRuntime::new(config_a.replication.as_ref().expect("repl a"), "node-a")
+            .expect("runtime a");
+    let height_one = replication_a
+        .build_local_commit_message(
+            "node-a",
+            world_id,
+            52_080,
+            &committed_decision(1),
+            Some("other-chain-exec-block-1"),
+            Some("other-chain-exec-state-1"),
+        )
+        .expect("build height-one tail")
+        .expect("height-one tail message");
+    let checkpoint_state_root = "other-chain-state-52032";
+    let checkpoint_message = replication_a
+        .build_local_commit_message_with_checkpoint(
+            "node-a",
+            world_id,
+            52_032,
+            &committed_decision_with_block_hash(checkpoint_height, checkpoint_block_hash),
+            Some("other-chain-exec-block-52032"),
+            Some(checkpoint_state_root),
+            Some(retained_boundary_bundle(
+                checkpoint_height,
+                "other-chain-exec-block-52032",
+                checkpoint_state_root,
+            )),
+        )
+        .expect("build forked retained checkpoint")
+        .expect("forked retained checkpoint message");
+    assert!(checkpoint_message.public_key_hex.is_some());
+    assert!(checkpoint_message.signature_hex.is_some());
+    let network: Arc<
+        dyn oasis7_proto::distributed_net::DistributedNetwork<WorldError> + Send + Sync,
+    > = Arc::new(AdvertisedHeadRetainedCheckpointNetwork {
+        inner: Arc::new(TestInMemoryNetwork::default()),
+        advertised_head: super::replication::FetchHeadResponse {
+            found: true,
+            head: Some(super::replication::ReplicationHeadSummary {
+                world_id: world_id.to_string(),
+                height: advertised_height,
+                block_hash: advertised_block_hash.to_string(),
+                state_root: "fork-chain-state-52079".to_string(),
+                timestamp_ms: 52_079,
+            }),
+        },
+    });
+    register_replication_fetch_handlers(
+        &NodeReplicationNetworkHandle::new(Arc::clone(&network)),
+        &replication_config_a,
+        world_id,
+        &config_a.network_policy,
+    )
+    .expect("register forked checkpoint provider");
+    let handle_b = NodeReplicationNetworkHandle::new(Arc::clone(&network));
+    let mut endpoint_b =
+        ReplicationNetworkEndpoint::new(&handle_b, world_id, true, &config_b.network_policy)
+            .expect("fresh observer endpoint");
+    let mut replication_b =
+        ReplicationRuntime::new(config_b.replication.as_ref().expect("repl b"), "node-b")
+            .expect("runtime b");
+    let mut engine_b = PosNodeEngine::new(&config_b).expect("fresh observer engine");
+    for (node_id, public_key_hex) in [("node-a", public_key_a), ("node-c", public_key_c)] {
+        engine_b.peer_heads.insert(
+            node_id.to_string(),
+            PeerCommittedHead {
+                height: advertised_height,
+                block_hash: advertised_block_hash.to_string(),
+                committed_at_ms: 52_079,
+                observed_at_ms: 52_080,
+                execution_block_hash: Some("fork-chain-exec-block-52079".to_string()),
+                execution_state_root: Some("fork-chain-exec-state-52079".to_string()),
+                action_root: empty_action_root(),
+                public_key_hex: Some(public_key_hex),
+                signature_hex: Some(format!("signed-{node_id}-{advertised_height}")),
+            },
+        );
+    }
+    assert_eq!(engine_b.peer_heads.len(), 2);
+    assert!(engine_b
+        .peer_heads
+        .values()
+        .all(|head| head.public_key_hex.is_some() && head.signature_hex.is_some()));
+    assert_eq!(endpoint_b.connected_peer_ids(), vec!["node-a"]);
+    let mut execution_hook = RetainedBoundaryExecutionHook {
+        installed: Vec::new(),
+        incremental_commits: Vec::new(),
+    };
+    endpoint_b
+        .publish_replication(&height_one)
+        .expect("publish height-one tail before lineage preflight");
+    endpoint_b
+        .publish_replication(&checkpoint_message)
+        .expect("publish forked retained checkpoint provider message");
+
+    let result = engine_b.tick(
+        "node-b",
+        world_id,
+        52_100,
+        None,
+        Some(&mut replication_b),
+        Some(&mut endpoint_b),
+        None,
+        Vec::new(),
+        Some(&mut execution_hook),
+    );
+    assert!(
+        result.is_ok(),
+        "forked lower checkpoint must fail closed before height-one execution: result={result:?} installed={:?} incremental={:?}",
+        execution_hook.installed,
+        execution_hook.incremental_commits
+    );
+    assert!(
+        execution_hook.installed.is_empty(),
+        "checkpoint C must not install when signed head H has no same-chain lineage: installed={:?}",
+        execution_hook.installed
+    );
+    assert!(execution_hook.incremental_commits.is_empty());
+    assert_eq!(engine_b.committed_height, 0);
+    assert_eq!(engine_b.replication_persisted_height, 0);
+    assert!(!dir_b
+        .join("checkpoint-verification")
+        .join(format!("{checkpoint_height}.json"))
+        .exists());
     let _ = fs::remove_dir_all(&dir_a);
     let _ = fs::remove_dir_all(&dir_b);
 }

--- a/crates/oasis7_node/src/tests_storage_replication_live_retained_boundary.rs
+++ b/crates/oasis7_node/src/tests_storage_replication_live_retained_boundary.rs
@@ -1,0 +1,324 @@
+use std::fs;
+use std::sync::{Arc, Mutex, OnceLock};
+
+use super::*;
+
+#[derive(Clone)]
+struct AdvertisedHeadRetainedCheckpointNetwork {
+    inner: Arc<TestInMemoryNetwork>,
+    advertised_head: super::replication::FetchHeadResponse,
+}
+
+impl oasis7_proto::distributed_net::DistributedNetwork<WorldError>
+    for AdvertisedHeadRetainedCheckpointNetwork
+{
+    fn publish(&self, topic: &str, payload: &[u8]) -> Result<(), WorldError> {
+        self.inner.publish(topic, payload)
+    }
+
+    fn subscribe(&self, topic: &str) -> Result<NetworkSubscription, WorldError> {
+        self.inner.subscribe(topic)
+    }
+
+    fn request(&self, protocol: &str, payload: &[u8]) -> Result<Vec<u8>, WorldError> {
+        if protocol == REPLICATION_GET_HEAD_PROTOCOL {
+            return serde_json::to_vec(&self.advertised_head).map_err(|err| {
+                WorldError::DistributedValidationFailed {
+                    reason: format!("encode advertised live head failed: {err}"),
+                }
+            });
+        }
+        if protocol == REPLICATION_FETCH_COMMIT_PROTOCOL {
+            let request = serde_json::from_slice::<super::replication::FetchCommitRequest>(payload)
+                .map_err(|err| WorldError::DistributedValidationFailed {
+                    reason: format!("decode retained-boundary fetch request failed: {err}"),
+                })?;
+            if request.height == 52_079 {
+                return serde_json::to_vec(&super::replication::FetchCommitResponse {
+                    found: false,
+                    message: None,
+                })
+                .map_err(|err| WorldError::DistributedValidationFailed {
+                    reason: format!("encode advertised-head miss failed: {err}"),
+                });
+            }
+        }
+        self.inner.request(protocol, payload)
+    }
+
+    fn connected_peer_ids(&self) -> Vec<String> {
+        vec!["node-a".to_string()]
+    }
+
+    fn known_peer_ids(&self) -> Vec<String> {
+        vec!["node-a".to_string()]
+    }
+
+    fn register_handler(
+        &self,
+        protocol: &str,
+        handler: Box<dyn Fn(&[u8]) -> Result<Vec<u8>, WorldError> + Send + Sync>,
+    ) -> Result<(), WorldError> {
+        self.inner.register_handler(protocol, handler)
+    }
+}
+
+struct RetainedBoundaryExecutionHook {
+    installed: Vec<u64>,
+    incremental_commits: Vec<u64>,
+}
+
+impl NodeExecutionHook for RetainedBoundaryExecutionHook {
+    fn on_commit(
+        &mut self,
+        context: NodeExecutionCommitContext,
+    ) -> Result<NodeExecutionCommitResult, String> {
+        self.incremental_commits.push(context.height);
+        Err(format!(
+            "{} at height {}",
+            EXECUTION_MISSING_PREDECESSOR_RECORD_SIGNATURE, context.height
+        ))
+    }
+
+    fn install_checkpoint_bundle(
+        &mut self,
+        context: NodeExecutionCheckpointInstallContext,
+        bundle: NodeExecutionCheckpointBundle,
+    ) -> Result<NodeExecutionCommitResult, String> {
+        if bundle.height != context.height
+            || bundle.execution_block_hash != context.execution_block_hash
+            || bundle.execution_state_root != context.execution_state_root
+        {
+            return Err("retained checkpoint closure binding mismatch".to_string());
+        }
+        self.installed.push(context.height);
+        Ok(NodeExecutionCommitResult {
+            execution_height: context.height,
+            execution_block_hash: context.execution_block_hash,
+            execution_state_root: context.execution_state_root,
+        })
+    }
+}
+
+fn retained_boundary_bundle(
+    height: u64,
+    execution_block_hash: &str,
+    execution_state_root: &str,
+) -> NodeExecutionCheckpointBundle {
+    let bytes = format!("retained-boundary-snapshot-{height}").into_bytes();
+    NodeExecutionCheckpointBundle {
+        height,
+        execution_block_hash: execution_block_hash.to_string(),
+        execution_state_root: execution_state_root.to_string(),
+        manifest_json: br#"{"test":"retained-boundary"}"#.to_vec(),
+        blobs: vec![NodeExecutionCheckpointBlob {
+            content_hash: oasis7_distfs::blake3_hex(bytes.as_slice()),
+            bytes,
+        }],
+    }
+}
+
+fn committed_decision(height: u64) -> PosDecision {
+    PosDecision {
+        height,
+        slot: height,
+        epoch: 0,
+        proposer_id: "node-a".to_string(),
+        status: PosConsensusStatus::Committed,
+        block_hash: format!("block-{height}"),
+        action_root: empty_action_root(),
+        committed_actions: Vec::new(),
+        approved_stake: 100,
+        rejected_stake: 0,
+        required_stake: 67,
+        total_stake: 100,
+    }
+}
+
+static PROBE_NONCE_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+
+struct ProbeNonceGuard;
+
+impl ProbeNonceGuard {
+    fn install() -> Self {
+        // SAFETY: this test holds PROBE_NONCE_LOCK for its full duration.
+        unsafe {
+            std::env::set_var(
+                "OASIS7_CHECKPOINT_PROBE_NONCE",
+                "retained-boundary-probe-nonce-0123456789abcdef0123456789abcdef",
+            );
+        }
+        Self
+    }
+}
+
+impl Drop for ProbeNonceGuard {
+    fn drop(&mut self) {
+        // SAFETY: this test holds PROBE_NONCE_LOCK for its full duration.
+        unsafe {
+            std::env::remove_var("OASIS7_CHECKPOINT_PROBE_NONCE");
+        }
+    }
+}
+
+#[test]
+fn fresh_observer_installs_latest_retained_checkpoint_below_non_aligned_live_head() {
+    let _nonce_lock = PROBE_NONCE_LOCK
+        .get_or_init(|| Mutex::new(()))
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let _probe_nonce = ProbeNonceGuard::install();
+    let world_id = "world-live-head-retained-boundary-52079";
+    let dir_a = temp_dir("live-head-retained-boundary-a");
+    let dir_b = temp_dir("live-head-retained-boundary-b");
+    let (_, public_key_a) = deterministic_keypair_hex(208);
+    let (_, public_key_b) = deterministic_keypair_hex(209);
+    let advertised_height = 52_079;
+    let checkpoint_height = 52_032;
+    let pos_config = signed_pos_config_with_signer_seeds(
+        vec![PosValidator {
+            validator_id: "node-a".to_string(),
+            stake: 100,
+        }],
+        &[("node-a", 208)],
+    );
+    let replication_config_a = signed_replication_config(dir_a.clone(), 208)
+        .with_remote_writer_allowlist(vec![public_key_b.clone()])
+        .expect("allowlist a")
+        .with_fetch_requester_allowlist(vec![public_key_b])
+        .expect("fetch allowlist a");
+    let replication_config_b = signed_replication_config(dir_b.clone(), 209)
+        .with_remote_writer_allowlist(vec![public_key_a.clone()])
+        .expect("allowlist b")
+        .with_fetch_requester_allowlist(vec![public_key_a])
+        .expect("fetch allowlist b");
+    let config_a = NodeConfig::new("node-a", world_id, NodeRole::Sequencer)
+        .expect("config a")
+        .with_pos_config(pos_config.clone())
+        .expect("pos config a")
+        .with_replication(replication_config_a.clone());
+    let config_b = NodeConfig::new("node-b", world_id, NodeRole::Observer)
+        .expect("config b")
+        .with_pos_config(pos_config)
+        .expect("pos config b")
+        .with_require_execution_on_commit(true)
+        .with_replication(replication_config_b.clone());
+    let mut replication_a =
+        ReplicationRuntime::new(config_a.replication.as_ref().expect("repl a"), "node-a")
+            .expect("runtime a");
+    let height_one = replication_a
+        .build_local_commit_message(
+            "node-a",
+            world_id,
+            52_080,
+            &committed_decision(1),
+            Some("exec-block-1"),
+            Some("exec-state-1"),
+        )
+        .expect("build height-one tail")
+        .expect("height-one tail message");
+    let checkpoint_block_hash = format!("exec-block-{checkpoint_height}");
+    let checkpoint_state_root = format!("exec-state-{checkpoint_height}");
+    let checkpoint_message = replication_a
+        .build_local_commit_message_with_checkpoint(
+            "node-a",
+            world_id,
+            52_032,
+            &committed_decision(checkpoint_height),
+            Some(checkpoint_block_hash.as_str()),
+            Some(checkpoint_state_root.as_str()),
+            Some(retained_boundary_bundle(
+                checkpoint_height,
+                checkpoint_block_hash.as_str(),
+                checkpoint_state_root.as_str(),
+            )),
+        )
+        .expect("build retained boundary checkpoint")
+        .expect("retained boundary checkpoint message");
+    let network: Arc<dyn oasis7_proto::distributed_net::DistributedNetwork<WorldError> + Send + Sync> =
+        Arc::new(AdvertisedHeadRetainedCheckpointNetwork {
+            inner: Arc::new(TestInMemoryNetwork::default()),
+            advertised_head: super::replication::FetchHeadResponse {
+                found: true,
+                head: Some(super::replication::ReplicationHeadSummary {
+                    world_id: world_id.to_string(),
+                    height: advertised_height,
+                    block_hash: format!("block-{advertised_height}"),
+                    state_root: format!("state-{advertised_height}"),
+                    timestamp_ms: 52_079,
+                }),
+            },
+        });
+    register_replication_fetch_handlers(
+        &NodeReplicationNetworkHandle::new(Arc::clone(&network)),
+        &replication_config_a,
+        world_id,
+        &config_a.network_policy,
+    )
+    .expect("register retained checkpoint provider");
+    let handle_b = NodeReplicationNetworkHandle::new(Arc::clone(&network));
+    let mut endpoint_b =
+        ReplicationNetworkEndpoint::new(&handle_b, world_id, true, &config_b.network_policy)
+            .expect("fresh observer endpoint");
+    let mut replication_b =
+        ReplicationRuntime::new(config_b.replication.as_ref().expect("repl b"), "node-b")
+            .expect("runtime b");
+    let mut engine_b = PosNodeEngine::new(&config_b).expect("fresh observer engine");
+    let mut execution_hook = RetainedBoundaryExecutionHook {
+        installed: Vec::new(),
+        incremental_commits: Vec::new(),
+    };
+    endpoint_b
+        .publish_replication(&height_one)
+        .expect("publish height-one tail before checkpoint preflight");
+    endpoint_b
+        .publish_replication(&checkpoint_message)
+        .expect("publish retained checkpoint provider message");
+
+    let result = engine_b.tick(
+        "node-b",
+        world_id,
+        52_100,
+        None,
+        Some(&mut replication_b),
+        Some(&mut endpoint_b),
+        None,
+        Vec::new(),
+        Some(&mut execution_hook),
+    );
+    assert!(
+        result.is_ok(),
+        "fresh observer must use retained checkpoint below advertised live head before height-one execution: result={result:?} incremental={:?}",
+        execution_hook.incremental_commits
+    );
+    assert_eq!(execution_hook.installed, vec![checkpoint_height]);
+    assert!(execution_hook.incremental_commits.is_empty());
+    assert_eq!(engine_b.committed_height, checkpoint_height);
+    assert_eq!(engine_b.replication_persisted_height, checkpoint_height);
+    let receipt_path = dir_b
+        .join("checkpoint-verification")
+        .join(format!("{checkpoint_height}.json"));
+    let receipt: serde_json::Value = serde_json::from_slice(
+        fs::read(&receipt_path)
+            .expect("retained checkpoint closure receipt")
+            .as_slice(),
+    )
+    .expect("decode retained checkpoint closure receipt");
+    assert_eq!(receipt["height"], checkpoint_height);
+    assert_eq!(receipt["probe_nonce"], "retained-boundary-probe-nonce-0123456789abcdef0123456789abcdef");
+    assert!(
+        receipt["fetch_observations"]
+            .as_array()
+            .is_some_and(|observations| !observations.is_empty()),
+        "closure receipt must retain signed fetch observations: {receipt}"
+    );
+    assert!(
+        replication_b
+            .load_commit_message_by_height(world_id, 1)
+            .expect("inspect height-one persistence")
+            .is_none(),
+        "height-one tail must not be persisted before retained checkpoint closure"
+    );
+    let _ = fs::remove_dir_all(&dir_a);
+    let _ = fs::remove_dir_all(&dir_b);
+}

--- a/crates/oasis7_node/src/tests_storage_replication_live_retained_boundary.rs
+++ b/crates/oasis7_node/src/tests_storage_replication_live_retained_boundary.rs
@@ -306,6 +306,7 @@ fn fresh_observer_installs_latest_retained_checkpoint_below_non_aligned_live_hea
 
 #[test]
 fn fresh_observer_rejects_lower_retained_checkpoint_without_head_lineage() {
+    let _nonce_lock = lock_checkpoint_probe_nonce();
     let world_id = "world-live-head-retained-fork-lineage-52079";
     let dir_a = temp_dir("live-head-retained-fork-lineage-a");
     let dir_b = temp_dir("live-head-retained-fork-lineage-b");

--- a/crates/oasis7_node/src/tests_storage_replication_live_retained_boundary.rs
+++ b/crates/oasis7_node/src/tests_storage_replication_live_retained_boundary.rs
@@ -1,7 +1,10 @@
 use std::fs;
-use std::sync::{Arc, Mutex, OnceLock};
+use std::sync::Arc;
 
 use super::*;
+use super::storage_replication_first_ready_checkpoint_tests::{
+    lock_checkpoint_probe_nonce, CheckpointProbeNonceGuard,
+};
 
 #[derive(Clone)]
 struct AdvertisedHeadRetainedCheckpointNetwork {
@@ -139,39 +142,10 @@ fn committed_decision_with_block_hash(height: u64, block_hash: &str) -> PosDecis
     }
 }
 
-static PROBE_NONCE_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-
-struct ProbeNonceGuard;
-
-impl ProbeNonceGuard {
-    fn install() -> Self {
-        // SAFETY: this test holds PROBE_NONCE_LOCK for its full duration.
-        unsafe {
-            std::env::set_var(
-                "OASIS7_CHECKPOINT_PROBE_NONCE",
-                "retained-boundary-probe-nonce-0123456789abcdef0123456789abcdef",
-            );
-        }
-        Self
-    }
-}
-
-impl Drop for ProbeNonceGuard {
-    fn drop(&mut self) {
-        // SAFETY: this test holds PROBE_NONCE_LOCK for its full duration.
-        unsafe {
-            std::env::remove_var("OASIS7_CHECKPOINT_PROBE_NONCE");
-        }
-    }
-}
-
 #[test]
 fn fresh_observer_installs_latest_retained_checkpoint_below_non_aligned_live_head() {
-    let _nonce_lock = PROBE_NONCE_LOCK
-        .get_or_init(|| Mutex::new(()))
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
-    let _probe_nonce = ProbeNonceGuard::install();
+    let _nonce_lock = lock_checkpoint_probe_nonce();
+    let _probe_nonce = CheckpointProbeNonceGuard::install();
     let world_id = "world-live-head-retained-boundary-52079";
     let dir_a = temp_dir("live-head-retained-boundary-a");
     let dir_b = temp_dir("live-head-retained-boundary-b");
@@ -309,7 +283,10 @@ fn fresh_observer_installs_latest_retained_checkpoint_below_non_aligned_live_hea
     )
     .expect("decode retained checkpoint closure receipt");
     assert_eq!(receipt["height"], checkpoint_height);
-    assert_eq!(receipt["probe_nonce"], "retained-boundary-probe-nonce-0123456789abcdef0123456789abcdef");
+    assert_eq!(
+        receipt["probe_nonce"],
+        "probe-nonce-0123456789abcdef0123456789abcdef"
+    );
     assert!(
         receipt["fetch_observations"]
             .as_array()
@@ -329,11 +306,6 @@ fn fresh_observer_installs_latest_retained_checkpoint_below_non_aligned_live_hea
 
 #[test]
 fn fresh_observer_rejects_lower_retained_checkpoint_without_head_lineage() {
-    let _nonce_lock = PROBE_NONCE_LOCK
-        .get_or_init(|| Mutex::new(()))
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
-    let _probe_nonce = ProbeNonceGuard::install();
     let world_id = "world-live-head-retained-fork-lineage-52079";
     let dir_a = temp_dir("live-head-retained-fork-lineage-a");
     let dir_b = temp_dir("live-head-retained-fork-lineage-b");


### PR DESCRIPTION
## Summary
- reproduce the live public-testnet case where the advertised head is not a retained checkpoint boundary
- probe bounded retained checkpoint candidates below the live head before permitting height-one replay
- fail closed when an authenticated high head exists but H→C lineage cannot be proven
- preserve signed descriptor/hash/size verification and existing fail-closed retry behavior

## Task truth
- Refs #3191
- Task: task_cd5a082bbdb34b65add5d0542c4d1681

## Live evidence
The governed clean-room probe connected to both testnet.251 validators but timed out without a receipt at live heads 51974/52079. Storage held a valid v2 checkpoint at 52032, proving the missing path was selection/attachment below a non-aligned live head.

## Verification
- lineage RED and valid retained-boundary focused tests passed
- storage replication serial suite 79/79 passed
- oasis7_node lib parallel and serial suites 457/457 passed
- fmt, file-size, diff-check passed

## Safety
Observers remain paused. This PR does not synthesize or copy checkpoint state and does not weaken signed fetch, descriptor equality, blob hash/size, connected-candidate, or fail-closed authority gates.

Closes no issue; live closure remains required under #3191 after merge/package rollout.

