### PR TITLE
Preserve target-owned DHT peer-record recovery

### DIFF
--- a/crates/oasis7_net/src/libp2p_net.rs
+++ b/crates/oasis7_net/src/libp2p_net.rs
@@ -920,6 +920,7 @@ impl Libp2pNetwork {
                                         &event_traffic_metrics,
                                         peer_id,
                                         local_peer_id,
+                                        peer_record_template.is_some(),
                                     );
                                     maybe_request_cached_discovery_peers(
                                         &mut swarm,

--- a/crates/oasis7_net/src/libp2p_net/discovery.rs
+++ b/crates/oasis7_net/src/libp2p_net/discovery.rs
@@ -42,6 +42,7 @@ const RR_GET_CACHED_DISCOVERY_PEERS: &str = "/aw/rr/1.0.0/get_cached_discovery_p
 pub(super) enum PendingPeerRecordRequest {
     ConnectedPeerRecord {
         peer_id: PeerId,
+        target_owned_route_expected: bool,
     },
     CachedPeerRecord {
         ask_peer: PeerId,
@@ -147,6 +148,7 @@ pub(super) fn handle_routing_updated(
             event_traffic_metrics,
             peer,
             local_peer_id,
+            peer_record_template.is_some(),
         );
     }
 }
@@ -336,6 +338,7 @@ pub(super) fn maybe_request_connected_peer_record(
     traffic_metrics: &SharedLibp2pTrafficMetrics,
     peer_id: PeerId,
     local_peer_id: PeerId,
+    target_owned_route_expected: bool,
 ) -> bool {
     let now_ms = super::now_ms();
     if peer_id == local_peer_id
@@ -356,7 +359,10 @@ pub(super) fn maybe_request_connected_peer_record(
     note_peer_record_request_cooldown(connected_peer_record_cooldowns, peer_id, now_ms);
     pending_peer_record_requests.insert(
         request_id,
-        PendingPeerRecordRequest::ConnectedPeerRecord { peer_id },
+        PendingPeerRecordRequest::ConnectedPeerRecord {
+            peer_id,
+            target_owned_route_expected,
+        },
     );
     true
 }
@@ -752,7 +758,7 @@ pub(super) fn handle_peer_record_response(
         pending_cached_discovery_peers,
     );
     let requested_peer_id = match &kind {
-        PendingPeerRecordRequest::ConnectedPeerRecord { peer_id }
+        PendingPeerRecordRequest::ConnectedPeerRecord { peer_id, .. }
         | PendingPeerRecordRequest::CachedDiscoveryPeers { peer_id } => *peer_id,
         PendingPeerRecordRequest::CachedPeerRecord { peer_id, .. } => *peer_id,
     };
@@ -911,19 +917,24 @@ pub(super) fn handle_peer_record_outbound_failure(
         pending_cached_discovery_peers,
     );
     match kind {
-        PendingPeerRecordRequest::ConnectedPeerRecord { peer_id } => {
+        PendingPeerRecordRequest::ConnectedPeerRecord {
+            peer_id,
+            target_owned_route_expected,
+        } => {
             connected_peer_record_cooldowns.remove(&peer_id);
             cached_peer_record_cooldowns.remove(&peer_id);
-            let _ = maybe_request_cached_peer_record(
-                swarm,
-                pending_peer_record_requests,
-                pending_cached_peer_records,
-                cached_peer_record_cooldowns,
-                traffic_metrics,
-                connected_peers,
-                peer_id,
-                local_peer_id,
-            );
+            if !target_owned_route_expected {
+                let _ = maybe_request_cached_peer_record(
+                    swarm,
+                    pending_peer_record_requests,
+                    pending_cached_peer_records,
+                    cached_peer_record_cooldowns,
+                    traffic_metrics,
+                    connected_peers,
+                    peer_id,
+                    local_peer_id,
+                );
+            }
         }
         PendingPeerRecordRequest::CachedPeerRecord {
             peer_id,
@@ -963,7 +974,7 @@ pub(super) fn clear_pending_peer_record_request(
     pending_cached_discovery_peers: &mut HashSet<PeerId>,
 ) {
     match kind {
-        PendingPeerRecordRequest::ConnectedPeerRecord { peer_id } => {
+        PendingPeerRecordRequest::ConnectedPeerRecord { peer_id, .. } => {
             pending_connected_peer_records.remove(peer_id);
         }
         PendingPeerRecordRequest::CachedPeerRecord { peer_id, .. } => {

--- a/crates/oasis7_net/src/libp2p_net/tests/discovery_peer_record_failure_tests.rs
+++ b/crates/oasis7_net/src/libp2p_net/tests/discovery_peer_record_failure_tests.rs
@@ -38,7 +38,9 @@ fn assert_mismatched_peer_record_response_is_rejected(
     let traffic_metrics = super::super::traffic_metrics::init_shared_traffic_metrics();
 
     match &kind {
-        super::super::discovery::PendingPeerRecordRequest::ConnectedPeerRecord { peer_id } => {
+        super::super::discovery::PendingPeerRecordRequest::ConnectedPeerRecord {
+            peer_id, ..
+        } => {
             assert_eq!(*peer_id, target_peer_id);
             pending_connected_peer_records.insert(*peer_id);
         }
@@ -90,6 +92,7 @@ fn connected_peer_record_response_rejects_signed_record_for_wrong_target() {
     assert_mismatched_peer_record_response_is_rejected(
         super::super::discovery::PendingPeerRecordRequest::ConnectedPeerRecord {
             peer_id: target_peer_id,
+            target_owned_route_expected: false,
         },
         target_peer_id,
     );
@@ -134,6 +137,7 @@ fn connected_peer_record_outbound_failure_falls_back_via_another_connected_peer(
         &mut swarm,
         super::super::discovery::PendingPeerRecordRequest::ConnectedPeerRecord {
             peer_id: target_peer_id,
+            target_owned_route_expected: false,
         },
         &mut pending_peer_record_requests,
         &mut pending_connected_peer_records,
@@ -165,4 +169,71 @@ fn connected_peer_record_outbound_failure_falls_back_via_another_connected_peer(
             && *peer_id == target_peer_id
             && *tried_proxies == vec![fallback_proxy]
     ));
+}
+
+#[test]
+fn connected_peer_record_failure_prefers_target_owned_dht_route_over_cache_proxy() {
+    let mut swarm = super::super::swarm_behaviour::build_swarm(
+        &Keypair::generate_ed25519(),
+        false,
+        true,
+        std::time::Duration::from_secs(30),
+        super::super::wire_bytes::init_shared_wire_byte_counters(),
+    );
+    let target_peer_id = PeerId::random();
+    let fallback_proxy = PeerId::random();
+    let local_peer_id = PeerId::random();
+    let mut pending_dht = HashMap::new();
+    let mut pending_discovery_peer_records = HashSet::new();
+    let discovered_peer_records = HashMap::new();
+    super::super::discovery::maybe_queue_discovery_peer_record(
+        &mut swarm,
+        &mut pending_dht,
+        &mut pending_discovery_peer_records,
+        &discovered_peer_records,
+        target_peer_id,
+        local_peer_id,
+        "world-a",
+    );
+    assert!(pending_discovery_peer_records.contains(&target_peer_id));
+    assert!(pending_dht.values().any(|query| matches!(
+        query,
+        super::super::kad_queries::PendingDhtQuery::DiscoverPeerRecord {
+            peer_id,
+            ..
+        } if *peer_id == target_peer_id
+    )));
+
+    let mut pending_peer_record_requests = HashMap::new();
+    let mut pending_connected_peer_records = HashSet::from([target_peer_id]);
+    let mut connected_peer_record_cooldowns = HashMap::from([(target_peer_id, i64::MAX)]);
+    let mut pending_cached_peer_records = HashSet::new();
+    let mut cached_peer_record_cooldowns = HashMap::new();
+    let mut pending_cached_discovery_peers = HashSet::new();
+    let mut cached_discovery_peer_cooldowns = HashMap::new();
+    let traffic_metrics = super::super::traffic_metrics::init_shared_traffic_metrics();
+
+    super::super::discovery::handle_peer_record_outbound_failure(
+        &mut swarm,
+        super::super::discovery::PendingPeerRecordRequest::ConnectedPeerRecord {
+            peer_id: target_peer_id,
+            target_owned_route_expected: true,
+        },
+        &mut pending_peer_record_requests,
+        &mut pending_connected_peer_records,
+        &mut connected_peer_record_cooldowns,
+        &mut pending_cached_peer_records,
+        &mut cached_peer_record_cooldowns,
+        &mut pending_cached_discovery_peers,
+        &mut cached_discovery_peer_cooldowns,
+        &[target_peer_id, fallback_proxy],
+        &traffic_metrics,
+        local_peer_id,
+    );
+
+    assert!(
+        pending_cached_peer_records.is_empty(),
+        "a pending target-owned DHT route must not be replaced by cache-only fallback"
+    );
+    assert!(pending_peer_record_requests.is_empty());
 }

--- a/crates/oasis7_net/src/libp2p_net/tests/discovery_peer_record_tests.rs
+++ b/crates/oasis7_net/src/libp2p_net/tests/discovery_peer_record_tests.rs
@@ -403,6 +403,7 @@ fn maybe_request_connected_peer_record_respects_short_cooldown() {
         &traffic_metrics,
         target_peer_id,
         local_peer_id,
+        false,
     );
     assert!(requested);
     assert_eq!(pending_peer_record_requests.len(), 1);
@@ -418,6 +419,7 @@ fn maybe_request_connected_peer_record_respects_short_cooldown() {
         &traffic_metrics,
         target_peer_id,
         local_peer_id,
+        false,
     );
     assert!(!requested_during_cooldown);
     assert!(pending_peer_record_requests.is_empty());
@@ -432,6 +434,7 @@ fn maybe_request_connected_peer_record_respects_short_cooldown() {
         &traffic_metrics,
         target_peer_id,
         local_peer_id,
+        false,
     );
     assert!(requested_after_expiry);
     assert_eq!(pending_peer_record_requests.len(), 1);
@@ -666,6 +669,7 @@ fn clear_disconnected_peer_state_removes_peer_record_cooldowns() {
             &traffic_metrics,
             target_peer_id,
             local_peer_id,
+            false,
         )
     );
     assert!(!super::super::discovery::maybe_request_cached_peer_record(
@@ -730,6 +734,7 @@ fn clear_disconnected_peer_state_removes_peer_record_cooldowns() {
         &traffic_metrics,
         target_peer_id,
         local_peer_id,
+        false,
     );
     assert!(connected_requested);
     pending_peer_record_requests.clear();


### PR DESCRIPTION
Task: task_3654acbb6f2d4e728600c8827ce7736f

Refs #3296

Generated by ./scripts/prepare-task-pr.sh.